### PR TITLE
Split out crt0 selection from oslib selection

### DIFF
--- a/doc/os.md
+++ b/doc/os.md
@@ -139,6 +139,10 @@ the Picolibc test suite. This implementation relies on semihosting
 support from the execution environment, which is available when
 running under qemu or when using openocd and gdb. Link this into your
 application using `--oslib=semihost` in your link command line.
+Please note that this will replace the default `crt0` with a variant
+calling `exit` upon return from `main`. The default is to enter an
+infinite loop, and the change ensure a clean return to the execution
+environment.
 
 ## POSIX console support
 

--- a/doc/using.md
+++ b/doc/using.md
@@ -48,39 +48,47 @@ you can plug your own code into:
     variables while ARM with hardware floating point needs to have the
     FPSCR register set up to match C semantics for rounding.
     
- 2) Data initialization. Here's the code inside Picocrt:
-```
-memcpy(__data_start, __data_source, (uintptr_t) __data_size);
-```
-For this to work, the linker script must assign correct values to
-each of these symbols:
+ 2) Data initialization. Here's the code inside Picocrt:\
+    \
+    `memcpy(__data_start, __data_source, (uintptr_t) __data_size);`\
+    \
+    For this to work, the linker script must assign correct values to
+    each of these symbols:
 
- * __data_start points to the RAM location where the .data segment
-   starts.
- * __data_source points to the Flash location where the .data segment
-   initialization values are stored.
- * __data_size is an absolute symbol noting the size of the
-   initialized data segment
+    * __data_start points to the RAM location where the .data segment
+      starts.
+    * __data_source points to the Flash location where the .data segment
+      initialization values are stored.
+    * __data_size is an absolute symbol noting the size of the
+      initialized data segment
 
- 3) BSS initialization. Here's the code inside Picocrt:
-```
-memset(__bss_start, '\0', (uintptr_t) __bss_size);
-```
-Assign these symbols in the linker script as follows:
+ 3) BSS initialization. Here's the code inside Picocrt:\
+    \
+    `memset(__bss_start, '\0', (uintptr_t) __bss_size);`\
+    \
+    Assign these symbols in the linker script as follows:
 
- * __bss_start points to the RAM location where the .bss segment
-   starts.
- * __bss_size is an absolute symbol noting the size of the cleared
-   data segment
+    * __bss_start points to the RAM location where the .bss segment
+      starts.
+    * __bss_size is an absolute symbol noting the size of the cleared
+      data segment
 
- 4) Call [initializers/constructors](init.md) using `__libc_init_array()`
+ 4) Optionally call constructors:
+
+    * The default and hosted crt0 variants call
+      [initializers/constructors](init.md) using `__libc_init_array()`
+
+    * The minimal crt0 variant doesn't call any constructors
 
  5) Call `main()`
 
- 6) If main returns, then the default crt0 will go into an infinite
-    loop. Applications wanting to call exit() must do that
-    explicitly. The 'hosted' crt0 version (crt0-hosted.o) calls exit,
-    passing the value returned from main.
+ 6) After main returns:
+
+    * The default and minimal crt0 variants run an infinite
+      loop if main returns.
+
+    * The hosted crt0 variant calls `exit`, passing it the value
+      returned from main.
 
 ## Semihosting
 
@@ -105,18 +113,24 @@ explicitly:
 
 	$ gcc --specs=picolibc.specs -o program.elf program.o -lc -lsemihost
 
-## Hosted environment crt0 version
+## Crt0 variants
 
-The default crt0 version provided by Picolibc goes into an infinite
-loop after main returns to avoid requiring an `_exit` function. In an
-environment which provides a useful `_exit` implementation, applications
-may want to use an alternate `crt0` that calls `exit` when main
+The default `crt0` version provided by Picolibc calls any constructors
+before it calls main and then goes into an infinite loop after main
+returns to avoid requiring an `_exit` function.
+
+In an environment which provides a useful `_exit` implementation, applications
+may want to use the `crt0-hosted` variant that calls `exit` when main
 returns, resulting in a clean return to the hosting environment (this
 conforms to a hosted execution environment as per the C
-specification).
+specification). Select this using the `--crt0=hosted` flag:
 
