### PR TITLE
Merge core C library with math library

### DIFF
--- a/newlib/empty.c
+++ b/newlib/empty.c
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2021 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */

--- a/newlib/libc/meson.build
+++ b/newlib/libc/meson.build
@@ -180,26 +180,15 @@ foreach target : targets
   instdir = join_paths(get_option('libdir'), value[0])
 
   if target == ''
-    libc_name = 'c'
+    libcpart_name = 'cpart'
   else
-    libc_name = join_paths(target, 'libc')
+    libcpart_name = join_paths(target, 'libcpart')
   endif
 
-  local_lib_c_target = static_library(libc_name,
-				      install : true,
-				      install_dir : instdir,
-				      pic: false,
-				      objects : libobjs)
+  local_lib_cpart_target = static_library(libcpart_name,
+				          pic: false,
+				          objects : libobjs)
 
-  set_variable('lib_c' + target, local_lib_c_target)
-
-  if check_duplicate_names
-    custom_target('libc_duplicates' + target,
-		  build_by_default: true,
-		  input: local_lib_c_target,
-		  output: 'libc_duplicates' + target,
-		  command: [duplicate_names, nm, '@INPUT@', '@OUTPUT@'],
-		  install: false)
-  endif
+  set_variable('lib_cpart' + target, local_lib_cpart_target)
 endforeach
 

--- a/newlib/libm/meson.build
+++ b/newlib/libm/meson.build
@@ -81,26 +81,15 @@ foreach target : targets
   instdir = join_paths(get_option('libdir'), value[0])
 
   if target == ''
-    libm_name = 'm'
+    libmpart_name = 'mpart'
   else
-    libm_name = join_paths(target, 'libm')
+    libmpart_name = join_paths(target, 'libmpart')
   endif
 
-  local_lib_m_target = static_library(libm_name,
-				      install : true,
-				      install_dir : instdir,
+  local_lib_mpart_target = static_library(libmpart_name,
 				      pic: false,
 				      objects : libobjs)
-  set_variable('lib_m' + target, local_lib_m_target)
-
-  if check_duplicate_names
-    custom_target('libm_duplicates' + target,
-		  build_by_default: true,
-		  input: local_lib_m_target,
-		  output: 'libm_duplicates' + target,
-		  command: [duplicate_names, nm, '@INPUT@', '@OUTPUT@'],
-		  install: false)
-  endif
+  set_variable('lib_mpart' + target, local_lib_mpart_target)
 endforeach
 
 if enable_tests

--- a/newlib/libm/test/meson.build
+++ b/newlib/libm/test/meson.build
@@ -132,7 +132,7 @@ endif
 foreach target : targets
   value = get_variable('target_' + target)
 
-  libs = [get_variable('lib_m' + target), get_variable('lib_c' + target)]
+  libs = [get_variable('lib_mpart' + target), get_variable('lib_cpart' + target)]
   if is_variable('lib_semihost' + target)
     libs += [get_variable('lib_semihost' + target)]
   endif

--- a/newlib/meson.build
+++ b/newlib/meson.build
@@ -34,6 +34,54 @@
 #
 subdir('libc')
 subdir('libm')
+
+libnames = ['cpart', 'mpart']
+
+foreach target : targets
+  value = get_variable('target_' + target)
+  libobjs = []
+
+  foreach libname : libnames
+    libobjs += get_variable('lib_' + libname + target).extract_all_objects(recursive:true)
+  endforeach
+
+  instdir = join_paths(get_option('libdir'), value[0])
+
+  if target == ''
+    libc_name = 'c'
+    libm_name = 'm'
+  else
+    libc_name = join_paths(target, 'libc')
+    libm_name = join_paths(target, 'libm')
+  endif
+
+  local_lib_c_target = static_library(libc_name,
+				      install : true,
+				      install_dir : instdir,
+				      pic: false,
+				      objects : libobjs)
+
+  set_variable('lib_c' + target, local_lib_c_target)
+
+  local_lib_m_target = static_library(libm_name,
+                                      ['empty.c'],
+                                      install : true,
+                                      install_dir : instdir,
+                                      pic: false,
+                                      objects : [])
+
+  set_variable('lib_m' + target, local_lib_m_target)
+
+  if check_duplicate_names
+    custom_target('libc_duplicates' + target,
+		  build_by_default: true,
+		  input: local_lib_c_target,
+		  output: 'libc_duplicates' + target,
+		  command: [duplicate_names, nm, '@INPUT@', '@OUTPUT@'],
+		  install: false)
+  endif
+endforeach
+
 if enable_tests
   subdir('testsuite')
 endif


### PR DESCRIPTION
Instead of creating a separate libm containing math functions, merge  those into libc. This simplifies application development and enables use of math functions in the core C library.

A stub libm is still created and installed that contains no contents.
    
Signed-off-by: Keith Packard <keithp@keithp.com>