### PR TITLE
Add double-underscore PICOLIBC version macros

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -831,10 +831,17 @@ else
   picolibc_patch_level = 0
 endif
 
+conf_data.set('__PICOLIBC_VERSION__', '"@0@"'.format(meson.project_version()), description: 'The Picolibc version in string format.')
+conf_data.set('__PICOLIBC__', version_array[0], description: 'The Picolibc major version number.')
+conf_data.set('__PICOLIBC_MINOR__', version_array[1], description: 'The Picolibc minor version number.')
+conf_data.set('__PICOLIBC_PATCHLEVEL__', picolibc_patch_level, description: 'The Picolibc patch level.')
+
+# Old version macros. These have just a single leading underscore,
+# which isn't consistent with the newlib macros; they were created
+# by mistake.
 conf_data.set('_PICOLIBC_VERSION', '"@0@"'.format(meson.project_version()), description: 'The Picolibc version in string format.')
 conf_data.set('_PICOLIBC__', version_array[0], description: 'The Picolibc major version number.')
 conf_data.set('_PICOLIBC_MINOR__', version_array[1], description: 'The Picolibc minor version number.')
-conf_data.set('__PICOLIBC_PATCHLEVEL__', picolibc_patch_level, description: 'The Picolibc patch level.')
 
 conf_data.set('_NEWLIB_VERSION', '"@0@"'.format(NEWLIB_VERSION), description: 'The newlib version in string format.')
 conf_data.set('__NEWLIB__', NEWLIB_MAJOR_VERSION, description: 'The newlib major version number.')

--- a/test/libc-testsuite/fnmatch.c
+++ b/test/libc-testsuite/fnmatch.c
@@ -90,7 +90,7 @@ struct {
     { "a*.c", "a/x.c", FNM_PATHNAME, FNM_NOMATCH },
     { "*/foo", "/foo", FNM_PATHNAME, 0 },
     { "-O[01]", "-O1", 0, 0 },
-#ifndef _PICOLIBC__
+#ifndef __PICOLIBC__
     { "[[?*\\]", "\\", 0, 0 },
     { "[]?*\\]", "]", 0, 0 },
 #endif
@@ -135,7 +135,7 @@ struct {
     { "*/*", "a/.b", FNM_PATHNAME|FNM_PERIOD, FNM_NOMATCH },
     { "*?*/*", "a/.b", FNM_PERIOD, 0 },
     { "*[.]/b", "a./b", FNM_PATHNAME|FNM_PERIOD, 0 },
-#ifndef _PICOLIBC__
+#ifndef __PICOLIBC__
     { "*[[:alpha:]]/*[[:alnum:]]", "a/b", FNM_PATHNAME, 0 },
 #endif
     /* These three tests should result in error according to SUSv3.

--- a/test/libc-testsuite/sscanf.c
+++ b/test/libc-testsuite/sscanf.c
@@ -118,7 +118,7 @@ int test_sscanf(void)
 	TEST_F(0.1e-10);
 	TEST_F(0x1234p56);
 
-#ifndef _PICOLIBC__
+#ifndef __PICOLIBC__
         /* both tinystdio and legacy stdio fail this test */
 	TEST(i, sscanf("10e", "%lf", &d), 0, "got %d fields, expected no match (%d)");
 #endif

--- a/test/math_errhandling_tests.c
+++ b/test/math_errhandling_tests.c
@@ -383,7 +383,7 @@ FLOAT_T makemathname(test_pow_neg0_neghalf)(void) { return makemathname(pow)(-ma
 FLOAT_T makemathname(test_pow_0_neg3)(void) { return makemathname(pow)(makemathname(zero), -makemathname(three)); }
 FLOAT_T makemathname(test_pow_neg0_neg3)(void) { return makemathname(pow)(-makemathname(zero), -makemathname(three)); }
 
-#ifndef _PICOLIBC__
+#ifndef __PICOLIBC__
 #define pow10(x) exp10(x)
 #define pow10f(x) exp10f(x)
 #endif
@@ -595,7 +595,7 @@ struct {
         TEST(fma_1_neginf_inf, (FLOAT_T)NAN, FE_INVALID, 0),
         TEST(fma_inf_0_1, (FLOAT_T)NAN, FE_INVALID, 0),
         TEST(fma_0_inf_1, (FLOAT_T)NAN, FE_INVALID, 0),
-#ifdef _PICOLIBC__
+#ifdef __PICOLIBC__
         /* Linux says these will set FE_INVALID, POSIX says optional, glibc does not set exception */
         TEST(fma_inf_0_nan, (FLOAT_T)NAN, FE_INVALID, 0),
         TEST(fma_0_inf_nan, (FLOAT_T)NAN, FE_INVALID, 0),
@@ -839,7 +839,7 @@ struct {
 	TEST(tgamma_negbig, (FLOAT_T)NAN, FE_INVALID, EDOM),
 	TEST(tgamma_inf, (FLOAT_T)INFINITY, 0, 0),
 	TEST(tgamma_neginf, (FLOAT_T)NAN, FE_INVALID, EDOM),
-#if !defined(TEST_FLOAT) || defined(_PICOLIBC__)
+#if !defined(TEST_FLOAT) || defined(__PICOLIBC__)
 	/* glibc has a bug with this test using float */
 	TEST(tgamma_small, (FLOAT_T)INFINITY, FE_OVERFLOW, ERANGE),
 	TEST(tgamma_negsmall, -(FLOAT_T)INFINITY, FE_OVERFLOW, ERANGE),

--- a/test/testcases.c
+++ b/test/testcases.c
@@ -17,7 +17,7 @@
 
 */
 
-#ifndef _PICOLIBC__
+#ifndef __PICOLIBC__
 # define _WANT_IO_C99_FORMATS
 # define _WANT_IO_LONG_LONG
 #elif defined(TINY_STDIO)


### PR DESCRIPTION
When I initially created the meson build files, I mistakenly used only
a single leading underscore in all of the version macros. This adds
double leading underscore names, leaving the single underscore names
for anyone using them.

Signed-off-by: Keith Packard <keithp@keithp.com>