### PR TITLE
.github: Reduce scope of actions

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,12 @@
 name: Mac OS X
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   macos:

--- a/.github/workflows/minsize.yml
+++ b/.github/workflows/minsize.yml
@@ -1,6 +1,12 @@
 name: Minsize
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,12 @@
 name: Release
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
Instead of running on any push/PR, only run on push/PR to main.

Signed-off-by: Keith Packard <keithp@keithp.com>