### PR TITLE
Fix interrupt vector compilation for Cortex-A9

### DIFF
--- a/newlib/libc/picolib/machine/arm/interrupt.c
+++ b/newlib/libc/picolib/machine/arm/interrupt.c
@@ -135,6 +135,7 @@ __weak_vector_table(void)
 #if __ARM_ARCH_ISA_THUMB == 2
 	/* Thumb 2 processors start in thumb mode */
 	__asm__(".thumb");
+	__asm__(".syntax unified");
 	__asm__("b.w _start");
 	__asm__("b.w arm_undef_vector");
 	__asm__("b.w arm_svc_vector");


### PR DESCRIPTION
Without the proposed change and with `-mcpu=cortex-a9` I am getting:
```
/tmp/cc4us9vr.s: Assembler messages:
/tmp/cc4us9vr.s:108: Error: unexpected character `w' in type specifier
/tmp/cc4us9vr.s:108: Error: bad instruction `b.w _start'
/tmp/cc4us9vr.s:112: Error: unexpected character `w' in type specifier
/tmp/cc4us9vr.s:112: Error: bad instruction `b.w arm_undef_vector'
/tmp/cc4us9vr.s:116: Error: unexpected character `w' in type specifier
/tmp/cc4us9vr.s:116: Error: bad instruction `b.w arm_svc_vector'
/tmp/cc4us9vr.s:120: Error: unexpected character `w' in type specifier
/tmp/cc4us9vr.s:120: Error: bad instruction `b.w arm_prefetch_abort_vector'
/tmp/cc4us9vr.s:124: Error: unexpected character `w' in type specifier
/tmp/cc4us9vr.s:124: Error: bad instruction `b.w arm_data_abort_vector'
/tmp/cc4us9vr.s:128: Error: unexpected character `w' in type specifier
/tmp/cc4us9vr.s:128: Error: bad instruction `b.w arm_not_used_vector'
/tmp/cc4us9vr.s:132: Error: unexpected character `w' in type specifier
/tmp/cc4us9vr.s:132: Error: bad instruction `b.w arm_irq_vector'
/tmp/cc4us9vr.s:136: Error: unexpected character `w' in type specifier
/tmp/cc4us9vr.s:136: Error: bad instruction `b.w arm_fiq_vector'
```