### PR TITLE
vfprintf: Wrap __d_vfprintf on MacOS

### DIFF
--- a/newlib/libc/tinystdio/vfprintf.c
+++ b/newlib/libc/tinystdio/vfprintf.c
@@ -886,8 +886,11 @@ int vfprintf (FILE * stream, const char *fmt, va_list ap)
 }
 
 #ifndef vfprintf
-int __d_vfprintf (FILE * stream, const char *fmt, va_list ap) __attribute__((alias("vfprintf"), nonnull));
+#ifdef HAVE_ALIAS_ATTRIBUTE
+__strong_reference(vfprintf, __d_vfprintf);
+#else
+int __d_vfprintf (FILE * stream, const char *fmt, va_list ap) { return vfprintf(stream, fmt, ap); }
 #endif
-
+#endif
 
 #endif	/* PRINTF_LEVEL > PRINTF_MIN */


### PR DESCRIPTION
Avoids `error: aliases are not supported on darwin`

I am trying to get picolibc to build and run to use it for running tests for an embedded project on native MacOS, but there are some things that work differently on Mac than on Linux. I will post some more PRs later with other Darwin and Clang fixes.
The end goal is to allow the build system in my project to build the same integration test applications as binaries for an embedded device and for MacOS/Linux hosted regular binary.

The extra indirection of the tiny wrapper function should be irrelevant on MacOS since picolibc will AFAICS only be used for testing embedded projects on this platform.

This part of the Darwin+Clang support was broken by 9d80f9c07b579c543e51370ac0dd67a78c72a775, but the build was already failing on my machine before that commit because of other incompatibilities.