### PR TITLE
Tests: Only use those -Wfoo which the compiler supports

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -323,6 +323,14 @@ test_specs = configure_file(input: 'test.specs.in',
 install_data('picolibc.ld',
 	     install_dir: lib_dir)
 
+# Not all compilers necessarily support all warnings used by the tests; only use these which are:
+test_c_warnings = []
+foreach arg : ['-Wno-missing-braces', '-Wno-implicit-int', '-Wno-return-type']
+  if meson.get_compiler('c').has_argument(arg)
+    test_c_warnings += [arg]
+  endif
+endforeach
+
 long_double_code = '''
 #include <float.h>
 #ifndef LDBL_MANT_DIG

--- a/newlib/libm/test/meson.build
+++ b/newlib/libm/test/meson.build
@@ -146,7 +146,7 @@ foreach target : targets
 
   test('math' + target,
        executable(test_name, math_test_src,
-		  c_args:  value[1] + ['-Wno-missing-braces', '-Wno-implicit-int', '-Wno-return-type', '-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + test_c_args,
+		  c_args:  value[1] + test_c_warnings + ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + test_c_args,
 		  link_with: libs,
 		  link_args: value[1] + test_link_args + ['-Wl,--gc-sections'],
 		  include_directories: inc),
@@ -160,7 +160,7 @@ if enable_native_tests
   if native_lib_m.found()
     test('math-native',
 	 executable('math_test_native', math_test_src,
-		    c_args: ['-Wno-missing-braces', '-Wno-implicit-int', '-Wno-return-type', '-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE', '-DNO_NEWLIB'],
+		    c_args: test_c_warnings + ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE', '-DNO_NEWLIB'],
 		    dependencies: native_lib_m))
   endif
 endif

--- a/newlib/testsuite/newlib.iconv/meson.build
+++ b/newlib/testsuite/newlib.iconv/meson.build
@@ -67,7 +67,7 @@ foreach target : targets
 
     test(test + target,
 	 executable(test_name, src,
-		    c_args: ['-Wno-missing-braces', '-Wno-implicit-int', '-Wno-return-type', '-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + _c_args + iconv_test_c_args,
+		    c_args: test_c_warnings + ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + _c_args + iconv_test_c_args,
 		    link_args: _link_args,
 		    link_with: _libs,
 		    include_directories: test_inc),

--- a/newlib/testsuite/newlib.locale/meson.build
+++ b/newlib/testsuite/newlib.locale/meson.build
@@ -41,7 +41,7 @@ foreach test : tests
   src = test + '.c'
   test(test,
        executable(test, src,
-		  c_args: ['-Wno-missing-braces', '-Wno-implicit-int', '-Wno-return-type', '-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + test_c_args,
+		  c_args: test_c_warnings + ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + test_c_args,
 		  link_args: test_link_args,
 		  link_with: [lib_m, lib_c, lib_semihost, lib_crt],
 		  include_directories: inc),

--- a/newlib/testsuite/newlib.search/meson.build
+++ b/newlib/testsuite/newlib.search/meson.build
@@ -60,7 +60,7 @@ foreach target : targets
 
     test(test + target,
 	 executable(test_name, src,
-		    c_args: ['-Wno-missing-braces', '-Wno-implicit-int', '-Wno-return-type', '-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + _c_args,
+		    c_args: test_c_warnings + ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + _c_args,
 		    link_args: _link_args,
 		    link_with: _libs,
 		    include_directories: test_inc),

--- a/newlib/testsuite/newlib.stdio/meson.build
+++ b/newlib/testsuite/newlib.stdio/meson.build
@@ -64,7 +64,7 @@ foreach target : targets
 
     test(test + target,
 	 executable(test_name, src,
-		    c_args: ['-Wno-missing-braces', '-Wno-implicit-int', '-Wno-return-type', '-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + _c_args,
+		    c_args: test_c_warnings + ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + _c_args,
 		    link_args: _link_args,
 		    link_with: _libs,
 		    include_directories: test_inc),

--- a/newlib/testsuite/newlib.stdlib/meson.build
+++ b/newlib/testsuite/newlib.stdlib/meson.build
@@ -60,7 +60,7 @@ foreach target : targets
 
     test(test + target,
 	 executable(test_name, src,
-		    c_args: ['-Wno-missing-braces', '-Wno-implicit-int', '-Wno-return-type', '-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + _c_args,
+		    c_args: test_c_warnings + ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + _c_args,
 		    link_args: _link_args,
 		    link_with: _libs,
 		    include_directories: test_inc),

--- a/newlib/testsuite/newlib.string/meson.build
+++ b/newlib/testsuite/newlib.string/meson.build
@@ -60,7 +60,7 @@ foreach target : targets
 
     test(test + target,
 	 executable(test_name, [src],
-		    c_args: ['-Wno-missing-braces', '-Wno-implicit-int', '-Wno-return-type', '-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + _c_args,
+		    c_args: test_c_warnings + ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + _c_args,
 		    link_args: _link_args,
 		    link_with: _libs,
 		    include_directories: test_inc),

--- a/newlib/testsuite/newlib.wctype/meson.build
+++ b/newlib/testsuite/newlib.wctype/meson.build
@@ -62,7 +62,7 @@ foreach target : targets
 
     test(test + target,
 	 executable(test_name, src,
-		    c_args: ['-Wno-missing-braces', '-Wno-implicit-int', '-Wno-return-type', '-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + _c_args,
+		    c_args: test_c_warnings + ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + _c_args,
 		    link_args: _link_args,
 		    link_with: _libs,
 		    include_directories: test_inc),

--- a/test/meson.build
+++ b/test/meson.build
@@ -145,7 +145,7 @@ if enable_native_tests
   if native_lib_m.found()
     test('math_errhandling_native',
 	 executable('math_errhandling_native', 'math_errhandling.c',
-		    c_args: ['-Wno-missing-braces', '-Wno-implicit-int', '-Wno-return-type', '-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE', '-DNO_NEWLIB'],
+		    c_args: test_c_warnings + ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE', '-DNO_NEWLIB'],
 		    dependencies: native_lib_m))
   endif
 endif


### PR DESCRIPTION
CompCert does not have `-Wmissing-braces`, but while at it, I just let the build file test all three common warnings used by all the tests.