### PR TITLE
.github: Search docker image based on the hash of packages.txt

### DIFF
--- a/.github/workflows/fortity-source-arm.yml
+++ b/.github/workflows/fortity-source-arm.yml
@@ -11,6 +11,7 @@ on:
 env:
   IMAGE_FILE: dockerimg.tar
   IMAGE: picolibc
+  HASHED_FILE: .github/packages.txt
 
 jobs:
   test:
@@ -66,11 +67,22 @@ jobs:
         with:
           path: picolibc
 
+      - name: Get current date
+        id: date
+        run: |
+          echo "::set-output name=today::$(date -u +'%Y%m%d')"
+          echo "::set-output name=yesterday::$(date -u -d '-1 day' +'%Y%m%d')"
+
       - name: Restore the Docker Image
         uses: actions/cache@v2
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-
+          key: no-exact-key-is-used
+          restore-keys: |
+            ${{ env.IMAGE_FILE }}-${{ hashFiles(format('picolibc/{0}', env.HASHED_FILE)) }}-${{ steps.date.outputs.today }}
+            ${{ env.IMAGE_FILE }}-${{ hashFiles(format('picolibc/{0}', env.HASHED_FILE)) }}-${{ steps.date.outputs.yesterday }}
+            ${{ env.IMAGE_FILE }}-${{ hashFiles(format('picolibc/{0}', env.HASHED_FILE)) }}-
+            ${{ env.IMAGE_FILE }}-
 
       - name: Check
         run: |

--- a/.github/workflows/fortity-source-riscv.yml
+++ b/.github/workflows/fortity-source-riscv.yml
@@ -11,6 +11,7 @@ on:
 env:
   IMAGE_FILE: dockerimg.tar
   IMAGE: picolibc
+  HASHED_FILE: .github/packages.txt
 
 jobs:
   test:
@@ -66,11 +67,22 @@ jobs:
         with:
           path: picolibc
 
+      - name: Get current date
+        id: date
+        run: |
+          echo "::set-output name=today::$(date -u +'%Y%m%d')"
+          echo "::set-output name=yesterday::$(date -u -d '-1 day' +'%Y%m%d')"
+
       - name: Restore the Docker Image
         uses: actions/cache@v2
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-
+          key: no-exact-key-is-used
+          restore-keys: |
+            ${{ env.IMAGE_FILE }}-${{ hashFiles(format('picolibc/{0}', env.HASHED_FILE)) }}-${{ steps.date.outputs.today }}
+            ${{ env.IMAGE_FILE }}-${{ hashFiles(format('picolibc/{0}', env.HASHED_FILE)) }}-${{ steps.date.outputs.yesterday }}
+            ${{ env.IMAGE_FILE }}-${{ hashFiles(format('picolibc/{0}', env.HASHED_FILE)) }}-
+            ${{ env.IMAGE_FILE }}-
 
       - name: Check
         run: |

--- a/.github/workflows/fortity-source.yml
+++ b/.github/workflows/fortity-source.yml
@@ -11,6 +11,7 @@ on:
 env:
   IMAGE_FILE: dockerimg.tar
   IMAGE: picolibc
+  HASHED_FILE: .github/packages.txt
 
 jobs:
   test:
@@ -68,11 +69,22 @@ jobs:
         with:
           path: picolibc
 
+      - name: Get current date
+        id: date
+        run: |
+          echo "::set-output name=today::$(date -u +'%Y%m%d')"
+          echo "::set-output name=yesterday::$(date -u -d '-1 day' +'%Y%m%d')"
+
       - name: Restore the Docker Image
         uses: actions/cache@v2
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-
+          key: no-exact-key-is-used
+          restore-keys: |
+            ${{ env.IMAGE_FILE }}-${{ hashFiles(format('picolibc/{0}', env.HASHED_FILE)) }}-${{ steps.date.outputs.today }}
+            ${{ env.IMAGE_FILE }}-${{ hashFiles(format('picolibc/{0}', env.HASHED_FILE)) }}-${{ steps.date.outputs.yesterday }}
+            ${{ env.IMAGE_FILE }}-${{ hashFiles(format('picolibc/{0}', env.HASHED_FILE)) }}-
+            ${{ env.IMAGE_FILE }}-
 
       - name: Check
         run: |

