### PR TITLE
Check for __GNUC_VA_LIST when typdef'ing __va_list

### DIFF
--- a/newlib/libc/include/sys/_types.h
+++ b/newlib/libc/include/sys/_types.h
@@ -255,7 +255,7 @@ typedef	unsigned long	__useconds_t;	/* microseconds (unsigned) */
  * <sys/cdefs.h>.  The <sys/cdefs.h> must not be included here to avoid cyclic
  * header dependencies.
  */
-#if __GNUC_MINOR__ > 95 || __GNUC__ >= 3
+#if __GNUC_MINOR__ > 95 || __GNUC__ >= 3 || defined(__GNUC_VA_LIST)
 typedef	__builtin_va_list	__va_list;
 #else
 typedef	char *			__va_list;

--- a/newlib/libc/include/sys/cdefs.h
+++ b/newlib/libc/include/sys/cdefs.h
@@ -123,7 +123,7 @@
 #undef __GNUCLIKE_BUILTIN_CONSTANT_P
 #endif
 
-#if (__GNUC_MINOR__ > 95 || __GNUC__ >= 3)
+#if __GNUC_MINOR__ > 95 || __GNUC__ >= 3 || defined(__GNUC_VA_LIST)
 #define	__GNUCLIKE_BUILTIN_VARARGS 1
 #define	__GNUCLIKE_BUILTIN_STDARG 1
 #define	__GNUCLIKE_BUILTIN_VAALIST 1


### PR DESCRIPTION
I am hesistant to just remove __va_list, since this seems to be relevant
for BSD. If I understood stdargs.h correctly, __GNUC_VA_LIST should be
defined in case __builtin_va_list is present.

The old code is probably wrong, as the type of va_list depends on the
compilation target, and char* is not always correct.

I'll submit this as a draft PR so we can see if this makes one of the CI
targets unhappy.