### PR TITLE
libc/stdio: Allow machine dependent files to override sys/stdio.h

### DIFF
--- a/newlib/libc/stdio/sys/meson.build
+++ b/newlib/libc/stdio/sys/meson.build
@@ -32,7 +32,21 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-install_headers(
+inc_stdio_sys_headers_all = [
   'stdio.h',
+]
+
+inc_stdio_sys_headers = []
+
+foreach file : inc_stdio_sys_headers_all
+  if not (file in inc_sys_headers_machine)
+    inc_stdio_sys_headers += file
+  else
+    message(file + ': machine overrides generic stdio/sys')
+  endif
+endforeach
+
+install_headers(
+  inc_stdio_sys_headers,
   subdir:'sys'
 )


### PR DESCRIPTION
This replicates the logic of the other sys/ header file installation. Proposed fix for issue #88 

Signed-off-by: Keith Packard <keithp@keithp.com>