### PR TITLE
Split picolibc.ld .except section into two parts

### DIFF
--- a/picolibc.ld.in
+++ b/picolibc.ld.in
@@ -110,19 +110,19 @@ SECTIONS
 		PROVIDE_HIDDEN ( __fini_array_end = . );
 	} >flash AT>flash :text
 
-        /* additional sections when compiling with C++ exception support */
+	/* additional sections when compiling with C++ exception support */
 	@CPP_START@
-        .except : {
+	.except_ordered : {
 		*(.gcc_except_table *.gcc_except_table.*)
 		KEEP (*(.eh_frame .eh_frame.*))
 		*(.ARM.extab* .gnu.linkonce.armextab.*)
-
-                . = ALIGN(8);
-
-        	PROVIDE(__exidx_start = .);
+	}
+	.except_unordered : {
+		. = ALIGN(8);
+		PROVIDE(__exidx_start = .);
 		*(.ARM.exidx*)
-        	PROVIDE(__exidx_end = .);
-        } >flash AT>flash :text
+		PROVIDE(__exidx_end = .);
+	} >flash AT>flash :text
 	@CPP_END@
 
 	/*


### PR DESCRIPTION
Split `.except :` sections within the picolibc.ld.in into
`.except_ordered` and `.except_unordered`. Keeping the ".ARM.extab" data
and the ".ARM.exidx" data in the same section results in this error:

```
.except has both ordered [`.ARM.exidx.text._ZN4sjsu4Uart5FlushEv
[_ZN4sjsu4Uart5FlushEv]' in /tmp/ccDxHV8f.o] and unordered [`.ARM.extab' in
arm-none-eabi/10.2.1/thumb/v7e-m+fp/hard/libgcc.a(pr-support.o)] sections

arm-none-eabi/10.2.1/../../../../arm-none-eabi/bin/ld: final link failed:
bad value
collect2: error: ld returned 1 exit status
```

Resolves #153