### PR TITLE
Fix tinystdio printf bugs, shrink code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,4 +6,6 @@ insert_final_newline = true
 
 [*.{c,h}]
 indent_size = 4
-trim_trailing_whitespace = true
+
+[Makefile]
+indent_style = tab

--- a/doc/printf.md
+++ b/doc/printf.md
@@ -88,7 +88,7 @@ Now we can build and run it with the default options:
 	$ arm-none-eabi-gcc -Os -march=armv7-m --specs=picolibc.specs --oslib=semihost --crt0=hosted -Wl,--defsym=__flash=0 -Wl,--defsym=__flash_size=0x00200000 -Wl,--defsym=__ram=0x20000000 -Wl,--defsym=__ram_size=0x200000 -o printf.elf printf.c
 	$ arm-none-eabi-size printf.elf
 	   text	   data	    bss	    dec	    hex	filename
-           7920	     80	   2056	  10056	   2748	printf.elf
+           7760	     80	   2056	   9896	   26a8	printf.elf
 	$ qemu-system-arm -chardev stdio,id=stdio0 -semihosting-config enable=on,chardev=stdio0 -monitor none -serial none -machine mps2-an385,accel=tcg -kernel printf.elf -nographic
 	 2⁶¹ = 2305843009213693952 π ≃ 3.141592653589793
 
@@ -98,8 +98,7 @@ although the floating point value has reduced precision:
 	$ arm-none-eabi-gcc -DPICOLIBC_FLOAT_PRINTF_SCANF -Os -march=armv7-m --specs=picolibc.specs --oslib=semihost --crt0=hosted -Wl,--defsym=__flash=0 -Wl,--defsym=__flash_size=0x00200000 -Wl,--defsym=__ram=0x20000000 -Wl,--defsym=__ram_size=0x200000 -o printf-float.elf printf.c
 	$ arm-none-eabi-size printf-float.elf
 	   text	   data	    bss	    dec	    hex	filename
-           6360	     80	   2056	   8496	   2130	printf-float.elf
-
+           6232	     80	   2056	   8368	   20b0	printf-float.elf
 	$ qemu-system-arm -chardev stdio,id=stdio0 -semihosting-config enable=on,chardev=stdio0 -monitor none -serial none -machine mps2-an385,accel=tcg -kernel printf-float.elf -nographic
 	 2⁶¹ = 2305843009213693952 π ≃ 3.1415927
 
@@ -109,7 +108,7 @@ the values correctly:
 	$ arm-none-eabi-gcc -DPICOLIBC_INTEGER_PRINTF_SCANF -Os -march=armv7-m --specs=picolibc.specs --oslib=semihost --crt0=hosted -Wl,--defsym=__flash=0 -Wl,--defsym=__flash_size=0x00200000 -Wl,--defsym=__ram=0x20000000 -Wl,--defsym=__ram_size=0x200000 -o printf-int.elf printf.c
 	$ arm-none-eabi-size printf-int.elf
 	   text	   data	    bss	    dec	    hex	filename
-           1872	     80	   2056	   4552	   11c8	printf-int.elf
+           1856	     80	   2056	   3992	    f98	printf-int.elf
 	$ qemu-system-arm -chardev stdio,id=stdio0 -semihosting-config enable=on,chardev=stdio0 -monitor none -serial none -machine mps2-an385,accel=tcg -kernel printf-int.elf -nographic
          2⁶¹ = 0 π ≃ *float*
 

--- a/hello-world/Makefile
+++ b/hello-world/Makefile
@@ -33,7 +33,7 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-CFLAGS=--oslib=semihost --crt0=hosted -O -g -Wl,-gc-sections
+CFLAGS=--oslib=semihost --crt0=hosted -Os -g
 
 CPP_RISCV=riscv64-unknown-elf-g++ -specs=picolibcpp.specs 
 CC_RISCV=riscv64-unknown-elf-gcc -specs=picolibc.specs 
