### PR TITLE
scripts: GCC in testing has updated to 10.3.1

### DIFF
--- a/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
@@ -30,6 +30,6 @@ c_link_args = [
 	'-mcpu=cortex-m7',
 	'-mfloat-abi=hard',
 	'-nostdlib',
-	'-L/usr/lib/gcc/arm-none-eabi/10.2.1/thumb/v7e-m+dp/hard/'
+	'-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+dp/hard/'
 	]
 needs_exe_wrapper = true

--- a/scripts/cross-clang-thumbv7m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7m-none-eabi.txt
@@ -28,6 +28,6 @@ c_link_args = [
 	'-target', 'thumbv7m-none-eabi',
 	'-mfloat-abi=soft',
 	'-nostdlib',
-	'-L/usr/lib/gcc/arm-none-eabi/10.2.1/thumb/v7-m/nofp/',
+	'-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7-m/nofp/',
 	]
 needs_exe_wrapper = true


### PR DESCRIPTION
This means the clang builds need to change the path to libgcc

Signed-off-by: Keith Packard <keithp@keithp.com>