### PR TITLE
tinystdio: Add -Dformat-default configuration option

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -26,6 +26,8 @@ jobs:
           # Tinystdio configurations
           "-Dio-float-exact=false",
           "-Dio-long-long=true",
+          "-Dformat-default=integer",
+          "-Dformat-default=float",
 
           # Malloc configurations
           "-Dnewlib-nano-malloc=false",

--- a/.github/workflows/minsize.yml
+++ b/.github/workflows/minsize.yml
@@ -26,6 +26,8 @@ jobs:
           # Tinystdio configurations
           "-Dio-float-exact=false",
           "-Dio-long-long=true",
+	  "-Dformat-default=integer",
+	  "-Dformat-default=float",
 
           # Malloc configurations
           "-Dnewlib-nano-malloc=false",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
           # Tinystdio configurations
           "-Dio-float-exact=false",
           "-Dio-long-long=true",
+          "-Dformat-default=integer",
+          "-Dformat-default=float",
 
           # Malloc configurations
           "-Dnewlib-nano-malloc=false",

--- a/meson.build
+++ b/meson.build
@@ -140,30 +140,6 @@ endif
 has_link_defsym=meson.get_compiler('c').has_link_argument('-Wl,--defsym=' + global_prefix + '_start=0')
 has_link_alias=meson.get_compiler('c').has_link_argument('-Wl,-alias,' + global_prefix + 'main,testalias')
 
-float_printf_compile_args=['-DPICOLIBC_FLOAT_PRINTF_SCANF']
-float_printf_link_args=float_printf_compile_args
-int_printf_compile_args=['-DPICOLIBC_INTEGER_PRINTF_SCANF']
-int_printf_link_args=int_printf_compile_args
-if tinystdio
-  vfprintf_symbol = global_prefix + 'vfprintf'
-  __f_vfprintf_symbol = global_prefix + '__f_vfprintf'
-  __i_vfprintf_symbol = global_prefix + '__i_vfprintf'
-  vfscanf_symbol = global_prefix + 'vfscanf'
-  __f_vfscanf_symbol = global_prefix + '__f_vfscanf'
-  __i_vfscanf_symbol = global_prefix + '__i_vfscanf'
-  if has_link_defsym
-    float_printf_link_args += '-Wl,--defsym=' + vfprintf_symbol +  '=' + __f_vfprintf_symbol
-    float_printf_link_args += '-Wl,--defsym=' + vfscanf_symbol + '=' + __f_vfscanf_symbol
-    int_printf_link_args += '-Wl,--defsym=' + vfprintf_symbol +  '=' + __i_vfprintf_symbol
-    int_printf_link_args += '-Wl,--defsym=' + vfscanf_symbol + '=' + __i_vfscanf_symbol
-  elif has_link_alias
-    float_printf_link_args += '-Wl,-alias,' + __f_vfprintf_symbol +  ',' + vfprintf_symbol
-    float_printf_link_args += '-Wl,-alias,' + __f_vfscanf_symbol + ',' + vfscanf_symbol
-    int_printf_link_args += '-Wl,-alias,' + __i_vfprintf_symbol +  ',' + vfprintf_symbol
-    int_printf_link_args += '-Wl,-alias,' + __i_vfscanf_symbol + ',' + vfscanf_symbol
-  endif
-endif
-
 # Shared stdio options
 io_long_long = get_option('io-long-long')
 newlib_io_long_long = get_option('newlib-io-long-long')
@@ -182,6 +158,69 @@ posix_io = tinystdio and get_option('posix-io')
 posix_console = posix_io and get_option('posix-console')
 io_float_exact = not tinystdio or get_option('io-float-exact')
 atomic_ungetc = tinystdio and get_option('atomic-ungetc')
