### PR TITLE
check for __builtin_expect

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -328,6 +328,9 @@ if have_long_double
   long_double_equals_double = meson.get_compiler('c').compiles(long_double_size_code, name : 'long double same as double')
 endif
 
+# CompCert does not have __builtin_expect
+have_builtin_expect = meson.get_compiler('c').compiles('int test = __builtin_expect(42, 0);', name : 'has __builtin_expect')
+
 if enable_multilib
   used_libs = []
 
@@ -457,6 +460,9 @@ conf_data.set('PICOLIBC_TLS', thread_local_storage, description: 'use thread loc
 conf_data.set('POSIX_IO', posix_io, description: 'Use open/close/read/write in tinystdio')
 conf_data.set('POSIX_CONSOLE', posix_console, description: 'Use POSIX I/O for stdin, stdout and stderr')
 conf_data.set('ATOMIC_UNGETC', atomic_ungetc, description: 'Use atomics for fgetc/ungetc for re-entrancy')
+if not have_builtin_expect
+  conf_data.set('__builtin_expect(cond, exp)', '(cond)', description: 'Compiler does not have __builtin_expect')
+endif
 
 if newlib_obsolete_math == 'auto'
   obsolete_math_value = false

--- a/meson.build
+++ b/meson.build
@@ -329,7 +329,13 @@ if have_long_double
 endif
 
 # CompCert does not have __builtin_expect
-have_builtin_expect = meson.get_compiler('c').compiles('int test = __builtin_expect(42, 0);', name : 'has __builtin_expect')
+builtin_expect_code = '''
+volatile int a = 42;
+int main (void) {
+  return __builtin_expect(a, 1);
+}
+'''
+have_builtin_expect = meson.get_compiler('c').links(builtin_expect_code, name : 'has __builtin_expect')
 
 if enable_multilib
   used_libs = []
@@ -460,7 +466,7 @@ conf_data.set('PICOLIBC_TLS', thread_local_storage, description: 'use thread loc
 conf_data.set('POSIX_IO', posix_io, description: 'Use open/close/read/write in tinystdio')
 conf_data.set('POSIX_CONSOLE', posix_console, description: 'Use POSIX I/O for stdin, stdout and stderr')
 conf_data.set('ATOMIC_UNGETC', atomic_ungetc, description: 'Use atomics for fgetc/ungetc for re-entrancy')
-conf_data.set('HAVE_BUILTIN_EXPECT', have_builtin_expect, 'Compiler has __builtin_expect')
+conf_data.set('HAVE_BUILTIN_EXPECT', have_builtin_expect, description: 'Compiler has __builtin_expect')
 
 if newlib_obsolete_math == 'auto'
   obsolete_math_value = false

--- a/meson.build
+++ b/meson.build
@@ -460,9 +460,7 @@ conf_data.set('PICOLIBC_TLS', thread_local_storage, description: 'use thread loc
 conf_data.set('POSIX_IO', posix_io, description: 'Use open/close/read/write in tinystdio')
 conf_data.set('POSIX_CONSOLE', posix_console, description: 'Use POSIX I/O for stdin, stdout and stderr')
 conf_data.set('ATOMIC_UNGETC', atomic_ungetc, description: 'Use atomics for fgetc/ungetc for re-entrancy')
-if not have_builtin_expect
-  conf_data.set('__builtin_expect(cond, exp)', '(cond)', description: 'Compiler does not have __builtin_expect')
-endif
+conf_data.set('HAVE_BUILTIN_EXPECT', have_builtin_expect, 'Compiler has __builtin_expect')
 
 if newlib_obsolete_math == 'auto'
   obsolete_math_value = false

--- a/newlib/libc/include/sys/cdefs.h
+++ b/newlib/libc/include/sys/cdefs.h
@@ -95,6 +95,15 @@
 #define	__END_DECLS
 #endif
 
+/**
+ * Not all compilers offer __builtin_expect (e.g. CompCert does
+ * not have it). In that case, transparently replace all
+ * occurences of that builtin with just the condition:
+ */
+#ifndef HAVE_BUILTIN_EXPECT
+#define __builtin_expect(cond, exp) (cond)
+#endif
+
 /*
  * This code has been put in place to help reduce the addition of
  * compiler specific defines in FreeBSD code.  It helps to aid in

--- a/newlib/libc/include/sys/features.h
+++ b/newlib/libc/include/sys/features.h
@@ -39,7 +39,6 @@ extern "C" {
 /* Version with trailing underscores for BSD compatibility. */
 #define	__GNUC_PREREQ__(ma, mi)	__GNUC_PREREQ(ma, mi)
 
-
 /*
  * Feature test macros control which symbols are exposed by the system
  * headers.  Any of these must be defined before including any headers.

--- a/newlib/libc/include/sys/features.h
+++ b/newlib/libc/include/sys/features.h
@@ -39,6 +39,7 @@ extern "C" {
 /* Version with trailing underscores for BSD compatibility. */
 #define	__GNUC_PREREQ__(ma, mi)	__GNUC_PREREQ(ma, mi)
 
+
 /*
  * Feature test macros control which symbols are exposed by the system
  * headers.  Any of these must be defined before including any headers.


### PR DESCRIPTION
Added support for detecting __builtin_expect.

(We created a fork at AbsInt/picolibc, but until everything is merged, I'll push to archi/picolibc and AbsInt/picolibc)