-Picolibc provides an alternate crt0 version, `crt0-hosted.o` for
-this. The picolibc specs file has code which selects this when gcc is
-passed the `--crt0=hosted` flag:
+	$ gcc --specs=picolibc.specs --crt0=hosted -o program.elf program.o
 
-	$ gcc --specs=picolibc.specs --crt0=hosted -o program.elf
+In a smaller environment which is not using any constructors (or any
+Picolibc code which requires constructors) may want to use the
+`crt0-minimal` variant that removes the call to
+`__libc_init_array()`. This variant also runs an infinite loop in case
+main returns. Select this using the `--crt0=minimal` flag:
+
+	$ gcc --specs=picolibc.specs --crt0=minimal -o program.elf program.o

--- a/doc/using.md
+++ b/doc/using.md
@@ -98,10 +98,18 @@ command line flag defined by picolibc.specs:
 
 	$ gcc --specs=picolibc.specs --oslib=semihost -o program.elf program.o
 
+This will also replace the `crt0` with a special semihost variant:
+The default `crt0` assumes a freestanding execution environment, entering
+an infinite loop upon returning from `main`. In semihosted mode, the
+alternate `crt0` will instead call `exit` from `libsemihost.a`, resulting
+in a clean return to the hosting environment (this conforms to a hosted
+execution environment as per the C specification).
+
 You can also list libc and libsemihost in the correct order
 explicitly:
 
 	$ gcc --specs=picolibc.specs -o program.elf -lc -lsemihost
 
-This second form doesn't force using the version of _exit from
-libsemihost.a, and so isn't quite as useful.
+This second form doesn't force using the semihosted version of `crt0`,
+so programs built that way will enter an infinite loop upon returning
+from `main` instead of calling `exit`.

--- a/doc/using.md
+++ b/doc/using.md
@@ -77,8 +77,10 @@ Assign these symbols in the linker script as follows:
 
  5) Call `main()`
 
- 6) If main returns, then crt0 will go into an infinite
-    loop. Applications wanting to call exit() must do that explicitly.
+ 6) If main returns, then the default crt0 will go into an infinite
+    loop. Applications wanting to call exit() must do that
+    explicitly. The 'hosted' crt0 version (crt0-hosted.o) calls exit,
+    passing the value returned from main.
 
 ## Semihosting
 
@@ -98,18 +100,23 @@ command line flag defined by picolibc.specs:
 
 	$ gcc --specs=picolibc.specs --oslib=semihost -o program.elf program.o
 
-This will also replace the `crt0` with a special semihost variant:
-The default `crt0` assumes a freestanding execution environment, entering
-an infinite loop upon returning from `main`. In semihosted mode, the
-alternate `crt0` will instead call `exit` from `libsemihost.a`, resulting
-in a clean return to the hosting environment (this conforms to a hosted
-execution environment as per the C specification).
-
 You can also list libc and libsemihost in the correct order
 explicitly:
 
-	$ gcc --specs=picolibc.specs -o program.elf -lc -lsemihost
+	$ gcc --specs=picolibc.specs -o program.elf program.o -lc -lsemihost
 
-This second form doesn't force using the semihosted version of `crt0`,
-so programs built that way will enter an infinite loop upon returning
-from `main` instead of calling `exit`.
+## Hosted environment crt0 version
+
+The default crt0 version provided by Picolibc goes into an infinite
+loop after main returns to avoid requiring an `_exit` function. In an
+environment which provides a useful `_exit` implementation, applications
+may want to use an alternate `crt0` that calls `exit` when main
+returns, resulting in a clean return to the hosting environment (this
+conforms to a hosted execution environment as per the C
+specification).
+
+Picolibc provides an alternate crt0 version, `crt0-hosted.o` for
+this. The picolibc specs file has code which selects this when gcc is
+passed the `--crt0=hosted` flag:
+
+	$ gcc --specs=picolibc.specs --crt0=hosted -o program.elf

