### PR TITLE
.github: Use specific date stamp on restore-keys

### DIFF
--- a/.github/workflows/fortity-source-arm.yml
+++ b/.github/workflows/fortity-source-arm.yml
@@ -66,11 +66,21 @@ jobs:
         with:
           path: picolibc
 
+      - name: Get current date
+        id: date
+        run: |
+          echo "::set-output name=today::$(date -u +'%Y%m%d')"
+          echo "::set-output name=yesterday::$(date -u -d '-1 day' +'%Y%m%d')"
+
       - name: Restore the Docker Image
         uses: actions/cache@v2
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-
+          key: no-exact-key-is-used
+          restore-keys: |
+            ${{ env.IMAGE_FILE }}-${{ steps.date.outputs.today }}-
+            ${{ env.IMAGE_FILE }}-${{ steps.date.outputs.yesterday }}-
+            ${{ env.IMAGE_FILE }}-
 
       - name: Check
         run: |

--- a/.github/workflows/fortity-source-riscv.yml
+++ b/.github/workflows/fortity-source-riscv.yml
@@ -66,11 +66,21 @@ jobs:
         with:
           path: picolibc
 
+      - name: Get current date
+        id: date
+        run: |
+          echo "::set-output name=today::$(date -u +'%Y%m%d')"
+          echo "::set-output name=yesterday::$(date -u -d '-1 day' +'%Y%m%d')"
+
       - name: Restore the Docker Image
         uses: actions/cache@v2
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-
+          key: no-exact-key-is-used
+          restore-keys: |
+            ${{ env.IMAGE_FILE }}-${{ steps.date.outputs.today }}-
+            ${{ env.IMAGE_FILE }}-${{ steps.date.outputs.yesterday }}-
+            ${{ env.IMAGE_FILE }}-
 
       - name: Check
         run: |

--- a/.github/workflows/fortity-source.yml
+++ b/.github/workflows/fortity-source.yml
@@ -68,11 +68,21 @@ jobs:
         with:
           path: picolibc
 
+      - name: Get current date
+        id: date
+        run: |
+          echo "::set-output name=today::$(date -u +'%Y%m%d')"
+          echo "::set-output name=yesterday::$(date -u -d '-1 day' +'%Y%m%d')"
+
       - name: Restore the Docker Image
         uses: actions/cache@v2
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-
+          key: no-exact-key-is-used
+          restore-keys: |
+            ${{ env.IMAGE_FILE }}-${{ steps.date.outputs.today }}-
+            ${{ env.IMAGE_FILE }}-${{ steps.date.outputs.yesterday }}-
+            ${{ env.IMAGE_FILE }}-
 
       - name: Check
         run: |

--- a/.github/workflows/minsize-arm.yml
+++ b/.github/workflows/minsize-arm.yml
@@ -66,11 +66,21 @@ jobs:
         with:
           path: picolibc
 
+      - name: Get current date
+        id: date
+        run: |
+          echo "::set-output name=today::$(date -u +'%Y%m%d')"
+          echo "::set-output name=yesterday::$(date -u -d '-1 day' +'%Y%m%d')"
+
       - name: Restore the Docker Image
         uses: actions/cache@v2
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-
+          key: no-exact-key-is-used
+          restore-keys: |
+            ${{ env.IMAGE_FILE }}-${{ steps.date.outputs.today }}-
+            ${{ env.IMAGE_FILE }}-${{ steps.date.outputs.yesterday }}-
+            ${{ env.IMAGE_FILE }}-
 
       - name: Check
         run: |

--- a/.github/workflows/minsize-riscv.yml
+++ b/.github/workflows/minsize-riscv.yml
@@ -66,11 +66,21 @@ jobs:
         with:
           path: picolibc
 
+      - name: Get current date
+        id: date
+        run: |
+          echo "::set-output name=today::$(date -u +'%Y%m%d')"
+          echo "::set-output name=yesterday::$(date -u -d '-1 day' +'%Y%m%d')"
+
       - name: Restore the Docker Image
         uses: actions/cache@v2
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-
+          key: no-exact-key-is-used
+          restore-keys: |
+            ${{ env.IMAGE_FILE }}-${{ steps.date.outputs.today }}-
+            ${{ env.IMAGE_FILE }}-${{ steps.date.outputs.yesterday }}-
+            ${{ env.IMAGE_FILE }}-
 
       - name: Check
         run: |

