### PR TITLE
libc: Set heap start for nano-malloc at first aligned block

### DIFF
--- a/newlib/libc/stdlib/nano-mallocr.c
+++ b/newlib/libc/stdlib/nano-mallocr.c
@@ -225,9 +225,6 @@ void* __malloc_sbrk_aligned(size_t s)
 {
     char *p, *align_p;
 
-    if (__malloc_sbrk_start == NULL)
-	__malloc_sbrk_start = sbrk(0);
-
 #ifdef __APPLE__
     /* Mac OS X 'emulates' sbrk, but the
      * parameter is int, not intptr_t or ptrdiff_t,
@@ -269,6 +266,8 @@ void* __malloc_sbrk_aligned(size_t s)
             return (void *) -1;
 	__malloc_sbrk_top = extra + adjust;
     }
+    if (__malloc_sbrk_start == NULL)
+	__malloc_sbrk_start = align_p;
 
     return align_p;
 }

--- a/test/malloc_stress.c
+++ b/test/malloc_stress.c
@@ -144,6 +144,10 @@ check_malloc(size_t in_use)
 		printf("expected at least %zu in use (%zu)\n", in_use, info.uordblks);
 		result++;
 	}
+        if (in_use == 0 && info.uordblks != 0) {
+                printf("expected all free but %zu still reported in use\n", info.uordblks);
+                result++;
+        }
 #endif
 	return result;
 }


### PR DESCRIPTION
On 32-bit targets, nano malloc aligns the first block from the heap so that the returned allocation is 8-byte aligned even though the header is 4 bytes long. This "wastes" 4 bytes at the start of the heap, which aren't accounted for in the computation returned from mallinfo, making the uordblks value off by 4 bytes. Fix this by marking the start of the heap at the start of the first aligned block. This has the additional benefit of saving a call to sbrk(0).
    
Signed-off-by: Keith Packard <keithp@keithp.com>