### PR TITLE
newlib: Replace file.split('.') with fs.replace_suffix()

### DIFF
--- a/newlib/libc/argz/meson.build
+++ b/newlib/libc/argz/meson.build
@@ -59,7 +59,7 @@ hdrs_argz = [
 
 srcs_argz_use = []
 foreach file : srcs_argz
-  s_file = file.split('.')[0] + '.S'
+  s_file = fs.replace_suffix(file, '.S')
   if file in srcs_machine
     message('libc/argz/' + file + ': machine overrides generic')
   elif s_file in srcs_machine

--- a/newlib/libc/ctype/meson.build
+++ b/newlib/libc/ctype/meson.build
@@ -114,7 +114,7 @@ hdrs_ctype = [
 
 srcs_ctype_use = []
 foreach file : srcs_ctype
-  s_file = file.split('.')[0] + '.S'
+  s_file = fs.replace_suffix(file, '.S')
   if file in srcs_machine
     message('libc/ctype/' + file + ': machine overrides generic')
   elif s_file in srcs_machine

--- a/newlib/libc/errno/meson.build
+++ b/newlib/libc/errno/meson.build
@@ -38,7 +38,7 @@ srcs_errno = [
 
 srcs_errno_use = []
 foreach file : srcs_errno
-  s_file = file.split('.')[0] + '.S'
+  s_file = fs.replace_suffix(file, '.S')
   if file in srcs_machine
     message('libc/errno/' + file + ': machine overrides generic')
   elif s_file in srcs_machine

--- a/newlib/libc/iconv/ccs/meson.build
+++ b/newlib/libc/iconv/ccs/meson.build
@@ -86,7 +86,7 @@ hdrs_iconv_ccs = [
 
 srcs_iconv_ccs_use = []
 foreach file : srcs_iconv_ccs
-  s_file = file.split('.')[0] + '.S'
+  s_file = fs.replace_suffix(file, '.S')
   if file in srcs_machine
     message('libc/iconv/ccs/' + file + ': machine overrides generic')
   elif s_file in srcs_machine

--- a/newlib/libc/iconv/ces/meson.build
+++ b/newlib/libc/iconv/ces/meson.build
@@ -52,7 +52,7 @@ hdrs_iconv_ces = [
 
 srcs_iconv_ces_use = []
 foreach file : srcs_iconv_ces
-  s_file = file.split('.')[0] + '.S'
+  s_file = fs.replace_suffix(file, '.S')
   if file in srcs_machine
     message('libc/iconv/ces/' + file + ': machine overrides generic')
   elif s_file in srcs_machine

--- a/newlib/libc/iconv/lib/meson.build
+++ b/newlib/libc/iconv/lib/meson.build
@@ -51,7 +51,7 @@ hdrs_iconv_lib = [
 
 srcs_iconv_lib_use = []
 foreach file : srcs_iconv_lib
-  s_file = file.split('.')[0] + '.S'
+  s_file = fs.replace_suffix(file, '.S')
   if file in srcs_machine
     message('libc/iconv/lib/' + file + ': machine overrides generic')
   elif s_file in srcs_machine

--- a/newlib/libc/locale/meson.build
+++ b/newlib/libc/locale/meson.build
@@ -60,7 +60,7 @@ hdrs_locale = [
 
 srcs_locale_use = []
 foreach file : srcs_locale
-  s_file = file.split('.')[0] + '.S'
+  s_file = fs.replace_suffix(file, '.S')
   if file in srcs_machine
     message('libc/locale/' + file + ': machine overrides generic')
   elif s_file in srcs_machine

--- a/newlib/libc/misc/meson.build
+++ b/newlib/libc/misc/meson.build
@@ -43,7 +43,7 @@ srcs_misc = [
 
 srcs_misc_use = []
 foreach file : srcs_misc
-  s_file = file.split('.')[0] + '.S'
+  s_file = fs.replace_suffix(file, '.S')
   if file in srcs_machine
     message('libc/misc/' + file + ': machine overrides generic')
   elif s_file in srcs_machine

--- a/newlib/libc/posix/meson.build
+++ b/newlib/libc/posix/meson.build
@@ -41,7 +41,7 @@ srcs_posix = [
 
 srcs_posix_use = []
 foreach file : srcs_posix
-  s_file = file.split('.')[0] + '.S'
+  s_file = fs.replace_suffix(file, '.S')
   if file in srcs_machine
     message('libc/posix/' + file + ': machine overrides generic')
   elif s_file in srcs_machine

--- a/newlib/libc/reent/meson.build
+++ b/newlib/libc/reent/meson.build
@@ -40,7 +40,7 @@ srcs_reent = [
 
 srcs_reent_use = []
 foreach file : srcs_reent
-  s_file = file.split('.')[0] + '.S'
+  s_file = fs.replace_suffix(file, '.S')
   if file in srcs_machine
     message('libc/reent/' + file + ': machine overrides generic')
   elif s_file in srcs_machine

--- a/newlib/libc/signal/meson.build
+++ b/newlib/libc/signal/meson.build
@@ -40,7 +40,7 @@ srcs_signal = [
 
 srcs_signal_use = []
 foreach file : srcs_signal
-  s_file = file.split('.')[0] + '.S'
+  s_file = fs.replace_suffix(file, '.S')
   if file in srcs_machine
     message('libc/signal/' + file + ': machine overrides generic')
   elif s_file in srcs_machine

--- a/newlib/libc/ssp/meson.build
+++ b/newlib/libc/ssp/meson.build
@@ -54,7 +54,7 @@ srcs_ssp = [
 
 srcs_ssp_use = []
 foreach file : srcs_ssp
-  s_file = file.split('.')[0] + '.S'
+  s_file = fs.replace_suffix(file, '.S')
   if file in srcs_machine
     message('libc/ssp/' + file + ': machine overrides generic')
   elif s_file in srcs_machine

--- a/newlib/libc/stdio/meson.build
+++ b/newlib/libc/stdio/meson.build
@@ -280,7 +280,7 @@ hdrs_stdio = [
 
 srcs_stdio_use = []
 foreach file : srcs_stdio
-  s_file = file.split('.')[0] + '.S'
+  s_file = fs.replace_suffix(file, '.S')
   if file in srcs_machine
     message('libc/stdio/' + file + ': machine overrides generic')
   elif s_file in srcs_machine

--- a/newlib/libc/stdio64/meson.build
+++ b/newlib/libc/stdio64/meson.build
@@ -47,7 +47,7 @@ srcs_stdio64 = [
 
 srcs_stdio64_use = []
 foreach file : srcs_stdio64
-  s_file = file.split('.')[0] + '.S'
+  s_file = fs.replace_suffix(file, '.S')
   if file in srcs_machine
     message('libc/stdio64/' + file + ': machine overrides generic')
   elif s_file in srcs_machine

--- a/newlib/libc/stdlib/meson.build
+++ b/newlib/libc/stdlib/meson.build
@@ -231,7 +231,7 @@ hdrs_stdlib = [
 
 srcs_stdlib_use = []
 foreach file : srcs_stdlib
-  s_file = file.split('.')[0] + '.S'
+  s_file = fs.replace_suffix(file, '.S')
   if file in srcs_machine
     message('libc/stdlib/' + file + ': machine overrides generic')
   elif s_file in srcs_machine
@@ -243,7 +243,7 @@ endforeach
 
 srcs_stdlib_malloc_use = []
 foreach file : srcs_stdlib_malloc
-  s_file = file.split('.')[0] + '.S'
+  s_file = fs.replace_suffix(file, '.S')
   if file in srcs_machine
     message('libc/stdlib/' + file + ': machine overrides generic')
   elif s_file in srcs_machine

--- a/newlib/libc/string/meson.build
+++ b/newlib/libc/string/meson.build
@@ -148,7 +148,7 @@ srcs_strcmp = [
 
 srcs_string_use = []
 foreach file : srcs_string
-  s_file = file.split('.')[0] + '.S'
+  s_file = fs.replace_suffix(file, '.S')
   if file in srcs_machine
     message('libc/string/' + file + ': machine overrides generic')
   elif s_file in srcs_machine
@@ -160,7 +160,7 @@ endforeach
 
 srcs_strcmp_use = []
 foreach file : srcs_strcmp
-  s_file = file.split('.')[0] + '.S'
+  s_file = fs.replace_suffix(file, '.S')
   if file in srcs_machine
     message('libc/string/' + file + ': machine overrides generic')
   elif s_file in srcs_machine

--- a/newlib/libc/time/meson.build
+++ b/newlib/libc/time/meson.build
@@ -64,7 +64,7 @@ hdrs_time = [
 
 srcs_time_use = []
 foreach file : srcs_time
-  s_file = file.split('.')[0] + '.S'
+  s_file = fs.replace_suffix(file, '.S')
   if file in srcs_machine
     message('libc/time/' + file + ': machine overrides generic')
   elif s_file in srcs_machine

--- a/newlib/libc/tinystdio/meson.build
+++ b/newlib/libc/tinystdio/meson.build
@@ -183,7 +183,7 @@ install_headers(
 
 srcs_tinystdio_use = []
 foreach file : srcs_tinystdio
-  s_file = file.split('.')[0] + '.S'
+  s_file = fs.replace_suffix(file, '.S')
   if file in srcs_machine
     message('libc/tinystdio/' + file + ': machine overrides generic')
   elif s_file in srcs_machine

--- a/newlib/libc/xdr/meson.build
+++ b/newlib/libc/xdr/meson.build
@@ -49,7 +49,7 @@ hdrs_xdr = [
 
 srcs_xdr_use = []
 foreach file : srcs_xdr
-  s_file = file.split('.')[0] + '.S'
+  s_file = fs.replace_suffix(file, '.S')
   if file in srcs_machine
     message('libc/xdr/' + file + ': machine overrides generic')
   elif s_file in srcs_machine

--- a/newlib/libm/common/meson.build
+++ b/newlib/libm/common/meson.build
@@ -236,7 +236,7 @@ endif
 
 srcs_common_use = []
 foreach file : srcs_common
-  s_file = file.split('.')[0] + '.S'
+  s_file = fs.replace_suffix(file, '.S')
   if file in srcs_libm_machine
     message('libm/common/' + file + ': machine overrides generic')
   elif s_file in srcs_libm_machine

--- a/newlib/libm/fenv/meson.build
+++ b/newlib/libm/fenv/meson.build
@@ -53,7 +53,7 @@ srcs_fenv = [
 
 srcs_fenv_use = []
 foreach file : srcs_fenv
-  s_file = file.split('.')[0] + '.S'
+  s_file = fs.replace_suffix(file, '.S')
   if file in srcs_libm_machine
     message('libm/fenv/' + file + ': machine overrides generic')
   elif s_file in srcs_libm_machine

--- a/newlib/libm/math/meson.build
+++ b/newlib/libm/math/meson.build
@@ -182,7 +182,7 @@ endif
 
 srcs_math_use = []
 foreach file : srcs_math
-  s_file = file.split('.')[0] + '.S'
+  s_file = fs.replace_suffix(file, '.S')
   if file in srcs_libm_machine
     message('libm/math/' + file + ': machine overrides generic')
   elif s_file in srcs_libm_machine


### PR DESCRIPTION
Since 05a34b376c6, we have `fs` module included.  Use `fs.replace_suffix()` to replace string manipulations.