### PR TITLE
meson.build: Remove unused POSIX_CONSOLE define from picolibc.h

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -721,7 +721,6 @@ conf_data.set('HAVE_INIT_FINI', newlib_initfini, description: 'Support _init() a
 conf_data.set('NEWLIB_TLS', thread_local_storage, description: 'use thread local storage')
 conf_data.set('PICOLIBC_TLS', thread_local_storage, description: 'use thread local storage')
 conf_data.set('POSIX_IO', posix_io, description: 'Use open/close/read/write in tinystdio')
-conf_data.set('POSIX_CONSOLE', posix_console, description: 'Use POSIX I/O for stdin, stdout and stderr')
 conf_data.set('ATOMIC_UNGETC', atomic_ungetc, description: 'Use atomics for fgetc/ungetc for re-entrancy')
 conf_data.set('HAVE_BITFIELDS_IN_PACKED_STRUCTS', have_bitfields_in_packed_structs, description: 'Use bitfields in packed structs')
 conf_data.set('HAVE_BUILTIN_MUL', have_builtin_mul_overflow, description: 'Compiler has __builtin_mul_overflow')


### PR DESCRIPTION
The definition POSIX_CONSOLE in picolibc.h is not used at all in the
tree.  In fact, it's never been used since it's introduced in
the commit 91b5c92e.

The build time option 'posix-console' _is_ in use for checking against
tinystdio and in newlib/libc/tinystdio/meson.build to enable building
posixiob.c.  The option itself is, of course, unchanged.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>