### PR TITLE
Add a configuration option for explicit register variables

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -187,6 +187,21 @@ if host_cpu_family == ''
   message('Computed host_cpu_family as ' + host_cpu_family)
 endif
 
+# Not all compilers support constructs like 'register int varName arm("r0") = 42;"
+# However, automatic detection depends on the target, since "r0" needs to be replaced with a valid register name
+# Hence, for default (auto) we look at the compiler (defaults to 'true' if unknown compiler), or let the user pass
+#  a setting to meson to override this.
+have_explicit_register_variables = get_option('compiler-has-explicit-register-variables')
+if have_explicit_register_variables == 'auto'
+  if meson.get_compiler('c').get_id() in ['ccomp']
+    have_explicit_register_variables = false
+  else
+    have_explicit_register_variables = true
+  endif
+else
+  have_explicit_register_variables = have_explicit_register_variables == 'true'
+endif
+
 if have_alias_attribute_option == 'auto'
   have_alias_attribute = meson.get_compiler('c').has_function_attribute('alias')
 else
@@ -474,6 +489,7 @@ conf_data.set('POSIX_IO', posix_io, description: 'Use open/close/read/write in t
 conf_data.set('POSIX_CONSOLE', posix_console, description: 'Use POSIX I/O for stdin, stdout and stderr')
 conf_data.set('ATOMIC_UNGETC', atomic_ungetc, description: 'Use atomics for fgetc/ungetc for re-entrancy')
 conf_data.set('HAVE_BITFIELDS_IN_PACKED_STRUCTS', have_bitfields_in_packed_structs, description: 'Use bitfields in packed structs')
+conf_data.set('HAVE_EXPLICIT_REGISTER_VARIABLES', have_explicit_register_variables, description: 'Use explicit register variables')
 
 if newlib_obsolete_math == 'auto'
   obsolete_math_value = false

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -128,6 +128,13 @@ option('newlib-wide-orient', type: 'boolean', value: false,
        description: 'Turn off wide orientation in streamio')
 
 #
+# Options applying to compiler capabilities
+#
+option('compiler-has-explicit-register-variables', type: 'combo',
+  choices: ['true', 'false', 'auto'], value: 'auto',
+  description: 'compiler supports explicit register variables')
+
+#
 # Internationalization options
 #
 

--- a/newlib/libc/machine/amdgcn/getreent.c
+++ b/newlib/libc/machine/amdgcn/getreent.c
@@ -18,6 +18,15 @@ they apply.
 #include <stdlib.h>
 #include <unistd.h>
 
+/* The below is not trivial to rewrite without explicit register variables,
+   so just complain if the feature is not available.
+   Since the default for most compilers is to have this, the user is
+   probably aware he needs to invest some work to port picolibc to this
+   target */
+#ifndef HAVE_EXPLICIT_REGISTER_VARIABLES
+#error This target uses hand-written assembly code which relies on explicit register variables being available!
+#endif
+
 /* Copied from the HSA documentation.  */
 typedef struct hsa_signal_s {
   uint64_t handle;

--- a/newlib/libc/machine/cris/memcpy.c
+++ b/newlib/libc/machine/cris/memcpy.c
@@ -40,6 +40,15 @@
 /* No name ambiguities in this file.  */
 __asm__ (".syntax no_register_prefix");
 
+/* The below is not trivial to rewrite without explicit register variables,
+   so just complain if the feature is not available.
+   Since the default for most compilers is to have this, the user is
+   probably aware he needs to invest some work to port picolibc to this
+   target */
+#ifndef HAVE_EXPLICIT_REGISTER_VARIABLES
+#error This target uses hand-written assembly code which relies on explicit register variables being available!
+#endif
+
 void *
 __inhibit_loop_to_libcall
 memcpy(void *__restrict pdst, const void *__restrict psrc, size_t pn)

--- a/newlib/libc/machine/cris/memmove.c
+++ b/newlib/libc/machine/cris/memmove.c
@@ -42,6 +42,15 @@
 /* No name ambiguities in this file.  */
 __asm__ (".syntax no_register_prefix");
 
+/* The below is not trivial to rewrite without explicit register variables,
+   so just complain if the feature is not available.
+   Since the default for most compilers is to have this, the user is
+   probably aware he needs to invest some work to port picolibc to this
+   target */
+#ifndef HAVE_EXPLICIT_REGISTER_VARIABLES
+#error This target uses hand-written assembly code which relies on explicit register variables being available!
+#endif
+
 void *
 memmove(void *pdst, const void *psrc, size_t pn)
 {

--- a/newlib/libc/machine/cris/memset.c
+++ b/newlib/libc/machine/cris/memset.c
@@ -44,6 +44,15 @@
 /* No name ambiguities in this file.  */
 __asm__ (".syntax no_register_prefix");
 
+/* The below is not trivial to rewrite without explicit register variables,
+   so just complain if the feature is not available.
+   Since the default for most compilers is to have this, the user is
+   probably aware he needs to invest some work to port picolibc to this
+   target */
+#ifndef HAVE_EXPLICIT_REGISTER_VARIABLES
+#error This target uses hand-written assembly code which relies on explicit register variables being available!
+#endif
+
 void *memset(void *pdst, int c, unsigned int plen)
 {
   /* Now we want the parameters in special registers.  Make sure the

--- a/newlib/libc/machine/xstormy16/tiny-malloc.c
+++ b/newlib/libc/machine/xstormy16/tiny-malloc.c
@@ -93,6 +93,15 @@ extern fle __malloc_freelist;
 
 extern void __malloc_start;
 
+/* The below is not trivial to rewrite without explicit register variables,
+   so just complain if the feature is not available.
+   Since the default for most compilers is to have this, the user is
+   probably aware he needs to invest some work to port picolibc to this
+   target */
+#ifndef HAVE_EXPLICIT_REGISTER_VARIABLES
+#error This target relies on explicit register variables being available!
+#endif
+
 /* This is the minimum gap allowed between __malloc_end and the top of
    the stack.  This is only checked for when __malloc_end is
    decreased; if instead the stack grows into the heap, silent data

--- a/semihost/machine/aarch64/semihost-aarch64.c
+++ b/semihost/machine/aarch64/semihost-aarch64.c
@@ -38,9 +38,16 @@
 uintptr_t
 sys_semihost(uintptr_t op, uintptr_t param)
 {
+#ifdef HAVE_EXPLICIT_REGISTER_VARIABLES
 	register sh_param_t w0 asm("w0") = op;
 	register sh_param_t x1 asm("x1") = param;
 	register sh_param_t x0 asm("x0");
+#else
+# define w0 op
+# define x1 param
+	register sh_param_t x0 asm("x0");
+#endif
+
 	asm("hlt #0xf000" : "=r" (x0) : "r" (w0), "r" (x1) : "memory");
 	return x0;
 }

--- a/semihost/machine/arm/semihost-arm.c
+++ b/semihost/machine/arm/semihost-arm.c
@@ -38,8 +38,14 @@
 uintptr_t
 sys_semihost(uintptr_t op, uintptr_t param)
 {
+#ifdef HAVE_EXPLICIT_REGISTER_VARIABLES
 	register uintptr_t r0 asm("r0") = op;
 	register uintptr_t r1 asm("r1") = param;
+#else
+# define r0 op
+# define r1 param
+#endif
+
 #if __ARM_ARCH_PROFILE == 'M'
 	asm("bkpt #0xab" : "=r" (r0) : "r" (r0), "r" (r1) : "memory");
 #else


### PR DESCRIPTION
An idea for an alternate implementation: Check this in each target's `meson.build`; that is, for each target which makes use of the feature. A general, automatic check would require to know a valid register name for each target, plus this is even used for only 5 targets, see the list below.

However, since this only really affects CompCert - implementing this in the register allocator's proof is quite complicated, however, implementing this in a normal compiler is probably rather easy - I think the proposed variant is simpler and less effort to maintain.

From my commit log:

This is difficult to auto-detect, since the the test would need to use a
register name that exists for the chosen target.
Hence, I added an option
> compiler-has-explicit-register-variables

It defaults to 'auto', which in turn defaults to true for all compilers
except 'ccomp'. However, the user can explicitly set it to true or false
to override the the decision.

I adapted all targets which use check for that feature:
* aarch64, arm: build a suboptimal variant in case the feature is not
  available or disabled.
* amdgcn, cris: Here the register names are also used in hand-written
  assembly, which I preferred not to touch. So these throws an #error in
  case the feature is not available.
* xstormy16: Access the stack pointer at r15 via a local variable, also
  not touched. This throws an #error in case the feature is not
  available.

Docs for that feature:
https://gcc.gnu.org/onlinedocs/gcc/Local-Register-Variables.html#Local-Register-Variables