### PR TITLE
Add long long support to tinystdio scanf

### DIFF
--- a/newlib/libc/stdio/stdio.h
+++ b/newlib/libc/stdio/stdio.h
@@ -155,6 +155,14 @@ typedef _fpos64_t fpos64_t;
  * Functions defined in ANSI C standard.
  */
 
+#ifndef __VALIST
+#ifdef __GNUC__
+#define __VALIST __gnuc_va_list
+#else
+#define __VALIST char*
+#endif
+#endif
+
 #if __POSIX_VISIBLE
 char *	ctermid (char *);
 #endif
@@ -629,7 +637,7 @@ FILE *_fopencookie_r (struct _reent *, void *__cookie,
 
 #ifndef __CUSTOM_FILE_IO__
 /*
- * The __sfoo macros are here so that we can 
+ * The __sfoo macros are here so that we can
  * define function versions in the C library.
  */
 #define       __sgetc_raw_r(__ptr, __f) (--(__f)->_r < 0 ? __srget_r(__ptr, __f) : (int)(*(__f)->_p++))
@@ -638,7 +646,7 @@ FILE *_fopencookie_r (struct _reent *, void *__cookie,
 /*  For a platform with CR/LF, additional logic is required by
   __sgetc_r which would otherwise simply be a macro; therefore we
   use an inlined function.  The function is only meant to be inlined
-  in place as used and the function body should never be emitted.  
+  in place as used and the function body should never be emitted.
 
   There are two possible means to this end when compiling with GCC,
   one when compiling with a standard C99 compiler, and for other

--- a/newlib/libc/stdio/vfprintf.c
+++ b/newlib/libc/stdio/vfprintf.c
@@ -654,8 +654,8 @@ _VFPRINTF_R (struct _reent *data,
 	register int n, m;	/* handy integers (short term usage) */
 	register char *cp;	/* handy char pointer (short term usage) */
 	register int flags;	/* flags as above */
-	char *fmt_anchor;       /* current format spec being processed */
 #ifndef _NO_POS_ARGS
+	char *fmt_anchor;       /* current format spec being processed */
 	int N;                  /* arg number */
 	int arg_index;          /* index into args processed directly */
 	int numargs;            /* number of varargs read */
@@ -919,7 +919,9 @@ _VFPRINTF_R (struct _reent *data,
                 if (*fmt == '\0')
                     goto done;
 #endif
+#ifndef _NO_POS_ARGS
 		fmt_anchor = fmt;
+#endif
 		fmt++;		/* skip over '%' */
 
 		flags = 0;

--- a/newlib/libc/stdio/vfwprintf.c
+++ b/newlib/libc/stdio/vfwprintf.c
@@ -379,8 +379,8 @@ _VFWPRINTF_R (struct _reent *data,
 	register int n, m;	/* handy integers (short term usage) */
 	register wchar_t *cp;	/* handy char pointer (short term usage) */
 	register int flags;	/* flags as above */
-	wchar_t *fmt_anchor;    /* current format spec being processed */
 #ifndef _NO_POS_ARGS
+	wchar_t *fmt_anchor;    /* current format spec being processed */
 	int N;                  /* arg number */
 	int arg_index;          /* index into args processed directly */
 	int numargs;            /* number of varargs read */
@@ -642,7 +642,9 @@ _VFWPRINTF_R (struct _reent *data,
 		}
                 if (*fmt == L'\0')
                     goto done;
+#ifndef _NO_POS_ARGS
 		fmt_anchor = fmt;
+#endif
 		fmt++;		/* skip over '%' */
 
 		flags = 0;

--- a/newlib/libc/tinystdio/scanf_private.h
+++ b/newlib/libc/tinystdio/scanf_private.h
@@ -71,17 +71,18 @@ typedef unsigned int width_t;
 #define FL_STAR	    0x01	/* '*': skip assignment		*/
 #define FL_WIDTH    0x02	/* width is present		*/
 #define FL_LONG	    0x04	/* 'long' type modifier		*/
-#define FL_CHAR	    0x08	/* 'char' type modifier		*/
-#define FL_SHORT    0x10	/* 'short' type modifier	*/
-#define FL_OCT	    0x20	/* octal number			*/
-#define FL_DEC	    0x40	/* decimal number		*/
-#define FL_HEX	    0x80	/* hexidecimal number		*/
-#define FL_MINUS    0x100	/* minus flag (field or value)	*/
-#define FL_ANY	    0x200	/* any digit was read	        */
-#define FL_OVFL	    0x400	/* significand overflowed       */
-#define FL_DOT	    0x800	/* decimal '.' was	        */
-#define FL_MEXP	    0x1000 	/* exponent 'e' is neg.	        */
-#define FL_FHEX     0x2000      /* hex significand              */
+#define FL_LONGLONG 0x08        /* 'long long' type modifier    */
+#define FL_CHAR	    0x10	/* 'char' type modifier		*/
+#define FL_SHORT    0x20	/* 'short' type modifier	*/
+#define FL_OCT	    0x40	/* octal number			*/
+#define FL_DEC	    0x80	/* decimal number		*/
+#define FL_HEX	    0x100	/* hexidecimal number		*/
+#define FL_MINUS    0x200	/* minus flag (field or value)	*/
+#define FL_ANY	    0x400	/* any digit was read	        */
+#define FL_OVFL	    0x800	/* significand overflowed       */
+#define FL_DOT	    0x1000	/* decimal '.' was	        */
+#define FL_MEXP	    0x2000 	/* exponent 'e' is neg.	        */
+#define FL_FHEX     0x4000      /* hex significand              */
 
 #ifndef	__AVR_HAVE_LPMX__
 # if  defined(__AVR_ENHANCED__) && __AVR_ENHANCED__

--- a/newlib/libc/tinystdio/scanf_private.h
+++ b/newlib/libc/tinystdio/scanf_private.h
@@ -37,10 +37,7 @@
 #define SCANF_LEVEL SCANF_FLT
 #endif
 
-#if	SCANF_LEVEL == SCANF_MIN
-# define SCANF_BRACKET	0
-# define SCANF_FLOAT	0
-#elif	SCANF_LEVEL == SCANF_STD
+#if	SCANF_LEVEL == SCANF_STD
 # define SCANF_BRACKET	1
 # define SCANF_FLOAT	0
 int vfscanf (FILE * stream, const char *fmt, va_list ap) __attribute__((weak));

--- a/newlib/libc/tinystdio/stdio_private.h
+++ b/newlib/libc/tinystdio/stdio_private.h
@@ -34,14 +34,12 @@
 #include <sys/lock.h>
 
 /* values for PRINTF_LEVEL */
-#define PRINTF_MIN 1
-#define PRINTF_STD 2
-#define PRINTF_FLT 3
+#define PRINTF_STD 1
+#define PRINTF_FLT 2
 
 /* values for SCANF_LEVEL */
-#define SCANF_MIN 1
-#define SCANF_STD 2
-#define SCANF_FLT 3
+#define SCANF_STD 1
+#define SCANF_FLT 2
 
 /* This is OR'd into the char stored in unget to make it non-zero to
  * flag the unget buffer as being full

--- a/newlib/libc/tinystdio/vfprintf.c
+++ b/newlib/libc/tinystdio/vfprintf.c
@@ -98,7 +98,7 @@ typedef int64_t printf_float_int_t;
 # define PRINTF_LONGLONG	((PRINTF_LEVEL >= PRINTF_FLT) || defined(_WANT_IO_LONG_LONG))
 #endif
 
-#ifdef PRINTF_LONGLONG
+#if PRINTF_LONGLONG
 typedef unsigned long long ultoa_unsigned_t;
 typedef long long ultoa_signed_t;
 #define SIZEOF_ULTOA __SIZEOF_LONG_LONG__


### PR DESCRIPTION
printf supports long long, but that was missing from scanf.