### PR TITLE
Fix test dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -892,6 +892,9 @@ has_semihost = false
 # arm compatible semihosting, enough to run arm semihost tests
 has_arm_semihost = false
 
+# some semihost needs bios to run the tests with qemu
+bios_bin = []
+
 # make sure to include semihost BEFORE picocrt!
 if enable_semihost
   subdir('semihost')

--- a/newlib/libm/test/meson.build
+++ b/newlib/libm/test/meson.build
@@ -153,6 +153,7 @@ foreach target : targets
 		  link_with: libs,
 		  link_args: value[1] + double_printf_link_args + test_link_args,
 		  include_directories: inc),
+       depends: bios_bin,
        env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
 endforeach
 

--- a/newlib/testsuite/newlib.iconv/meson.build
+++ b/newlib/testsuite/newlib.iconv/meson.build
@@ -71,7 +71,7 @@ foreach target : targets
 		    link_args: _link_args,
 		    link_with: _libs,
 		    include_directories: test_inc),
-	 depends: iconv_data_link,
+	 depends: [iconv_data_link, bios_bin],
 	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
   endforeach
 endforeach

--- a/newlib/testsuite/newlib.locale/meson.build
+++ b/newlib/testsuite/newlib.locale/meson.build
@@ -45,5 +45,6 @@ foreach test : tests
 		  link_args: test_link_args,
 		  link_with: [lib_c, lib_semihost, lib_crt],
 		  include_directories: inc),
+       depends: bios_bin,
        env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
 endforeach

--- a/newlib/testsuite/newlib.search/meson.build
+++ b/newlib/testsuite/newlib.search/meson.build
@@ -64,6 +64,7 @@ foreach target : targets
 		    link_args: _link_args,
 		    link_with: _libs,
 		    include_directories: test_inc),
+         depends: bios_bin,
 	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
   endforeach
 endforeach

--- a/newlib/testsuite/newlib.stdio/meson.build
+++ b/newlib/testsuite/newlib.stdio/meson.build
@@ -68,6 +68,7 @@ foreach target : targets
 		    link_args: _link_args,
 		    link_with: _libs,
 		    include_directories: test_inc),
+	 depends: bios_bin,
 	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
   endforeach
 endforeach

--- a/newlib/testsuite/newlib.stdlib/meson.build
+++ b/newlib/testsuite/newlib.stdlib/meson.build
@@ -64,6 +64,7 @@ foreach target : targets
 		    link_args: _link_args,
 		    link_with: _libs,
 		    include_directories: test_inc),
+         depends: bios_bin,
 	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
   endforeach
 endforeach

--- a/newlib/testsuite/newlib.string/meson.build
+++ b/newlib/testsuite/newlib.string/meson.build
@@ -64,6 +64,7 @@ foreach target : targets
 		    link_args: _link_args,
 		    link_with: _libs,
 		    include_directories: test_inc),
+         depends: bios_bin,
 	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
   endforeach
 endforeach

--- a/newlib/testsuite/newlib.wctype/meson.build
+++ b/newlib/testsuite/newlib.wctype/meson.build
@@ -66,6 +66,7 @@ foreach target : targets
 		    link_args: _link_args,
 		    link_with: _libs,
 		    include_directories: test_inc),
+         depends: bios_bin,
 	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
   endforeach
 endforeach

--- a/scripts/monitor-e9
+++ b/scripts/monitor-e9
@@ -8,6 +8,9 @@ status = 1
 
 with subprocess.Popen(sys.argv[1:], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL) as proc:
     while True:
+        status = proc.poll()
+        if status:
+            break;
         c = proc.stdout.read(1)
         if c == b'\xe9':
             c = proc.stdout.readline().decode('utf-8')

--- a/semihost/machine/i386/meson.build
+++ b/semihost/machine/i386/meson.build
@@ -78,13 +78,13 @@ foreach target : targets
 		      c_args: value[1],
 		      link_args: ['-nostartfiles', '-nostdlib', '-Wl,--build-id=none', '-T', bios_ld])
 
