### PR TITLE
check if the compiler supports '-fno-stack-protector'

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -82,7 +82,10 @@ c_args = ['-include', '@0@/@1@'.format(meson.current_build_dir(), 'picolibc.h')]
 
 # Disable ssp and fortify source while building picolibc (it's enabled
 # by default by the ubuntu native compiler)
-c_args += ['-fno-stack-protector', '-U_FORTIFY_SOURCE']
+if meson.get_compiler('c').has_argument('-fno-stack-protector')
+  c_args += '-fno-stack-protector'
+endif
+c_args += '-U_FORTIFY_SOURCE'
 
 if meson.get_compiler('c').has_argument('-fno-common')
   c_args += '-fno-common'


### PR DESCRIPTION
As the title says: This patch checks if the compiler supports '-fno-stack-protector' before adding it to the list of options.
The `-U`ndefine should be safe for most compilers, so I did not touch it.