### PR TITLE
test: Don't use lib_m when building tests

### DIFF
--- a/newlib/testsuite/newlib.iconv/meson.build
+++ b/newlib/testsuite/newlib.iconv/meson.build
@@ -45,7 +45,7 @@ iconv_test_c_args = ['-DTEST_NLSPATH="' + meson.current_build_dir() + '"']
 foreach target : targets
   value = get_variable('target_' + target)
 
-  _libs = [get_variable('lib_m' + target), get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c' + target)]
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]
   endif

--- a/newlib/testsuite/newlib.locale/meson.build
+++ b/newlib/testsuite/newlib.locale/meson.build
@@ -43,7 +43,7 @@ foreach test : tests
        executable(test, src,
 		  c_args: test_c_warnings + ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + test_c_args,
 		  link_args: test_link_args,
-		  link_with: [lib_m, lib_c, lib_semihost, lib_crt],
+		  link_with: [lib_c, lib_semihost, lib_crt],
 		  include_directories: inc),
        env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
 endforeach

--- a/newlib/testsuite/newlib.search/meson.build
+++ b/newlib/testsuite/newlib.search/meson.build
@@ -38,7 +38,7 @@ tests = ['hsearchtest']
 foreach target : targets
   value = get_variable('target_' + target)
 
-  _libs = [get_variable('lib_m' + target), get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c' + target)]
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]
   endif

--- a/newlib/testsuite/newlib.stdio/meson.build
+++ b/newlib/testsuite/newlib.stdio/meson.build
@@ -42,7 +42,7 @@ endif
 foreach target : targets
   value = get_variable('target_' + target)
 
-  _libs = [get_variable('lib_m' + target), get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c' + target)]
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]
   endif

--- a/newlib/testsuite/newlib.stdlib/meson.build
+++ b/newlib/testsuite/newlib.stdlib/meson.build
@@ -38,7 +38,7 @@ tests = ['atexit', 'size_max']
 foreach target : targets
   value = get_variable('target_' + target)
 
-  _libs = [get_variable('lib_m' + target), get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c' + target)]
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]
   endif

--- a/newlib/testsuite/newlib.string/meson.build
+++ b/newlib/testsuite/newlib.string/meson.build
@@ -38,7 +38,7 @@ tests = ['memcpy-1', 'memmove1', 'strcmp-1', 'tstring' ]
 foreach target : targets
   value = get_variable('target_' + target)
 
-  _libs = [get_variable('lib_m' + target), get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c' + target)]
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]
   endif

--- a/newlib/testsuite/newlib.wctype/meson.build
+++ b/newlib/testsuite/newlib.wctype/meson.build
@@ -40,7 +40,7 @@ cygwin_tests = ['twctype']
 foreach target : targets
   value = get_variable('target_' + target)
 
-  _libs = [get_variable('lib_m' + target), get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c' + target)]
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]
   endif

--- a/test/meson.build
+++ b/test/meson.build
@@ -35,7 +35,7 @@
 foreach target : targets
   value = get_variable('target_' + target)
 
-  _libs_base = [get_variable('lib_m' + target), get_variable('lib_c' + target)]
+  _libs_base = [get_variable('lib_c' + target)]
   if is_variable('lib_semihost' + target)
     _libs_base += [get_variable('lib_semihost' + target)]
   endif

--- a/test/semihost/meson.build
+++ b/test/semihost/meson.build
@@ -72,7 +72,7 @@ command_line = 'command-line'
 foreach target : targets
   value = get_variable('target_' + target)
 
-  _libs = [get_variable('lib_m' + target), get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c' + target)]
   _libs += [get_variable('lib_semihost' + target)]
   if is_variable('lib_crt_hosted' + target)
     _libs += [get_variable('lib_crt_hosted'+ target)]


### PR DESCRIPTION
lib_m is now empty, so there's no need to include that when linking
tests.

Signed-off-by: Keith Packard <keithp@keithp.com>