### PR TITLE
Mac build fixes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -738,6 +738,8 @@ if has_semihost
   # Make sure all of the tests get re-linked if the linker scripts change
 
   test_link_depends += test_link_dep + files('picolibc.ld') + [picolibc_specs]
+elif meson.get_compiler('c').get_id() == 'clang'
+  # Clang does not support spec files
 else
   test_link_depends += test_specs
   test_c_args += ['--specs', '@0@/@1@'.format(meson.current_build_dir(), test_specs)]

--- a/newlib/libc/include/sys/cdefs.h
+++ b/newlib/libc/include/sys/cdefs.h
@@ -398,6 +398,10 @@
 #define	__noinline
 #endif
 
+#if defined(__clang__) && defined(__nonnull)
+/* Clang has a builtin macro __nonnull for the _Nonnull qualifier */
+#undef __nonnull
+#endif
 #if __GNUC_PREREQ__(3, 3)
 #define	__nonnull(x)	__attribute__((__nonnull__ x))
 #define	__nonnull_all	__attribute__((__nonnull__))

--- a/newlib/libc/tinystdio/vfprintf.c
+++ b/newlib/libc/tinystdio/vfprintf.c
@@ -886,8 +886,11 @@ int vfprintf (FILE * stream, const char *fmt, va_list ap)
 }
 
 #ifndef vfprintf
-int __d_vfprintf (FILE * stream, const char *fmt, va_list ap) __attribute__((alias("vfprintf"), nonnull));
+#ifdef HAVE_ALIAS_ATTRIBUTE
+__strong_reference(vfprintf, __d_vfprintf);
+#else
+int __d_vfprintf (FILE * stream, const char *fmt, va_list ap) { return vfprintf(stream, fmt, ap); }
 #endif
-
+#endif
 
 #endif	/* PRINTF_LEVEL > PRINTF_MIN */

--- a/newlib/libm/test/meson.build
+++ b/newlib/libm/test/meson.build
@@ -148,7 +148,7 @@ foreach target : targets
        executable(test_name, math_test_src,
 		  c_args:  value[1] + test_c_warnings + ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + test_c_args,
 		  link_with: libs,
-		  link_args: value[1] + test_link_args + ['-Wl,--gc-sections'],
+		  link_args: value[1] + test_link_args,
 		  include_directories: inc),
        env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
 endforeach

--- a/newlib/testsuite/newlib.iconv/meson.build
+++ b/newlib/testsuite/newlib.iconv/meson.build
@@ -38,7 +38,7 @@ tests = ['iconvjp', 'iconvnm', 'iconvru' ]
 iconv_data_link = custom_target('iconv_data link',
 				install: false,
 				output: 'iconv_data',
-				command: ['ln', '-srf', '@SOURCE_DIR@' / 'newlib/libc/iconv/ccs/binary', '@OUTPUT@'])
+				command: ['ln', '-sf', meson.source_root() / 'newlib/libc/iconv/ccs/binary', '@OUTPUT@'])
 
 iconv_test_c_args = ['-DTEST_NLSPATH="' + meson.current_build_dir() + '"']
 

--- a/scripts/duplicate-names
+++ b/scripts/duplicate-names
@@ -3,7 +3,7 @@ NM="$1"
 FILE="$2"
 OUTPUT="$3"
 
-"$NM" -g "$FILE" | grep ' [A-TV-Z] ' | grep -v '__x86' | sort | uniq -d > "$OUTPUT"
+"$NM" -g "$FILE" 2>/dev/null | grep ' [A-TV-Z] ' | grep -v '__x86' | sort | uniq -d > "$OUTPUT"
 if [ -e "$OUTPUT" -a -s "$OUTPUT" ]; then
     echo "Duplicate names in ${FILE}"
     cat "$OUTPUT"


### PR DESCRIPTION
This PR contains various small fixes to make the whole library including tests buildable on Macos.

The `__weak_reference` is a bit of a kludge because it seems to be necessary to mark the original symbol as weak when creating a weak reference for the exported symbol to actually become weak. Building the stack-smash test fails if the `__stack_check_fail` symbol is not correctly marked as weak so it can be used as a test for this if anybody wants to experiment further, but this is the best I have managed to come up with for now.

The `printff_scanff` and `printff-tests` tests fail because of not being correctly linked after I had to remove the `-spec` flags when building on Clang.

The `fenv` test seems very broken on Mac, a whole bunch of test cases get zero or ~ulp.
`math_errhandling` tests fail for `logf(zero)`

The malloc tests crash with segfault, but I built it with `-Dpicolib=false` and I did not have time to look further into this because it was not a priority for my personal project.

Based on #83 