+format_default = get_option('format-default')
+
+double_printf_compile_args=['-DPICOLIBC_DOUBLE_PRINTF_SCANF']
+double_printf_link_args=double_printf_compile_args
+float_printf_compile_args=['-DPICOLIBC_FLOAT_PRINTF_SCANF']
+float_printf_link_args=float_printf_compile_args
+int_printf_compile_args=['-DPICOLIBC_INTEGER_PRINTF_SCANF']
+int_printf_link_args=int_printf_compile_args
+if tinystdio
+  vfprintf_symbol = global_prefix + 'vfprintf'
+  __d_vfprintf_symbol = global_prefix + '__d_vfprintf'
+  __f_vfprintf_symbol = global_prefix + '__f_vfprintf'
+  __i_vfprintf_symbol = global_prefix + '__i_vfprintf'
+  vfscanf_symbol = global_prefix + 'vfscanf'
+  __d_vfscanf_symbol = global_prefix + '__d_vfscanf'
+  __f_vfscanf_symbol = global_prefix + '__f_vfscanf'
+  __i_vfscanf_symbol = global_prefix + '__i_vfscanf'
+  if has_link_defsym
+    if format_default != 'double'	
+      double_printf_link_args += '-Wl,--defsym=' + vfprintf_symbol +  '=' + __d_vfprintf_symbol
+      double_printf_link_args += '-Wl,--defsym=' + vfscanf_symbol + '=' + __d_vfscanf_symbol
+    endif
+    if format_default != 'float'
+      float_printf_link_args += '-Wl,--defsym=' + vfprintf_symbol +  '=' + __f_vfprintf_symbol
+      float_printf_link_args += '-Wl,--defsym=' + vfscanf_symbol + '=' + __f_vfscanf_symbol
+    endif
+    if format_default != 'integer'
+      int_printf_link_args += '-Wl,--defsym=' + vfprintf_symbol +  '=' + __i_vfprintf_symbol
+      int_printf_link_args += '-Wl,--defsym=' + vfscanf_symbol + '=' + __i_vfscanf_symbol
+    endif
+  elif has_link_alias
+    if format_default == 'double'
+      float_printf_link_args += '-Wl,-alias,' + vfprintf_symbol +  ',' + __d_vfprintf_symbol
+      float_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + ',' + __d_vfscanf_symbol
+      int_printf_link_args += '-Wl,-alias,' + vfprintf_symbol +  ',' + __d_vfprintf_symbol
+      int_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + ',' + __d_vfscanf_symbol
+    endif
+    if format_default == 'float'
+      double_printf_link_args += '-Wl,-alias,' + vfprintf_symbol +  ',' + __f_vfprintf_symbol
+      double_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + ',' + __f_vfscanf_symbol
+      int_printf_link_args += '-Wl,-alias,' + vfprintf_symbol +  ',' + __f_vfprintf_symbol
+      int_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + ',' + __f_vfscanf_symbol
+    endif
+    if format_default == 'int'
+      double_printf_link_args += '-Wl,-alias,' + vfprintf_symbol +  ',' + __i_vfprintf_symbol
+      double_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + ',' + __i_vfscanf_symbol
+      float_printf_link_args += '-Wl,-alias,' + vfprintf_symbol +  ',' + __i_vfprintf_symbol
+      float_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + ',' + __i_vfscanf_symbol
+    endif
+    if format_default != 'double'
+      double_printf_link_args += '-Wl,-alias,' + __d_vfprintf_symbol +  ',' + vfprintf_symbol
+      double_printf_link_args += '-Wl,-alias,' + __d_vfscanf_symbol + ',' + vfscanf_symbol
+    endif
+    if format_default != 'float'
+      float_printf_link_args += '-Wl,-alias,' + __f_vfprintf_symbol +  ',' + vfprintf_symbol
+      float_printf_link_args += '-Wl,-alias,' + __f_vfscanf_symbol + ',' + vfscanf_symbol
+    endif
+    if format_default != 'integer'
+      int_printf_link_args += '-Wl,-alias,' + __i_vfprintf_symbol +  ',' + vfprintf_symbol
+      int_printf_link_args += '-Wl,-alias,' + __i_vfscanf_symbol + ',' + vfscanf_symbol
+    endif
+  endif
+endif
 
 # A bunch of newlib-stdio only options
 newlib_io_pos_args = get_option('newlib-io-pos-args')
@@ -359,6 +398,8 @@ specs_data.set(
 if tinystdio
   specs_printf=('%{DPICOLIBC_FLOAT_PRINTF_SCANF:--defsym=vfprintf=__f_vfprintf}' +
 		' %{DPICOLIBC_FLOAT_PRINTF_SCANF:--defsym=vfscanf=__f_vfscanf}' +
+		' %{DPICOLIBC_DOUBLE_PRINTF_SCANF:--defsym=vfprintf=__d_vfprintf}' +
+		' %{DPICOLIBC_DOUBLE_PRINTF_SCANF:--defsym=vfscanf=__d_vfscanf}' +
 		' %{DPICOLIBC_INTEGER_PRINTF_SCANF:--defsym=vfprintf=__i_vfprintf}' +
 		' %{DPICOLIBC_INTEGER_PRINTF_SCANF:--defsym=vfscanf=__i_vfscanf}')
 else

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -107,6 +107,8 @@ option('posix-io', type: 'boolean', value: true,
        description: 'Provide fopen/fdopen using POSIX I/O (open, close, read, write, lseek)')
 option('posix-console', type: 'boolean', value: false,
        description: 'Use POSIX I/O for stdin/stdout/stderr')
+option('format-default', type: 'combo', choices: ['double', 'float', 'integer'], value: 'double',
+       description: 'which printf/scanf versions should be the default')
 
 #
 # Options applying to only legacy stdio

--- a/newlib/libc/tinystdio/meson.build
+++ b/newlib/libc/tinystdio/meson.build
@@ -180,6 +180,14 @@ install_headers(
   'stdio.h'
 )
 
+if format_default == 'double'
+  c_args_format = '-DFORMAT_DEFAULT_DOUBLE'
+elif format_default == 'float'
+  c_args_format = '-DFORMAT_DEFAULT_FLOAT'
+elif format_default == 'integer'
+  c_args_format = '-DFORMAT_DEFAULT_INTEGER'
+endif
+
 srcs_tinystdio_use = []
 foreach file : srcs_tinystdio
   s_file = file.split('.')[0] + '.S'
@@ -199,5 +207,5 @@ foreach target : targets
 				    srcs_tinystdio_use,
 				    pic: false,
 				    include_directories: inc,
-				    c_args: value[1]))
+				    c_args: value[1] + [c_args_format]))
 endforeach

