### PR TITLE
Flatten build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -214,6 +214,15 @@ if tinystdio
   __d_vfscanf_symbol = global_prefix + '__d_vfscanf'
   __f_vfscanf_symbol = global_prefix + '__f_vfscanf'
   __i_vfscanf_symbol = global_prefix + '__i_vfscanf'
+
+  if format_default == 'double'
+    c_args += '-DFORMAT_DEFAULT_DOUBLE'
+  elif format_default == 'float'
+    c_args += '-DFORMAT_DEFAULT_FLOAT'
+  elif format_default == 'integer'
+    c_args += '-DFORMAT_DEFAULT_INTEGER'
+  endif
+
   if has_link_defsym
     if format_default != 'double'
       double_printf_link_args += '-Wl,--defsym=' + vfprintf_symbol +  '=' + __d_vfprintf_symbol

--- a/newlib/libc/argz/meson.build
+++ b/newlib/libc/argz/meson.build
@@ -69,12 +69,4 @@ foreach file : srcs_argz
   endif
 endforeach
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_argz' + target,
-		static_library('argz' + target,
-			srcs_argz_use,
-			pic: false,
-			include_directories: inc,
-			c_args: value[1]))
-endforeach
+src_argz = files(srcs_argz_use)

--- a/newlib/libc/ctype/meson.build
+++ b/newlib/libc/ctype/meson.build
@@ -124,12 +124,4 @@ foreach file : srcs_ctype
   endif
 endforeach
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_ctype' + target,
-		static_library('ctype' + target,
-			srcs_ctype_use,
-			pic: false,
-			include_directories: inc,
-			c_args: value[1]))
-endforeach
+src_ctype = files(srcs_ctype_use)

--- a/newlib/libc/errno/meson.build
+++ b/newlib/libc/errno/meson.build
@@ -48,12 +48,4 @@ foreach file : srcs_errno
   endif
 endforeach
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_errno' + target,
-		static_library('errno' + target,
-			srcs_errno_use,
-			pic: false,
-			include_directories: inc,
-			c_args: value[1]))
-endforeach
+src_errno = files(srcs_errno_use)

--- a/newlib/libc/iconv/ccs/meson.build
+++ b/newlib/libc/iconv/ccs/meson.build
@@ -96,12 +96,5 @@ foreach file : srcs_iconv_ccs
   endif
 endforeach
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_iconv_ccs' + target,
-		static_library('iconv_ccs' + target,
-			       srcs_iconv_ccs,
-			       pic: false,
-			       include_directories: inc,
-			       c_args: value[1]))
-endforeach
+src_iconv_ccs = files(srcs_iconv_ccs_use)
+

--- a/newlib/libc/iconv/ces/meson.build
+++ b/newlib/libc/iconv/ces/meson.build
@@ -62,12 +62,4 @@ foreach file : srcs_iconv_ces
   endif
 endforeach
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_iconv_ces' + target,
-		static_library('iconv_ces' + target,
-			       srcs_iconv_ces_use,
-			       pic: false,
-			       include_directories: inc,
-			       c_args: value[1]))
-endforeach
+src_iconv_ces = files(srcs_iconv_ces_use)

--- a/newlib/libc/iconv/lib/meson.build
+++ b/newlib/libc/iconv/lib/meson.build
@@ -61,12 +61,4 @@ foreach file : srcs_iconv_lib
   endif
 endforeach
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_iconv_lib' + target,
-		static_library('iconv_lib' + target,
-			       srcs_iconv_lib,
-			       pic: false,
-			       include_directories: inc,
-			       c_args: value[1]))
-endforeach
+src_iconv_lib = files(srcs_iconv_lib_use)

--- a/newlib/libc/iconv/meson.build
+++ b/newlib/libc/iconv/meson.build
@@ -34,20 +34,12 @@
 #
 libdirs = ['ces', 'ccs', 'lib']
 
+libsrcs = []
+
 foreach libdir : libdirs
   subdir(libdir)
+  libsrcs += get_variable('src_iconv_' + libdir, [])
 endforeach
 
-foreach target : targets
-  value = get_variable('target_' + target)
-  libobjs = []
-  foreach libname : libdirs
-    libobjs += get_variable('lib_iconv_' + libname + target).extract_all_objects(recursive:true)
-  endforeach
-  
-	set_variable('lib_iconv' + target,
-		static_library('iconv' + target,
-			       objects : libobjs,
-			       pic: false))
-endforeach
+src_iconv = libsrcs
 

--- a/newlib/libc/locale/meson.build
+++ b/newlib/libc/locale/meson.build
@@ -70,12 +70,4 @@ foreach file : srcs_locale
   endif
 endforeach
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_locale' + target,
-		static_library('locale' + target,
-			srcs_locale_use,
-			pic: false,
-			include_directories: inc,
-			c_args: value[1]))
-endforeach
+src_locale = files(srcs_locale_use)

--- a/newlib/libc/machine/csky/meson.build
+++ b/newlib/libc/machine/csky/meson.build
@@ -36,12 +36,4 @@ srcs_machine = [
   'setjmp.S',
 ]
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_machine' + target,
-		static_library('machine' + target,
-			srcs_machine,
-			pic: false,
-			include_directories: inc,
-			c_args: value[1] + arg_fnobuiltin))
-endforeach
+src_machine = files(srcs_machine)

--- a/newlib/libc/machine/i386/meson.build
+++ b/newlib/libc/machine/i386/meson.build
@@ -41,17 +41,8 @@ srcs_machine = [
   'setjmp.S',
   'strchr.S',
   'strlen.S',
-  'i386mach.h'
 ]
 
 subdir('machine')
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_machine' + target,
-		static_library('machine' + target,
-			srcs_machine,
-			pic: false,
-			include_directories: inc,
-			c_args: value[1]))
-endforeach
+set_variable('src_machine', files(srcs_machine))

