### PR TITLE
Test if the compiler has the __alloc_size__ attribute

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -368,6 +368,15 @@ int main (void) {
 '''
 have_builtin_expect = meson.get_compiler('c').links(builtin_expect_code, name : 'has __builtin_expect')
 
+# CompCert uses the GCC preprocessor, which causes to
+#  > #if __has_attribute(__alloc_size__)
+# produce a wrong result. So test if the compiler has that attribute
+alloc_size_code = '''
+void *foobar(size_t) __attribute__((__alloc_size__(1)));
+void *foobar2(size_t, size_t) __attribute__((__alloc_size__(1, 2)));
+'''
+have_alloc_size = meson.get_compiler('c').compiles(alloc_size_code, name : 'attribute __alloc_size__')
+
 if enable_multilib
   used_libs = []
 
@@ -521,6 +530,7 @@ conf_data.set('HAVE_BITFIELDS_IN_PACKED_STRUCTS', have_bitfields_in_packed_struc
 conf_data.set('HAVE_BUILTIN_MUL', have_builtin_mul_overflow, description: 'Compiler has __builtin_mul_overflow')
 conf_data.set('HAVE_COMPLEX', have_complex, description: 'Compiler supports _Complex')
 conf_data.set('HAVE_BUILTIN_EXPECT', have_builtin_expect, description: 'Compiler has __builtin_expect')
+conf_data.set('HAVE_ALLOC_SIZE', have_alloc_size, description: 'The compiler REALLY has the attribute __alloc_size__')
 
 if newlib_obsolete_math == 'auto'
   obsolete_math_value = false

--- a/newlib/libc/include/sys/cdefs.h
+++ b/newlib/libc/include/sys/cdefs.h
@@ -257,7 +257,8 @@
 #define	__aligned(x)	__attribute__((__aligned__(x)))
 #define	__section(x)	__attribute__((__section__(x)))
 #endif
-#if __GNUC_PREREQ__(4, 3) || __has_attribute(__alloc_size__)
+
+#ifdef HAVE_ALLOC_SIZE
 #define	__alloc_size(x)	__attribute__((__alloc_size__(x)))
 #define	__alloc_size2(n, x)	__attribute__((__alloc_size__(n, x)))
 #else


### PR DESCRIPTION
For CompCert this is necessary, as the GCC preprocessor believes that
the compiler supports that attribute - but in fact the compiler does not
have it.