### PR TITLE
Use __restrict instead of restrict in strfromd and strfromf

### DIFF
--- a/newlib/libc/include/stdlib.h
+++ b/newlib/libc/include/stdlib.h
@@ -175,14 +175,14 @@ void	setkey (const char *__key);
 void	srand (unsigned __seed);
 double	strtod (const char *__restrict __n, char **__restrict __end_PTR);
 #ifdef TINY_STDIO
-int strfromd(char *restrict str, size_t n,
-	     const char *restrict format, double fp);
+int strfromd(char *__restrict str, size_t n,
+	     const char *__restrict format, double fp);
 #endif
 #if __ISO_C_VISIBLE >= 1999
 float	strtof (const char *__restrict __n, char **__restrict __end_PTR);
 #ifdef TINY_STDIO
-int strfromf(char *restrict str, size_t n,
-	     const char *restrict format, float fp);
+int strfromf(char *__restrict str, size_t n,
+	     const char *__restrict format, float fp);
 #endif
 #endif
 #if __MISC_VISIBLE


### PR DESCRIPTION
Otherwise, C++ compilation fails.

Signed-off-by: R. Diez <rdiezmail-newlib@yahoo.de>