### PR TITLE
Detect support for _Complex

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -463,7 +463,7 @@ conf_data.set('PICOLIBC_TLS', thread_local_storage, description: 'use thread loc
 conf_data.set('POSIX_IO', posix_io, description: 'Use open/close/read/write in tinystdio')
 conf_data.set('POSIX_CONSOLE', posix_console, description: 'Use POSIX I/O for stdin, stdout and stderr')
 conf_data.set('ATOMIC_UNGETC', atomic_ungetc, description: 'Use atomics for fgetc/ungetc for re-entrancy')
-conf_data.set('HAVE_COMPLEX', have_complex, description: 'Support for _Complex')
+conf_data.set('HAVE_COMPLEX', have_complex, description: 'Only add support for _Complex if the compiler supports it as well')
 
 if newlib_obsolete_math == 'auto'
   obsolete_math_value = false

--- a/meson.build
+++ b/meson.build
@@ -328,6 +328,12 @@ if have_long_double
   long_double_equals_double = meson.get_compiler('c').compiles(long_double_size_code, name : 'long double same as double')
 endif
 
+# CompCert does not support _Complex
+complex_code = '''
+float _Complex test(float _Complex z) { return z; }
+'''
+have_complex = meson.get_compiler('c').compiles(complex_code, name : 'supports _Complex')
+
 if enable_multilib
   used_libs = []
 
@@ -457,6 +463,7 @@ conf_data.set('PICOLIBC_TLS', thread_local_storage, description: 'use thread loc
 conf_data.set('POSIX_IO', posix_io, description: 'Use open/close/read/write in tinystdio')
 conf_data.set('POSIX_CONSOLE', posix_console, description: 'Use POSIX I/O for stdin, stdout and stderr')
 conf_data.set('ATOMIC_UNGETC', atomic_ungetc, description: 'Use atomics for fgetc/ungetc for re-entrancy')
+conf_data.set('HAVE_COMPLEX', have_complex, description: 'Support for _Complex')
 
 if newlib_obsolete_math == 'auto'
   obsolete_math_value = false

--- a/newlib/libc/include/complex.h
+++ b/newlib/libc/include/complex.h
@@ -14,7 +14,6 @@
 
 #include <sys/cdefs.h>
 
-#ifdef HAVE_COMPLEX
 __BEGIN_DECLS
 
 /* 7.3.5 Trigonometric functions */
@@ -152,4 +151,3 @@ long double complex clog10l(long double complex);
 __END_DECLS
 
 #endif  /* #ifndef _COMPLEX_H */
-#endif	/* #ifdef HAVE_COMPLEX */

--- a/newlib/libc/include/complex.h
+++ b/newlib/libc/include/complex.h
@@ -150,4 +150,4 @@ long double complex clog10l(long double complex);
 
 __END_DECLS
 
-#endif  /* #ifndef _COMPLEX_H */
+#endif	/* ! _COMPLEX_H */

--- a/newlib/libc/include/complex.h
+++ b/newlib/libc/include/complex.h
@@ -14,6 +14,7 @@
 
 #include <sys/cdefs.h>
 
+#ifdef HAVE_COMPLEX
 __BEGIN_DECLS
 
 /* 7.3.5 Trigonometric functions */
@@ -150,4 +151,5 @@ long double complex clog10l(long double complex);
 
 __END_DECLS
 
-#endif	/* ! _COMPLEX_H */
+#endif  /* #ifndef _COMPLEX_H */
+#endif	/* #ifdef HAVE_COMPLEX */

--- a/newlib/libc/include/meson.build
+++ b/newlib/libc/include/meson.build
@@ -42,7 +42,6 @@ inc_headers = [
   'argz.h',
   'ar.h',
   'assert.h',
-  'complex.h',
   'cpio.h',
   'ctype.h',
   'devctl.h',
@@ -95,6 +94,10 @@ inc_headers = [
   'wctype.h',
   'wordexp.h'
 ]
+
+if have_complex
+  inc_headers += ['complex.h']
+endif
 
 inc_headers += ['picotls.h']
 

--- a/newlib/libm/meson.build
+++ b/newlib/libm/meson.build
@@ -49,7 +49,10 @@ libm_machine_dirs = {
 		      'xtensa': 'xtensa',
 		    }
 
-libdirs = ['math', 'common', 'complex']
+libdirs = ['math', 'common']
+if have_complex
+  libdirs = libdirs + ['complex']
+endif
 
 libnames = libdirs
 


### PR DESCRIPTION
Check if the compiler supports _Complex. If not, disable building `libm/complex/` and disable the `complex.h` header.