### PR TITLE
github/workflows: Disable gha cache backend

### DIFF
--- a/.github/workflows/minsize.yml
+++ b/.github/workflows/minsize.yml
@@ -25,8 +25,6 @@ jobs:
           platforms: linux/amd64
           file: .github/Dockerfile
           tags: ${{ env.IMAGE }}:latest
-          cache-from: type=gha
-          cache-to: type=gha
           outputs: type=docker,dest=${{ env.IMAGE_FILE }}
 
       - name: Check size

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,6 @@ jobs:
           platforms: linux/amd64
           file: .github/Dockerfile
           tags: ${{ env.IMAGE }}:latest
-          cache-from: type=gha
-          cache-to: type=gha
           outputs: type=docker,dest=${{ env.IMAGE_FILE }}
 
       - name: Check size


### PR DESCRIPTION
@keith-packard, I assume that the recent build failures with the following message is due to the experimental GitHub Actions cache exporter backend.  This PR disables it for both minsize and release builds.  Apologize for using such a feature without testing extensively before merge.

```
cache-maker
buildx failed with: error: failed to solve: blob sha256:175e4f431a281b94c2242a18f699a0500f6cd4da8354839102c2446848593bc2 not found
```

With this commit, we only stores the final docker image on the cache, which is about 1.5 GB right now.  So, it should fit on the 5 GB cache.