### PR TITLE
link against libcompcert when using picolibc.specs with CompCert

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -275,6 +275,19 @@ specs_data.set(
   meson.get_cross_property('cc1plus_spec', '')
 )
 
+# When passing the specs file to CompCert, the libcompcert needs to be included there as well
+if meson.get_compiler('c').get_id() == 'ccomp'
+  specs_data.set(
+    'ADDITIONAL_LIBS',
+    '-lcompcert'
+  )
+else
+  specs_data.set(
+    'ADDITIONAL_LIBS',
+    ''
+  )
+endif
+
 specs_extra_list = meson.get_cross_property('specs_extra', [])
 if specs_extra_list != []
   specs_extra = '\n' + '\n'.join(specs_extra_list)

--- a/picolibc.specs.in
+++ b/picolibc.specs.in
@@ -16,7 +16,7 @@
 @SPECS_PRINTF@ -L@LIBDIR@/%M -L@LIBDIR@ %{!T:-Tpicolibc.ld} %(picolibc_link) --gc-sections @LINK_SPEC@
 
 *lib:
---start-group %(libgcc) -lc %{-oslib=*:--undefined=_exit} %{-oslib=*:-l%*} --end-group
+--start-group %(libgcc) @ADDITIONAL_LIBS@ -lc %{-oslib=*:--undefined=_exit} %{-oslib=*:-l%*} --end-group
 
 *endfile:
 


### PR DESCRIPTION
CompCert uses some support functions, which live in the libcompcert. Add
that lib to the specs file.

When building the lib with CompCert and then an application with another compiler, this will cause trouble - the other compiler doesn't have libcompcert. Hence the "best" approach would probably to include the libcompcert used for building the libc in the libc itself. But as just adding `-lcompcert'` is a much less invasive, I went with this simple variant (also, I'm not 100% sure how to properly put the libcompcert into the libc).