--- a/newlib/libc/machine/powerpc/meson.build
+++ b/newlib/libc/machine/powerpc/meson.build
@@ -57,12 +57,4 @@ srcs_machine = [
 #  'vfscanf.c',
 ]
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_machine' + target,
-		static_library('machine' + target,
-			srcs_machine,
-			pic: false,
-			include_directories: inc,
-			c_args: value[1] + arg_fnobuiltin))
-endforeach
+src_machine = files(srcs_machine)

--- a/newlib/libc/machine/x86_64/meson.build
+++ b/newlib/libc/machine/x86_64/meson.build
@@ -36,15 +36,6 @@ srcs_machine = [
   'memcpy.S',
   'memset.S',
   'setjmp.S',
-  'x86_64mach.h'
 ]
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_machine' + target,
-		static_library('machine' + target,
-			srcs_machine,
-			pic: false,
-			include_directories: inc,
-			c_args: value[1]))
-endforeach
+src_machine = files(srcs_machine)

--- a/newlib/libc/machine/xtensa/meson.build
+++ b/newlib/libc/machine/xtensa/meson.build
@@ -46,12 +46,4 @@ srcs_machine = [
 subdir('sys')
 subdir('machine')
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_machine' + target,
-		static_library('machine' + target,
-			srcs_machine,
-			pic: false,
-			include_directories: inc,
-			c_args: value[1] + arg_fnobuiltin))
-endforeach
+src_machine = files(srcs_machine)

--- a/newlib/libc/meson.build
+++ b/newlib/libc/meson.build
@@ -170,27 +170,39 @@ foreach libdir : libdirs
   subdir(libdir)
 endforeach
 
+src_cpart = []
+
+foreach libname : libnames
+  src_cpart += get_variable('src_' + libname, [])
+endforeach
+
 subdir('include')
 
 foreach target : targets
   value = get_variable('target_' + target)
   libobjs = []
+  libsrcs_target = []
 
   foreach libname : libnames
-    libobjs += get_variable('lib_' + libname + target).extract_all_objects(recursive:true)
+    if is_variable('lib_' + libname + target)
+      libobjs += get_variable('lib_' + libname + target).extract_all_objects(recursive:true)
+    endif
+    libsrcs_target += get_variable('src_' + libname + target, [])
   endforeach
 
-  instdir = join_paths(get_option('libdir'), value[0])
+  set_variable('src_cpart_' + target, libsrcs_target)
 
   if target == ''
     libcpart_name = 'cpart'
   else
-    libcpart_name = join_paths(target, 'libcpart')
+    libcpart_name = 'cpart' + '_' + target
   endif
 
   local_lib_cpart_target = static_library(libcpart_name,
 				          pic: false,
-				          objects : libobjs)
+				          objects : libobjs,
+					  include_directories: inc,
+					  c_args: value[1] + ['-D_COMPILING_NEWLIB'])
 
   set_variable('lib_cpart' + target, local_lib_cpart_target)
 endforeach

--- a/newlib/libc/misc/meson.build
+++ b/newlib/libc/misc/meson.build
@@ -53,12 +53,4 @@ foreach file : srcs_misc
   endif
 endforeach
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_misc' + target,
-		static_library('misc' + target,
-			srcs_misc_use,
-			pic: false,
-			include_directories: inc,
-			c_args: value[1]))
-endforeach
+src_misc = files(srcs_misc_use)

--- a/newlib/libc/picolib/machine/aarch64/meson.build
+++ b/newlib/libc/picolib/machine/aarch64/meson.build
@@ -34,5 +34,5 @@
 #
 
 if thread_local_storage
-  srcs_picolib += files('tls.c')
+  src_picolib += files('tls.c')
 endif

--- a/newlib/libc/picolib/machine/arm/meson.build
+++ b/newlib/libc/picolib/machine/arm/meson.build
@@ -33,7 +33,7 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-srcs_picolib += files('interrupt.c')
+src_picolib += files('interrupt.c')
 if thread_local_storage
-  srcs_picolib += files('tls.c', 'read_tp.S')
+  src_picolib += files('tls.c', 'read_tp.S')
 endif

--- a/newlib/libc/picolib/machine/riscv/meson.build
+++ b/newlib/libc/picolib/machine/riscv/meson.build
@@ -34,5 +34,5 @@
 #
 
 if thread_local_storage
-  srcs_picolib += files('tls.c')
+  src_picolib += files('tls.c')
 endif

--- a/newlib/libc/picolib/meson.build
+++ b/newlib/libc/picolib/meson.build
@@ -43,16 +43,9 @@ if thread_local_storage
   srcs_picolib += 'inittls.c'
 endif
 
+src_picolib = files(srcs_picolib)
+
 if fs.is_dir('machine' / host_cpu_family)
   subdir('machine' / host_cpu_family)
 endif
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_picolib' + target,
-		     static_library('picolib' + target,
-				    srcs_picolib,
-				    pic: false,
-				    include_directories: inc,
-				    c_args: value[1]))
-endforeach

--- a/newlib/libc/posix/meson.build
+++ b/newlib/libc/posix/meson.build
@@ -51,13 +51,5 @@ foreach file : srcs_posix
   endif
 endforeach
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_posix' + target,
-		static_library('posix' + target,
-			srcs_posix_use,
-			pic: false,
-			include_directories: inc,
-			c_args: value[1]))
-endforeach
+src_posix = files(srcs_posix_use)
   

--- a/newlib/libc/reent/meson.build
+++ b/newlib/libc/reent/meson.build
@@ -50,12 +50,4 @@ foreach file : srcs_reent
   endif
 endforeach
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_reent' + target,
-		static_library('reent' + target,
-			srcs_reent_use,
-			pic: false,
-			include_directories: inc,
-			c_args: value[1]))
-endforeach
+src_reent = files(srcs_reent_use)

