### PR TITLE
Remove definition of abort() from malloc_stress.c

### DIFF
--- a/test/malloc_stress.c
+++ b/test/malloc_stress.c
@@ -148,12 +148,6 @@ check_malloc(size_t in_use)
 	return result;
 }
 
-void
-abort(void)
-{
-	exit(127);
-}
-
 #ifdef _NANO_MALLOC
 extern size_t __malloc_minsize, __malloc_align, __malloc_head;
 #endif


### PR DESCRIPTION
Signed-off-by: R. Diez <rdiezmail-newlib@yahoo.de>