--- a/newlib/libc/tinystdio/scanf_private.h
+++ b/newlib/libc/tinystdio/scanf_private.h
@@ -34,7 +34,10 @@
 #define _SCANF_PRIVATE_H_
 
 #if	!defined (SCANF_LEVEL)
-#define SCANF_LEVEL SCANF_FLT
+# define SCANF_LEVEL SCANF_FLT
+# ifndef FORMAT_DEFAULT_DOUBLE
+#  define vfscanf __d_vfscanf
+# endif
 #endif
 
 #if	SCANF_LEVEL == SCANF_STD

--- a/newlib/libc/tinystdio/vfiprintf.c
+++ b/newlib/libc/tinystdio/vfiprintf.c
@@ -31,6 +31,16 @@
 */
 
 #define PRINTF_LEVEL PRINTF_STD
+#ifndef FORMAT_DEFAULT_INTEGER
 #define vfprintf __i_vfprintf
+#endif
 
 #include <vfprintf.c>
+
+#ifdef FORMAT_DEFAULT_INTEGER
+#ifdef HAVE_ALIAS_ATTRIBUTE
+__strong_reference(vfprintf, __i_vfprintf);
+#else
+int __i_vfprintf (FILE * stream, const char *fmt, va_list ap) { return vfprintf(stream, fmt, ap); }
+#endif
+#endif

--- a/newlib/libc/tinystdio/vfiscanf.c
+++ b/newlib/libc/tinystdio/vfiscanf.c
@@ -31,6 +31,16 @@
 */
 
 #define SCANF_LEVEL SCANF_STD
+#ifndef FORMAT_DEFAULT_INTEGER
 #define vfscanf __i_vfscanf
+#endif
 
 #include <vfscanf.c>
+
+#ifdef FORMAT_DEFAULT_INTEGER
+#ifdef HAVE_ALIAS_ATTRIBUTE
+__strong_reference(vfscanf, __i_vfscanf);
+#else
+int __i_vfscanf (FILE * stream, const char *fmt, va_list ap) { return vfscanf(stream, fmt, ap); }
+#endif
+#endif

--- a/newlib/libc/tinystdio/vfprintf.c
+++ b/newlib/libc/tinystdio/vfprintf.c
@@ -83,14 +83,13 @@ typedef int64_t printf_float_int_t;
  */
 
 #ifndef PRINTF_LEVEL
-# define PRINTF_LEVEL PRINTF_FLT
+#  define PRINTF_LEVEL PRINTF_FLT
+#  ifndef FORMAT_DEFAULT_DOUBLE
+#    define vfprintf __d_vfprintf
+#  endif
 #endif
 
 #if PRINTF_LEVEL == PRINTF_STD || PRINTF_LEVEL == PRINTF_FLT
-/* OK */
-#else
-# error "Not a known printf level."
-#endif
 
 #if ((PRINTF_LEVEL >= PRINTF_FLT) || defined(_WANT_IO_LONG_LONG))
 #define PRINTF_LONGLONG
@@ -845,10 +844,11 @@ int vfprintf (FILE * stream, const char *fmt, va_list ap)
 #undef my_putc
 }
 
-#ifndef vfprintf
+#if defined(FORMAT_DEFAULT_DOUBLE) && !defined(vfprintf)
 #ifdef HAVE_ALIAS_ATTRIBUTE
 __strong_reference(vfprintf, __d_vfprintf);
 #else
 int __d_vfprintf (FILE * stream, const char *fmt, va_list ap) { return vfprintf(stream, fmt, ap); }
+#endif
 #endif
 #endif

--- a/newlib/libc/tinystdio/vfprintff.c
+++ b/newlib/libc/tinystdio/vfprintff.c
@@ -32,6 +32,16 @@
 
 #define PRINTF_LEVEL PRINTF_FLT
 #define PICOLIBC_FLOAT_PRINTF_SCANF