--- a/newlib/libc/search/meson.build
+++ b/newlib/libc/search/meson.build
@@ -57,12 +57,5 @@ hdrs_search = [
     'hash.h',
     'page.h',
 ]
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_search' + target,
-		static_library('search' + target,
-			srcs_search,
-			pic: false,
-			include_directories: inc,
-			c_args: value[1]))
-endforeach
+
+src_search = files(srcs_search)

--- a/newlib/libc/signal/meson.build
+++ b/newlib/libc/signal/meson.build
@@ -50,12 +50,4 @@ foreach file : srcs_signal
   endif
 endforeach
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_signal' + target,
-		static_library('signal' + target,
-			srcs_signal_use,
-			pic: false,
-			include_directories: inc,
-			c_args: value[1]))
-endforeach
+src_signal = files(srcs_signal_use)

--- a/newlib/libc/ssp/meson.build
+++ b/newlib/libc/ssp/meson.build
@@ -64,12 +64,4 @@ foreach file : srcs_ssp
   endif
 endforeach
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_ssp' + target,
-		static_library('ssp' + target,
-			srcs_ssp_use,
-			pic: false,
-			include_directories: inc,
-			c_args: value[1]))
-endforeach
+src_ssp = files(srcs_ssp_use)

--- a/newlib/libc/stdio/meson.build
+++ b/newlib/libc/stdio/meson.build
@@ -290,12 +290,4 @@ foreach file : srcs_stdio
   endif
 endforeach
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_stdio' + target,
-		static_library('stdio' + target,
-			srcs_stdio_use,
-			pic: false,
-			include_directories: inc,
-			c_args: value[1] + ['-D_COMPILING_NEWLIB']))
-endforeach
+src_stdio = files(srcs_stdio_use)

--- a/newlib/libc/stdio64/fdopen64.c
+++ b/newlib/libc/stdio64/fdopen64.c
@@ -30,9 +30,9 @@ File pointer or <<NULL>>, as for <<fopen>>.
 
 #include <stdio.h>
 #include <errno.h>
-#include "local.h"
 #include <_syslist.h>
 #include <sys/lock.h>
+#include "../stdio/local.h"
 
 extern int __sflags ();
 

--- a/newlib/libc/stdio64/fopen64.c
+++ b/newlib/libc/stdio64/fopen64.c
@@ -56,9 +56,9 @@ static char sccsid[] = "%W% (Berkeley) %G%";
 #define _DEFAULT_SOURCE
 #include <stdio.h>
 #include <errno.h>
-#include "local.h"
 #include <fcntl.h>
 #include <sys/lock.h>
+#include "../stdio/local.h"
 
 #ifdef __LARGE64_FILES
 

--- a/newlib/libc/stdio64/freopen64.c
+++ b/newlib/libc/stdio64/freopen64.c
@@ -67,7 +67,7 @@ Supporting OS subroutines required: <<close>>, <<fstat>>, <<isatty>>,
 #include <fcntl.h>
 #include <stdlib.h>
 #include <sys/lock.h>
-#include "local.h"
+#include "../stdio/local.h"
 
 /*
  * Re-direct an existing, open (probably) file to some other file.

--- a/newlib/libc/stdio64/fseeko64.c
+++ b/newlib/libc/stdio64/fseeko64.c
@@ -74,7 +74,7 @@ Supporting OS subroutines required: <<close>>, <<fstat64>>, <<isatty>>,
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include "local.h"
+#include "../stdio/local.h"
 
 #define	POS_ERR	(-(_fpos64_t)1)
 

--- a/newlib/libc/stdio64/ftello64.c
+++ b/newlib/libc/stdio64/ftello64.c
@@ -71,8 +71,7 @@ static char sccsid[] = "%W% (Berkeley) %G%";
 #define _DEFAULT_SOURCE
 #include <stdio.h>
 #include <errno.h>
-
-#include "local.h"
+#include "../stdio/local.h"
 
 #ifdef __LARGE64_FILES
 

--- a/newlib/libc/stdio64/meson.build
+++ b/newlib/libc/stdio64/meson.build
@@ -57,13 +57,5 @@ foreach file : srcs_stdio64
   endif
 endforeach
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_stdio64' + target,
-		static_library('stdio64' + target,
-			srcs_stdio64_use,
-			pic: false,
-			include_directories: inc,
-			c_args: value[1] + ['-D_COMPILING_NEWLIB']))
-endforeach
+src_stdio64 = files(srcs_stdio64_use)
 

--- a/newlib/libc/stdio64/stdio64.c
+++ b/newlib/libc/stdio64/stdio64.c
@@ -23,7 +23,7 @@
 #include <fcntl.h>
 #include <sys/unistd.h>
 #include <errno.h>
-#include "local.h"
+#include "../stdio/local.h"
 
 #ifdef __LARGE64_FILES
 

--- a/newlib/libc/stdlib/meson.build
+++ b/newlib/libc/stdlib/meson.build
@@ -253,21 +253,17 @@ foreach file : srcs_stdlib_malloc
   endif
 endforeach
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_stdlib_malloc' + target,
-		     static_library('stdlib_malloc' + target,
-				    srcs_stdlib_malloc_use,
-				    pic: false,
-				    include_directories: inc,
-				    c_args: value[1] + ['-DINTERNAL_NEWLIB'] + c_args_malloc))
-	lib_stdlib_malloc_objs = get_variable('lib_stdlib_malloc' + target).extract_all_objects(recursive:true)
+src_stdlib = files(srcs_stdlib_use)
 
-	set_variable('lib_stdlib' + target,
-		     static_library('stdlib' + target,
-				    srcs_stdlib_use,
-				    objects: lib_stdlib_malloc_objs,
-				    pic: false,
-				    include_directories: inc,
-				    c_args: value[1] + ['-DINTERNAL_NEWLIB']))
+foreach target : targets
+  value = get_variable('target_' + target)
+
+  # Have to build a sub-library to get custom c_args for malloc
+  set_variable('lib_stdlib' + target,
+	       static_library('stdlib_malloc' + target,
+			      srcs_stdlib_malloc_use,
+			      pic: false,
+			      include_directories: inc,
+			      c_args: value[1] + ['-DINTERNAL_NEWLIB'] + c_args_malloc))
+
 endforeach

--- a/newlib/libc/string/meson.build
+++ b/newlib/libc/string/meson.build
@@ -176,20 +176,19 @@ else
   cargs_strcmp = []
 endif
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_strcmp' + target,
-		     static_library('strcmp' + target,
-				    srcs_strcmp_use,
-				    pic: false,
-				    c_args: value[1] + cargs_strcmp,
-				    include_directories: inc))
-	strcmp_objs = get_variable('lib_strcmp' + target).extract_all_objects(recursive:true)
-	set_variable('lib_string' + target,
-		static_library('string' + target,
-			       srcs_string_use,
-			       objects: strcmp_objs,
-			       pic: false,
-			       include_directories: inc,
-			       c_args: value[1]))
-endforeach
+src_string = files(srcs_string_use)
+
+# Need a sub-library to pass custom cflags to strcmp
+
+if srcs_strcmp_use != []
+  foreach target : targets
+    value = get_variable('target_' + target)
+
+    set_variable('lib_string' + target,
+		 static_library('strcmp' + target,
+				srcs_strcmp_use,
+				pic: false,
+				c_args: value[1] + cargs_strcmp,
+				include_directories: inc))
+  endforeach
+endif

--- a/newlib/libc/time/gettzinfo.c
+++ b/newlib/libc/time/gettzinfo.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 2005 Jeff Johnston <jjohnstn@redhat.com> */
 #include <sys/types.h>
