### PR TITLE
tinystdio: Use simple globals for stdin/stdout/stderr

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -64,13 +64,14 @@ types and formats.
 
 These options apply when tinystdio is enabled, which is the
 default. For stdin/stdout/stderr, the application will need to provide
-`__iob`, which is an array of three pointers to FILE structures (which
-can be a single shared FILE structure).
+`stdin`, `stdout` and `stderr`, which are three pointers to FILE
+structures (which can all reference a single shared FILE structure,
+and which can be aliases to the same underlying global pointer).
 
 Note that while posix-io support is enabled by default, using it will
 require that the underlying system offer the required functions. POSIX
-console support offers a built-in `__iob` definition which uses the
-same POSIX I/O functions.
+console support offers built-in `stdin`, `stdout` and `stderr`
+definitions which use the same POSIX I/O functions.
 
 | Option                      | Default | Description                                                                          |
 | ------                      | ------- | -----------                                                                          |

--- a/doc/os.md
+++ b/doc/os.md
@@ -16,11 +16,12 @@ complex file operations so that a minimal system can easily support
 the former with only a few functions.
 
 To get stdin/stdout/stderr working, the application needs to define
-the '__iob' array, which contains pointers to FILE objects for each of
-stdin/stdout/stderr. The __iob array may reside in read-only memory,
-but the FILE objects may not. A single FILE object may be used for all
-three pointers. The FILE object contains function pointers for putc,
-getc, which might be defined as follows:
+the `stdin`, `stdout` and `stderr` globals, which contain pointers to
+FILE objects. The pointers may reside in read-only memory, but the
+FILE objects may not. A single FILE object may be used for all three
+pointers, and linker aliases may be used to make all three pointers be
+stored in the same location. The FILE object contains function
+pointers for putc, getc, which might be defined as follows:
 
 	static int
 	sample_putc(char c, FILE *file)
@@ -69,9 +70,12 @@ supported, can be one of the following:
 | _FDEV_SETUP_WRITE | Write      | putc               |
 | _FDEV_SETUP_RW    | Read/Write | putc, getc         |
 
-Finally, the FILE is used to initialize the __iob array:
+Finally, the FILE is used to initialize the `stdin`, `stdout` and
+`stderr` values, the latter two of which are simply aliases to `stdin`:
 
-	FILE *const __iob[3] = { &__stdio, &__stdio, &__stdio };
+   FILE *const stdin = &__stdio;
+   __strong_reference(stdin, stdout);
+   __strong_reference(stdin, stderr);
 
 ### fopen, fdopen
 

--- a/dummyhost/iob.c
+++ b/dummyhost/iob.c
@@ -39,7 +39,7 @@
 /*
  * Dummy stdio hooks. This allows programs to link without requiring
  * any system-dependent functions. This is only used if the program
- * doesn't provide its own version of __iob
+ * doesn't provide its own version of stdin, stdout, stderr
  */
 
 static int
@@ -47,7 +47,7 @@ dummy_putc(char c, FILE *file)
 {
 	(void) c;
 	(void) file;
-	return c;
+	return (unsigned char) c;
 }
 
 static int
@@ -66,4 +66,12 @@ dummy_flush(FILE *file)
 
 static FILE __stdio = FDEV_SETUP_STREAM(dummy_putc, dummy_getc, dummy_flush, _FDEV_SETUP_RW);
 
-FILE *const __iob[3] = { &__stdio, &__stdio, &__stdio };
+#ifdef __strong_reference
+#define STDIO_ALIAS(x) __strong_reference(stdin, x);
+#else
+#define STDIO_ALIAS(x) FILE *const x = &__stdio;
+#endif
+
+FILE *const stdin = &__stdio;
+STDIO_ALIAS(stdout);
+STDIO_ALIAS(stderr);

--- a/newlib/libc/include/sys/cdefs.h
+++ b/newlib/libc/include/sys/cdefs.h
@@ -554,7 +554,7 @@
 #endif
 
 #if defined(__GNUC__) || defined(__INTEL_COMPILER)
