### PR TITLE
Add guard when testing complex

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -126,8 +126,12 @@ foreach target : targets
   plain_tests = ['rand', 'regex', 'ungetc', 'fenv',
 		 'math_errhandling', 'malloc', 'tls',
 		 'ffs', 'setjmp', 'atexit', 'on_exit',
-		 'complex-funcs', 'math-funcs',
+		 'math-funcs',
 		]
+
+  if have_complex
+    plain_tests += 'complex-funcs'
+  endif
 
   if newlib_nano_malloc or not tests_disable_full_malloc_stress
     plain_tests += 'malloc_stress'


### PR DESCRIPTION
Just a small fix for commit 873050cfc3: The new test `complex-funcs` should only be run if the compiler is known to support the `_Complex` data type.