@@ -47,7 +47,7 @@ CPP_AARCH64=aarch64-linux-gnu-g++ -specs=picolibcpp.specs
 CC_AARCH64=aarch64-linux-gnu-gcc -specs=picolibc.specs 
 CFLAGS_AARCH64=$(CFLAGS) -Wl,-Thello-world-aarch64.ld
 
-all: hello-world-riscv.elf hello-world-arm.elf hello-world-aarch64.elf \
+all: hello-world-riscv.elf hello-world-arm.elf hello-world-aarch64.elf printf.elf printf-int.elf printf-float.elf \
 	hello-world++-riscv.elf hello-world++-arm.elf hello-world++-aarch64.elf
 
 
@@ -74,3 +74,12 @@ hello-world++-riscv.elf:  hello-world++.c++
 
 hello-world++-aarch64.elf:  hello-world++.c++
 	$(CPP_AARCH64) $(CFLAGS_AARCH64) -Wl,-Map=hello-world++-aarch64.map -o $@ $^
+
+printf.elf: printf.c
+	$(CC_ARM) $(CFLAGS_ARM) -o $@ $^ -Wl,-Map=printf.map
+
+printf-int.elf: printf.c
+	$(CC_ARM) $(CFLAGS_ARM) -DPICOLIBC_INTEGER_PRINTF_SCANF -o $@ $^ -Wl,-Map=printf-int.map
+
+printf-float.elf: printf.c
+	$(CC_ARM) $(CFLAGS_ARM) -DPICOLIBC_FLOAT_PRINTF_SCANF -o $@ $^ -Wl,-Map=printf-float.map

