### PR TITLE
Check for __builtin_ffs and __builtin_ctz

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -410,6 +410,26 @@ endif
 
 conf_data = configuration_data()
 
+# The supported builtins vary depending on compiler and target.
+# If you want to check for a given builtin, add an array
+#   ['some_builtin_name', '__call_to_builtin(1,2,3);']
+# The below loop will then add the define HAVE_SOME_BUILTIN_NAME if the code snippet
+#   > int main (void) { __call_to_builtin(1,2,3); return 0; }
+# can be compiled + linked.
+# The name should match the builtin, but technically it's not necessary
+builtins = [
+  ['builtin_ffs', '__builtin_ffs(42);'],
+  ['builtin_ffsl', '__builtin_ffsl((long)42);'],
+  ['builtin_ffsll', '__builtin_ffsll((long long)42);'],
+  ['builtin_ctz', '__builtin_ctz((unsigned int)42);'],
+  ['builtin_ctzl', '__builtin_ctzl((unsigned long)42);'],
+  ['builtin_ctzll', '__builtin_ctzll((unsigned long long)42);'],
+]
+foreach builtin : builtins
+  have_current_builtin = meson.get_compiler('c').links('int main(void) { ' + builtin[1] + ' return 0; }', name : 'test for __' + builtin[0])
+  conf_data.set('HAVE_' + builtin[0].to_upper(), have_current_builtin, description: 'The compiler supports __' + builtin[0])
+endforeach
+
 NEWLIB_VERSION='3.3.0'
 NEWLIB_MAJOR_VERSION=3
 NEWLIB_MINOR_VERSION=3

--- a/newlib/libc/machine/riscv/ffs.c
+++ b/newlib/libc/machine/riscv/ffs.c
@@ -13,8 +13,12 @@
 int
 ffs (int word)
 {
-#if __riscv_xlen == 32
+#if __riscv_xlen == 32 && defined(HAVE_BUILTIN_FFS)
   return (__builtin_ffs (word));
+#elif __riscv_xlen == 32 && defined(HAVE_BUILTIN_CTZ)
+  if (word == 0)
+	  return 0;
+  return (__builtin_ctz((unsigned int)word) + 1);
 #else
   int i;
 

--- a/newlib/libc/misc/ffs.c
+++ b/newlib/libc/misc/ffs.c
@@ -55,6 +55,13 @@ No supporting OS subroutines are required.  */
 int
 ffs(int i)
 {
-
+#ifdef HAVE_BUILTIN_FFS
 	return (__builtin_ffs(i));
+#elif defined(HAVE_BUILTIN_CTZ)
+	if (i == 0)
+		return 0;
+	return __builtin_ctz((unsigned int)i) + 1;
+#else
+#error No __builtin_ffs or __builtin_ctz available!
+#endif
 }

--- a/newlib/libc/string/ffsl.c
+++ b/newlib/libc/string/ffsl.c
@@ -29,6 +29,13 @@
 int
 ffsl(long i)
 {
-
+#ifdef HAVE_BUILTIN_FFSL
 	return (__builtin_ffsl(i));
+#elif defined(HAVE_BUILTIN_CTZL)
+	if (i == 0)
+		return 0;
+	return __builtin_ctzl((unsigned long)i) + 1;
+#else
+#error No __builtin_ffsl or __builtin_ctzl available!
+#endif
 }

--- a/newlib/libc/string/ffsll.c
+++ b/newlib/libc/string/ffsll.c
@@ -29,6 +29,13 @@
 int
 ffsll(long long i)
 {
-
+#ifdef HAVE_BUILTIN_FFSLL
 	return (__builtin_ffsll(i));
+#elif defined(HAVE_BUILTIN_CTZLL)
+	if (i == 0)
+		return 0;
+	return __builtin_ctzll((unsigned long long)i) + 1;
+#else
+#error No __builtin_ffsll or __builtin_ctzll available!
+#endif
 }


### PR DESCRIPTION
_If the ffs variant is not available, use the ctz instead.

`libc/machine/riscv/ffs.c` contains generic code._


This also adds some simple machinery for generic __builtin detection - maybe we want to simplify checking for other builtins by adding them here as well.