### PR TITLE
tinystdio: Avoid building atold_engine.c unless needed

### DIFF
--- a/newlib/libc/tinystdio/meson.build
+++ b/newlib/libc/tinystdio/meson.build
@@ -34,7 +34,6 @@
 #
 srcs_tinystdio = [
     'asprintf.c',
-    'atold_engine.c',
     'clearerr.c',
     'ecvt_data.c',
     'ecvtf_data.c',
@@ -136,7 +135,7 @@ else
 endif
 
 if have_long_double and not long_double_equals_double
-  srcs_tinystdio += ['strtold.c', 'strtold_l.c']
+  srcs_tinystdio += ['strtold.c', 'strtold_l.c', 'atold_engine.c']
 endif
 
 if atomic_ungetc


### PR DESCRIPTION
atold_engine.c is currently only used when building strtold.c as
vfscanf doesn't have long double support at this point. Compiling this
file generates numerous warnings on hosts like arm where long double
is the same type as double.

Signed-off-by: Keith Packard <keithp@keithp.com>