### PR TITLE
Check for presence of __builtin_mul_overflow

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -290,21 +290,21 @@ endif
 specs_data.set(
   'SPECS_PRINTF',
   specs_printf
-)
+  )
 
 picolibc_specs = configure_file(input: 'picolibc.specs.in',
-				output: '@BASENAME@',
-				configuration: specs_data,
-				install_dir: specs_dir,
-				install: specs_install)
-				     
+  output: '@BASENAME@',
+  configuration: specs_data,
+  install_dir: specs_dir,
+  install: specs_install)
+
 test_specs = configure_file(input: 'test.specs.in',
-			    output: '@BASENAME@',
-			    configuration: specs_data,
-			    install: false)
+  output: '@BASENAME@',
+  configuration: specs_data,
+  install: false)
 
 install_data('picolibc.ld',
-	     install_dir: lib_dir)
+  install_dir: lib_dir)
 
 long_double_code = '''
 #include <float.h>
@@ -313,8 +313,8 @@ long_double_code = '''
 #endif
 long double test()
 {
-	long double ld = 0.0L;
-	 return ld;
+    long double ld = 0.0L;
+     return ld;
 }
 '''
 have_long_double = meson.get_compiler('c').compiles(long_double_code, name : 'long double check')
@@ -334,6 +334,13 @@ struct test { int part: 24; } __attribute__((packed));
 unsigned int foobar (const struct test *p) { return p->part; }
 '''
 have_bitfields_in_packed_structs = meson.get_compiler('c').compiles(bitfields_in_packed_structs_code, name : 'packed structs may contain bitfields')
+
+# CompCert does not have __builtin_mul_overflow
+builtin_mul_overflow_code = '''
+#include <stddef.h>
+int overflows (size_t a, size_t b) { size_t x; return __builtin_mul_overflow(a, b, &x); }
+'''
+have_builtin_mul_overflow = meson.get_compiler('c').compiles(builtin_mul_overflow_code, name : 'has __builtin_mul_overflow')
 
 if enable_multilib
   used_libs = []
@@ -465,6 +472,7 @@ conf_data.set('POSIX_IO', posix_io, description: 'Use open/close/read/write in t
 conf_data.set('POSIX_CONSOLE', posix_console, description: 'Use POSIX I/O for stdin, stdout and stderr')
 conf_data.set('ATOMIC_UNGETC', atomic_ungetc, description: 'Use atomics for fgetc/ungetc for re-entrancy')
 conf_data.set('HAVE_BITFIELDS_IN_PACKED_STRUCTS', have_bitfields_in_packed_structs, description: 'Use bitfields in packed structs')
+conf_data.set('HAVE_BUILTIN_MUL', have_builtin_mul_overflow, description: 'Compiler has __builtin_mul_overflow')
 
 if newlib_obsolete_math == 'auto'
   obsolete_math_value = false

--- a/newlib/libc/include/sys/features.h
+++ b/newlib/libc/include/sys/features.h
@@ -39,7 +39,6 @@ extern "C" {
 /* Version with trailing underscores for BSD compatibility. */
 #define	__GNUC_PREREQ__(ma, mi)	__GNUC_PREREQ(ma, mi)
 
-
 /*
  * Feature test macros control which symbols are exposed by the system
  * headers.  Any of these must be defined before including any headers.

--- a/newlib/libc/stdlib/mallocr.c
+++ b/newlib/libc/stdlib/mallocr.c
@@ -278,7 +278,6 @@ extern "C" {
 #include <stdio.h>    /* needed for malloc_stats */
 #include <limits.h>   /* needed for overflow checks */
 #include <errno.h>    /* needed to set errno to ENOMEM */
-#include "mul_overflow.h"
 
 #ifdef WIN32
 #define WIN32_LEAN_AND_MEAN

--- a/newlib/libc/stdlib/mul_overflow.h
+++ b/newlib/libc/stdlib/mul_overflow.h
@@ -1,0 +1,27 @@
+#ifdef HAVE_BUILTIN_MUL_OVERFLOW
+// gcc should use the correct one here
+#define mul_overflow __builtin_mul_overflow
+#else
+/**
+ * Since __builtin_mul_overflow doesn't seem to exist,
+ * use a (slower) software implementation instead.
+ * This is only implemented for size_t, so in case mallocr.c's INTERNAL_SIZE_T
+ *  is non default, mallocr.c throws an #error.
+ */
+static int mul_overflow_size_t(a, b, res)
+    size_t a;
+    size_t b;
+    size_t *res;
+{
+    // always fill the result (gcc doesn't define what happens here)
+    if (res)
+        *res = a * b;
+
+    // check if overflow would happen:
+    if ( (a > SIZE_MAX / b) || (b > SIZE_MAX / a))
+        return 1;
+
+    return 0;
+}
+#define mul_overflow mul_overflow_size_t
+#endif

--- a/newlib/libc/stdlib/nano-mallocr.c
+++ b/newlib/libc/stdlib/nano-mallocr.c
@@ -450,6 +450,7 @@ void cfree(void * ptr)
 #endif /* DEFINE_CFREE */
 
 #ifdef DEFINE_CALLOC
+#include "mul_overflow.h"
 
 /* Function calloc
  *
@@ -461,7 +462,7 @@ void * calloc(size_t n, size_t elem)
 {
     size_t bytes;
 
-    if (__builtin_mul_overflow (n, elem, &bytes))
+    if (mul_overflow (n, elem, &bytes))
     {
         errno = ENOMEM;
         return NULL;

--- a/newlib/libc/stdlib/reallocarray.c
+++ b/newlib/libc/stdlib/reallocarray.c
@@ -20,13 +20,14 @@
 #include <errno.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include "mul_overflow.h"
 
 void *
 reallocarray(void *optr, size_t nmemb, size_t size)
 {
 	ptrdiff_t bytes;
 
-	if (__builtin_mul_overflow (nmemb, size, &bytes))
+	if (mul_overflow (nmemb, size, &bytes))
 	{
 		errno = ENOMEM;
 		return NULL;


### PR DESCRIPTION
If `__builtin_mul_overflow` not there, use a software implementation (which assumes size_t).

Caveat: mallocr.c uses a macro `INTERNAL_SIZE_T`, which defaults
to `size_t` in case that macro is not defined. So in case that macro
is defined, an `#error` has been added to avoid subtle errors.