### PR TITLE
CompCert: Use more builtins in math.h

### DIFF
--- a/newlib/libc/include/math.h
+++ b/newlib/libc/include/math.h
@@ -44,7 +44,7 @@ _BEGIN_STD_C
 /* Natural log of 2 */
 #define _M_LN2        0.693147180559945309417
 
-#if __GNUC_PREREQ (3, 3) || defined(__clang__)
+#if __GNUC_PREREQ (3, 3) || defined(__clang__) || defined(__COMPCERT__)
  /* gcc >= 3.3 implicitly defines builtins for HUGE_VALx values.  */
 
 # ifndef HUGE_VAL


### PR DESCRIPTION
And a small one: As the title says, CompCert has these builtins, so they should be used. This also removes bogus warnings when the e.g. the INFINITY constant is used.

Since `math.h` is an installed header, I check for the magic define instead of handling this in the build system.