### PR TITLE
stdlib: Fix typo in ldtoa

### DIFF
--- a/newlib/libc/stdlib/ldtoa.c
+++ b/newlib/libc/stdlib/ldtoa.c
@@ -2904,7 +2904,7 @@ stripspaces:
   else				/* account for sign + max precision digs + E + exp sign + exponent */
     i = orig_ndigits + MAX_EXP_DIGITS + 4;
 
-  outstr = _alloc_dtoa_result(i);
+  outstr = __alloc_dtoa_result(i);
   if (!outstr)
     return NULL;
 


### PR DESCRIPTION
The code uses `_alloc_dtoa_result`, but it looks like it should be `__alloc_dtoa_result`.

This was flagged when I tried to compile the code with Clang. I didn't test it but it very much looks like a typo, so I made a PR.