### PR TITLE
libc: Remove #ifdef check before #undef

### DIFF
--- a/newlib/libc/machine/arm/aeabi_memcpy.c
+++ b/newlib/libc/machine/arm/aeabi_memcpy.c
@@ -57,9 +57,7 @@ void __aeabi_memcpy8 (void *dest, const void *source, size_t n)
 
 /* Support the routine __aeabi_memcpy.  Can't alias to memcpy
    because it's not defined in the same translation unit.  */
-#ifdef memcpy
 #undef memcpy
-#endif
 
 void __aeabi_memcpy (void *dest, const void *source, size_t n)
 {

--- a/newlib/libc/machine/arm/aeabi_memmove.c
+++ b/newlib/libc/machine/arm/aeabi_memmove.c
@@ -60,9 +60,7 @@ void __aeabi_memmove8 (void *dest, const void *source, size_t n)
  *__attribute__((used)) added so that building with clang -flto
  * doesn't discard this function
  */
-#ifdef memmove
 #undef memmove
-#endif
 
 void __attribute__((used)) __aeabi_memmove (void *dest, const void *source, size_t n)
 {

--- a/newlib/libc/machine/arm/aeabi_memset.c
+++ b/newlib/libc/machine/arm/aeabi_memset.c
@@ -60,9 +60,7 @@ void __aeabi_memset8 (void *dest, size_t n, int c)
  *__attribute__((used)) added so that building with clang -flto
  * doesn't discard this function
  */
-#ifdef memset
 #undef memset
-#endif
 
 void __attribute__((used)) __aeabi_memset (void *dest, size_t n, int c)
 {

--- a/newlib/libc/machine/arm/strcpy.c
+++ b/newlib/libc/machine/arm/strcpy.c
@@ -38,9 +38,7 @@
 #define magic2(REG) #REG ", lsl #7"
 #endif
 
-#ifdef strcpy
 #undef strcpy
-#endif
 
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 char* __attribute__((naked))

--- a/newlib/libc/machine/riscv/memcpy.c
+++ b/newlib/libc/machine/riscv/memcpy.c
@@ -19,9 +19,7 @@
 
 #define unlikely(X) __builtin_expect (!!(X), 0)
 
-#ifdef memcpy
 #undef memcpy
-#endif
 
 void *
 __inhibit_loop_to_libcall

--- a/newlib/libc/machine/riscv/strcpy.c
+++ b/newlib/libc/machine/riscv/strcpy.c
@@ -12,9 +12,7 @@
 #include <string.h>
 #include <stdint.h>
 
-#ifdef strcpy
 #undef strcpy
-#endif
 
 char *strcpy(char *dst, const char *src)
 {

--- a/newlib/libc/ssp/memmove_chk.c
+++ b/newlib/libc/ssp/memmove_chk.c
@@ -38,9 +38,7 @@ __RCSID("$NetBSD: memmove_chk.c,v 1.5 2014/09/17 00:39:28 joerg Exp $");
 
 #undef memmove
 
-#ifdef __memmove_chk
 #undef __memmove_chk
-#endif
 
 void *__memmove_chk(void *, const void *src, size_t, size_t);
 

--- a/newlib/libc/stdio/gets.c
+++ b/newlib/libc/stdio/gets.c
@@ -92,9 +92,7 @@ _gets_r (struct _reent *ptr,
 
 #ifndef _REENT_ONLY
 
-#ifdef gets
 #undef gets
-#endif
 
 char *
 gets (char *buf)

--- a/newlib/libc/stdio/snprintf.c
+++ b/newlib/libc/stdio/snprintf.c
@@ -62,9 +62,7 @@ _sniprintf_r (struct _reent *, char *, size_t, const char *, ...)
 
 #ifndef _REENT_ONLY
 
-#ifdef snprintf
 #undef snprintf
-#endif
 
 int
 snprintf (char *__restrict str,

--- a/newlib/libc/stdio/sprintf.c
+++ b/newlib/libc/stdio/sprintf.c
@@ -602,9 +602,7 @@ _siprintf_r (struct _reent *, char *, const char *, ...)
 
 #ifndef _REENT_ONLY
 
-#ifdef sprintf
 #undef sprintf
-#endif
 
 int
 sprintf (char *__restrict str,

--- a/newlib/libc/stdio/vsnprintf.c
+++ b/newlib/libc/stdio/vsnprintf.c
@@ -31,9 +31,7 @@ static char sccsid[] = "%W% (Berkeley) %G%";
 
 #ifndef _REENT_ONLY
 
-#ifdef vsnprintf
 #undef vsnprintf
-#endif
 
 int
 vsnprintf (char *__restrict str,

--- a/newlib/libc/stdio/vsprintf.c
+++ b/newlib/libc/stdio/vsprintf.c
@@ -30,9 +30,7 @@ static char sccsid[] = "%W% (Berkeley) %G%";
 
 #ifndef _REENT_ONLY
 
-#ifdef vsprintf
 #undef vsprintf
-#endif
 
 int
 vsprintf (char *__restrict str,

--- a/newlib/libc/string/bcopy.c
+++ b/newlib/libc/string/bcopy.c
@@ -39,9 +39,7 @@ QUICKREF
 #include <string.h>
 #include <strings.h>
 
-#ifdef bcopy
 #undef bcopy
-#endif
 
 void
 bcopy (const void *b1,

--- a/newlib/libc/string/memcpy.c
+++ b/newlib/libc/string/memcpy.c
@@ -60,9 +60,7 @@ QUICKREF
 /* Threshhold for punting to the byte copier.  */
 #define TOO_SMALL(LEN)  ((LEN) < BIGBLOCKSIZE)
 
-#ifdef memcpy
 #undef memcpy
-#endif
 
 void *
 __inhibit_loop_to_libcall

--- a/newlib/libc/string/memmove.c
+++ b/newlib/libc/string/memmove.c
@@ -63,9 +63,7 @@ QUICKREF
 /* Threshhold for punting to the byte copier.  */
 #define TOO_SMALL(LEN)  ((LEN) < BIGBLOCKSIZE)
 
-#ifdef memmove
 #undef memmove
-#endif
 
 /*SUPPRESS 20*/
 void *
@@ -115,7 +113,7 @@ memmove (void *dst_void,
     }
   else
     {
-      /* Use optimizing algorithm for a non-destructive copy to closely 
+      /* Use optimizing algorithm for a non-destructive copy to closely
          match memcpy. If the size is small or either SRC or DST is unaligned,
          then punt into the byte copy loop.  This should be rare.  */
       if (!TOO_SMALL(length) && !UNALIGNED (src, dst))

--- a/newlib/libc/string/memset.c
+++ b/newlib/libc/string/memset.c
@@ -49,9 +49,7 @@ QUICKREF
 #define UNALIGNED(X)   ((long)X & (LBLOCKSIZE - 1))
 #define TOO_SMALL(LEN) ((LEN) < LBLOCKSIZE)
 
-#ifdef memset
 #undef memset
-#endif
 
 void *
 __inhibit_loop_to_libcall

--- a/newlib/libc/string/strcat.c
+++ b/newlib/libc/string/strcat.c
@@ -69,9 +69,7 @@ QUICKREF
 /*SUPPRESS 560*/
 /*SUPPRESS 530*/
 
-#ifdef strcat
 #undef strcat
-#endif
 
 char *
 strcat (char *__restrict s1,
@@ -111,7 +109,7 @@ strcat (char *__restrict s1,
      s1 is much less likely to be aligned.  I don't know if its worth
      tweaking strcpy to handle this better.  */
   strcpy (s1, s2);
-	
+
   return s;
 #endif /* not PREFER_SIZE_OVER_SPEED */
 }

--- a/newlib/libc/string/strcpy.c
+++ b/newlib/libc/string/strcpy.c
@@ -67,9 +67,7 @@ QUICKREF
 #error long int is not a 32bit or 64bit byte
 #endif
 
-#ifdef strcpy
 #undef strcpy
-#endif
 
 char*
 strcpy (char *dst0,

--- a/newlib/libc/string/strncat.c
+++ b/newlib/libc/string/strncat.c
@@ -73,9 +73,7 @@ QUICKREF
 #error long int is not a 32bit or 64bit byte
 #endif
 
-#ifdef strncat
 #undef strncat
-#endif
 
 char *
 strncat (char *__restrict s1,
@@ -121,7 +119,7 @@ strncat (char *__restrict s1,
       if (n == 0)
 	*s1 = '\0';
     }
-	
+
   return s;
 #endif /* not PREFER_SIZE_OVER_SPEED */
 }

--- a/newlib/libc/string/strncpy.c
+++ b/newlib/libc/string/strncpy.c
@@ -74,9 +74,7 @@ QUICKREF
 
 #define TOO_SMALL(LEN) ((LEN) < sizeof (long))
 
-#ifdef strncpy
 #undef strncpy
-#endif
 
 char *
 strncpy (char *__restrict dst0,


### PR DESCRIPTION
C Standards state that

> It is ignored if the specified identifier is not currently defined as a macro name.

So we don't need to check with `#ifdef` before `#undef`.  It seems that old compilers might error out, but we specify `c18` in the `meson.build`, anyway.

`newlib/libc/reent/getreent.c` has the line `#undef __getreent` but it's not added by the recent commit c2c593afa60b64bff, so this commit doesn't change it.
