### PR TITLE
Test for 'constructor'/'destructor' attributes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -477,7 +477,14 @@ alloc_size_code = '''
 void *foobar(size_t) __attribute__((__alloc_size__(1)));
 void *foobar2(size_t, size_t) __attribute__((__alloc_size__(1, 2)));
 '''
-have_alloc_size = meson.get_compiler('c').compiles(alloc_size_code, name : 'attribute __alloc_size__')
+have_alloc_size = meson.get_compiler('c').compiles(alloc_size_code, name : 'attribute __alloc_size__', args : (meson.get_compiler('c').has_argument('-Werror') ? '-Werror' : ''))
+
+# attributes constructor/destructor are a GNU extension - if the compiler doesn't have them, don't test them.
+attr_ctor_dtor_code = '''
+void __attribute__((constructor(101))) ctor (void) {}
+void __attribute__((destructor(101))) dtor (void) {}
+'''
+have_attr_ctor_dtor = meson.get_compiler('c').compiles(attr_ctor_dtor_code, name : 'attributes constructor/destructor', args : (meson.get_compiler('c').has_argument('-Werror') ? '-Werror' : ''))
 
 if enable_multilib
   used_libs = []

--- a/test/meson.build
+++ b/test/meson.build
@@ -184,8 +184,12 @@ foreach target : targets
   plain_tests = ['rand', 'regex', 'ungetc', 'fenv',
 		 'math_errhandling', 'malloc', 'tls',
 		 'ffs', 'setjmp', 'atexit', 'on_exit',
-		 'math-funcs', 'constructor'
+		 'math-funcs'
 		]
+
+  if have_attr_ctor_dtor
+    plain_tests += 'constructor'
+  endif
 
   if have_complex
     plain_tests += 'complex-funcs'


### PR DESCRIPTION
Once again, an attribute that CompCert does not support. From my commit log:

These are GNU extension, and if the compiler doesn't have them, there is
no point testing for correct behavior.
This only affects the test. Other locations use that attribute, too
(at least the ssp). So maybe it would make sense to use make wider use
of the new test.

Apply the better test (with '-Werror' -- if available) to the other
attribute test as well.