### PR TITLE
Check for compiler-support of some arguments

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -513,9 +513,9 @@ conf_data.set('__OBSOLETE_MATH_DOUBLE', obsolete_math_double_value, description:
 
 # Check if compiler has -fno-builtin
 
-arg_fnobuiltin = ['-fno-builtin']
-if not meson.get_compiler('c').has_argument('-fno-builtin')
-  arg_fnobuiltin = []
+arg_fnobuiltin = []
+if meson.get_compiler('c').has_argument('-fno-builtin')
+  arg_fnobuiltin = ['-fno-builtin']
 endif
 
 # Compute iconv encodings to support in the library

--- a/meson.build
+++ b/meson.build
@@ -503,6 +503,13 @@ conf_data.set('__OBSOLETE_MATH', obsolete_math_value, description: 'Use old math
 conf_data.set('__OBSOLETE_MATH_FLOAT', obsolete_math_float_value, description: 'Use old math code for float funcs (undef auto, 0 no, 1 yes)')
 conf_data.set('__OBSOLETE_MATH_DOUBLE', obsolete_math_double_value, description: 'Use old math code for double funcs (undef auto, 0 no, 1 yes)')
 
+# Check if compiler has -fno-builtin
+
+arg_fnobuiltin = ['-fno-builtin']
+if not meson.get_compiler('c').has_argument('-fno-builtin')
+  arg_fnobuiltin = []
+endif
+
 # Compute iconv encodings to support in the library
 
 # Dig out the list of available encodings from the encoding.aliases file. Only
@@ -580,10 +587,15 @@ includedir = join_paths(prefix, get_option('includedir'))
 # versions of gcc for RISC-V which have a bug that mis-names
 # initialized read-only data segments when -fdata-sections
 # is defined
-arguments = ['-ffunction-sections']
+arguments = []
+if meson.get_compiler('c').has_argument('-ffunction-sections')
+  arguments += ['-ffunction-sections']
+endif
 
 if tls_model != ''
-  arguments += ['-ftls-model=' + tls_model]
+  tls_arg = '-ftls-model=' + tls_model
+  assert(meson.get_compiler('c').has_argument(tls_arg), 'Compiler does not support \'-ftls-model\'!')
+  arguments += [tls_arg]
 endif
 
 add_project_arguments(arguments, language: 'c')

--- a/meson.build
+++ b/meson.build
@@ -255,10 +255,18 @@ specs_data.set(
   sysroot_install? join_paths('%R', get_option('libdir')) : lib_dir
 )
 
-specs_data.set(
-  'TLSMODEL',
-  tls_model
-)
+if tls_model != ''
+  specs_data.set(
+    'TLSMODEL',
+    '%{!ftls-model:-ftls-model=' + tls_model + '}'
+  )
+else
+  specs_data.set(
+    'TLSMODEL',
+    ''
+  )
+endif
+
 
 specs_data.set(
   'LINK_SPEC',

--- a/newlib/libc/machine/aarch64/meson.build
+++ b/newlib/libc/machine/aarch64/meson.build
@@ -77,5 +77,5 @@ foreach target : targets
             srcs_machine,
             pic: false,
             include_directories: inc,
-            c_args: value[1] + ['-fno-builtin']))
+            c_args: value[1] + arg_fnobuiltin))
 endforeach

--- a/newlib/libc/machine/arm/meson.build
+++ b/newlib/libc/machine/arm/meson.build
@@ -60,5 +60,5 @@ foreach target : targets
 			srcs_machine,
 			pic: false,
 			include_directories: inc,
-			c_args: value[1] + ['-fno-builtin']))
+			c_args: value[1] + arg_fnobuiltin))
 endforeach

--- a/newlib/libc/machine/powerpc/meson.build
+++ b/newlib/libc/machine/powerpc/meson.build
@@ -64,5 +64,5 @@ foreach target : targets
 			srcs_machine,
 			pic: false,
 			include_directories: inc,
-			c_args: value[1] + ['-fno-builtin']))
+			c_args: value[1] + arg_fnobuiltin))
 endforeach

--- a/newlib/libc/machine/riscv/meson.build
+++ b/newlib/libc/machine/riscv/meson.build
@@ -57,5 +57,5 @@ foreach target : targets
 			srcs_machine,
 			pic: false,
 			include_directories: inc,
-			c_args: value[1] + ['-fno-builtin']))
+			c_args: value[1] + arg_fnobuiltin))
 endforeach

--- a/newlib/libc/machine/xtensa/meson.build
+++ b/newlib/libc/machine/xtensa/meson.build
@@ -52,5 +52,5 @@ foreach target : targets
 			srcs_machine,
 			pic: false,
 			include_directories: inc,
-			c_args: value[1] + ['-fno-builtin']))
+			c_args: value[1] + arg_fnobuiltin))
 endforeach

--- a/newlib/libc/stdlib/meson.build
+++ b/newlib/libc/stdlib/meson.build
@@ -191,7 +191,14 @@ if newlib_nano_malloc
 else
   srcs_stdlib += std_malloc_srcs_stdlib
   # Work around compiler optimizing calls involving malloc/free