-#include <local.h>
+#include "local.h"
 
 /* Shared timezone information for libc/time functions.  */
 static __tzinfo_type tzinfo = {1, 0,

--- a/newlib/libc/time/meson.build
+++ b/newlib/libc/time/meson.build
@@ -74,12 +74,4 @@ foreach file : srcs_time
   endif
 endforeach
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_time' + target,
-		static_library('time' + target,
-			srcs_time_use,
-			pic: false,
-			include_directories: inc,
-			c_args: value[1]))
-endforeach
+src_time = files(srcs_time_use)

--- a/newlib/libc/tinystdio/meson.build
+++ b/newlib/libc/tinystdio/meson.build
@@ -181,14 +181,6 @@ install_headers(
   'stdio.h'
 )
 
-if format_default == 'double'
-  c_args_format = '-DFORMAT_DEFAULT_DOUBLE'
-elif format_default == 'float'
-  c_args_format = '-DFORMAT_DEFAULT_FLOAT'
-elif format_default == 'integer'
-  c_args_format = '-DFORMAT_DEFAULT_INTEGER'
-endif
-
 srcs_tinystdio_use = []
 foreach file : srcs_tinystdio
   s_file = file.split('.')[0] + '.S'
@@ -201,12 +193,4 @@ foreach file : srcs_tinystdio
   endif
 endforeach
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_tinystdio' + target,
-		     static_library('tinystdio' + target,
-				    srcs_tinystdio_use,
-				    pic: false,
-				    include_directories: inc,
-				    c_args: value[1] + [c_args_format]))
-endforeach
+src_tinystdio = files(srcs_tinystdio_use)

--- a/newlib/libc/tinystdio/vfiprintf.c
+++ b/newlib/libc/tinystdio/vfiprintf.c
@@ -35,7 +35,7 @@
 #define vfprintf __i_vfprintf
 #endif
 
-#include <vfprintf.c>
+#include "vfprintf.c"
 
 #ifdef FORMAT_DEFAULT_INTEGER
 #ifdef HAVE_ALIAS_ATTRIBUTE

--- a/newlib/libc/tinystdio/vfiscanf.c
+++ b/newlib/libc/tinystdio/vfiscanf.c
@@ -35,7 +35,7 @@
 #define vfscanf __i_vfscanf
 #endif
 
-#include <vfscanf.c>
+#include "vfscanf.c"
 
 #ifdef FORMAT_DEFAULT_INTEGER
 #ifdef HAVE_ALIAS_ATTRIBUTE

--- a/newlib/libc/tinystdio/vfprintff.c
+++ b/newlib/libc/tinystdio/vfprintff.c
@@ -36,7 +36,7 @@
 #define vfprintf __f_vfprintf
 #endif
 
-#include <vfprintf.c>
+#include "vfprintf.c"
 
 #ifdef FORMAT_DEFAULT_FLOAT
 #ifdef HAVE_ALIAS_ATTRIBUTE

--- a/newlib/libc/xdr/meson.build
+++ b/newlib/libc/xdr/meson.build
@@ -59,13 +59,4 @@ foreach file : srcs_xdr
   endif
 endforeach
 
-
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_xdr' + target,
-		static_library('xdr' + target,
-			srcs_xdr_use,
-			pic: false,
-			include_directories: inc,
-			c_args: value[1]))
-endforeach
+src_xdr = files(srcs_xdr_use)

