### PR TITLE
gitignore: Remove config.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@
 
 autom4te.cache
 config.cache
-config.h
 config.intl
 config.log
 config.status


### PR DESCRIPTION
This entry matches all "config.h" in the tree.  We actually have
"config.h" in the tree right now.

  - newlib/libc/include/sys/config.h

Modern tools, such as the Silver Searcher or Ripgrep, check .gitignore
and drop matched files and directories.  That means, we are hiding the
actual files.

The .gitignore is inherited from Newlib and have many files from the
GNU Autotools era.  Removing config.h doesn't hurt picolibc
development.

We can specifically ignore config.h in the root directory with
'/config.h' but decided to simply remove it.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>