### PR TITLE
Create packaging script for Freedom Tools

### DIFF
--- a/scripts/do-configure
+++ b/scripts/do-configure
@@ -76,7 +76,7 @@ case "$*" in
 		;;
 	    *)
 		SYSROOT=`${ARCH}-gcc -print-sysroot`
-		PREFIX=-Dprefix="'"`readlink -f "$SYSROOT"`"'"
+		PREFIX=-Dprefix="`readlink -f "$SYSROOT"`"
 		;;
 	esac
 	;;

--- a/scripts/do-freedom-tools-configure
+++ b/scripts/do-freedom-tools-configure
@@ -33,4 +33,4 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-"$DIR"/do-riscv-configure -Dsysroot-install=true "$@"
+`dirname $0`/do-riscv-configure -Dsysroot-install=true "$@"

--- a/scripts/do-freedom-tools-package
+++ b/scripts/do-freedom-tools-package
@@ -1,0 +1,77 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2020 SiFive Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# do-freedom-tools-package VERSION
+#
+#     Given Freedom Tools installed and available in the PATH, build
+#     and package picolibc for Freedom tools.
+#
+#     VERSION is the picolibc version number
+#
+
+set -euxo pipefail
+
+VERSION="$1"
+FREEDOM_TOOLS_VERSION="`riscv64-unknown-elf-gcc --version | head -n 1 | sed -re 's%.*\(.*\-(.*)\).*%\1%'`"
+TARBALL=riscv64-unknown-elf-picolibc-${VERSION}-${FREEDOM_TOOLS_VERSION}.tar.gz
+
+DIRNAME=`dirname $0`
+PICOLIBC_ROOT="$( cd ${DIRNAME} ; pwd )/../"
+
+BUILD_DIR="${PICOLIBC_ROOT}/build"
+SYSROOT=`riscv64-unknown-elf-gcc -print-sysroot`
+PREFIX=`readlink -f ${SYSROOT}`
+
+# Create the build directory
+mkdir -p ${BUILD_DIR}
+pushd ${BUILD_DIR}
+
+# Configure and build picolibc
+${PICOLIBC_ROOT}/scripts/do-freedom-tools-configure
+ninja
+DESTDIR=${BUILD_DIR} ninja install
+
+# Create the tarball
+pushd "${BUILD_DIR}/${PREFIX}/.."
+rm -f ${TARBALL}
+tar czf ${TARBALL} *
+popd # "./${PREFIX}/.."
+
+popd # ${BUILD_DIR}
+
+# Place the tarball at the top-level diretory
+mv ${BUILD_DIR}/${PREFIX}/../${TARBALL} ${PICOLIBC_ROOT}/


### PR DESCRIPTION
Adds a script which automates the packaging of picolibc for SiFive Freedom Tools.

The script takes a single argument, the version of picolibc. The calendar version of Freedom Tools is inferred from the compiler with `--version`.