-#ifndef __INTEL_COMPILER
+#if !defined(__INTEL_COMPILER) && defined(HAVE_ALIAS_ATTRIBUTE)
 #define	__strong_reference(sym,aliassym)	\
 	extern __typeof (sym) aliassym __attribute__ ((__alias__ (#sym)))
 #endif

--- a/newlib/libc/stdlib/pico-onexit.c
+++ b/newlib/libc/stdlib/pico-onexit.c
@@ -77,9 +77,9 @@ __call_exitprocs(int code, void *param)
 {
 	for (;;) {
 		int	                i;
-                union on_exit_func      func;
+                union on_exit_func      func = {};
                 int                     kind = PICO_ONEXIT_EMPTY;
-		void	                *arg;
+		void	                *arg = 0;
 
 		__LIBC_LOCK();
 		for (i = ATEXIT_MAX - 1; i >= 0; i--) {

--- a/newlib/libc/tinystdio/posixiob.c
+++ b/newlib/libc/tinystdio/posixiob.c
@@ -58,8 +58,18 @@ static struct __file_posix __stdout = {
 	.write_buf = write_buf
 };
 
-FILE *const __posix_iob[3] = { &__stdin.cfile.file, &__stdout.cfile.file, &__stdout.cfile.file };
-__weak_reference(__posix_iob,__iob);
+FILE *const __posix_stdin = &__stdin.cfile.file;
+FILE *const __posix_stdout = &__stdout.cfile.file;
+
+#ifdef __strong_reference
+__strong_reference(__posix_stdout, __posix_stderr);
+#else
+FILE *const __posix_stderr = &__stdout.cfile.file;
+#endif
+
+__weak_reference(__posix_stdin,stdin);
+__weak_reference(__posix_stdout,stdout);
+__weak_reference(__posix_stderr,stderr);
 
 /*
  * Add a destructor function to get stdout flushed on

--- a/newlib/libc/tinystdio/stdio.h
+++ b/newlib/libc/tinystdio/stdio.h
@@ -114,12 +114,12 @@
     conversion should be performed, but instead any string that aims
     to issue a CR-LF sequence must use <tt>"\r\n"</tt> explicitly.
 
-    stdin, stdout and stderr are macros which refer to an undefined
-    array of FILE pointers, __iob. If you want to use this, your
-    application must define this array and initialize it. It is
-    declared 'const' so that you can place it in ROM if you don't need
-    to modify it after startup. FILEs cannot be placed in ROM as they
-    have values which are modified during runtime.
+    stdin, stdout and stderr are undefined global FILE pointers. If
+    you want to use this, your application must define these variables
+    and initialize them. They are declared 'const' so that you can place
+    them in ROM if you don't need to modify it after startup. FILEs
+    cannot be placed in ROM as they have values which are modified
+    during runtime.
 
     \anchor stdio_without_malloc
     <h3>Running stdio without malloc()</h3>
@@ -283,22 +283,29 @@ typedef __FILE FILE;
 #endif
 
 /**
+   This symbol is defined when stdin/stdout/stderr are global
+   variables. When undefined, the old __iob array is used which
+   contains the pointers instead
+*/
+#define PICOLIBC_STDIO_GLOBALS
+
+/**
    Stream that will be used as an input stream by the simplified
    functions that don't take a \c stream argument.
 */
-#define stdin (__iob[0])
+extern FILE *const stdin;
 
 /**
    Stream that will be used as an output stream by the simplified
    functions that don't take a \c stream argument.
 */
-#define stdout (__iob[1])
+extern FILE *const stdout;
 
 /**
    Stream destined for error output.  Unless specifically assigned,
    identical to \c stdout.
 */
-#define stderr (__iob[2])
+extern FILE *const stderr;
 
 /**
    \c EOF declares the value that is returned by various standard IO
@@ -387,8 +394,6 @@ extern "C" {
 /*
  * Doxygen documentation can be found in fdevopen.c.
  */
-
-extern struct __file *const __iob[];
 
 extern FILE *fdevopen(int (*__put)(char, FILE*), int (*__get)(FILE*), int(*__flush)(FILE *));
 

--- a/newlib/testsuite/stdio-bits.c
+++ b/newlib/testsuite/stdio-bits.c
@@ -102,7 +102,15 @@ static FILE __stdio = {
 	.flush = ao_flush,
 };
 
-FILE *const __iob[3] = { &__stdio, &__stdio, &__stdio };
+#ifdef __strong_reference
+#define STDIO_ALIAS(x) __strong_reference(stdin, x);
+#else
+#define STDIO_ALIAS(x) FILE *const x = &__stdio;
+#endif
+
+FILE *const stdin = &__stdio;
+STDIO_ALIAS(stdout);
+STDIO_ALIAS(stderr);
 
 #else
 int fstat(int fd, struct stat *statb) { errno = ENOTTY; return -1; }

--- a/semihost/iob.c
+++ b/semihost/iob.c
@@ -37,4 +37,12 @@
 
 static FILE __stdio = FDEV_SETUP_STREAM(sys_semihost_putc, sys_semihost_getc, NULL, _FDEV_SETUP_RW);
 
-FILE *const __iob[3] = { &__stdio, &__stdio, &__stdio };
+#ifdef __strong_reference
+#define STDIO_ALIAS(x) __strong_reference(stdin, x);
+#else
+#define STDIO_ALIAS(x) FILE *const x = &__stdio;
+#endif
+
+FILE *const stdin = &__stdio;
+STDIO_ALIAS(stdout);
+STDIO_ALIAS(stderr);

--- a/semihost/machine/i386/e9_io.c
+++ b/semihost/machine/i386/e9_io.c
@@ -54,4 +54,12 @@ e9_getc(FILE *file)
 
 static FILE __stdio = FDEV_SETUP_STREAM(e9_putc, e9_getc, NULL, _FDEV_SETUP_RW);
 
-FILE *const __iob[3] = { &__stdio, &__stdio, &__stdio };
+#ifdef __strong_reference
+#define STDIO_ALIAS(x) __strong_reference(stdin, x);
+#else
+#define STDIO_ALIAS(x) FILE *const x = &__stdio;
+#endif
+
+FILE *const stdin = &__stdio;
+STDIO_ALIAS(stdout);
+STDIO_ALIAS(stderr);


### PR DESCRIPTION
This swaps the __iob array for global variables, which conform to the
POSIX spec more closely, avoid using array indexing which might
generate longer code on some platforms and allow sharing all three in
a single location in ROM with symbol aliasing.

This changes the tinystdio API/ABI in an incompatible fashion.

Signed-off-by: Keith Packard <keithp@keithp.com>