### PR TITLE
avoid void pointer arithmetic

### DIFF
--- a/newlib/libc/stdlib/nano-mallocr.c
+++ b/newlib/libc/stdlib/nano-mallocr.c
@@ -236,7 +236,7 @@ void* __malloc_sbrk_aligned(size_t s)
      * is MALLOC_CHUNK_ALIGN aligned and the head is
      * MALLOC_HEAD_ALIGN aligned.
      */
-    align_p = ALIGN_PTR(p + MALLOC_HEAD, MALLOC_CHUNK_ALIGN) - MALLOC_HEAD;
+    align_p = (char*)ALIGN_PTR(p + MALLOC_HEAD, MALLOC_CHUNK_ALIGN) - MALLOC_HEAD;
 
     if (align_p != p)
     {

--- a/newlib/libc/tinystdio/vfscanf.c
+++ b/newlib/libc/tinystdio/vfscanf.c
@@ -736,7 +736,10 @@ int vfscanf (FILE * stream, const char *fmt, va_list ap)
 		do {
 		    if ((i = scanf_getc (stream, lenp)) < 0)
 			goto eof;
-		    if (addr) *(char *)addr++ = i;
+		    if (addr) {
+                *(char *)addr = i;
+                addr = (char*)addr + 1;
+            }
 		} while (--width);
 		c = 1;			/* no matter with smart GCC	*/
 
@@ -762,7 +765,10 @@ int vfscanf (FILE * stream, const char *fmt, va_list ap)
 			    scanf_ungetc (i, stream, lenp);
 			    break;
 			}
-			if (addr) *(char *)addr++ = i;
+		    if (addr) {
+                *(char *)addr = i;
+                addr = (char*)addr + 1;
+            }
 		    } while (--width);
 		    if (addr) *(char *)addr = 0;
 		    c = 1;		/* no matter with smart GCC	*/


### PR DESCRIPTION
there were three instances of arithmetic on `void*`, now they are explicitly cast to `char*`.