--- a/newlib/libm/common/meson.build
+++ b/newlib/libm/common/meson.build
@@ -32,11 +32,11 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-src_common = [
+srcs_common = [
     'signgam.c'
 ]  
 
-dsrc_common = [
+dsrcs_common = [
   's_finite.c',
   's_copysign.c',
   's_modf.c',
@@ -93,7 +93,7 @@ dsrc_common = [
   'pow_log_data.c',
 ]
 
-fsrc_common = [
+fsrcs_common = [
   'sf_finite.c',
   'sf_copysign.c',
   'sf_modf.c',
@@ -225,7 +225,7 @@ lsrc_wrap = [
   'sincosl.c',
 ]
 
-srcs_common = src_common + dsrc_common + fsrc_common
+srcs_common += dsrcs_common + fsrcs_common
 
 if have_long_double
   srcs_common += lsrc_full
@@ -253,12 +253,4 @@ hdrs_common = [
     'sincosf.h',
 ]
 
-foreach target : targets
-  value = get_variable('target_' + target)
-  set_variable('lib_common' + target,
-	       static_library('common' + target,
-			      srcs_common_use,
-			      pic: false,
-			      include_directories: inc,
-			      c_args: value[1]))
-endforeach
+src_libm_common = files(srcs_common_use)

--- a/newlib/libm/complex/meson.build
+++ b/newlib/libm/complex/meson.build
@@ -130,12 +130,5 @@ hdrs_complex = [
     'cephes_subr.h',
     'cephes_subrl.h',
 ]
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_complex' + target,
-		static_library('complex' + target,
-			srcs_complex,
-			pic: false,
-			include_directories: inc,
-			c_args: value[1]))
-endforeach
+
+src_libm_complex = files(srcs_complex)

--- a/newlib/libm/fenv/meson.build
+++ b/newlib/libm/fenv/meson.build
@@ -63,12 +63,4 @@ foreach file : srcs_fenv
   endif
 endforeach
 
-foreach target : targets
-  value = get_variable('target_' + target)
-  set_variable('lib_fenv' + target,
-	       static_library('fenv' + target,
-			      srcs_fenv_use,
-			      pic: false,
-			      include_directories: inc,
-			      c_args: value[1]))
-endforeach
+src_libm_fenv = files(srcs_fenv_use)

--- a/newlib/libm/machine/aarch64/meson.build
+++ b/newlib/libm/machine/aarch64/meson.build
@@ -82,12 +82,4 @@ srcs_libm_machine = srcs_libm_machine_real + [
   'feupdateenv.c',
 ]
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_machine' + target,
-		static_library('machine' + target,
-			srcs_libm_machine_real,
-			pic: false,
-			include_directories: math_inc,
-			c_args: value[1] + arg_fnobuiltin))
-endforeach
+src_libm_machine = files(srcs_libm_machine_real)

--- a/newlib/libm/machine/arm/meson.build
+++ b/newlib/libm/machine/arm/meson.build
@@ -65,12 +65,4 @@ srcs_libm_machine = [
   's_trunc.c'
 ]
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_machine' + target,
-		static_library('machine' + target,
-			srcs_libm_machine,
-			pic: false,
-			include_directories: math_inc,
-			c_args: value[1] + arg_fnobuiltin))
-endforeach
+src_libm_machine = files(srcs_libm_machine)

--- a/newlib/libm/machine/i386/meson.build
+++ b/newlib/libm/machine/i386/meson.build
@@ -80,12 +80,4 @@ srcs_libm_machine = srcs_libm_machine_real + [
   'feupdateenv.c',
 ]
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_machine' + target,
-		static_library('machine' + target,
-			srcs_libm_machine_real,
-			pic: false,
-			include_directories: [ inc, include_directories('../../common') ],
-			c_args: value[1] + arg_fnobuiltin))
-endforeach
+src_libm_machine = files(srcs_libm_machine_real)

--- a/newlib/libm/machine/powerpc/meson.build
+++ b/newlib/libm/machine/powerpc/meson.build
@@ -51,12 +51,5 @@ srcs_libm_machine = srcs_libm_machine_real + [
   'fetestexcept.c',
   'feupdateenv.c',
 ]
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_machine' + target,
-		static_library('machine' + target,
-			srcs_libm_machine_real,
-			pic: false,
-			include_directories: math_inc,
-			c_args: value[1] + arg_fnobuiltin))
-endforeach
+
+src_libm_machine = files(srcs_libm_machine_real)

--- a/newlib/libm/machine/riscv/meson.build
+++ b/newlib/libm/machine/riscv/meson.build
@@ -74,14 +74,4 @@ srcs_libm_machine = [
   'sf_lround.c',
 ]
 
-srcs_libm_machine_dontuse = [
-  ]
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_machine' + target,
-		static_library('machine' + target,
-			srcs_libm_machine,
-			pic: false,
-			include_directories: math_inc,
-			c_args: value[1] + arg_fnobuiltin))
-endforeach
+src_libm_machine = files(srcs_libm_machine)

--- a/newlib/libm/machine/x86_64/meson.build
+++ b/newlib/libm/machine/x86_64/meson.build
@@ -54,12 +54,4 @@ srcs_libm_machine = srcs_libm_machine_real + [
   'feupdateenv.c',
 ]
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_machine' + target,
-		static_library('machine' + target,
-			srcs_libm_machine_real,
-			pic: false,
-			include_directories: math_inc,
-			c_args: value[1] + arg_fnobuiltin))
-endforeach
+src_libm_machine = files(srcs_libm_machine_real)

--- a/newlib/libm/machine/xtensa/meson.build
+++ b/newlib/libm/machine/xtensa/meson.build
@@ -50,14 +50,4 @@ srcs_libm_machine = [
   'feupdateenv.c',
 ]
 
-foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_machine' + target,
-		static_library('machine' + target,
-			srcs_libm_machine,
-			pic: false,
-			include_directories: [ inc,
-					       include_directories('../../common'),
-					       include_directories('../../../libc/machine/xtensa') ],
-			c_args: value[1] + arg_fnobuiltin))
-endforeach
+src_libm_machine = files(srcs_libm_machine)

--- a/newlib/libm/math/meson.build
+++ b/newlib/libm/math/meson.build
@@ -194,21 +194,15 @@ endforeach
 
 math_inc = [ inc, include_directories('../common') ]
 
+src_libm_math = files(srcs_math_use)
+
 foreach target : targets
-	value = get_variable('target_' + target)
-	set_variable('lib_math_exp2' + target,
-		     static_library('math_exp2' + target,
-				    ['w_exp2.c', 'wf_exp2.c'],
-				    pic: false,
-				    include_directories: math_inc,
-				    c_args: value[1] + c_args_exp2)
-		    )
-	lib_math_exp2_objs = get_variable('lib_math_exp2' + target).extract_all_objects(recursive:true)
-	set_variable('lib_math' + target,
-		static_library('math' + target,
-			       srcs_math_use,
-			       objects: lib_math_exp2_objs,
-			       pic: false,
-			       include_directories: math_inc,
-			       c_args: value[1]))
+  value = get_variable('target_' + target)
+  set_variable('lib_math' + target,
+	       static_library('math_exp2' + target,
+			      ['w_exp2.c', 'wf_exp2.c'],
+			      pic: false,
+			      include_directories: math_inc,
+			      c_args: value[1] + c_args_exp2)
+	      )
 endforeach

