### PR TITLE
Minor fixes to tests

### DIFF
--- a/newlib/libm/test/math.c
+++ b/newlib/libm/test/math.c
@@ -233,7 +233,7 @@ int calc;
 extern int reduce;
 
 
-frontline (FILE *f,
+void frontline (FILE *f,
        int mag,
        one_line_type *p,
        double result,
@@ -289,7 +289,7 @@ frontline (FILE *f,
   fprintf(f, ")*/\n");
 }
 
-finish (FILE *f,
+void finish (FILE *f,
        int vector,
        double result,
        one_line_type *p,
@@ -305,7 +305,7 @@ finish (FILE *f,
   }
 }
 
-finish2 (FILE *f,
+void finish2 (FILE *f,
 	 int vector,
 	 double result,
 	 double result2,
@@ -329,7 +329,7 @@ finish2 (FILE *f,
   }
 }
 
-ffinish (FILE *f,
+void ffinish (FILE *f,
        int vector,
        float fresult,
        one_line_type *p,
@@ -345,7 +345,7 @@ ffinish (FILE *f,
   }
 }
 
-ffinish2 (FILE *f,
+void ffinish2 (FILE *f,
 	  int vector,
 	  float fresult,
 	  float fresult2,
@@ -379,8 +379,7 @@ in_float_range(double arg)
 	return -FLT_MAX <= arg && arg < FLT_MAX;
 }
 
-void
-run_vector_1 (int vector,
+void run_vector_1 (int vector,
        one_line_type *p,
        char *func,
        char *name,
@@ -559,8 +558,7 @@ run_vector_1 (int vector,
   }
 }
 
-void
-test_math (int vector)
+void test_math (int vector)
 {
   test_acos(vector);
   test_acosf(vector);

--- a/newlib/libm/test/math.c
+++ b/newlib/libm/test/math.c
@@ -47,7 +47,8 @@ double mretval = 64;
 int traperror = 1;
 char *mname;
 
-void translate_to (FILE *file,
+void
+translate_to (FILE *file,
 	    double r)
 {
   __ieee_double_shape_type bits;
@@ -233,7 +234,8 @@ int calc;
 extern int reduce;
 
 
-void frontline (FILE *f,
+void
+frontline (FILE *f,
        int mag,
        one_line_type *p,
        double result,
@@ -289,7 +291,8 @@ void frontline (FILE *f,
   fprintf(f, ")*/\n");
 }
 
-void finish (FILE *f,
+void
+finish (FILE *f,
        int vector,
        double result,
        one_line_type *p,
@@ -305,7 +308,8 @@ void finish (FILE *f,
   }
 }
 
-void finish2 (FILE *f,
+void
+finish2 (FILE *f,
 	 int vector,
 	 double result,
 	 double result2,
@@ -329,7 +333,8 @@ void finish2 (FILE *f,
   }
 }
 
-void ffinish (FILE *f,
+void
+ffinish (FILE *f,
        int vector,
        float fresult,
        one_line_type *p,
@@ -345,7 +350,8 @@ void ffinish (FILE *f,
   }
 }
 
-void ffinish2 (FILE *f,
+void
+ffinish2 (FILE *f,
 	  int vector,
 	  float fresult,
 	  float fresult2,
@@ -379,7 +385,8 @@ in_float_range(double arg)
 	return -FLT_MAX <= arg && arg < FLT_MAX;
 }
 
-void run_vector_1 (int vector,
+void
+run_vector_1 (int vector,
        one_line_type *p,
        char *func,
        char *name,
@@ -558,7 +565,8 @@ void run_vector_1 (int vector,
   }
 }
 
-void test_math (int vector)
+void
+test_math (int vector)
 {
   test_acos(vector);
   test_acosf(vector);

--- a/newlib/libm/test/test.c
+++ b/newlib/libm/test/test.c
@@ -92,8 +92,7 @@ main (int ac,
 }
 
 static const char *iname = "foo";
-void 
-newfunc (const char *string)
+void newfunc (const char *string)
 {
   if (strcmp(iname, string)) 
   {
@@ -388,7 +387,7 @@ kill() {}
 getpid() {}
 #endif
 
-bt(){
+void bt(){
 
   double f1,f2;
   f1 = 0.0;

--- a/newlib/libm/test/test_is.c
+++ b/newlib/libm/test/test_is.c
@@ -355,7 +355,7 @@ test_is_single (int i)
       setlower = 39;
       setupper = 39;
       break;
-    case '\(':
+    case '(':
       myascii = 1;
       mygraph = 1;
       myprint = 1;

--- a/newlib/libm/test/yn_vec.c
+++ b/newlib/libm/test/yn_vec.c
@@ -217,4 +217,4 @@
 {64,0,123,__LINE__, 0x3fbefed6, 0x4831e4df, 0x40080000, 0x00000000, 0x3fff3333, 0x33333338},
 {64,0,123,__LINE__, 0x3f9fc826, 0xafa66438, 0x40100000, 0x00000000, 0x3fff3333, 0x33333338},
 0,};
-test_yn(m)   {run_vector_1(m,yn_vec,(char *)(yn),"yn","did");   }	
+void test_yn(m)   {run_vector_1(m,yn_vec,(char *)(yn),"yn","did");   }	

--- a/newlib/testsuite/newlib.string/tstring.c
+++ b/newlib/testsuite/newlib.string/tstring.c
@@ -54,31 +54,21 @@ void myset (char *target, char ch, int size)
     }
 }
 
+static char target[MAX_1] = "A";
+static char buffer2[MAX_1];
+static char buffer3[MAX_1];
+static char buffer4[MAX_1];
+static char buffer5[MAX_2];
+static char buffer6[MAX_2];
+static char buffer7[MAX_2];
+static char expected[MAX_1];
+
 int main()
 {
-  /**
-   * CompCert's proof of correct compilation of array initialization
-   *  is O(pow(length of the array, 2)).
-   * So better not initialize a 11000/33000 element array "the usual way".
-   */
-#ifndef __COMPCERT__
-  char target[MAX_1] = "A";
-#else
-  char target[MAX_1];
-  target[0] = 'A';
-  target[1] = '\0';
-#endif
   char first_char;
   char second_char;
   char array[] = "abcdefghijklmnopqrstuvwxz";
   char array2[] = "0123456789!@#$%^&*(";
-  char buffer2[MAX_1];
-  char buffer3[MAX_1];
-  char buffer4[MAX_1];
-  char buffer5[MAX_2];
-  char buffer6[MAX_2];
-  char buffer7[MAX_2];
-  char expected[MAX_1];
   char *tmp1, *tmp2, *tmp3, *tmp4, *tmp5, *tmp6, *tmp7;
   int i, j, k, x, z = 0, align_test_iterations;
 

--- a/newlib/testsuite/newlib.string/tstring.c
+++ b/newlib/testsuite/newlib.string/tstring.c
@@ -56,7 +56,18 @@ void myset (char *target, char ch, int size)
 
 int main()
 {
+  /**
+   * CompCert's proof of correct compilation of array initialization
+   *  is O(pow(length of the array, 2)).
+   * So better not initialize a 11000/33000 element array "the usual way".
+   */
+#ifndef __COMPCERT__
   char target[MAX_1] = "A";
+#else
+  char target[MAX_1];
+  target[0] = 'A';
+  target[1] = '\0';
+#endif
   char first_char;
   char second_char;
   char array[] = "abcdefghijklmnopqrstuvwxz";


### PR DESCRIPTION
1. Add void return type instead of relying on implicit int
2. adapt array initialization for CompCert [tstring.c]
3. remove invalid escape sequence [test_is.c]

I assume 1.+3. were not intentional, @keith-packard?