--- a/.github/workflows/image-maker.yml
+++ b/.github/workflows/image-maker.yml
@@ -11,14 +11,18 @@ on:
 env:
   IMAGE_FILE: dockerimg.tar
   IMAGE: picolibc
+  HASHED_FILE: .github/packages.txt
 
 jobs:
   cache-maker:
     runs-on: ubuntu-latest
     steps:
+      - name: Clone picolibc
+        uses: actions/checkout@v2
+
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date -u +'%Y%m%d')"
+        run: echo "::set-output name=datetime::$(date -u +'%Y%m%d-%R')"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -26,6 +30,7 @@ jobs:
       - name: Build picolibc container
         uses: docker/build-push-action@v2
         with:
+          context: .
           platforms: linux/amd64
           file: .github/Dockerfile
           tags: ${{ env.IMAGE }}:latest
@@ -39,4 +44,4 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-${{ steps.date.outputs.date }}-${{ hashFiles(format('{0}', env.IMAGE_FILE)) }}
+          key: ${{ env.IMAGE_FILE }}-${{ hashFiles(format('{0}', env.HASHED_FILE)) }}-${{ steps.date.outputs.datetime }}

--- a/.github/workflows/minsize-arm.yml
+++ b/.github/workflows/minsize-arm.yml
@@ -11,6 +11,7 @@ on:
 env:
   IMAGE_FILE: dockerimg.tar
   IMAGE: picolibc
+  HASHED_FILE: .github/packages.txt
 
 jobs:
   test:
@@ -66,11 +67,22 @@ jobs:
         with:
           path: picolibc
 
+      - name: Get current date
+        id: date
+        run: |
+          echo "::set-output name=today::$(date -u +'%Y%m%d')"
+          echo "::set-output name=yesterday::$(date -u -d '-1 day' +'%Y%m%d')"
+
       - name: Restore the Docker Image
         uses: actions/cache@v2
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-
+          key: no-exact-key-is-used
+          restore-keys: |
+            ${{ env.IMAGE_FILE }}-${{ hashFiles(format('picolibc/{0}', env.HASHED_FILE)) }}-${{ steps.date.outputs.today }}
+            ${{ env.IMAGE_FILE }}-${{ hashFiles(format('picolibc/{0}', env.HASHED_FILE)) }}-${{ steps.date.outputs.yesterday }}
+            ${{ env.IMAGE_FILE }}-${{ hashFiles(format('picolibc/{0}', env.HASHED_FILE)) }}-
+            ${{ env.IMAGE_FILE }}-
 
       - name: Check
         run: |

--- a/.github/workflows/minsize-riscv.yml
+++ b/.github/workflows/minsize-riscv.yml
@@ -11,6 +11,7 @@ on:
 env:
   IMAGE_FILE: dockerimg.tar
   IMAGE: picolibc
+  HASHED_FILE: .github/packages.txt
 
 jobs:
   test:
@@ -66,11 +67,22 @@ jobs:
         with:
           path: picolibc
 
+      - name: Get current date
+        id: date
+        run: |
+          echo "::set-output name=today::$(date -u +'%Y%m%d')"
+          echo "::set-output name=yesterday::$(date -u -d '-1 day' +'%Y%m%d')"
+
       - name: Restore the Docker Image
         uses: actions/cache@v2
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-
+          key: no-exact-key-is-used
+          restore-keys: |
+            ${{ env.IMAGE_FILE }}-${{ hashFiles(format('picolibc/{0}', env.HASHED_FILE)) }}-${{ steps.date.outputs.today }}
+            ${{ env.IMAGE_FILE }}-${{ hashFiles(format('picolibc/{0}', env.HASHED_FILE)) }}-${{ steps.date.outputs.yesterday }}
+            ${{ env.IMAGE_FILE }}-${{ hashFiles(format('picolibc/{0}', env.HASHED_FILE)) }}-
+            ${{ env.IMAGE_FILE }}-
 
       - name: Check
         run: |

--- a/.github/workflows/release-arm.yml
+++ b/.github/workflows/release-arm.yml
@@ -11,6 +11,7 @@ on:
 env:
   IMAGE_FILE: dockerimg.tar
   IMAGE: picolibc
+  HASHED_FILE: .github/packages.txt
 
 jobs:
   test:
@@ -66,11 +67,22 @@ jobs:
         with:
           path: picolibc
 
