### PR TITLE
CompCert also properly defines __func__

### DIFF
--- a/newlib/libc/include/sys/cdefs.h
+++ b/newlib/libc/include/sys/cdefs.h
@@ -431,7 +431,7 @@
 #endif
 
 /* XXX: should use `#if __STDC_VERSION__ < 199901'. */
-#if !__GNUC_PREREQ__(2, 7) && !defined(__INTEL_COMPILER)
+#if !__GNUC_PREREQ__(2, 7) && !defined(__INTEL_COMPILER) && !defined(__COMPCERT__)
 #define	__func__	NULL
 #endif
 


### PR DESCRIPTION
Just a minor fix: Since CompCert properly defines `__func__`, it should not be set to `NULL`. Since this is `cdefs.h`, the check is also needed during compile time of the actual program, not just the lib.

No test here, since this really just depends on the compiler ;-)

There is a comment how there should be a better check here, but I don't know enough about other compilers/preprocessors to just enable that. So I sticked to keeping it simple.


Regarding the other PRs:

> I've merged in a fix and your tests; thanks so much for finding this (and creating test cases!)

You're welcome! And thanks back to you as well: For doing picolibc and making contribution so straight-forward :)