### PR TITLE
Minor changes for CompCert

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -475,11 +475,6 @@ conf_data.set('POSIX_CONSOLE', posix_console, description: 'Use POSIX I/O for st
 conf_data.set('ATOMIC_UNGETC', atomic_ungetc, description: 'Use atomics for fgetc/ungetc for re-entrancy')
 conf_data.set('HAVE_BITFIELDS_IN_PACKED_STRUCTS', have_bitfields_in_packed_structs, description: 'Use bitfields in packed structs')
 
-# This needs to be manually set for CompCert
-if meson.get_compiler('c').get_id() == 'ccomp'
-  conf_data.set('_DEFAULT_SOURCE', 1, description: 'CompCert should be handled like this')
-endif
-
 if newlib_obsolete_math == 'auto'
   obsolete_math_value = false
 elif newlib_obsolete_math == 'true'

--- a/meson.build
+++ b/meson.build
@@ -475,6 +475,11 @@ conf_data.set('POSIX_CONSOLE', posix_console, description: 'Use POSIX I/O for st
 conf_data.set('ATOMIC_UNGETC', atomic_ungetc, description: 'Use atomics for fgetc/ungetc for re-entrancy')
 conf_data.set('HAVE_BITFIELDS_IN_PACKED_STRUCTS', have_bitfields_in_packed_structs, description: 'Use bitfields in packed structs')
 
+# This needs to be manually set for CompCert
+if meson.get_compiler('c').get_id() == 'ccomp'
+  conf_data.set('_DEFAULT_SOURCE', 1, description: 'CompCert should be handled like this')
+endif
+
 if newlib_obsolete_math == 'auto'
   obsolete_math_value = false
 elif newlib_obsolete_math == 'true'

--- a/newlib/libc/include/strings.h
+++ b/newlib/libc/include/strings.h
@@ -36,9 +36,18 @@
 #include <sys/_locale.h>
 #endif
 
-#ifndef _SIZE_T_DECLARED
+// As per the GCC source, _SIZE_T_DECLARD is FreeBSD 5
+// So: Also check for _SIZE_T
+#if !defined(_SIZE_T_DECLARED) && !defined(_SIZE_T)
 typedef	__size_t	size_t;
+#endif
+
+#ifndef _SIZE_T_DECLARED
 #define	_SIZE_T_DECLARED
+#endif
+
+#ifndef _SIZE_T
+#define _SIZE_T
 #endif
 
 __BEGIN_DECLS

--- a/newlib/libc/include/sys/features.h
+++ b/newlib/libc/include/sys/features.h
@@ -39,6 +39,10 @@ extern "C" {
 /* Version with trailing underscores for BSD compatibility. */
 #define	__GNUC_PREREQ__(ma, mi)	__GNUC_PREREQ(ma, mi)
 
+/* Is this CompCert? */
+#ifdef __COMPCERT__
+#define	_DEFAULT_SOURCE		1
+#endif
 
 /*
  * Feature test macros control which symbols are exposed by the system


### PR DESCRIPTION
Two minor changes for CompCert:

1. If the compiler is `ccomp`, define `_DEFAULT_SOURCE` (via meson.build). Alternatively, this could go into `sys/features.h` via a `#ifdef __COMPCERT__` (that's how it's done for the other compilers).
2. It's not always enough to check for `_SIZE_T_DECLARED`, so also check for `_SIZE_T`. [GCC sets several of these for various platforms](https://github.com/gcc-mirror/gcc/blob/master/gcc/ginclude/stddef.h#L163).