--- a/.github/workflows/minsize.yml
+++ b/.github/workflows/minsize.yml
@@ -68,11 +68,21 @@ jobs:
         with:
           path: picolibc
 
+      - name: Get current date
+        id: date
+        run: |
+          echo "::set-output name=today::$(date -u +'%Y%m%d')"
+          echo "::set-output name=yesterday::$(date -u -d '-1 day' +'%Y%m%d')"
+
       - name: Restore the Docker Image
         uses: actions/cache@v2
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-
+          key: no-exact-key-is-used
+          restore-keys: |
+            ${{ env.IMAGE_FILE }}-${{ steps.date.outputs.today }}-
+            ${{ env.IMAGE_FILE }}-${{ steps.date.outputs.yesterday }}-
+            ${{ env.IMAGE_FILE }}-
 
       - name: Check
         run: |

--- a/.github/workflows/release-arm.yml
+++ b/.github/workflows/release-arm.yml
@@ -66,11 +66,21 @@ jobs:
         with:
           path: picolibc
 
+      - name: Get current date
+        id: date
+        run: |
+          echo "::set-output name=today::$(date -u +'%Y%m%d')"
+          echo "::set-output name=yesterday::$(date -u -d '-1 day' +'%Y%m%d')"
+
       - name: Restore the Docker Image
         uses: actions/cache@v2
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-
+          key: no-exact-key-is-used
+          restore-keys: |
+            ${{ env.IMAGE_FILE }}-${{ steps.date.outputs.today }}-
+            ${{ env.IMAGE_FILE }}-${{ steps.date.outputs.yesterday }}-
+            ${{ env.IMAGE_FILE }}-
 
       - name: Check
         run: |

--- a/.github/workflows/release-riscv.yml
+++ b/.github/workflows/release-riscv.yml
@@ -66,11 +66,21 @@ jobs:
         with:
           path: picolibc
 
+      - name: Get current date
+        id: date
+        run: |
+          echo "::set-output name=today::$(date -u +'%Y%m%d')"
+          echo "::set-output name=yesterday::$(date -u -d '-1 day' +'%Y%m%d')"
+
       - name: Restore the Docker Image
         uses: actions/cache@v2
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-
+          key: no-exact-key-is-used
+          restore-keys: |
+            ${{ env.IMAGE_FILE }}-${{ steps.date.outputs.today }}-
+            ${{ env.IMAGE_FILE }}-${{ steps.date.outputs.yesterday }}-
+            ${{ env.IMAGE_FILE }}-
 
       - name: Check
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,11 +68,21 @@ jobs:
         with:
           path: picolibc
 
+      - name: Get current date
+        id: date
+        run: |
+          echo "::set-output name=today::$(date -u +'%Y%m%d')"
+          echo "::set-output name=yesterday::$(date -u -d '-1 day' +'%Y%m%d')"
+
       - name: Restore the Docker Image
         uses: actions/cache@v2
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-
+          key: no-exact-key-is-used
+          restore-keys: |
+            ${{ env.IMAGE_FILE }}-${{ steps.date.outputs.today }}-
+            ${{ env.IMAGE_FILE }}-${{ steps.date.outputs.yesterday }}-
+            ${{ env.IMAGE_FILE }}-
 
       - name: Check
         run: |


### PR DESCRIPTION
GitHub Actions Cache doesn't seems to return the latest.  We have to specify which one we want.

Documentation for Github Actions states[1] that

    If there are no exact matches, the action searches for partial
    matches of the restore keys. When the action finds a partial
    match, the most recent cache is restored to the path directory.

So, a partial hit should get you the latest docker image, but it
doesn't seems so.  Use specific date stamp on restore-keys so that one
of the keys should hit an image.

This doesn't prevent loading the latest if multiple images are
generated in a day, or no image is generated in the last two days.

[1]: https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#matching-a-cache-key

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>