--- a/hello-world/Makefile
+++ b/hello-world/Makefile
@@ -39,12 +39,12 @@ CPP_RISCV=riscv64-unknown-elf-g++ -specs=picolibcpp.specs
 CC_RISCV=riscv64-unknown-elf-gcc -specs=picolibc.specs 
 CFLAGS_RISCV=$(CFLAGS) -march=rv32imac -mabi=ilp32 -Wl,-Thello-world-riscv.ld
 
-CPP_ARM=arm-picolibc-eabi-c++ -specs=picolibcpp.specs 
-CC_ARM=arm-picolibc-eabi-gcc -specs=picolibc.specs 
+CPP_ARM=arm-none-eabi-c++ -specs=picolibcpp.specs 
+CC_ARM=arm-none-eabi-gcc -specs=picolibc.specs 
 CFLAGS_ARM=$(CFLAGS) -mcpu=cortex-m3 -Wl,-Thello-world-arm.ld
 
-CPP_AARCH64=aarch64-unknown-elf-g++ -specs=picolibcpp.specs 
-CC_AARCH64=aarch64-unknown-elf-gcc -specs=picolibc.specs 
+CPP_AARCH64=aarch64-linux-gnu-g++ -specs=picolibcpp.specs 
+CC_AARCH64=aarch64-linux-gnu-gcc -specs=picolibc.specs 
 CFLAGS_AARCH64=$(CFLAGS) -Wl,-Thello-world-aarch64.ld
 
 all: hello-world-riscv.elf hello-world-arm.elf hello-world-aarch64.elf \

--- a/hello-world/Makefile
+++ b/hello-world/Makefile
@@ -33,7 +33,7 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-CFLAGS=--oslib=semihost -O -g -Wl,-gc-sections
+CFLAGS=--oslib=semihost --crt0=hosted -O -g -Wl,-gc-sections
 
 CPP_RISCV=riscv64-unknown-elf-g++ -specs=picolibcpp.specs 
 CC_RISCV=riscv64-unknown-elf-gcc -specs=picolibc.specs 

--- a/hello-world/hello-world.c
+++ b/hello-world/hello-world.c
@@ -35,7 +35,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#ifdef HAVE_SEMIHOST_
+#ifdef HAVE_SEMIHOST
 #include <semihost.h>
 #endif
 
@@ -44,7 +44,7 @@ main(void)
 {
 	printf("hello, world\n");
 
-#ifdef HAVE_SEMIHOST_
+#ifdef HAVE_SEMIHOST
 	char	cmdline[128];
 	if (sys_semihost_get_cmdline(cmdline, sizeof(cmdline)) == 0) {
 		printf("Command line %s\n", cmdline);

--- a/hello-world/hello-world.c
+++ b/hello-world/hello-world.c
@@ -56,6 +56,5 @@ main(void)
 		}
 	}
 #endif
-
-	exit(0);
+	return 0;
 }

--- a/meson.build
+++ b/meson.build
@@ -769,6 +769,7 @@ has_ieeefp_funcs = false
 # semihost will adjust this if supported
 has_semihost = false
 
+# make sure to include semihost BEFORE picocrt!
 subdir('semihost')
 if tinystdio
   subdir('dummyhost')
@@ -826,6 +827,7 @@ endif
 
 has_picolibc_tls_api = false
 
+# make sure to include semihost BEFORE picocrt!
 if enable_picocrt
   subdir('picocrt')
 endif

--- a/picocrt/crt0.h
+++ b/picocrt/crt0.h
@@ -36,6 +36,7 @@
 #include <string.h>
 #include <picotls.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 extern char __data_source[];
 extern char __data_start[];
@@ -82,11 +83,11 @@ __start(void)
 #ifdef HAVE_INITFINI_ARRAY
 	__libc_init_array();
 #endif
-#ifdef _PICOLIBC_CRT0_SEMIHOST_
 	int ret = main(0, NULL);
+#ifdef CRT0_EXIT
 	exit(ret);
 #else
-	(void) main(0, NULL);
-#endif
+	(void) ret;
 	for(;;);
+#endif
 }

