### PR TITLE
Refactor compiler warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -517,14 +517,9 @@ picolibcpp_ld = configure_file(input: 'picolibc.ld.in',
 			     install_dir: lib_dir)
 
 # Not all compilers necessarily support all warnings; only use these which are:
-c_warnings = []
-foreach arg : ['-Wall', '-Wextra', '-Wno-missing-braces', '-Wno-implicit-int', '-Wno-return-type', '-Werror=implicit-function-declaration', '-Werror=vla', '-Wno-unused-command-line-argument', '-Warray-bounds', '-Wold-style-definition']
-  if cc.has_argument(arg)
-    c_warnings += [arg]
-  endif
-endforeach
-
-c_args += c_warnings
+c_warnings = ['-Wall', '-Wextra', '-Werror=implicit-function-declaration', '-Werror=vla', '-Warray-bounds', '-Wold-style-definition']
+disabled_warnings = ['-Wno-missing-braces', '-Wno-implicit-int', '-Wno-return-type', '-Wno-unused-command-line-argument']
+c_args += cc.get_supported_arguments(c_warnings, disabled_warnings)
 
 # CompCert does not support bitfields in packed structs, so avoid using this optimization
 bitfields_in_packed_structs_code = '''

--- a/meson.build
+++ b/meson.build
@@ -38,6 +38,7 @@ project('picolibc', 'c',
 	  'debug=true',
 	  'c_std=c18',
 	  'b_staticpic=false',
+          'warning_level=2',
 	],
 	license : 'BSD',
 	meson_version : '>= 0.53',
@@ -517,7 +518,7 @@ picolibcpp_ld = configure_file(input: 'picolibc.ld.in',
 			     install_dir: lib_dir)
 
 # Not all compilers necessarily support all warnings; only use these which are:
-c_warnings = ['-Wall', '-Wextra', '-Werror=implicit-function-declaration', '-Werror=vla', '-Warray-bounds', '-Wold-style-definition']
+c_warnings = ['-Werror=implicit-function-declaration', '-Werror=vla', '-Warray-bounds', '-Wold-style-definition']
 disabled_warnings = ['-Wno-missing-braces', '-Wno-implicit-int', '-Wno-return-type', '-Wno-unused-command-line-argument']
 c_args += cc.get_supported_arguments(c_warnings, disabled_warnings)
 


### PR DESCRIPTION
This PR does two things:

 - Replace the option check with `get_supported_arguments()`
 - Replace `-Wall` and `-Wextra` with `warning_level()`