### PR TITLE
Add -Werror=vla to build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -426,7 +426,7 @@ picolibcpp_ld = configure_file(input: 'picolibc.ld.in',
 
 # Not all compilers necessarily support all warnings used by the tests; only use these which are:
 test_c_warnings = []
-foreach arg : ['-Wno-missing-braces', '-Wno-implicit-int', '-Wno-return-type', '-Wimplicit-function-declaration']
+foreach arg : ['-Wno-missing-braces', '-Wno-implicit-int', '-Wno-return-type', '-Wimplicit-function-declaration', '-Werror=vla']
   if meson.get_compiler('c').has_argument(arg)
     test_c_warnings += [arg]
   endif


### PR DESCRIPTION
This will cause any uses of variable length arrays to generate a
compile-time error.
    
Signed-off-by: Keith Packard <keithp@keithp.com>