### PR TITLE
Add TEST_EXIT_CODE_SKIPPED etc.

### DIFF
--- a/test/semihost/semihost-exit-extended-failure.c
+++ b/test/semihost/semihost-exit-extended-failure.c
@@ -35,6 +35,7 @@
 
 #include <stdlib.h>
 #include <semihost.h>
+#include "../test-definitions.h"
 
 int
 main(void)
@@ -42,5 +43,5 @@ main(void)
 	if (sys_semihost_feature(SH_EXT_EXIT_EXTENDED))
 		sys_semihost_exit_extended(1);
 	printf("SYS_EXIT_EXTENDED not supported, skipping\n");
-	exit(77);
+	exit(TEST_EXIT_CODE_SKIPPED);
 }

--- a/test/test-definitions.h
+++ b/test/test-definitions.h
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * Copyright © 2020 Keith Packard
+ * Copyright © 2020 R. Diez
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,15 +33,9 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <stdlib.h>
-#include <semihost.h>
-#include "../test-definitions.h"
 
-int
-main(void)
-{
-	if (sys_semihost_feature(SH_EXT_EXIT_EXTENDED))
-		sys_semihost_exit_extended(0);
-	printf("SYS_EXIT_EXTENDED not supported, skipping\n");
-	exit(TEST_EXIT_CODE_SKIPPED);
-}
+// The Meson test() routine checks for some special exit status codes.
+
+#define TEST_EXIT_CODE_SUCCESS  0
+#define TEST_EXIT_CODE_SKIPPED  77
+#define TEST_EXIT_CODE_UNEXPECTED_FAILURE  99


### PR DESCRIPTION
When writing tests, one could be mistaken for thinking that any non-zero exit status code is a valid failure indication.
Perhaps we should add:
  #define TEST_EXIT_CODE_FAILURE 1
and then make all tests exit with exactly that code.
Or perhaps add a few constants like TEST_EXIT_CODE_FAILURE_1, TEST_EXIT_CODE_FAILURE_2, ...
Are using the exact test failure exit codes (like 1 or 2) for some other purpose?