### PR TITLE
tinystdio: Fix negative precision modifiers for vfprintf

### DIFF
--- a/newlib/libc/tinystdio/vfprintf.c
+++ b/newlib/libc/tinystdio/vfprintf.c
@@ -389,8 +389,10 @@ int vfprintf (FILE * stream, const char *fmt, va_list ap)
 		if (c == '*') {
 		    if (flags & FL_PREC) {
 			prec = va_arg(ap, int);
-			if (prec < 0)
+			if (prec < 0) {
 			    prec = 0;
+			    flags &= ~(FL_PREC);
+		    }
 		    } else {
 			width = va_arg(ap, int);
 			flags |= FL_WIDTH;

--- a/newlib/libc/tinystdio/vfprintf.c
+++ b/newlib/libc/tinystdio/vfprintf.c
@@ -389,10 +389,6 @@ int vfprintf (FILE * stream, const char *fmt, va_list ap)
 		if (c == '*') {
 		    if (flags & FL_PREC) {
 			prec = va_arg(ap, int);
-			if (prec < 0) {
-			    prec = 0;
-			    flags &= ~(FL_PREC);
-		    }
 		    } else {
 			width = va_arg(ap, int);
 			flags |= FL_WIDTH;
@@ -458,6 +454,16 @@ int vfprintf (FILE * stream, const char *fmt, va_list ap)
 
 	    break;
 	} while ( (c = *fmt++) != 0);
+
+	/* This can happen only when prec is set via a '*'
+	 * specifier, in which case it works as if no precision
+	 * was specified. Set the precision to zero and clear the
+	 * flag.
+	 */
+	if (prec < 0) {
+	    prec = 0;
+	    flags &= ~FL_PREC;
+	}
 
 	/* Only a format character is valid.	*/
 

--- a/test/testcases.c
+++ b/test/testcases.c
@@ -465,3 +465,18 @@
     result |= test(437, "10.0000", "%#.6g", 10.0);
     result |= test(438, "10", "%.6g", 10.0);
     result |= test(439, "10.00000000000000000000", "%#.22g", 10.0);
+
+#ifdef TINY_STDIO
+    // Regression test for wrong behavior with negative precision in tinystdio
+    // this might fail for configurations not using tinystdio, so for a first
+    // PR, only run these test for tinystdio.
+    result |= test(440,         "", "%.*s",  0, "123456");
+    result |= test(441,     "1234", "%.*s",  4, "123456");
+    result |= test(442,   "123456", "%.*s", -4, "123456");
+    result |= test(443,       "42", "%.*d",  0, 42);
+    result |= test(444,   "000042", "%.*d",  6, 42);
+    result |= test(445,       "42", "%.*d", -6, 42);
+    result |= test(446,        "0", "%.*f",  0, 0.123);
+    result |= test(447,      "0.1", "%.*f",  1, 0.123);
+    result |= test(448, "0.123000", "%.*f", -1, 0.123);
+#endif

--- a/test/testcases.c
+++ b/test/testcases.c
@@ -466,7 +466,6 @@
     result |= test(438, "10", "%.6g", 10.0);
     result |= test(439, "10.00000000000000000000", "%#.22g", 10.0);
 
-#ifdef TINY_STDIO
     // Regression test for wrong behavior with negative precision in tinystdio
     // this might fail for configurations not using tinystdio, so for a first
     // PR, only run these test for tinystdio.
@@ -479,4 +478,3 @@
     result |= test(446,        "0", "%.*f",  0, 0.123);
     result |= test(447,      "0.1", "%.*f",  1, 0.123);
     result |= test(448, "0.123000", "%.*f", -1, 0.123);
-#endif


### PR DESCRIPTION
The attached commits fix the mentioned (small) mistake in vfprintf, and add some regressions tests.

The problem is that a negative precision specifier should behave as if no precision modifier was set at all.
The code did set the precision to 0, but because the the FL_PREC flag was not unset, a later check failed to set the precision to the correct default width.

See the commit messages for more details.

Here is a simple test program (I'd attach it, but GitHub still doesn't like `.c` files):
```c
#include <stdio.h>
#include <string.h>

#define test_vfprintf(_FMT_, _PREC_, _ARG_, _EXPECT_) { \
    snprintf(buf, 32, (_FMT_), (_PREC_), (_ARG_)); \
    if (strncmp(buf, (_EXPECT_), 32) != 0) { \
        ++ecnt; \
        printf("Error for format string '%s' with precision %i:\n       Got: '%s'\n  Expected: '%s'\n\n", (_FMT_), (_PREC_), buf, (_EXPECT_)); \
    } \
}

int main (void) {
    char buf[32];
    int ecnt = 0;

    test_vfprintf("%.*s",  0, "1234567890", "");
    test_vfprintf("%.*s",  8, "1234567890", "12345678");
    test_vfprintf("%.*s", -8, "1234567890", "1234567890");
  
    test_vfprintf("%.*d",  0, 42, "42");
    test_vfprintf("%.*d",  4, 42, "0042");
    test_vfprintf("%.*d", -4, 42, "42");
  
    test_vfprintf("%.*f",  0, 0.123, "0");
    test_vfprintf("%.*f",  1, 0.123, "0.1");
    test_vfprintf("%.*f", -1, 0.123, "0.123000");
   
    printf("Had %i errors\n", ecnt); 
    return ecnt == 0 ? 0 : 1;
}
```