-  c_args_malloc = ['-fno-builtin-malloc', '-fno-builtin-free']
+  c_args_malloc = []
+  if meson.get_compiler('c').has_argument('-fno-builtin-malloc')
+    c_args_malloc += ['-fno-builtin-malloc']
+  endif
+
+  if meson.get_compiler('c').has_argument('-fno-builtin-free')
+    c_args_malloc += ['-fno-builtin-free']
+  endif
 endif
 
 hdrs_stdlib = [

--- a/newlib/libm/machine/aarch64/meson.build
+++ b/newlib/libm/machine/aarch64/meson.build
@@ -81,11 +81,12 @@ srcs_libm_machine = srcs_libm_machine_real + [
 ]
 
 foreach target : targets
-	value = get_variable('target_' + target)
+
+  endifvalue = get_variable('target_' + target)
 	set_variable('lib_machine' + target,
 		static_library('machine' + target,
 			srcs_libm_machine_real,
 			pic: false,
 			include_directories: math_inc,
-			c_args: value[1] + ['-fno-builtin']))
+			c_args: value[1] + arg_fnobuiltin))
 endforeach

--- a/newlib/libm/machine/aarch64/meson.build
+++ b/newlib/libm/machine/aarch64/meson.build
@@ -81,8 +81,7 @@ srcs_libm_machine = srcs_libm_machine_real + [
 ]
 
 foreach target : targets
-
-  endifvalue = get_variable('target_' + target)
+	value = get_variable('target_' + target)
 	set_variable('lib_machine' + target,
 		static_library('machine' + target,
 			srcs_libm_machine_real,

--- a/newlib/libm/machine/arm/meson.build
+++ b/newlib/libm/machine/arm/meson.build
@@ -73,5 +73,5 @@ foreach target : targets
 			srcs_libm_machine,
 			pic: false,
 			include_directories: math_inc,
-			c_args: value[1] + ['-fno-builtin']))
+			c_args: value[1] + arg_fnobuiltin))
 endforeach

--- a/newlib/libm/machine/i386/meson.build
+++ b/newlib/libm/machine/i386/meson.build
@@ -85,5 +85,5 @@ foreach target : targets
 			srcs_libm_machine_real,
 			pic: false,
 			include_directories: [ inc, include_directories('../../common') ],
-			c_args: value[1] + ['-fno-builtin']))
+			c_args: value[1] + arg_fnobuiltin))
 endforeach

--- a/newlib/libm/machine/riscv/meson.build
+++ b/newlib/libm/machine/riscv/meson.build
@@ -58,5 +58,5 @@ foreach target : targets
 			srcs_libm_machine,
 			pic: false,
 			include_directories: math_inc,
-			c_args: value[1] + ['-fno-builtin']))
+			c_args: value[1] + arg_fnobuiltin))
 endforeach

--- a/newlib/libm/machine/x86_64/meson.build
+++ b/newlib/libm/machine/x86_64/meson.build
@@ -59,5 +59,5 @@ foreach target : targets
 			srcs_libm_machine_real,
 			pic: false,
 			include_directories: math_inc,
-			c_args: value[1] + ['-fno-builtin']))
+			c_args: value[1] + arg_fnobuiltin))
 endforeach

--- a/newlib/libm/machine/xtensa/meson.build
+++ b/newlib/libm/machine/xtensa/meson.build
@@ -54,5 +54,5 @@ foreach target : targets
 			include_directories: [ inc,
 					       include_directories('../../common'),
 					       include_directories('../../../libc/machine/xtensa') ],
-			c_args: value[1] + ['-fno-builtin']))
+			c_args: value[1] + arg_fnobuiltin))
 endforeach

--- a/picocrt/meson.build
+++ b/picocrt/meson.build
@@ -64,7 +64,7 @@ foreach target : targets
 	     include_directories : inc,
 	     install : true,
 	     install_dir : instdir,
-	     c_args : value[1] + ['-fno-builtin', '-ffreestanding'],
+	     c_args : value[1] + arg_fnobuiltin + ['-ffreestanding'],
 	     link_args : value[1] + ['-r', '-ffreestanding', '-nostdlib'])
 
   # Tests link against this because using the .o isn't supported under meson

--- a/picolibc.specs.in
+++ b/picolibc.specs.in
@@ -7,10 +7,10 @@
 -isystem @INCLUDEDIR@ %(picolibc_cpp)
 
 *cc1:
-%{!ftls-model:-ftls-model=@TLSMODEL@} %(picolibc_cc1) @CC1_SPEC@
+@TLSMODEL@ %(picolibc_cc1) @CC1_SPEC@
 
 *cc1plus:
-%{!ftls-model:-ftls-model=@TLSMODEL@} %(picolibc_cc1plus) @CC1_SPEC@ @CC1PLUS_SPEC@
+@TLSMODEL@ %(picolibc_cc1plus) @CC1_SPEC@ @CC1PLUS_SPEC@
 
 *link:
 @SPECS_PRINTF@ -L@LIBDIR@/%M -L@LIBDIR@ %{!T:-Tpicolibc.ld} %(picolibc_link) --gc-sections @LINK_SPEC@


### PR DESCRIPTION
[The meson dev says](https://github.com/mesonbuild/meson/pull/7674#issuecomment-688520023):

> This seems like a thing that should be fixed in picolibc build files, because if they add these flags unconditionally then they will break with all compilers that don't support them.

Hence this commits checks if the compiler has the arguments:
> -fno-builtin
> -ffunction-sections
> -ftls-model

They're only used if present; or in the case of `-ftls-model`, which depends on `-Dtls-model=foobar`, an asserts ensures that the compiler has that tls model. Drawback: If a compiler has a different name for an argument (e.g. `-fnobuiltins` instead of `-fno-builtin`), the compile might run through, but not produce the intended result. So maybe this needs to be done more compiler-specific than the general approach in this commit.