--- a/newlib/libm/meson.build
+++ b/newlib/libm/meson.build
@@ -68,35 +68,43 @@ else
   srcs_libm_machine = []
 endif
 
-math_inc = [include_directories('common'), inc]
+inc = [include_directories('common'), inc]
 
 foreach libdir : libdirs
   subdir(libdir)
 endforeach
 
+src_mpart = []
+
+foreach libname : libnames
+  src_mpart += get_variable('src_libm_' + libname, [])
+endforeach
+
 foreach target : targets
   value = get_variable('target_' + target)
   libobjs = []
+  libsrcs_target = []
 
   foreach libname : libnames
-    libobjs += get_variable('lib_' + libname + target).extract_all_objects(recursive:true)
+    if is_variable('lib_' + libname + target)
+      libobjs += get_variable('lib_' + libname + target).extract_all_objects(recursive:true)
+    endif
+    libsrcs_target += get_variable('src_libm_' + libname + target, [])
   endforeach
 
-  instdir = join_paths(get_option('libdir'), value[0])
+  set_variable('src_mpart_' + target, libsrcs_target)
 
   if target == ''
     libmpart_name = 'mpart'
   else
-    libmpart_name = join_paths(target, 'libmpart')
+    libmpart_name = 'mpart' + '_' + target
   endif
 
   local_lib_mpart_target = static_library(libmpart_name,
-				      pic: false,
-				      objects : libobjs)
+					  pic: false,
+					  objects : libobjs,
+					  include_directories: inc,
+					  c_args: value[1] + ['-D_COMPILING_NEWLIB'])
   set_variable('lib_mpart' + target, local_lib_mpart_target)
 endforeach
-
-if enable_tests
-  subdir('test')
-endif
 

--- a/newlib/libm/test/meson.build
+++ b/newlib/libm/test/meson.build
@@ -133,7 +133,7 @@ endif
 foreach target : targets
   value = get_variable('target_' + target)
 
-  libs = [get_variable('lib_mpart' + target), get_variable('lib_cpart' + target)]
+  libs = [get_variable('lib_c' + target)]
   if is_variable('lib_semihost' + target)
     libs += [get_variable('lib_semihost' + target)]
   endif

--- a/newlib/libm/test/meson.build
+++ b/newlib/libm/test/meson.build
@@ -144,10 +144,10 @@ foreach target : targets
   if target == ''
     test_name = 'math_test'
   else
-    test_name = join_paths(target, 'math_test')
+    test_name = 'math_test_' + target
   endif
 