-    custom_target('bios' + target + '.bin',
-		  build_by_default: true,
-		  input: bios,
-		  install: true,
-		  install_dir: instdir,
-		  output: 'bios' + target + '.bin',
-		  command: [objcopy, '-O', 'binary', '@INPUT@', '@OUTPUT@'])
+    bios_bin = custom_target('bios' + target + '.bin',
+		             build_by_default: true,
+		             input: bios,
+		             install: true,
+		             install_dir: instdir,
+		             output: 'bios' + target + '.bin',
+		             command: [objcopy, '-O', 'binary', '@INPUT@', '@OUTPUT@'])
   endif
 
 endforeach

--- a/test/meson.build
+++ b/test/meson.build
@@ -70,6 +70,7 @@ foreach target : targets
 		  link_with: _libs,
 		  link_depends:  test_link_depends,
 		  include_directories: inc),
+       depends: bios_bin,
        env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
 
   t1 = 'printff_scanff'
@@ -86,6 +87,7 @@ foreach target : targets
 		  link_with: _libs,
 		  link_depends:  test_link_depends,
 		  include_directories: inc),
+       depends: bios_bin,
        env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
 
   t1 = 'printf-tests'
@@ -101,6 +103,7 @@ foreach target : targets
 		  link_args: double_printf_link_args + _link_args,
 		  link_with: _libs,
 		  include_directories: inc),
+       depends: bios_bin,
        env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
 
   t1 = 'printff-tests'
@@ -116,6 +119,7 @@ foreach target : targets
 		  link_args: float_printf_link_args + _link_args,
 		  link_with: _libs,
 		  include_directories: inc),
+       depends: bios_bin,
        env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
 
   t1 = 'printfi-tests'
@@ -131,6 +135,7 @@ foreach target : targets
 		  link_args: int_printf_link_args + _link_args,
 		  link_with: _libs,
 		  include_directories: inc),
+       depends: bios_bin,
        env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
 
   t1 = 'try-ilp32'
@@ -146,6 +151,7 @@ foreach target : targets
 		  link_args: _link_args,
 		  link_with: _libs,
 		  include_directories: inc),
+       depends: bios_bin,
        env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
 
   t1 = 'hosted-exit'
@@ -161,6 +167,7 @@ foreach target : targets
 		  link_args:  _link_args,
 		  link_with: _libs,
 		  include_directories: inc),
+       depends: bios_bin,
        env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
 
   test(t1 + '-fail' + target,
@@ -169,6 +176,7 @@ foreach target : targets
 		  link_args:  _link_args,
 		  link_with: _libs,
 		  include_directories: inc),
+       depends: bios_bin,
        env: ['MESON_SOURCE_ROOT=' + meson.source_root()],
        should_fail: true
       )
@@ -186,6 +194,7 @@ foreach target : targets
 		  link_args:  _link_args,
 		  link_with: _libs,
 		  include_directories: inc),
+       depends: bios_bin,
        env: ['MESON_SOURCE_ROOT=' + meson.source_root()],
        should_fail: true
       )
@@ -204,6 +213,7 @@ foreach target : targets
 		    link_args:  _link_args,
 		    link_with: _libs_minimal,
 		    include_directories: inc),
+         depends: bios_bin,
 	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
   endif
 
@@ -220,6 +230,7 @@ foreach target : targets
 		  link_args: _link_args,
 		  link_with: _libs,
 		  include_directories: inc),
+       depends: bios_bin,
        env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
 
   plain_tests = ['rand', 'regex', 'ungetc', 'fenv',
@@ -264,6 +275,7 @@ foreach target : targets
 		    link_with: _libs,
 		    link_depends:  test_link_depends,
 		    include_directories: inc),
+         depends: bios_bin,
 	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
   endforeach
 

--- a/test/semihost/meson.build
+++ b/test/semihost/meson.build
@@ -98,6 +98,7 @@ foreach target : targets
 		    link_depends:  test_link_depends,
 		    include_directories: inc),
 	 args: [command_line],
+         depends: bios_bin,
 	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
   endforeach
 


### PR DESCRIPTION
When I `meson test -C builddir-x86_64` after `meson configure`, all tests failed with timeouts.  It was same for i386, too.  But other arches just worked.  Strangely, `.github/do-test` works for both x86s.  I didn't know what was going on but figured out that there were two issues

1. `monitor-e9` was busy looping waiting for qemu to spit `\xe9` when `qemu` was already dead because of `bios.bin` not found.
2. For i386 and x86_64, we need `bios.bin` to run the tests but no tests depends on it.  This make `qemu` to exit immediately.

This PR has two commits addressing the issues.
