### PR TITLE
github: Build and cache the docker image by cron

### DIFF
--- a/.github/workflows/fortity-source.yml
+++ b/.github/workflows/fortity-source.yml
@@ -13,32 +13,7 @@ env:
   IMAGE: picolibc
 
 jobs:
-  cache-maker:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build picolibc container
-        uses: docker/build-push-action@v2
-        with:
-          platforms: linux/amd64
-          file: .github/Dockerfile
-          tags: ${{ env.IMAGE }}:latest
-          outputs: type=docker,dest=${{ env.IMAGE_FILE }}
-
-      - name: Check size
-        run: |
-          ls -al
-
-      - name: Cache the Docker Image
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-${{ hashFiles(format('{0}', env.IMAGE_FILE)) }}
-
   test:
-    needs: cache-maker
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/image-maker.yml
+++ b/.github/workflows/image-maker.yml
@@ -1,0 +1,39 @@
+name: Docker Image Builder
+
+on:
+  schedule:
+    # We build 5:00 UTC every day
+    - cron: '0 5 * * *'
+
+env:
+  IMAGE_FILE: dockerimg.tar
+  IMAGE: picolibc
+
+jobs:
+  cache-maker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date -u +'%Y%m%d')"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build picolibc container
+        uses: docker/build-push-action@v2
+        with:
+          platforms: linux/amd64
+          file: .github/Dockerfile
+          tags: ${{ env.IMAGE }}:latest
+          outputs: type=docker,dest=${{ env.IMAGE_FILE }}
+
+      - name: Check size
+        run: |
+          ls -al
+
+      - name: Cache the Docker Image
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.IMAGE_FILE }}
+          key: ${{ env.IMAGE_FILE }}-${{ steps.date.outputs.date }}-${{ hashFiles(format('{0}', env.IMAGE_FILE)) }}

--- a/.github/workflows/minsize.yml
+++ b/.github/workflows/minsize.yml
@@ -13,32 +13,7 @@ env:
   IMAGE: picolibc
 
 jobs:
-  cache-maker:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build picolibc container
-        uses: docker/build-push-action@v2
-        with:
-          platforms: linux/amd64
-          file: .github/Dockerfile
-          tags: ${{ env.IMAGE }}:latest
-          outputs: type=docker,dest=${{ env.IMAGE_FILE }}
-
-      - name: Check size
-        run: |
-          ls -al
-
-      - name: Cache the Docker Image
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-${{ hashFiles(format('{0}', env.IMAGE_FILE)) }}
-
   test:
-    needs: cache-maker
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,32 +13,7 @@ env:
   IMAGE: picolibc
 
 jobs:
-  cache-maker:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build picolibc container
-        uses: docker/build-push-action@v2
-        with:
-          platforms: linux/amd64
-          file: .github/Dockerfile
-          tags: ${{ env.IMAGE }}:latest
-          outputs: type=docker,dest=${{ env.IMAGE_FILE }}
-
-      - name: Check size
-        run: |
-          ls -al
-
-      - name: Cache the Docker Image
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-${{ hashFiles(format('{0}', env.IMAGE_FILE)) }}
-
   test:
-    needs: cache-maker
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
This PR is to move cache-maker to a new workflow which runs 5:00 every day.  This means that we'll generate the Debian Testing docker image once a day.  All other workflow will uses the latest version of the cached docker image.  This can kill about 10 min of running time of cache-maker for each workflow.

We have 5 GB of cache right now and the image is 1.5 GB.  So it should store 3 days worth of images.  If this doesn't work, I think we can use a docker registry.  But it was much slower when I last tested.

There is one situation this setup fails.  For new repository with empty cache.  Because cache will only be created 5:00, if there is no cached image, workflows will fail.  This shouldn't happen for picolibc repository unless GitHub accidentally remove the cache.  Or on forked repositories with modified event for testing.  We should have some safe guard in each workflow.

The key for the cache now has date in it, just in case.
`${{ env.IMAGE_FILE }}-${{ steps.date.outputs.date }}-${{ hashFiles(format('{0}', env.IMAGE_FILE)) }}` 
But retrieval is still `${{ env.IMAGE_FILE }}-`.  This should return the latest cache image.

https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
> If there are multiple partial matches for a restore key, the action returns the most recently created cache.

Leave this PR at least for a day to see how the cache maker work.

5:00 is arbitrary time I picked from no where.  It shouldn't affect anyone but we can change to any time we wish.