--- a/meson.build
+++ b/meson.build
@@ -142,17 +142,25 @@ has_link_alias=meson.get_compiler('c').has_link_argument('-Wl,-alias,' + global_
 
 float_printf_compile_args=['-DPICOLIBC_FLOAT_PRINTF_SCANF']
 float_printf_link_args=float_printf_compile_args
+int_printf_compile_args=['-DPICOLIBC_INTEGER_PRINTF_SCANF']
+int_printf_link_args=int_printf_compile_args
 if tinystdio
   vfprintf_symbol = global_prefix + 'vfprintf'
   __f_vfprintf_symbol = global_prefix + '__f_vfprintf'
+  __i_vfprintf_symbol = global_prefix + '__i_vfprintf'
   vfscanf_symbol = global_prefix + 'vfscanf'
   __f_vfscanf_symbol = global_prefix + '__f_vfscanf'
+  __i_vfscanf_symbol = global_prefix + '__i_vfscanf'
   if has_link_defsym
     float_printf_link_args += '-Wl,--defsym=' + vfprintf_symbol +  '=' + __f_vfprintf_symbol
     float_printf_link_args += '-Wl,--defsym=' + vfscanf_symbol + '=' + __f_vfscanf_symbol
+    int_printf_link_args += '-Wl,--defsym=' + vfprintf_symbol +  '=' + __i_vfprintf_symbol
+    int_printf_link_args += '-Wl,--defsym=' + vfscanf_symbol + '=' + __i_vfscanf_symbol
   elif has_link_alias
     float_printf_link_args += '-Wl,-alias,' + __f_vfprintf_symbol +  ',' + vfprintf_symbol
     float_printf_link_args += '-Wl,-alias,' + __f_vfscanf_symbol + ',' + vfscanf_symbol
+    int_printf_link_args += '-Wl,-alias,' + __i_vfprintf_symbol +  ',' + vfprintf_symbol
+    int_printf_link_args += '-Wl,-alias,' + __i_vfscanf_symbol + ',' + vfscanf_symbol
   endif
 endif
 

--- a/newlib/libc/tinystdio/ultoa_invert.c
+++ b/newlib/libc/tinystdio/ultoa_invert.c
@@ -47,7 +47,7 @@ typedef struct {
 } uint72_t;
 
 /* Compute (x +1 ) * 51 */
-static inline uint72_t mul51(uint64_t x)
+static uint72_t mul51(uint64_t x)
 {
 	uint32_t	xlo = x;
 	uint64_t	xhi = x >> 32;
@@ -65,7 +65,7 @@ static inline uint72_t mul51(uint64_t x)
 }
 
 /* Add two 72-bit numbers */
-static inline uint72_t plus72(uint72_t a, uint64_t b)
+static uint72_t plus72(uint72_t a, uint64_t b)
 {
 	uint64_t lo = a.lo + b;
 	uint8_t hi = a.hi;
@@ -75,13 +75,13 @@ static inline uint72_t plus72(uint72_t a, uint64_t b)
 }
 
 /* Shift a 72-bit number by more than 8 */
-static inline uint64_t shift72to64(uint72_t a, int amt)
+static uint64_t shift72to64(uint72_t a, int amt)
 {
 	return (((uint64_t) a.hi) << (64 - amt)) | (amt == 64 ? 0 : (a.lo >> amt));
 }
 
 /* Shift a 72-bit number an arbitrary amount */
-static inline uint72_t shift72(uint72_t a, int amt)
+static uint72_t shift72(uint72_t a, int amt)
 {
 	return (uint72_t) {
 		.hi = a.hi >> amt,
@@ -90,7 +90,7 @@ static inline uint72_t shift72(uint72_t a, int amt)
 }
 
 /* Compute t/10 and t % 10 simultaneously */
-static inline divmod_t divmod10(uint64_t t)
+static divmod_t divmod10(uint64_t t)
 {
 	/*
 	 * We're computing (t + 1) * 256 / 10 by doing:
@@ -148,7 +148,7 @@ static inline divmod_t divmod10(uint64_t t)
 	return a;
 }
 
-static inline divmod_t divmodbase(uint64_t val, int base)
+static divmod_t divmodbase(uint64_t val, int base)
 {
 	switch (base) {
 	default:
@@ -161,37 +161,31 @@ static inline divmod_t divmodbase(uint64_t val, int base)
 }
 
 #else
-static inline divmod_t divmodbase(ultoa_unsigned_t val, int base)
+static divmod_t divmodbase(ultoa_unsigned_t val, int base)
 {
 	return (divmod_t) { .mod = val % base, .div = val / base };
 }
 #endif
 
-
-static char *
+static __noinline char *
 __ultoa_invert(ultoa_unsigned_t val, char *str, int base)
 {
-	int upper = 0;
+	char hex = 'a' - '0' - 10;
 
 	if (base & XTOA_UPPER) {
-		upper = 1;
+		hex = 'A' - '0' - 10;
 		base &= ~XTOA_UPPER;
 	}
 	do {
-		int	v;
+		char	v;
 
 		divmod_t d = divmodbase(val, base);
 		v = d.mod;
 		val = d.div;
 
-		if (v <= 9)
-			v += '0';
-		else {
-			if (upper)
-				v += 'A' - 10;
-			else
-				v += 'a' - 10;
-		}
+		if (v > 9)
+                        v += hex;
+                v += '0';
 		*str++ = v;
 	} while (val);
 	return str;

--- a/test/meson.build
+++ b/test/meson.build
@@ -118,6 +118,21 @@ foreach target : targets
 		  include_directories: inc),
        env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
 
+  t1 = 'printfi-tests'
+  if target == ''
+    t1_name = t1
+  else
+    t1_name = join_paths(target, t1)
+  endif
+
+  test(t1 + target,
+       executable(t1_name, ['printf-tests.c'],
+		  c_args: int_printf_compile_args + _c_args,
+		  link_args: int_printf_link_args + _link_args,
+		  link_with: _libs,
+		  include_directories: inc),
+       env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+
   t1 = 'try-ilp32'
   if target == ''
     t1_name = t1

--- a/test/testcases.c
+++ b/test/testcases.c
@@ -17,11 +17,32 @@
 
 */
 
+#ifdef TINY_STDIO
+# ifdef PICOLIBC_FLOAT_PRINTF_SCANF
+#  define LOW_FLOAT
+# endif
+# ifdef PICOLIBC_INTEGER_PRINTF_SCANF
+#  define NO_FLOAT
+#  ifndef _WANT_IO_LONG_LONG
+#   define NO_LONGLONG
+#  endif
+# endif
+#else
+# ifdef NO_FLOATING_POINT
+#  define NO_FLOAT
+# endif
+# ifndef _WANT_IO_LONG_LONG
+#  define NO_LONGLONG
+# endif
+#endif
+
 /* XXX This code generated automatically by gen-testcases.hs
    from ../../printf-tests.txt . You probably do not want to
    manually edit this file. */
+#ifndef NO_FLOAT
     result |= test(0, "0", "%.7g", 0.0);
     result |= test(1, "0.33", "%.*f", 2, 0.33333333);
+#endif
     result |= test(2, "foo", "%.3s", "foobar");
     result |= test(3, "     00004", "%10.5d", 4);
     result |= test(4, " 42", "% d", 42);
@@ -60,9 +81,10 @@
     result |= test(37, "-42  ", "%0-5d", -42);
     result |= test(38, "42             ", "%0-15d", 42);
     result |= test(39, "-42            ", "%0-15d", -42);
+#ifndef NO_FLOAT
     result |= test(43, "42.90", "%.2f", 42.8952);
     result |= test(44, "42.90", "%.2F", 42.8952);
-#ifdef PICOLIBC_FLOAT_PRINTF_SCANF
+#ifdef LOW_FLOAT
     result |= test(45, "42.89520", "%.5f", 42.8952);
 #else
     result |= test(45, "42.8952000000", "%.10f", 42.8952);
@@ -70,11 +92,12 @@
     result |= test(46, "42.90", "%1.2f", 42.8952);
     result |= test(47, " 42.90", "%6.2f", 42.8952);
     result |= test(49, "+42.90", "%+6.2f", 42.8952);
-#ifdef PICOLIBC_FLOAT_PRINTF_SCANF
+#ifdef LOW_FLOAT
     result |= test(50, "42.89520", "%5.5f", 42.8952);
 #else
     result |= test(50, "42.8952000000", "%5.10f", 42.8952);
 #endif
+#endif /* NO_FLOAT */
     /* 51: anti-test */
     /* 52: anti-test */
     /* 53: excluded for C */
@@ -85,8 +108,10 @@
     result |= test(59, "%(foo", "%(foo");
 #endif
     result |= test(60, " foo", "%*s", 4, "foo");
+#ifndef NO_FLOAT
     result |= test(61, "      3.14", "%*.*f", 10, 2, 3.14159265);
     result |= test(63, "3.14      ", "%-*.*f", 10, 2, 3.14159265);
+#endif
     /* 64: anti-test */
     /* 65: anti-test */
     result |= test(66, "+hello+", "+%s+", "hello");
@@ -99,7 +124,8 @@
     /* 73: anti-test */
     /* 74: excluded for C */
     /* 75: excluded for C */
-#ifdef PICOLIBC_FLOAT_PRINTF_SCANF
+#ifndef NO_FLOAT
+#ifdef LOW_FLOAT
     result |= test(76, "         +7.894561e+08", "%+#22.6e", 7.89456123e8);
     result |= test(77, "7.894561e+08          ", "%-#22.6e", 7.89456123e8);
     result |= test(78, "          7.894561e+08", "%#22.6e", 7.89456123e8);
@@ -109,7 +135,8 @@
     result |= test(78, " 7.894561230000000e+08", "%#22.15e", 7.89456123e8);
 #endif
     result |= test(79, "8.e+08", "%#1.1g", 7.89456123e8);
-#if defined(TINY_STDIO) || defined(_WANT_IO_LONG_LONG)
+#endif
+#ifndef NO_LONGLONG
     result |= test(81, "    +100", "%+8lld", 100LL);
     result |= test(82, "+00000100", "%+.8lld", 100LL);
     result |= test(83, " +00000100", "%+10.8lld", 100LL);
@@ -173,6 +200,7 @@
     result |= test(149, "1234", "%3d", 1234);
     /* 150: excluded for C */
     result |= test(152, "2", "%-1d", 2);
+#ifndef NO_FLOAT
     result |= test(153, "8.6000", "%2.4f", 8.6);
     result |= test(154, "0.600000", "%0f", 0.6);
     result |= test(155, "1", "%.0f", 0.6);
@@ -181,6 +209,7 @@
     result |= test(159, "-8.6000e+00", "% 2.4e", -8.6);
     result |= test(160, "+8.6000e+00", "%+2.4e", 8.6);
     result |= test(161, "8.6", "%2.4g", 8.6);
+#endif
     result |= test(162, "-1", "%-i", -1);
     result |= test(163, "1", "%-i", 1);
     result |= test(164, "+1", "%+i", 1);
@@ -440,11 +469,14 @@
     result |= test(414, "1234ABCD            ", "% -+0*.*X", 20, 5, 305441741);
     result |= test(415, "00EDCB5433          ", "% -+0*.*X", 20, 10, 3989525555U);
     result |= test(416, "hi x", "%*sx", -3, "hi");
+#ifndef NO_FLOAT
     result |= test(417, "1.000e-38", "%.3e", 1e-38);
-#ifndef PICOLIBC_FLOAT_PRINTF_SCANF
+#ifndef LOW_FLOAT
     result |= test(418, "1.000e-308", "%.3e", 1e-308);
 #endif
+#endif
     result |= test(419, "1, 1", "%-*.llu, %-*.llu",1,(int64_t)1,1,(int64_t)1);
+#ifndef NO_FLOAT
     result |= test(420, "1e-09", "%g", 0.000000001);
     result |= test(421, "1e-08", "%g", 0.00000001);
     result |= test(422, "1e-07", "%g", 0.0000001);
@@ -465,6 +497,7 @@
     result |= test(437, "10.0000", "%#.6g", 10.0);
     result |= test(438, "10", "%.6g", 10.0);
     result |= test(439, "10.00000000000000000000", "%#.22g", 10.0);
+#endif
 
     // Regression test for wrong behavior with negative precision in tinystdio
     // this might fail for configurations not using tinystdio, so for a first
@@ -475,9 +508,11 @@
     result |= test(443,       "42", "%.*d",  0, 42);
     result |= test(444,   "000042", "%.*d",  6, 42);
     result |= test(445,       "42", "%.*d", -6, 42);
+#ifndef NO_FLOAT
     result |= test(446,        "0", "%.*f",  0, 0.123);
     result |= test(447,      "0.1", "%.*f",  1, 0.123);
     result |= test(448, "0.123000", "%.*f", -1, 0.123);
+#endif
 #ifdef _WANT_IO_C99_FORMATS
 {
     char c[64];
@@ -487,7 +522,8 @@
     result |= test(449, "  42", "%4jd", (intmax_t)42L);
     result |= test(450, "64", "%zu", sizeof c);
     result |= test(451, "12", "%td", (c+12) - c);
-#if defined(PICOLIBC_FLOAT_PRINTF_SCANF) && defined(TINY_STDIO)
+#ifndef NO_FLOAT
+#ifdef LOW_FLOAT
     result |= test(452, "0x1.000000p+0", "%a", (double) 0x1.0p+0f);
     result |= test(453, "0x0.000002p-126", "%a", (double) 0x1.000000p-149f);
     result |= test(454, "0x0.000000p+0", "%a", (double) 0.0f);
@@ -507,6 +543,7 @@
     result |= test(455, "0x1.fffffffffffffp+1022", "%a", 0x1.fffffffffffffp+1022);
     result |= test(456, "0x1.23456789abcdep-1022", "%a", 0x1.23456789abcdep-1022);
     result |= test(457, "0x1.23456789abcdfp-1022", "%a", 0x1.23456789abcdfp-1022);
+#endif
 #endif
 }
 #endif


### PR DESCRIPTION
I was cleaning up the tinystdio printf code to make it more readable, adding comments and untangling the conditionals when I found a couple of bugs and some opportunities to shrink the code.

bugs:

 *  'hh' length modifier not supported in integer-only printf.
 *  %q for q some non-supported format char would consume an integer argument from the input

