### PR TITLE
check if 'f' constraint for 'asm' is available

### DIFF
--- a/newlib/libm/machine/riscv/e_sqrt.c
+++ b/newlib/libm/machine/riscv/e_sqrt.c
@@ -44,7 +44,7 @@ double
 __ieee754_sqrt (double x)
 {
 	double result;
-#if HAVE_FLOAT_CONSTRAINT
+#ifdef HAVE_FLOAT_CONSTRAINT
 	asm ("fsqrt.d %0, %1" : "=f" (result) : "f" (x));
 #else
 	asm ("fsqrt.d %0, %1" : "=r" (result) : "r" (x));

--- a/newlib/libm/machine/riscv/e_sqrt.c
+++ b/newlib/libm/machine/riscv/e_sqrt.c
@@ -44,7 +44,11 @@ double
 __ieee754_sqrt (double x)
 {
 	double result;
+#if HAVE_FLOAT_CONSTRAINT
 	asm ("fsqrt.d %0, %1" : "=f" (result) : "f" (x));
+#else
+	asm ("fsqrt.d %0, %1" : "=r" (result) : "r" (x));
+#endif
 	return result;
 }
 

--- a/newlib/libm/machine/riscv/ef_sqrt.c
+++ b/newlib/libm/machine/riscv/ef_sqrt.c
@@ -44,7 +44,11 @@ float
 __ieee754_sqrtf (float x)
 {
 	float result;
+#ifdef HAVE_FLOAT_CONSTRAINT
 	asm ("fsqrt.s %0, %1" : "=f" (result) : "f" (x));
+#else
+	asm ("fsqrt.s %0, %1" : "=r" (result) : "r" (x));
+#endif
 	return result;
 }
 

--- a/newlib/libm/machine/riscv/meson.build
+++ b/newlib/libm/machine/riscv/meson.build
@@ -51,6 +51,24 @@ srcs_libm_machine = [
   'sf_fma_riscv.c',
 ]
 
+# CompCert does generally not support the float constraint `f` for
+# `asm` statements; in that case, those have to be relaxed to `r`
+# and `=r`. Since the test needs target specific asm, it is not in
+# the generic meson.build.
+# Mind that with GCC the test also fails for targets without an FPU
+# (e.g. rv32imac); for these, using float registers is inherently
+# wrong anyway.
+float_constraint_code = '''
+double test (double x)
+{
+  double result;
+  asm ("fsqrt.d %0, %1" : "=f" (result) : "f" (x));
+  return result;
+}
+'''
+have_float_constraint = meson.get_compiler('c').compiles(float_constraint_code, name : 'supports asm float constraints')
+conf_data.set('HAVE_FLOAT_CONSTRAINT', have_float_constraint, description: 'Compiler supports the float constraints `f` and `=f`')
+
 foreach target : targets
 	value = get_variable('target_' + target)
 	set_variable('lib_machine' + target,


### PR DESCRIPTION
This regards the two riscv sqrt implementations, which essentially wrap around `fsqrt.s` and `fsqrt.d`:

> asm ("fsqrt.s %0, %1" : "=f" (result) : "f" (x));

CompCert doesn't have the `f`-family of constraints, so I check for it (target-dependent).
I don't have floating-point capable riscv targets set up locally (will do so tomorrow), so I'll let the CI work its magic.

_The commit comment:_

**check if 'f' constraint for 'asm' is available**
Obviously, it isn't for CompCert.
Since this uses target-specific code, I've put it in
newlib/libm/machine/riscv.

The alternatives are to

1. check for `__COMPCERT__` (as done in branch 'compcert'; which I try to
   avoid as much as possible)
2. Or invent a 'compiler-has-asm-float-constraints' (like for local
   register variables)

@keith-packard: I will submit this as a draft. If you prefer this variant I can
rewrite the PR https://github.com/picolibc/picolibc/pull/65 to behave
similar; or if you prefer the PR variant, I can rewrite this one ;)