### PR TITLE
guard usage of __strong_reference with `#ifdef HAVE_ALIAS_ATTRIBUTE`

### DIFF
--- a/newlib/libc/tinystdio/fgetc.c
+++ b/newlib/libc/tinystdio/fgetc.c
@@ -55,4 +55,8 @@ fgetc(FILE *stream)
 	return (unsigned char)rv;
 }
 
+#ifdef HAVE_ALIAS_ATTRIBUTE
 __strong_reference(fgetc, getc);
+#elif !defined(getc)
+int getc(FILE *stream) { return fgetc(stream); }
+#endif

--- a/newlib/libc/tinystdio/fputc.c
+++ b/newlib/libc/tinystdio/fputc.c
@@ -45,5 +45,8 @@ fputc(int c, FILE *stream)
 	return c;
 }
 
-
+#ifdef HAVE_ALIAS_ATTRIBUTE
 __strong_reference(fputc, putc);
+#elif !defined(getc)
+int putc(int c, FILE *stream) { return fputc(c, stream); }
+#endif


### PR DESCRIPTION
There were two occurrences of unguarded use of __strong_reference.
To avoid this, I added wrapper functions in case `putc`/`getc` isn't `#define`ed as `fputc`/`fgetc`.