### PR TITLE
Guard usage of __ASMNAME macro

### DIFF
--- a/newlib/libc/include/string.h
+++ b/newlib/libc/include/string.h
@@ -198,11 +198,11 @@ int	 strverscmp (const char *, const char *);
    this also implies that the POSIX version is used in this case.  That's made
    sure here. */
 #if __GNU_VISIBLE && !defined(basename)
-# define basename basename
 # ifdef __ASMNAME
+#  define basename basename
 char	*__nonnull ((1)) basename (const char *) __asm__(__ASMNAME("__gnu_basename"));
 # else
-char	*__nonnull ((1)) basename (const char *s) { return __gnu_basename(s); }
+#  define basename(s) (__gnu_basename(s))
 # endif
 #endif
 

--- a/newlib/libc/include/string.h
+++ b/newlib/libc/include/string.h
@@ -199,7 +199,11 @@ int	 strverscmp (const char *, const char *);
    sure here. */
 #if __GNU_VISIBLE && !defined(basename)
 # define basename basename
+# ifdef __ASMNAME
 char	*__nonnull ((1)) basename (const char *) __asm__(__ASMNAME("__gnu_basename"));
+# else
+char	*__nonnull ((1)) basename (const char *s) { return __gnu_basename(s); }
+# endif
 #endif
 
 #include <sys/string.h>


### PR DESCRIPTION
The __ASMNAME macro is guarded by an `#ifdef __GNUC__`, however the usage is not. Before using it, ensure the macro is really defined.
If not, fall back to a wrapper function (the GNU variant behaves different than the POSIX variant).