+      - name: Get current date
+        id: date
+        run: |
+          echo "::set-output name=today::$(date -u +'%Y%m%d')"
+          echo "::set-output name=yesterday::$(date -u -d '-1 day' +'%Y%m%d')"
+
       - name: Restore the Docker Image
         uses: actions/cache@v2
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-
+          key: no-exact-key-is-used
+          restore-keys: |
+            ${{ env.IMAGE_FILE }}-${{ hashFiles(format('picolibc/{0}', env.HASHED_FILE)) }}-${{ steps.date.outputs.today }}
+            ${{ env.IMAGE_FILE }}-${{ hashFiles(format('picolibc/{0}', env.HASHED_FILE)) }}-${{ steps.date.outputs.yesterday }}
+            ${{ env.IMAGE_FILE }}-${{ hashFiles(format('picolibc/{0}', env.HASHED_FILE)) }}-
+            ${{ env.IMAGE_FILE }}-
 
       - name: Check
         run: |

--- a/.github/workflows/release-riscv.yml
+++ b/.github/workflows/release-riscv.yml
@@ -11,6 +11,7 @@ on:
 env:
   IMAGE_FILE: dockerimg.tar
   IMAGE: picolibc
+  HASHED_FILE: .github/packages.txt
 
 jobs:
   test:
@@ -66,11 +67,22 @@ jobs:
         with:
           path: picolibc
 
+      - name: Get current date
+        id: date
+        run: |
+          echo "::set-output name=today::$(date -u +'%Y%m%d')"
+          echo "::set-output name=yesterday::$(date -u -d '-1 day' +'%Y%m%d')"
+
       - name: Restore the Docker Image
         uses: actions/cache@v2
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-
+          key: no-exact-key-is-used
+          restore-keys: |
+            ${{ env.IMAGE_FILE }}-${{ hashFiles(format('picolibc/{0}', env.HASHED_FILE)) }}-${{ steps.date.outputs.today }}
+            ${{ env.IMAGE_FILE }}-${{ hashFiles(format('picolibc/{0}', env.HASHED_FILE)) }}-${{ steps.date.outputs.yesterday }}
+            ${{ env.IMAGE_FILE }}-${{ hashFiles(format('picolibc/{0}', env.HASHED_FILE)) }}-
+            ${{ env.IMAGE_FILE }}-
 
       - name: Check
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
 env:
   IMAGE_FILE: dockerimg.tar
   IMAGE: picolibc
+  HASHED_FILE: .github/packages.txt
 
 jobs:
   test:
@@ -68,11 +69,22 @@ jobs:
         with:
           path: picolibc
 
+      - name: Get current date
+        id: date
+        run: |
+          echo "::set-output name=today::$(date -u +'%Y%m%d')"
+          echo "::set-output name=yesterday::$(date -u -d '-1 day' +'%Y%m%d')"
+
       - name: Restore the Docker Image
         uses: actions/cache@v2
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-
+          key: no-exact-key-is-used
+          restore-keys: |
+            ${{ env.IMAGE_FILE }}-${{ hashFiles(format('picolibc/{0}', env.HASHED_FILE)) }}-${{ steps.date.outputs.today }}
+            ${{ env.IMAGE_FILE }}-${{ hashFiles(format('picolibc/{0}', env.HASHED_FILE)) }}-${{ steps.date.outputs.yesterday }}
+            ${{ env.IMAGE_FILE }}-${{ hashFiles(format('picolibc/{0}', env.HASHED_FILE)) }}-
+            ${{ env.IMAGE_FILE }}-
 
       - name: Check
         run: |


### PR DESCRIPTION
If we can ignore Debian's base packages update, we can search a docker image by the hash value from `.github/packages.txt`.

In order to hash the file, we must change from "Git Context" to "Path Context".  To do that, we clone the repo with `actions/checkout@v2` and tell `docker/build-push-action@v2` we want "Path Context" by adding "`context: .`".

https://github.com/docker/build-push-action#path-context

`image-maker` uses the current directory for the working directory. All other tests workflows, OTOH, use `picolibc/` sub-directory under the current directory.  Thus, `format('picolibc/{0}', env.HASHED_FILE)`.

Just in case we generate multiple images in a day with the same `packages.txt`, we now have hours and minutes in the key.  Unfortunately, we don't know the time of generation at the time of retrieval, thus we only specify date without time.

We also try to retrieve yesterday's image if we can, because GitHub Actions cache doesn't seems to load the latest image (#232).  This won't work if we change generation interval, though.
