### PR TITLE
Check for presence of __builtin_mul_overflow

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -339,8 +339,10 @@ have_bitfields_in_packed_structs = meson.get_compiler('c').compiles(bitfields_in
 builtin_mul_overflow_code = '''
 #include <stddef.h>
 int overflows (size_t a, size_t b) { size_t x; return __builtin_mul_overflow(a, b, &x); }
+volatile size_t aa = 42;
+int main (void) { return overflows(aa, aa); }
 '''
-have_builtin_mul_overflow = meson.get_compiler('c').compiles(builtin_mul_overflow_code, name : 'has __builtin_mul_overflow')
+have_builtin_mul_overflow = meson.get_compiler('c').links(builtin_mul_overflow_code, name : 'has __builtin_mul_overflow')
 
 if enable_multilib
   used_libs = []

--- a/meson.build
+++ b/meson.build
@@ -335,6 +335,13 @@ unsigned int foobar (const struct test *p) { return p->part; }
 '''
 have_bitfields_in_packed_structs = meson.get_compiler('c').compiles(bitfields_in_packed_structs_code, name : 'packed structs may contain bitfields')
 
+# CompCert does not have __builtin_mul_overflow
+builtin_mul_overflow_code = '''
+#include <stddef.h>
+int overflows (size_t a, size_t b) { size_t x; return __builtin_mul_overflow(a, b, &x); }
+'''
+have_builtin_mul_overflow = meson.get_compiler('c').compiles(builtin_mul_overflow_code, name : 'has __builtin_mul_overflow')
+
 if enable_multilib
   used_libs = []
 
@@ -465,6 +472,7 @@ conf_data.set('POSIX_IO', posix_io, description: 'Use open/close/read/write in t
 conf_data.set('POSIX_CONSOLE', posix_console, description: 'Use POSIX I/O for stdin, stdout and stderr')
 conf_data.set('ATOMIC_UNGETC', atomic_ungetc, description: 'Use atomics for fgetc/ungetc for re-entrancy')
 conf_data.set('HAVE_BITFIELDS_IN_PACKED_STRUCTS', have_bitfields_in_packed_structs, description: 'Use bitfields in packed structs')
+conf_data.set('HAVE_BUILTIN_MUL', have_builtin_mul_overflow, description: 'Compiler has __builtin_mul_overflow')
 
 if newlib_obsolete_math == 'auto'
   obsolete_math_value = false

--- a/newlib/libc/stdlib/mallocr.c
+++ b/newlib/libc/stdlib/mallocr.c
@@ -412,10 +412,15 @@ extern void __malloc_unlock();
   at the expense of not being able to handle requests greater than
   2^31. This limitation is hardly ever a concern; you are encouraged
   to set this. However, the default version is the same as size_t.
+  Since the implementation relies on __builtin_mul_overflow, defining
+  a custom INTERNAL_SIZE_T on machines/compilers without
+  __builtin_mul_overflow is not permitted.
 */
 
 #ifndef INTERNAL_SIZE_T
 #define INTERNAL_SIZE_T size_t
+#elif !defined(HAVE_BUILTIN_MUL_OVERFLOW)
+#error Compiler does not support __builtin_mul_overflow, hence INTERNAL_SIZE_T shall not be set
 #endif
 
 /*
@@ -3147,7 +3152,7 @@ Void_t* pvALLOc(bytes) RDECL size_t bytes;
 #endif /* DEFINE_PVALLOC */
 
 #ifdef DEFINE_CALLOC
-
+#include "mul_overflow.h"
 /*
 
   calloc calls malloc, then zeroes out the allocated chunk.
@@ -3171,7 +3176,7 @@ Void_t* cALLOc(n, elem_size) RDECL size_t n; size_t elem_size;
 #endif
   Void_t* mem;
 
-  if (__builtin_mul_overflow((INTERNAL_SIZE_T) n, (INTERNAL_SIZE_T) elem_size, &sz))
+  if (mul_overflow((INTERNAL_SIZE_T) n, (INTERNAL_SIZE_T) elem_size, &sz))
   {
     errno = ENOMEM;
     return 0;

--- a/newlib/libc/stdlib/mallocr.c
+++ b/newlib/libc/stdlib/mallocr.c
@@ -420,7 +420,7 @@ extern void __malloc_unlock();
 #ifndef INTERNAL_SIZE_T
 #define INTERNAL_SIZE_T size_t
 #elif !defined(HAVE_BUILTIN_MUL_OVERFLOW)
-#error Compiler does not support __builtin_mul_overflow, hence INTERNAL_SIZE_T shall not be set
+#error Compiler does not support __builtin_mul_overflow, hence INTERNAL_SIZE_T cannot be set
 #endif
 
 /*

--- a/newlib/libc/stdlib/mul_overflow.h
+++ b/newlib/libc/stdlib/mul_overflow.h
@@ -1,0 +1,27 @@
+#ifdef HAVE_BUILTIN_MUL_OVERFLOW
+// gcc should use the correct one here
+#define mul_overflow __builtin_mul_overflow
+#else
+/**
+ * Since __builtin_mul_overflow doesn't seem to exist,
+ * use a (slower) software implementation instead.
+ * This is only implemented for size_t, so in case mallocr.c's INTERNAL_SIZE_T
+ *  is non default, mallocr.c throws an #error.
+ */
+static int mul_overflow_size_t(a, b, res)
+    size_t a;
+    size_t b;
+    size_t *res;
+{
+    // always fill the result (gcc doesn't define what happens here)
+    if (res)
+        *res = a * b;
+
+    // check if overflow would happen:
+    if ( (a > SIZE_MAX / b) || (b > SIZE_MAX / a))
+        return 1;
+
+    return 0;
+}
+#define mul_overflow mul_overflow_size_t
+#endif

--- a/newlib/libc/stdlib/mul_overflow.h
+++ b/newlib/libc/stdlib/mul_overflow.h
@@ -17,6 +17,10 @@ static int mul_overflow_size_t(a, b, res)
     if (res)
         *res = a * b;
 
+    // multiply with 0 can not overflow (and avoid div-by-zero):
+    if (a == 0 || b == 0)
+        return 1;
+
     // check if overflow would happen:
     if ( (a > SIZE_MAX / b) || (b > SIZE_MAX / a))
         return 1;

--- a/newlib/libc/stdlib/nano-mallocr.c
+++ b/newlib/libc/stdlib/nano-mallocr.c
@@ -450,7 +450,7 @@ void cfree(void * ptr)
 #endif /* DEFINE_CFREE */
 
 #ifdef DEFINE_CALLOC
-
+#include "mul_overflow.h"
 /* Function calloc
  *
  * Implement calloc by multiplying sizes (with overflow check) and
@@ -461,7 +461,7 @@ void * calloc(size_t n, size_t elem)
 {
     size_t bytes;
 
-    if (__builtin_mul_overflow (n, elem, &bytes))
+    if (mul_overflow (n, elem, &bytes))
     {
         errno = ENOMEM;
         return NULL;

--- a/newlib/libc/stdlib/reallocarray.c
+++ b/newlib/libc/stdlib/reallocarray.c
@@ -20,13 +20,14 @@
 #include <errno.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include "mul_overflow.h"
 
 void *
 reallocarray(void *optr, size_t nmemb, size_t size)
 {
 	ptrdiff_t bytes;
 
-	if (__builtin_mul_overflow (nmemb, size, &bytes))
+	if (mul_overflow (nmemb, size, &bytes))
 	{
 		errno = ENOMEM;
 		return NULL;


### PR DESCRIPTION
After being tricked by git, this is a second attempt at PR #57 - now with cleaner commit :)

from commit:
Check for presence of __builtin_mul_overflow
ONLY if it's not there, use a software implementation.
That software implementation assumes size_t to be compatible with
CompCert (which does support neither statement expressions (=> no
macro magic) and no _Generic).

In two of the three locations this is no problem at all, since they are
hardcoded to operate on size_t. But the third location only defaults to
size_t - but that can be overwritten by some define.

However, I don't think that's a real problem: Previously compilers
without __builtin_mul_overflow were not supported at all, now they're
supported as long as the user sticks to a default setting.

An appropriate `#error` has been added.