### PR TITLE
Call `exit` upon returning from `main` in semihosted mode

### DIFF
--- a/doc/os.md
+++ b/doc/os.md
@@ -139,6 +139,10 @@ the Picolibc test suite. This implementation relies on semihosting
 support from the execution environment, which is available when
 running under qemu or when using openocd and gdb. Link this into your
 application using `--oslib=semihost` in your link command line.
+Please note that this will replace the default `crt0` with a variant
+calling `exit` upon return from `main`. The default is to enter an
+infinite loop, and the change ensure a clean return to the execution
+environment.
 
 ## POSIX console support
 

--- a/doc/using.md
+++ b/doc/using.md
@@ -97,10 +97,18 @@ command line flag defined by picolibc.specs:
 
 	$ gcc --specs=picolibc.specs --oslib=semihost -o program.elf program.o
 
+This will also replace the `crt0` with a special semihost variant:
+The default `crt0` assumes a freestanding execution environment, entering
+an infinite loop upon returning from `main`. In semihosted mode, the
+alternate `crt0` will instead call `exit` from `libsemihost.a`, resulting
+in a clean return to the hosting environment (this conforms to a hosted
+execution environment as per the C specification).
+
 You can also list libc and libsemihost in the correct order
 explicitly:
 
 	$ gcc --specs=picolibc.specs -o program.elf -lc -lsemihost
 
-This second form doesn't force using the version of _exit from
-libsemihost.a, and so isn't quite as useful.
+This second form doesn't force using the semihosted version of `crt0`,
+so programs built that way will enter an infinite loop upon returning
+from `main` instead of calling `exit`.

--- a/meson.build
+++ b/meson.build
@@ -765,6 +765,7 @@ has_ieeefp_funcs = false
 # semihost will adjust this if supported
 has_semihost = false
 
+# make sure to include semihost BEFORE picocrt!
 subdir('semihost')
 if tinystdio
   subdir('dummyhost')
@@ -822,6 +823,7 @@ endif
 
 has_picolibc_tls_api = false
 
+# make sure to include semihost BEFORE picocrt!
 if enable_picocrt
   subdir('picocrt')
 endif

--- a/picocrt/crt0.h
+++ b/picocrt/crt0.h
@@ -71,9 +71,6 @@ extern void __libc_init_array(void);
 #include <picotls.h>
 #include <stdio.h>
 
-extern void
-_exit(int) __weak_symbol;
-
 static inline void
 __start(void)
 {
@@ -85,6 +82,11 @@ __start(void)
 #ifdef HAVE_INITFINI_ARRAY
 	__libc_init_array();
 #endif
+#ifdef _PICOLIBC_CRT0_SEMIHOST_
+	int ret = main(0, NULL);
+	exit(ret);
+#else
 	(void) main(0, NULL);
+#endif
 	for(;;);
 }

--- a/picocrt/machine/riscv/crt0.S
+++ b/picocrt/machine/riscv/crt0.S
@@ -96,5 +96,10 @@ _start:
 	li	a0, 0
 	li	a1, 0
 	call	main
+
+#ifdef _PICOLIBC_CRT0_SEMIHOST_
+    call exit
+#endif
+
 .L1:	
 	j	.L1

--- a/picocrt/meson.build
+++ b/picocrt/meson.build
@@ -53,12 +53,15 @@ foreach target : targets
 
   if target == ''
     crt_name = 'crt0.o'
+    crt_semihost_name = 'crt0-semihost.o'
     libcrt_name = 'crt'
   else
     crt_name = join_paths(target, 'crt0.o')
+    crt_semihost_name = join_paths(target, 'crt0-semihost.o')
     libcrt_name = join_paths(target, 'libcrt')
   endif
 
+  # The normal variant does not call 'exit' after return from main (c lingo: freestanding execution environment)
   executable(crt_name,
 	     srcs_picocrt,
 	     include_directories : inc,
@@ -66,6 +69,17 @@ foreach target : targets
 	     install_dir : instdir,
 	     c_args : value[1] + arg_fnobuiltin + ['-ffreestanding'],
 	     link_args : value[1] + ['-r', '-ffreestanding', '-nostdlib'])
+
+  # The semihost variant call 'exit' after return from main (c lingo: hosted execution environment)
+  if has_semihost
+    executable(crt_semihost_name,
+           srcs_picocrt,
+           include_directories : inc,
+           install : true,
+           install_dir : instdir,
+           c_args : value[1] + arg_fnobuiltin + ['-ffreestanding', '-D_PICOLIBC_CRT0_SEMIHOST_'],
+           link_args : value[1] + ['-r', '-ffreestanding', '-nostdlib'])
+  endif
 
   # Tests link against this because using the .o isn't supported under meson
   set_variable('lib_crt' + target,

--- a/picolibc.specs.in
+++ b/picolibc.specs.in
@@ -22,5 +22,5 @@
 @CRTEND@
 
 *startfile:
-@LIBDIR@/%M/crt0%O%s @CRTBEGIN@
+@LIBDIR@/%M/crt0%{-oslib=semihost:-semihost}%O%s @CRTBEGIN@
 @SPECS_EXTRA@


### PR DESCRIPTION
As described in issue #107

When built with semihosting support, the `crt0.*` is build twice:

1. `crt0.o` will enter an infinite loop upon returning from `main`
2. `crt0-semihost.o` will call `exit` after `main` (in case `exit`
   unexpectedly returns, the infinite loop is entered as well)

The spec file is changed to use the second variant iff --oslib=semihost
is passed to gcc.

The documentation has been updated to reflect the changed behavior.

Added some comments to meson.build to point out that the picocrt subdir
depends on the semihost subdir (`has_semihost` has to be correctly set).