### PR TITLE
string: Fix buffer overrun in picolibc/newlib/libc/string/strrchr.c. Fixes #184

### DIFF
--- a/newlib/libc/string/strrchr.c
+++ b/newlib/libc/string/strrchr.c
@@ -50,10 +50,11 @@ strrchr (const char *s,
 	int i)
 {
   const char *last = NULL;
+  char c = i;
 
-  if (i)
+  if (c)
     {
-      while ((s=strchr(s, i)))
+      while ((s=strchr(s, c)))
 	{
 	  last = s;
 	  s++;
@@ -61,8 +62,8 @@ strrchr (const char *s,
     }
   else
     {
-      last = strchr(s, i);
+      last = strchr(s, c);
     }
-		  
+
   return (char *) last;
 }

--- a/test/meson.build
+++ b/test/meson.build
@@ -226,7 +226,7 @@ foreach target : targets
 		 'math_errhandling', 'malloc', 'tls',
 		 'ffs', 'setjmp', 'atexit', 'on_exit',
 		 'math-funcs', 'timegm', 'time-tests',
-                 'test-strtod',
+                 'test-strtod', 'test-strchr',
 		]
 
   if have_attr_ctor_dtor

--- a/test/test-strchr.c
+++ b/test/test-strchr.c
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2021 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <string.h>
+#include <stdio.h>
+
+const char haystack[] = "hello world";
+
+#define check(func, needle, expect) do {                                \
+    char *ptr = func(haystack, needle);                                 \
+    int result = -1;                                                    \
+    if (ptr)                                                            \
+        result = ptr - haystack;                                        \
+    if (result != expect) {                                             \
+        printf("%s(%s, 0x%x). Got %d expect %d\n",                      \
+               #func, haystack, needle, result, expect);                \
+        ret++;                                                          \
+    }                                                                   \
+    } while(0)
+
+#define many_check(func, needle, expect) do { \
+        check(func, needle, expect);                    \
+        check(func, needle | 0xffffff00, expect);       \
+        check(func, needle | 0x00000100, expect);       \
+        check(func, needle | 0x80000000, expect);       \
+    } while(0)
+
+int
+main(void)
+{
+    int ret = 0;
+
+    many_check(strchr, 'h', 0);
+    many_check(strrchr, 'h', 0);
+    many_check(strchr, 'l', 2);
+    many_check(strrchr, 'l', 9);
+    many_check(strchr, '\0', 11);
+    many_check(strrchr, '\0', 11);
+    return ret;
+}


### PR DESCRIPTION
Reported by prodisDown:
    
    	In picolibc/newlib/libc/string/strrchr.c
    
    	if (i) { while ((s=strchr(s, i))) { last = s; s++; } } else { last = strchr(s, i); }
    
    	Value (for example 0xFFFFFF00) in if (i) can pass test and
    	then be typecasted to char inside strchr(). Then s++ and then
    	buffer overrun.
    
    	It can be fixed by preventive typecast i = (int) (char) i; or
    	typecasting inside expression if ((char) i).
    
Fixed by casting to char.

Fixes #184 
    
Signed-off-by: Keith Packard <keithp@keithp.com>