### PR TITLE
Initializer lists shall not be empty

### DIFF
--- a/newlib/libc/stdlib/pico-onexit.c
+++ b/newlib/libc/stdlib/pico-onexit.c
@@ -77,7 +77,7 @@ __call_exitprocs(int code, void *param)
 {
 	for (;;) {
 		int	                i;
-                union on_exit_func      func = {};
+                union on_exit_func      func = {0};
                 int                     kind = PICO_ONEXIT_EMPTY;
 		void	                *arg = 0;
 


### PR DESCRIPTION
C99 does not permit empty initializer lists. See "6.7.8 Initialization".

I'd expect most compilers to happily do the "right thing", but CompCert
is a little bit more strict here.

---
Let's see if I'm right once the CI on GitHub is finished :)