### PR TITLE
scripts: Fix unclosed string literal typo

### DIFF
--- a/scripts/cross-riscv64-zephyr-elf.txt
+++ b/scripts/cross-riscv64-zephyr-elf.txt
@@ -7,7 +7,7 @@ strip = 'riscv64-zephyr-elf-strip'
 exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-riscv "$@"', 'run-riscv']
 
 [host_machine]
-system = 'zephyr
+system = 'zephyr'
 cpu_family = 'riscv'
 cpu = 'riscv'
 endian = 'little'


### PR DESCRIPTION
Need a closing '.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>