### PR TITLE
Use size_t instead of ptrdiff_t for size_t multiplication result

### DIFF
--- a/newlib/libc/stdlib/reallocarray.c
+++ b/newlib/libc/stdlib/reallocarray.c
@@ -25,7 +25,7 @@
 void *
 reallocarray(void *optr, size_t nmemb, size_t size)
 {
-	ptrdiff_t bytes;
+	size_t bytes;
 
 	if (mul_overflow (nmemb, size, &bytes))
 	{


### PR DESCRIPTION
The `ptrdiff_t` is signed, `size_t` is unsigned. Since every variant
of `mul_overflow` checks for an overflow, even on targets with
`sizeof(ptrdiff_t) > sizeof(size_t)` there is nothing to gain by
using that type.
Especially since its then cast to `size_t` when passed to `realloc`.