### PR TITLE
clang support (using lld)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -763,14 +763,7 @@ if has_semihost
 
   # Undefine _exit as that's in libsemihost and needs to replace the weak _exit
 
-  test_link_args += test_c_args
-
-  # Clang does not support -nostartfiles
-  if meson.get_compiler('c').get_id() != 'clang'
-    test_link_args += '-nostartfiles'
-  endif
-
-  test_link_args += ['-nostdlib', '-T', test_link_path, '-T', picolibc_link_path, '-Wl,--undefined=_exit', '-lgcc']
+  test_link_args += test_c_args + ['-nostdlib', '-T', test_link_path, '-T', picolibc_link_path, '-Wl,--undefined=_exit', '-lgcc']
 
   # Make sure all of the tests get re-linked if the linker scripts change
 

--- a/meson.build
+++ b/meson.build
@@ -756,20 +756,33 @@ if has_semihost
 
   picolibc_link_path = '@0@/@1@'.format(meson.current_source_dir(), 'picolibc.ld')
 
-  test_c_args += ['--specs', '@0@/@1@'.format(meson.current_build_dir(), picolibc_specs)]
+  # Clang does not support spec files
+  if meson.get_compiler('c').get_id() != 'clang'
+    test_c_args += ['--specs', '@0@/@1@'.format(meson.current_build_dir(), picolibc_specs)]
+  endif
 
   # Undefine _exit as that's in libsemihost and needs to replace the weak _exit
 
-  test_link_args += test_c_args + ['-nostartfiles', '-nostdlib', '-T', test_link_path, '-T', picolibc_link_path, '-Wl,--undefined=_exit', '-lgcc']
+  test_link_args += test_c_args
+
+  # Clang does not support -nostartfiles
+  if meson.get_compiler('c').get_id() != 'clang'
+    test_link_args += '-nostartfiles'
+  endif
+
+  test_link_args += ['-nostdlib', '-T', test_link_path, '-T', picolibc_link_path, '-Wl,--undefined=_exit', '-lgcc']
 
   # Make sure all of the tests get re-linked if the linker scripts change
 
   test_link_depends += test_link_dep + files('picolibc.ld') + [picolibc_specs]
-elif meson.get_compiler('c').get_id() == 'clang'
-  # Clang does not support spec files
 else
   test_link_depends += test_specs
-  test_c_args += ['--specs', '@0@/@1@'.format(meson.current_build_dir(), test_specs)]
+
+  # Clang does not support spec files
+  if meson.get_compiler('c').get_id() != 'clang'
+    test_c_args += ['--specs', '@0@/@1@'.format(meson.current_build_dir(), test_specs)]
+  endif
+
   test_link_args += test_c_args
 endif
 

--- a/picolibc.ld
+++ b/picolibc.ld
@@ -42,8 +42,8 @@ ENTRY(_start)
 
 MEMORY
 {
-	flash (rxai!w) : ORIGIN = DEFINED(__flash) ? __flash : 0x10000000, LENGTH = DEFINED(__flash_size) ? __flash_size : 0x10000
-	ram (wxa!ri)   : ORIGIN = DEFINED(__ram  ) ? __ram   : 0x20000000, LENGTH = DEFINED(__ram_size  ) ? __ram_size   : 0x08000
+	flash (rx) : ORIGIN = DEFINED(__flash) ? __flash : 0x10000000, LENGTH = DEFINED(__flash_size) ? __flash_size : 0x10000
+	ram (rwx)   : ORIGIN = DEFINED(__ram  ) ? __ram   : 0x20000000, LENGTH = DEFINED(__ram_size  ) ? __ram_size   : 0x08000
 }
 
 PHDRS
@@ -132,6 +132,16 @@ SECTIONS
 		KEEP (*(.dtors))
 	} >flash AT>flash :text
 
+	.ARM.extab : {
+		*(.ARM.extab*)
+	} >flash
+
+	.ARM.exidx : {
+		__exidx_start = .;
+		*(.ARM.exidx*)
+		__exidx_end = .;
+	} >flash
+
 	/*
 	 * Data values which are preserved across reset
 	 */
@@ -142,7 +152,7 @@ SECTIONS
 		PROVIDE(__preserve_end__ = .);
 	} >ram AT>ram :ram
 
-	.data : ALIGN_WITH_INPUT {
+	.data : {
 		PROVIDE(__data_start = .);
 		*(.data .data.*)
 		*(.gnu.linkonce.d.*)
@@ -161,7 +171,7 @@ SECTIONS
 	 * into the allocate ram addresses by the existing
 	 * data initialization code in crt0
 	 */
-	.tdata : ALIGN_WITH_INPUT {
+	.tdata : {
 		PROVIDE( __tls_base = .);
 		*(.tdata .tdata.* .gnu.linkonce.td.*)
 		PROVIDE(__data_end = .);


### PR DESCRIPTION
This fixes test build on clang

Usage:
```
meson.py setup -Dmultilib=false -Dtests=true -Dnative-tests=false -Dnewlib-io-long-double=false --buildtype=debug builddir
```

Don't know how to fix `picolibc.ld` file