### PR TITLE
Fix __file flag initialization for C++ apps

### DIFF
--- a/newlib/libc/tinystdio/stdio.h
+++ b/newlib/libc/tinystdio/stdio.h
@@ -333,10 +333,10 @@ typedef __FILE FILE;
 #else  /* !DOXYGEN */
 #define fdev_setup_stream(stream, p, g, fl, f)	\
 	do { \
+		(stream)->flags = f; \
 		(stream)->put = p; \
 		(stream)->get = g; \
 		(stream)->flush = fl; \
-		(stream)->flags = f; \
 	} while(0)
 #endif /* DOXYGEN */
 
@@ -372,10 +372,10 @@ typedef __FILE FILE;
 #else  /* !DOXYGEN */
 #define FDEV_SETUP_STREAM(p, g, fl, f)		\
 	{ \
+		.flags = f, \
 		.put = p, \
 		.get = g, \
 		.flush = fl, \
-		.flags = f, \
 	}
 #endif /* DOXYGEN */
 
@@ -465,7 +465,7 @@ extern int	fclose(FILE *__stream);
             signed conversion.  A + overrides a space if both are
             used.</li>
       </ul>
-      
+
    -   An optional decimal digit string specifying a minimum field width.
        If the converted value has fewer characters than the field width, it
        will be padded with spaces on the left (or right, if the left-adjustment
@@ -753,7 +753,7 @@ extern int	getchar(void);
 
    Currently, only a single character can be pushed back onto the
    stream.
-   
+
    The ungetc() function returns the character pushed back after the
    conversion, or \c EOF if the operation fails.  If the value of the
    argument \c c character equals \c EOF, the operation will fail and


### PR DESCRIPTION
C++ requires that designated initializers, like the ones used in
the `FDEV_SETUP_STREAM` macro, must be in the order in which they appear
in the data members of the `__file` struct. See:

https://en.cppreference.com/w/cpp/language/aggregate_initialization

Move the `.flags` initialization to the top of the initializer list
for the macro `FDEV_SETUP_STREAM`.
Perform the same with `fdev_setup_stream` to keep them consistent.