+#ifndef FORMAT_DEFAULT_FLOAT
 #define vfprintf __f_vfprintf
+#endif
 
 #include <vfprintf.c>
+
+#ifdef FORMAT_DEFAULT_FLOAT
+#ifdef HAVE_ALIAS_ATTRIBUTE
+__strong_reference(vfprintf, __f_vfprintf);
+#else
+int __f_vfprintf (FILE * stream, const char *fmt, va_list ap) { return vfprintf(stream, fmt, ap); }
+#endif
+#endif

--- a/newlib/libc/tinystdio/vfscanf.c
+++ b/newlib/libc/tinystdio/vfscanf.c
@@ -631,3 +631,11 @@ int vfscanf (FILE * stream, const char *fmt, va_list ap)
   eof:
     return nconvs ? nconvs : EOF;
 }
+
+#if defined(FORMAT_DEFAULT_DOUBLE) && !defined(vfscanf)
+#ifdef HAVE_ALIAS_ATTRIBUTE
+__strong_reference(vfscanf, __d_vfscanf);
+#else
+int __d_vfscanf (FILE * stream, const char *fmt, va_list ap) { return vfscanf(stream, fmt, ap); }
+#endif
+#endif

--- a/newlib/libc/tinystdio/vfscanff.c
+++ b/newlib/libc/tinystdio/vfscanff.c
@@ -31,6 +31,17 @@
 */
 
 #define PICOLIBC_FLOAT_PRINTF_SCANF
+#define SCANF_LEVEL SCANF_FLT
+#ifndef FORMAT_DEFAULT_FLOAT
 #define vfscanf __f_vfscanf
+#endif
 
 #include "vfscanf.c"
+
+#ifdef FORMAT_DEFAULT_FLOAT
+#ifdef HAVE_ALIAS_ATTRIBUTE
+__strong_reference(vfscanf, __f_vfscanf);
+#else
+int __f_vfscanf (FILE * stream, const char *fmt, va_list ap) { return vfscanf(stream, fmt, ap); }
+#endif
+#endif

--- a/newlib/libm/test/meson.build
+++ b/newlib/libm/test/meson.build
@@ -149,9 +149,9 @@ foreach target : targets
 
   test('math' + target,
        executable(test_name, math_test_src,
-		  c_args: value[1] + test_c_args,
+		  c_args: value[1] + double_printf_compile_args + test_c_args,
 		  link_with: libs,
-		  link_args: value[1] + test_link_args,
+		  link_args: value[1] + double_printf_link_args + test_link_args,
 		  include_directories: inc),
        env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
 endforeach

--- a/test/meson.build
+++ b/test/meson.build
@@ -65,8 +65,8 @@ foreach target : targets
 
   test(t1 + target,
        executable(t1_name, 'printf_scanf.c',
-		  c_args: _c_args,
-		  link_args: _link_args,
+		  c_args: double_printf_compile_args + _c_args,
+		  link_args: double_printf_link_args + _link_args,
 		  link_with: _libs,
 		  link_depends:  test_link_depends,
 		  include_directories: inc),
@@ -97,8 +97,8 @@ foreach target : targets
 
   test(t1 + target,
        executable(t1_name, ['printf-tests.c'],
-		  c_args: _c_args,
-		  link_args: _link_args,
+		  c_args: double_printf_compile_args + _c_args,
+		  link_args: double_printf_link_args + _link_args,
 		  link_with: _libs,
 		  include_directories: inc),
        env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
@@ -259,8 +259,8 @@ foreach target : targets
 
     test(t1 + target,
 	 executable(t1_name, [t1_src],
-		    c_args: _c_args,
-		    link_args: _link_args,
+		    c_args: double_printf_compile_args + _c_args,
+		    link_args: double_printf_link_args + _link_args,
 		    link_with: _libs,
 		    link_depends:  test_link_depends,
 		    include_directories: inc),


### PR DESCRIPTION
This option selects which printf/scanf variant is the default for the
library

	-Dformat-default=double		vfprintf/vfscanf support double (and float for scanf)
	-Dformat-default=float		vfprintf/vfscanf support floats, not double
	-Dformat-default=integer	vfprintf/vfscanf do not support floating point

Applications wanting other floating point support may select that at build time
using:

	-DPICOLIBC_DOUBLE_PRINTF_SCANF	always choose version with double support
	-DPICOLIBC_FLOAT_PRINTF_SCANF	always choose version with float support
	-DPICOLIBC_INTEGER_PRINTF_SCANF	always choose version without float/double support

Signed-off-by: Keith Packard <keithp@keithp.com>