-  test('math' + target,
+  test(test_name,
        executable(test_name, math_test_src,
 		  c_args: value[1] + double_printf_compile_args + test_c_args,
 		  link_with: libs,

--- a/newlib/meson.build
+++ b/newlib/meson.build
@@ -37,12 +37,22 @@ subdir('libm')
 
 libnames = ['cpart', 'mpart']
 
+libsrcs = []
+
+foreach libname : libnames
+  libsrcs += get_variable('src_' + libname, [])
+endforeach
+
 foreach target : targets
   value = get_variable('target_' + target)
   libobjs = []
+  libsrcs_target = libsrcs
 
   foreach libname : libnames
-    libobjs += get_variable('lib_' + libname + target).extract_all_objects(recursive:true)
+    if is_variable('lib_' + libname + target)
+      libobjs += get_variable('lib_' + libname + target).extract_all_objects(recursive:true)
+    endif
+    libsrcs_target += get_variable('src_' + libname + target, [])
   endforeach
 
   instdir = join_paths(get_option('libdir'), value[0])
@@ -56,10 +66,13 @@ foreach target : targets
   endif
 
   local_lib_c_target = static_library(libc_name,
+				      libsrcs_target,
 				      install : true,
 				      install_dir : instdir,
 				      pic: false,
-				      objects : libobjs)
+				      objects : libobjs,
+				      include_directories: inc,
+				      c_args: value[1] + ['-D_COMPILING_NEWLIB'])
 
   set_variable('lib_c' + target, local_lib_c_target)
 
@@ -84,4 +97,5 @@ endforeach
 
 if enable_tests
   subdir('testsuite')
+  subdir('libm/test')
 endif

--- a/newlib/testsuite/newlib.iconv/meson.build
+++ b/newlib/testsuite/newlib.iconv/meson.build
@@ -60,12 +60,12 @@ foreach target : targets
     if target == ''
       test_name = test
     else
-      test_name = join_paths(target, test)
+      test_name = test + '_' + target
     endif
 
     src = test + '.c'
 
-    test(test + target,
+    test(test_name,
 	 executable(test_name, src,
 		    c_args: ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + _c_args + iconv_test_c_args,
 		    link_args: _link_args,

--- a/newlib/testsuite/newlib.search/meson.build
+++ b/newlib/testsuite/newlib.search/meson.build
@@ -53,12 +53,12 @@ foreach target : targets
     if target == ''
       test_name = test
     else
-      test_name = join_paths(target, test)
+      test_name = test + '_' + target
     endif
 
     src = test + '.c'
 
-    test(test + target,
+    test(test_name,
 	 executable(test_name, src,
 		    c_args: ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + _c_args,
 		    link_args: _link_args,

--- a/newlib/testsuite/newlib.stdio/meson.build
+++ b/newlib/testsuite/newlib.stdio/meson.build
@@ -57,12 +57,12 @@ foreach target : targets
     if target == ''
       test_name = test
     else
-      test_name = join_paths(target, test)
+      test_name = test + '_' + target
     endif
 
     src = test + '.c'
 
-    test(test + target,
+    test(test_name,
 	 executable(test_name, src,
 		    c_args: ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + _c_args,
 		    link_args: _link_args,

--- a/newlib/testsuite/newlib.stdlib/meson.build
+++ b/newlib/testsuite/newlib.stdlib/meson.build
@@ -53,12 +53,12 @@ foreach target : targets
     if target == ''
       test_name = test
     else
-      test_name = join_paths(target, test)
+      test_name = test + '_' + target
     endif
 
     src = test + '.c'
 
-    test(test + target,
+    test(test_name,
 	 executable(test_name, src,
 		    c_args: ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + _c_args,
 		    link_args: _link_args,

--- a/newlib/testsuite/newlib.string/meson.build
+++ b/newlib/testsuite/newlib.string/meson.build
@@ -53,12 +53,12 @@ foreach target : targets
     if target == ''
       test_name = test
     else
-      test_name = join_paths(target, test)
+      test_name = test + '_' + target
     endif
 
     src = test + '.c'
 
-    test(test + target,
+    test(test_name,
 	 executable(test_name, [src],
 		    c_args: ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + _c_args,
 		    link_args: _link_args,

--- a/newlib/testsuite/newlib.wctype/meson.build
+++ b/newlib/testsuite/newlib.wctype/meson.build
@@ -55,12 +55,12 @@ foreach target : targets
     if target == ''
       test_name = test
     else
-      test_name = join_paths(target, test)
+      test_name = test + '_' + target
     endif
 
     src = test + '.c'
 
-    test(test + target,
+    test(test_name,
 	 executable(test_name, src,
 		    c_args: ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + _c_args,
 		    link_args: _link_args,

--- a/scripts/run-arm
+++ b/scripts/run-arm
@@ -49,91 +49,91 @@ memory=
 #
 
 case "$elf" in
-    */arm_v5te_hard/*|*/arm_v5te_softfp/*)
+    *arm_v5te_hard*|*arm_v5te_softfp*)
 	# The only v5 supported by qemu is the arm946,
 	# which doesn't have an FPU, and all of the GCC
 	#cpu=arm946
 	;;
 
     # v6-m - Cortex-M0
-    */thumb_v6_m_nofp/*)
+    *thumb_v6_m_nofp*)
 	cpu=cortex-m0
 	;;
 
     # v7-a/v7ve - Cortex-A7
-    */thumb_v7_a*|*/thumb_v7ve_*)
+    *thumb_v7_a*|*thumb_v7ve_*)
 	cpu=cortex-a7
 	;;
 
     # v7-m - Cortex-M3
-    */thumb_v7_m_nofp/*)
+    *thumb_v7_m_nofp*)
 	cpu=cortex-m3
 	;;
 
     # v7-r - Cortex-R5
-    */thumb_v7_r*)
+    *thumb_v7_r*)
 	cpu=cortex-r5f
 	;;
 
     # v7e-m - Cortex-M4
-    */thumb_v7e_m_nofp/*)
+    *thumb_v7e_m_nofp*)
 	cpu=cortex-m4
 	;;
-    */thumb_v7e_m_fp_hard/*)
+    *thumb_v7e_m_fp_hard*)
 	cpu=cortex-m4
 	;;
-    */thumb_v7e_m_fp_softfp/*)
+    *thumb_v7e_m_fp_softfp*)
 	cpu=cortex-m4
 	;;
 
     # v7e-m dp - Cortex-M7
-    */thumb_v7e_m_dp_hard/*)
+    *thumb_v7e_m_dp_hard*)
 	cpu=cortex-m7
 	;;
-    */thumb_v7e_m_dp_softfp/*)
+    *thumb_v7e_m_dp_softfp*)
 	cpu=cortex-m7
 	;;
 
     # v8-a - unknown
-    */thumb_v8_a*)
+    *thumb_v8_a*)
 	cpu=unknown
 	;;
 
     # v8.1 - unknown
-    */thumb_v8_1*)
+    *thumb_v8_1*)
 	cpu=unknown
 	;;
 
     # v8-m with single-precision FPU - Cortex-M33
-    */thumb_v8_m_base_nofp/*)
+    *thumb_v8_m_base_nofp*)
 	cpu=cortex-m33
 	;;
-    */thumb_v8_m_main_fp_softfp/*)
+    *thumb_v8_m_main_fp_softfp*)
 	cpu=cortex-m33
 	;;
-    */thumb_v8_m_main_dp_softfp/*)
+    *thumb_v8_m_main_dp_softfp*)
 	;;
-    */thumb_v8_m_main_fp_hard/*)
+    *thumb_v8_m_main_fp_hard*)
 	cpu=cortex-m33
 	;;
-    */thumb_v8_m_main_nofp/*)
+    *thumb_v8_m_main_nofp*)
 	cpu=cortex-m33
 	;;
 
     # v8-m with double-preicision FPU - none
-    */thumb_v8_m_main_dp_hard/*)
+    *thumb_v8_m_main_dp_hard*)
 	;;
 
     # v7 - Cortex-A7
-    */thumb_v7_nofp/*)
+    *thumb_v7_nofp*)
 	cpu=cortex-a7
 	;;
 
     # v7 with FPU - Cortex-A9
-    */thumb_v7_fp_hard/*)
+    *thumb_v7_fp_hard*)
 	cpu=cortex-a8
 	;;
-    */thumb_v7_fp_softfp/*)
+    *thumb_v7_fp_softfp*)
 	cpu=cortex-a8
 	;;
 

--- a/scripts/run-riscv
+++ b/scripts/run-riscv
@@ -41,11 +41,11 @@ elf="$1"
 shift
 
 case "$elf" in
-    */rv32*_ilp32*/*)
+    *rv32*_ilp32*)
 	qemu="qemu-system-riscv32"
 	cpu=rv32
 	;;
-    */rv64*_lp64*/*)
+    *rv64*_lp64*)
 	qemu="qemu-system-riscv64"
 	cpu=rv64
 	;;

--- a/test/meson.build
+++ b/test/meson.build
@@ -60,10 +60,10 @@ foreach target : targets
   if target == ''
     t1_name = t1
   else
-    t1_name = join_paths(target, t1)
+    t1_name = t1 + '_' + target
   endif
 
-  test(t1 + target,
+  test(t1_name,
        executable(t1_name, 'printf_scanf.c',
 		  c_args: double_printf_compile_args + _c_args,
 		  link_args: double_printf_link_args + _link_args,
@@ -76,10 +76,10 @@ foreach target : targets
   if target == ''
     t1_name = t1
   else
-    t1_name = join_paths(target, t1)
+    t1_name = t1 + '_' + target
   endif
 
-  test(t1 + target,
+  test(t1_name,
        executable(t1_name, 'printf_scanf.c',
 		  c_args: float_printf_compile_args + _c_args,
 		  link_args: float_printf_link_args + _link_args,
@@ -92,10 +92,10 @@ foreach target : targets
   if target == ''
     t1_name = t1
   else
-    t1_name = join_paths(target, t1)
+    t1_name = t1 + '_' + target
   endif
 
-  test(t1 + target,
+  test(t1_name,
        executable(t1_name, ['printf-tests.c'],
 		  c_args: double_printf_compile_args + _c_args,
 		  link_args: double_printf_link_args + _link_args,
@@ -107,10 +107,10 @@ foreach target : targets
   if target == ''
     t1_name = t1
   else
-    t1_name = join_paths(target, t1)
+    t1_name = t1 + '_' + target
   endif
 
-  test(t1 + target,
+  test(t1_name,
        executable(t1_name, ['printf-tests.c'],
 		  c_args: float_printf_compile_args + _c_args,
 		  link_args: float_printf_link_args + _link_args,
@@ -122,10 +122,10 @@ foreach target : targets
   if target == ''
     t1_name = t1
   else
-    t1_name = join_paths(target, t1)
+    t1_name = t1 + '_' + target
   endif
 
-  test(t1 + target,
+  test(t1_name,
        executable(t1_name, ['printf-tests.c'],
 		  c_args: int_printf_compile_args + _c_args,
 		  link_args: int_printf_link_args + _link_args,
@@ -137,10 +137,10 @@ foreach target : targets
   if target == ''
     t1_name = t1
   else
-    t1_name = join_paths(target, t1)
+    t1_name = t1 + '_' + target
   endif
 
-  test(t1 + target,
+  test(t1_name,
        executable(t1_name, ['try-ilp32.c', 'try-ilp32-sub.c'],
 		  c_args: _c_args,
 		  link_args: _link_args,
@@ -152,10 +152,10 @@ foreach target : targets
   if target == ''
     t1_name = t1
   else
-    t1_name = join_paths(target, t1)
+    t1_name = t1 + '_' + target
   endif
 
-  test(t1 + target,
+  test(t1_name,
        executable(t1_name, 'hosted-exit.c',
 		  c_args: _c_args,
 		  link_args:  _link_args,
@@ -177,10 +177,10 @@ foreach target : targets
   if target == ''
     t1_name = t1
   else
-    t1_name = join_paths(target, t1)
+    t1_name = t1 + '_' + target
   endif
 
-  test(t1 + target,
+  test(t1_name,
        executable(t1_name, 'abort.c',
 		  c_args: _c_args,
 		  link_args:  _link_args,
@@ -195,10 +195,10 @@ foreach target : targets
     if target == ''
       t1_name = t1
     else
-      t1_name = join_paths(target, t1)
+      t1_name = t1 + '_' + target
     endif
 
-    test(t1 + target,
+    test(t1_name,
 	 executable(t1_name, 'constructor-skip.c',
 		    c_args: _c_args,
 		    link_args:  _link_args,
@@ -211,10 +211,10 @@ foreach target : targets
   if target == ''
     t1_name = t1
   else
-    t1_name = join_paths(target, t1)
+    t1_name = t1 + '_' + target
   endif
 
-  test(t1 + target,
+  test(t1_name,
        executable(t1_name, ['rounding-mode.c', 'rounding-mode-sub.c'],
 		  c_args: _c_args,
 		  link_args: _link_args,
@@ -254,10 +254,10 @@ foreach target : targets
     if target == ''
       t1_name = t1
     else
-      t1_name = join_paths(target, t1)
+      t1_name = t1 + '_' + target
     endif
 
-    test(t1 + target,
+    test(t1_name,
 	 executable(t1_name, [t1_src],
 		    c_args: double_printf_compile_args + _c_args,
 		    link_args: double_printf_link_args + _link_args,

--- a/test/semihost/meson.build
+++ b/test/semihost/meson.build
@@ -87,10 +87,10 @@ foreach target : targets
     if target == ''
       semihost_test_name = semihost_test
     else
-      semihost_test_name = join_paths(target, semihost_test)
+      semihost_test_name = semihost_test + '_' + target
     endif
 
-    test(semihost_test + target,
+    test(semihost_test_name,
 	 executable(semihost_test_name, [semihost_test_src],
 		    c_args: _c_args,
 		    link_args: _link_args,
@@ -106,10 +106,10 @@ foreach target : targets
     if target == ''
       semihost_fail_test_name = semihost_fail_test
     else
-      semihost_fail_test_name = join_paths(target, semihost_fail_test)
+      semihost_fail_test_name = semihost_fail_test + '_' + target
     endif
 
-    test(semihost_fail_test + target,
+    test(semihost_fail_test_name,
 	 executable(semihost_fail_test_name, [semihost_fail_test_src],
 		    c_args: _c_args,
 		    link_args: _link_args,


### PR DESCRIPTION
Change the build process to concatenate lists of source files where possible instead of always building intermediate libraries. This should speed up the build a bit.

Also, change the test names to eliminate the path separator. This makes meson a lot happier.