### PR TITLE
Replace min/max macro with an inline function

### DIFF
--- a/newlib/libc/tinystdio/ftoa_ryu.c
+++ b/newlib/libc/tinystdio/ftoa_ryu.c
@@ -49,16 +49,6 @@ static uint32_t decimalLength9(const uint32_t v) {
 	return len;
 }
 
-#define max(a, b) ({				\
-			typeof(a) _a = a;	\
-			typeof(b) _b = b;	\
-			_a > _b ? _a : _b; })
-
-#define min(a, b) ({				\
-			typeof(a) _a = a;	\
-			typeof(b) _b = b;	\
-			_a < _b ? _a : _b; })
-
 // A floating decimal representing m * 10^e.
 typedef struct floating_decimal_32 {
 	uint32_t mantissa;
@@ -217,7 +207,7 @@ f2d(const uint32_t ieeeMantissa, const uint32_t ieeeExponent, int max_digits, in
 		 * cases, which is kinda cool
 		 */
 		/* max_decimals comes in biased by 1 to flag the 'f' case */
-		max_digits = min(max_digits, max(0, max_decimals - 1 + exp + 1));
+		max_digits = min_int(max_digits, max_int(0, max_decimals - 1 + exp + 1));
 	}
 
 	for (;;) {
@@ -280,7 +270,7 @@ f2d(const uint32_t ieeeMantissa, const uint32_t ieeeExponent, int max_digits, in
 			if(max_decimals != 0) {
 				int exp = e10 + len - 1;
 				/* max_decimals comes in biased by 1 to flag the 'f' case */
-				max_digits = min(save_max_digits, max(0, max_decimals - 1 + exp + 1));
+				max_digits = min_int(save_max_digits, max_int(0, max_decimals - 1 + exp + 1));
 			}
 
 			if (len > max_digits) {

--- a/newlib/libc/tinystdio/ryu/common.h
+++ b/newlib/libc/tinystdio/ryu/common.h
@@ -32,6 +32,9 @@
 #define HAS_UINT128
 #endif
 
+static inline int max_int(int a, int b) { return a > b ? a : b; }
+static inline int min_int(int a, int b) { return a < b ? a : b; }
+
 // Returns e == 0 ? 1 : [log_2(5^e)]; requires 0 <= e <= 3528.
 int32_t __log2pow5(const int32_t e);
 


### PR DESCRIPTION
As suggested, I removed the macros `min` and `max`, and added a (shared) `static inline` function instead.