### PR TITLE
Fix the vprintf 'j', 'z' and 't'

### DIFF
--- a/newlib/libc/tinystdio/vfprintf.c
+++ b/newlib/libc/tinystdio/vfprintf.c
@@ -439,7 +439,7 @@ int vfprintf (FILE * stream, const char *fmt, va_list ap)
 #define CHECK_INT_SIZE(letter, type) do {			\
 		if (c == letter) {				\
 		    if (sizeof(type) == sizeof(int))		\
-			continue;				\
+			goto is_int;				\
 		    if (sizeof(type) == sizeof(long))		\
 			goto is_long;				\
 		    if (sizeof(type) == sizeof(long long))	\
@@ -453,8 +453,12 @@ int vfprintf (FILE * stream, const char *fmt, va_list ap)
 	    CHECK_INT_SIZE('z', size_t);
 	    CHECK_INT_SIZE('t', ptrdiff_t);
 #endif
-
 	    break;
+
+#ifdef _WANT_IO_C99_FORMATS
+	    is_int:
+	    continue;
+#endif
 	} while ( (c = *fmt++) != 0);
 
 	/* Only a format character is valid.	*/

--- a/test/testcases.c
+++ b/test/testcases.c
@@ -465,3 +465,11 @@
     result |= test(437, "10.0000", "%#.6g", 10.0);
     result |= test(438, "10", "%.6g", 10.0);
     result |= test(439, "10.00000000000000000000", "%#.22g", 10.0);
+#ifdef _WANT_IO_C99_FORMATS
+{
+    char c[64];
+    result |= test(440, "  42", "%4jd", (intmax_t)42L);
+    result |= test(441, "64", "%zu", sizeof c);
+    result |= test(442, "12", "%td", (c+12) - c);
+}
+#endif


### PR DESCRIPTION
Inside the macro handling these modifiers was the following `continue`:
```c
if (sizeof(type) == sizeof(int))
  continue;
```

I suppose the intention was to continue with the format string parser's
big `while`-loop. Due to the macros `do`/`while`-encapsulation this
doesn't work.
Replaced it with a `goto` and added a small regression test.