### PR TITLE
clang CI: Cortex-M3 coverage

### DIFF
--- a/scripts/cross-arm-none-eabi.txt
+++ b/scripts/cross-arm-none-eabi.txt
@@ -9,7 +9,7 @@ exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"
 [host_machine]
 system = 'none'
 cpu_family = 'arm'
-cpu = 'arm'
+cpu = 'cortex-m3'
 endian = 'little'
 
 [properties]


### PR DESCRIPTION
Just found what Cortex-M3 is not covered by CI

Is this appropriate solution?