### PR TITLE
tinystdio: Fix handling of fread with size=0

### DIFF
--- a/newlib/libc/tinystdio/fread.c
+++ b/newlib/libc/tinystdio/fread.c
@@ -39,7 +39,7 @@ fread(void *ptr, size_t size, size_t nmemb, FILE *stream)
 	uint8_t *cp;
 	int c;
 
-	if ((stream->flags & __SRD) == 0)
+	if ((stream->flags & __SRD) == 0 || size == 0)
 		return 0;
 
 	for (i = 0, cp = (uint8_t *)ptr; i < nmemb; i++)


### PR DESCRIPTION
The without the new condition, `fread(foo, 0, x, bar);` would return
`x`: The outer loop iterates that many times (doing nothing).
However both C11 (7.21.8.1) and C99 (7.19.8.1) expect fread to return 0.

The standard says:
 
> The fread function returns the number of elements successfully read, which may be
> less than nmemb if a read error or end-of-file is encountered. If size or nmemb is zero,
> fread returns zero and the contents of the array and the state of the stream remain
> unchanged