### PR TITLE
Kill warnings

### DIFF
--- a/scripts/cross-clang-riscv64-unknown-elf.txt
+++ b/scripts/cross-clang-riscv64-unknown-elf.txt
@@ -8,7 +8,7 @@ exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"
 
 [host_machine]
 system = 'none'
-cpu_family = 'riscv'
+cpu_family = 'riscv64'
 cpu = 'riscv'
 endian = 'little'
 

--- a/scripts/cross-clang-rv32imafdc-unknown-elf.txt
+++ b/scripts/cross-clang-rv32imafdc-unknown-elf.txt
@@ -9,7 +9,7 @@ exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"
 
 [host_machine]
 system = 'none'
-cpu_family = 'riscv'
+cpu_family = 'riscv32'
 cpu = 'riscv'
 endian = 'little'
 

--- a/scripts/cross-i686-linux-gnu.txt
+++ b/scripts/cross-i686-linux-gnu.txt
@@ -9,7 +9,7 @@ exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"
 
 [host_machine]
 system='linux'
-cpu_family='i386'
+cpu_family='x86'
 cpu='i386'
 endian='little'
 

--- a/scripts/cross-riscv64-unknown-elf.txt
+++ b/scripts/cross-riscv64-unknown-elf.txt
@@ -8,7 +8,7 @@ exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"
 
 [host_machine]
 system = 'unknown'
-cpu_family = 'riscv'
+cpu_family = 'riscv64'
 cpu = 'riscv'
 endian = 'little'
 

--- a/scripts/cross-riscv64-zephyr-elf.txt
+++ b/scripts/cross-riscv64-zephyr-elf.txt
@@ -8,7 +8,7 @@ exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"
 
 [host_machine]
 system = 'zephyr'
-cpu_family = 'riscv'
+cpu_family = 'riscv64'
 cpu = 'riscv'
 endian = 'little'
 

--- a/scripts/cross-rv32imac.txt
+++ b/scripts/cross-rv32imac.txt
@@ -8,7 +8,7 @@ exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"
 
 [host_machine]
 system = 'unknown'
-cpu_family = 'riscv'
+cpu_family = 'riscv32'
 cpu = 'riscv32'
 endian = 'little'
 


### PR DESCRIPTION
Kill most of warnings from meson.

The remaining one is:

```
DEPRECATION: c_args in the [properties] section of the machine file is deprecated, use the [built-in options] section.
```

But, this one can't be fixed until we bump meson version to 0.56.
https://mesonbuild.com/Machine-files.html#meson-builtin-options

Distribution version having Meson 0.56 or later are:
- Ubuntu 21.04 Hirsute or later
- Debian 11 Bullseye or later
- Fedora 33 or later