--- a/picocrt/crt0.h
+++ b/picocrt/crt0.h
@@ -71,9 +71,6 @@ extern void __libc_init_array(void);
 #include <picotls.h>
 #include <stdio.h>
 
-extern void
-_exit(int) __weak_symbol;
-
 static inline void
 __start(void)
 {
@@ -85,6 +82,11 @@ __start(void)
 #ifdef HAVE_INITFINI_ARRAY
 	__libc_init_array();
 #endif
+#ifdef _PICOLIBC_CRT0_SEMIHOST_
+	int ret = main(0, NULL);
+	exit(ret);
+#else
 	(void) main(0, NULL);
+#endif
 	for(;;);
 }

--- a/picocrt/crt0.h
+++ b/picocrt/crt0.h
@@ -72,6 +72,10 @@ extern void __libc_init_array(void);
 #include <picotls.h>
 #include <stdio.h>
 
+#ifndef CONSTRUCTORS
+#define CONSTRUCTORS 1
+#endif
+
 static inline void
 __start(void)
 {
@@ -80,7 +84,7 @@ __start(void)
 #ifdef PICOLIBC_TLS
 	_set_tls(__tls_base);
 #endif
-#ifdef HAVE_INITFINI_ARRAY
+#if defined(HAVE_INITFINI_ARRAY) && CONSTRUCTORS
 	__libc_init_array();
 #endif
 	int ret = main(0, NULL);

--- a/picocrt/machine/riscv/crt0.S
+++ b/picocrt/machine/riscv/crt0.S
@@ -35,6 +35,10 @@
 
 #include <picolibc.h>	
 
+#ifndef CONSTRUCTORS
+#define CONSTRUCTORS 1
+#endif
+
 	/**
 	 * seems clang has no option "nopic". Now this could be problematic,
 	 * since according to the clang devs at [0], that option has an effect
@@ -88,7 +92,7 @@ _start:
 	call	_set_tls
 #endif
 
-#ifdef HAVE_INITFINI_ARRAY
+#if defined(HAVE_INITFINI_ARRAY) && CONSTRUCTORS
 	call	__libc_init_array
 #endif
 

--- a/picocrt/machine/riscv/crt0.S
+++ b/picocrt/machine/riscv/crt0.S
@@ -97,9 +97,9 @@ _start:
 	li	a1, 0
 	call	main
 
-#ifdef _PICOLIBC_CRT0_SEMIHOST_
-    call exit
-#endif
-
+#ifdef CRT0_EXIT
+	call exit
+#else
 .L1:	
 	j	.L1
+#endif

--- a/picocrt/machine/riscv/crt0.S
+++ b/picocrt/machine/riscv/crt0.S
@@ -96,5 +96,10 @@ _start:
 	li	a0, 0
 	li	a1, 0
 	call	main
+
+#ifdef _PICOLIBC_CRT0_SEMIHOST_
+    call exit
+#endif
+
 .L1:	
 	j	.L1

--- a/picocrt/meson.build
+++ b/picocrt/meson.build
@@ -53,11 +53,11 @@ foreach target : targets
 
   if target == ''
     crt_name = 'crt0.o'
-    crt_semihost_name = 'crt0-semihost.o'
+    crt_hosted_name = 'crt0-hosted.o'
     libcrt_name = 'crt'
   else
     crt_name = join_paths(target, 'crt0.o')
-    crt_semihost_name = join_paths(target, 'crt0-semihost.o')
+    crt_hosted_name = join_paths(target, 'crt0-hosted.o')
     libcrt_name = join_paths(target, 'libcrt')
   endif
 
@@ -70,16 +70,14 @@ foreach target : targets
 	     c_args : value[1] + arg_fnobuiltin + ['-ffreestanding'],
 	     link_args : value[1] + ['-r', '-ffreestanding', '-nostdlib'])
 
-  # The semihost variant call 'exit' after return from main (c lingo: hosted execution environment)
-  if has_semihost
-    executable(crt_semihost_name,
-           srcs_picocrt,
-           include_directories : inc,
-           install : true,
-           install_dir : instdir,
-           c_args : value[1] + arg_fnobuiltin + ['-ffreestanding', '-D_PICOLIBC_CRT0_SEMIHOST_'],
-           link_args : value[1] + ['-r', '-ffreestanding', '-nostdlib'])
-  endif
+  # The 'hosted' variant calls 'exit' after return from main (c lingo: hosted execution environment)
+  executable(crt_hosted_name,
+             srcs_picocrt,
+             include_directories : inc,
+             install : true,
+             install_dir : instdir,
+             c_args : value[1] + arg_fnobuiltin + ['-ffreestanding', '-DCRT0_EXIT'],
+             link_args : value[1] + ['-r', '-ffreestanding', '-nostdlib'])
 
   # Tests link against this because using the .o isn't supported under meson
   set_variable('lib_crt' + target,

--- a/picocrt/meson.build
+++ b/picocrt/meson.build
@@ -53,12 +53,15 @@ foreach target : targets
 
   if target == ''
     crt_name = 'crt0.o'
+    crt_semihost_name = 'crt0-semihost.o'
     libcrt_name = 'crt'
   else
     crt_name = join_paths(target, 'crt0.o')
+    crt_semihost_name = join_paths(target, 'crt0-semihost.o')
     libcrt_name = join_paths(target, 'libcrt')
   endif
 
+  # The normal variant does not call 'exit' after return from main (c lingo: freestanding execution environment)
   executable(crt_name,
 	     srcs_picocrt,
 	     include_directories : inc,
@@ -66,6 +69,17 @@ foreach target : targets
 	     install_dir : instdir,
 	     c_args : value[1] + arg_fnobuiltin + ['-ffreestanding'],
 	     link_args : value[1] + ['-r', '-ffreestanding', '-nostdlib'])
+
+  # The semihost variant call 'exit' after return from main (c lingo: hosted execution environment)
+  if has_semihost
+    executable(crt_semihost_name,
+           srcs_picocrt,
+           include_directories : inc,
+           install : true,
+           install_dir : instdir,
+           c_args : value[1] + arg_fnobuiltin + ['-ffreestanding', '-D_PICOLIBC_CRT0_SEMIHOST_'],
+           link_args : value[1] + ['-r', '-ffreestanding', '-nostdlib'])
+  endif
 
   # Tests link against this because using the .o isn't supported under meson
   set_variable('lib_crt' + target,

--- a/picocrt/meson.build
+++ b/picocrt/meson.build
@@ -54,13 +54,17 @@ foreach target : targets
   if target == ''
     crt_name = 'crt0.o'
     crt_hosted_name = 'crt0-hosted.o'
+    crt_minimal_name = 'crt0-minimal.o'
     libcrt_name = 'crt'
     libcrt_hosted_name = 'crt-hosted'
+    libcrt_minimal_name = 'crt-minimal'
   else
     crt_name = join_paths(target, 'crt0.o')
     crt_hosted_name = join_paths(target, 'crt0-hosted.o')
+    crt_minimal_name = join_paths(target, 'crt0-minimal.o')
     libcrt_name = join_paths(target, 'libcrt')
     libcrt_hosted_name = join_paths(target, 'libcrt-hosted')
+    libcrt_minimal_name = join_paths(target, 'libcrt-minimal')
   endif
 
   # The normal variant does not call 'exit' after return from main (c lingo: freestanding execution environment)
@@ -72,6 +76,14 @@ foreach target : targets
 	     c_args : value[1] + arg_fnobuiltin + ['-ffreestanding'],
 	     link_args : value[1] + ['-r', '-ffreestanding', '-nostdlib'])
 
+  # Tests link against this because using the .o isn't supported under meson
+  set_variable('lib_crt' + target,
+	       static_library(libcrt_name,
+			      srcs_picocrt,
+			      install : false,
+			      include_directories : inc,
+			      c_args : value[1]))
+
   # The 'hosted' variant calls 'exit' after return from main (c lingo: hosted execution environment)
   executable(crt_hosted_name,
              srcs_picocrt,
@@ -82,18 +94,27 @@ foreach target : targets
              link_args : value[1] + ['-r', '-ffreestanding', '-nostdlib'])
 
   # Tests link against this because using the .o isn't supported under meson
-  set_variable('lib_crt' + target,
-	       static_library(libcrt_name,
-			      srcs_picocrt,
-			      install : false,
-			      include_directories : inc,
-			      c_args : value[1]))
-
-  # Tests link against this because using the .o isn't supported under meson
   set_variable('lib_crt_hosted' + target,
 	       static_library(libcrt_hosted_name,
 			      srcs_picocrt,
 			      install : false,
 			      include_directories : inc,
 			      c_args : value[1] + ['-DCRT0_EXIT']))
+
+  # The 'minimal' variant doesn't call exit, nor does it invoke any constructors
+  executable(crt_minimal_name,
+             srcs_picocrt,
+             include_directories : inc,
+             install : true,
+             install_dir : instdir,
+             c_args : value[1] + arg_fnobuiltin + ['-ffreestanding', '-DCONSTRUCTORS=0'],
+             link_args : value[1] + ['-r', '-ffreestanding', '-nostdlib'])
+
+  # Tests link against this because using the .o isn't supported under meson
+  set_variable('lib_crt_minimal' + target,
+	       static_library(libcrt_minimal_name,
+			      srcs_picocrt,
+			      install : false,
+			      include_directories : inc,
+			      c_args : value[1] + ['-DCONSTRUCTORS=0']))
 endforeach

--- a/picocrt/meson.build
+++ b/picocrt/meson.build
@@ -55,10 +55,12 @@ foreach target : targets
     crt_name = 'crt0.o'
     crt_hosted_name = 'crt0-hosted.o'
     libcrt_name = 'crt'
+    libcrt_hosted_name = 'crt-hosted'
   else
     crt_name = join_paths(target, 'crt0.o')
     crt_hosted_name = join_paths(target, 'crt0-hosted.o')
     libcrt_name = join_paths(target, 'libcrt')
+    libcrt_hosted_name = join_paths(target, 'libcrt-hosted')
   endif
 
   # The normal variant does not call 'exit' after return from main (c lingo: freestanding execution environment)
@@ -86,4 +88,12 @@ foreach target : targets
 			      install : false,
 			      include_directories : inc,
 			      c_args : value[1]))
+
+  # Tests link against this because using the .o isn't supported under meson
+  set_variable('lib_crt_hosted' + target,
+	       static_library(libcrt_hosted_name,
+			      srcs_picocrt,
+			      install : false,
+			      include_directories : inc,
+			      c_args : value[1] + ['-DCRT0_EXIT']))
 endforeach

--- a/picolibc.specs.in
+++ b/picolibc.specs.in
@@ -22,5 +22,5 @@
 @CRTEND@
 
 *startfile:
-@LIBDIR@/%M/crt0%O%s @CRTBEGIN@
+@LIBDIR@/%M/crt0%{-oslib=semihost:-semihost}%O%s @CRTBEGIN@
 @SPECS_EXTRA@

--- a/picolibc.specs.in
+++ b/picolibc.specs.in
@@ -22,5 +22,5 @@
 @CRTEND@
 
 *startfile:
-@LIBDIR@/%M/crt0%{-oslib=semihost:-semihost}%O%s @CRTBEGIN@
+@LIBDIR@/%M/crt0%{-crt0=*:-%*%O;:%O}%s @CRTBEGIN@
 @SPECS_EXTRA@

--- a/test/constructor-skip.c
+++ b/test/constructor-skip.c
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2021 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define CONSTRUCTOR_RET 1
+#include "constructor.c"

--- a/test/constructor.c
+++ b/test/constructor.c
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2021 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdio.h>
+
+#ifndef CONSTRUCTOR_RET
+#define CONSTRUCTOR_RET 0
+#endif
+
+#define REGULAR_RET (1 - CONSTRUCTOR_RET)
+
+void __attribute__((constructor(101)))
+crt_startup(void)
+{
+	_exit(CONSTRUCTOR_RET);
+}
+
+int main(void)
+{
+	_exit(REGULAR_RET);
+}

--- a/test/hosted-exit.c
+++ b/test/hosted-exit.c
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2021 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdio.h>
+
+#ifndef RETVAL
+#define RETVAL 0
+#endif
+
+int main(void)
+{
+	return RETVAL;
+}

--- a/test/meson.build
+++ b/test/meson.build
@@ -52,6 +52,13 @@ foreach target : targets
     _libs_hosted = _libs_base
   endif
 
+  have_crt_minimal = is_variable('lib_crt_minimal' + target)
+  if have_crt_minimal
+    _libs_minimal = [get_variable('lib_crt_minimal'+ target)] + _libs_base
+  else
+    _libs_minimal = _libs_base
+  endif
+
   _c_args = value[1] + test_c_args + test_c_warnings
   _link_args = value[1] + test_link_args
 
@@ -157,10 +164,27 @@ foreach target : targets
        should_fail: true
       )
 
+  if have_crt_minimal
+    t1 = 'constructor-skip'
+    if target == ''
+      t1_name = t1
+    else
+      t1_name = join_paths(target, t1)
+    endif
+
+    test(t1 + target,
+	 executable(t1_name, 'constructor-skip.c',
+		    c_args: float_printf_compile_args + _c_args,
+		    link_args:  float_printf_link_args + _link_args,
+		    link_with: _libs_minimal,
+		    include_directories: inc),
+	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+  endif
+
   plain_tests = ['rand', 'regex', 'ungetc', 'fenv',
 		 'math_errhandling', 'malloc', 'tls',
 		 'ffs', 'setjmp', 'atexit', 'on_exit',
-		 'complex-funcs', 'math-funcs',
+		 'complex-funcs', 'math-funcs', 'constructor'
 		]
 
   if newlib_nano_malloc or not tests_disable_full_malloc_stress

--- a/test/meson.build
+++ b/test/meson.build
@@ -35,14 +35,23 @@
 foreach target : targets
   value = get_variable('target_' + target)
 
-  _libs = [get_variable('lib_m' + target), get_variable('lib_c' + target)]
+  _libs_base = [get_variable('lib_m' + target), get_variable('lib_c' + target)]
   if is_variable('lib_semihost' + target)
-    _libs += [get_variable('lib_semihost' + target)]
+    _libs_base += [get_variable('lib_semihost' + target)]
   endif
+
   if is_variable('lib_crt' + target)
-    _libs += [get_variable('lib_crt'+ target)]
+    _libs = [get_variable('lib_crt'+ target)] + _libs_base
+  else
+    _libs = _libs_base
   endif
-  
+
+  if is_variable('lib_crt_hosted' + target)
+    _libs_hosted = [get_variable('lib_crt_hosted'+ target)] + _libs_base
+  else
+    _libs_hosted = _libs_base
+  endif
+
   _c_args = value[1] + test_c_args + test_c_warnings
   _link_args = value[1] + test_link_args
 
@@ -122,6 +131,31 @@ foreach target : targets
 		  link_with: _libs,
 		  include_directories: inc),
        env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+
+  t1 = 'hosted-exit'
+  if target == ''
+    t1_name = t1
+  else
+    t1_name = join_paths(target, t1)
+  endif
+
+  test(t1 + target,
+       executable(t1_name, 'hosted-exit.c',
+		  c_args: float_printf_compile_args + _c_args,
+		  link_args:  float_printf_link_args + _link_args,
+		  link_with: _libs_hosted,
+		  include_directories: inc),
+       env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+
+  test(t1 + '-fail' + target,
+       executable(t1_name + '-fail', 'hosted-exit.c',
+		  c_args: float_printf_compile_args + _c_args + ['-DRETVAL=1'],
+		  link_args:  float_printf_link_args + _link_args,
+		  link_with: _libs_hosted,
+		  include_directories: inc),
+       env: ['MESON_SOURCE_ROOT=' + meson.source_root()],
+       should_fail: true
+      )
 
   plain_tests = ['rand', 'regex', 'ungetc', 'fenv',
 		 'math_errhandling', 'malloc', 'tls',


### PR DESCRIPTION
This builds on PR #109 by making the selection of crt0 separate from the oslib version.