### PR TITLE
Make clang happy with qsort pointer alignment test

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -218,8 +218,8 @@ endif
 # Select stdio implementation
 tinystdio = get_option('tinystdio')
 
-has_link_defsym = cc.has_link_argument('-Wl,--defsym=' + global_prefix + '_start=0')
-has_link_alias = cc.has_link_argument('-Wl,-alias,' + global_prefix + 'main,testalias')
+has_link_defsym = meson.get_cross_property('has_link_defsym', cc.has_link_argument('-Wl,--defsym=' + global_prefix + '_start=0'))
+has_link_alias = meson.get_cross_property('has_link_alias', cc.has_link_argument('-Wl,-alias,' + global_prefix + 'main,testalias'))
 
 # tinystdio options
 posix_io = tinystdio and get_option('posix-io')

--- a/newlib/libc/posix/engine.c
+++ b/newlib/libc/posix/engine.c
@@ -363,11 +363,6 @@ dissect(struct match *m,
 	char *ssp;		/* start of string matched by subsubRE */
 	char *sep;		/* end of string matched by subsubRE */
 	char *oldssp;		/* previous ssp */
-#if __GNUC_PREREQ (4, 6)
-/* dp is only used for assertion testing which, for some reason, is not
-   recognized as usage. */
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#endif
 	char *dp;
 
 	AT("diss", start, stop, startst, stopst);
@@ -428,6 +423,7 @@ dissect(struct match *m,
 			/* did innards match? */
 			if (slow(m, sp, rest, ssub, esub) != NULL) {
 				dp = dissect(m, sp, rest, ssub, esub);
+                                (void) dp;
 				assert(dp == rest);
 			} else		/* no */
 				assert(sp == rest);
@@ -466,6 +462,7 @@ dissect(struct match *m,
 			assert(sep == rest);	/* must exhaust substring */
 			assert(slow(m, ssp, sep, ssub, esub) == rest);
 			dp = dissect(m, ssp, sep, ssub, esub);
+                        (void) dp;
 			assert(dp == sep);
 			sp = rest;
 			break;
@@ -501,6 +498,7 @@ dissect(struct match *m,
 					assert(OP(m->g->strip[esub]) == O_CH);
 			}
 			dp = dissect(m, sp, rest, ssub, esub);
+                        (void) dp;
 			assert(dp == rest);
 			sp = rest;
 			break;

--- a/newlib/libc/search/qsort.c
+++ b/newlib/libc/search/qsort.c
@@ -65,6 +65,7 @@ PORTABILITY
 #include <_ansi.h>
 #include <sys/cdefs.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 #ifndef __GNUC__
 #define inline
@@ -96,8 +97,8 @@ static inline void	 swapfunc (char *, char *, int, int);
         } while (--i > 0);				\
 }
 
-#define SWAPINIT(a, es) swaptype = ((char *)a - (char *)0) % sizeof(long) || \
-	es % sizeof(long) ? 2 : es == sizeof(long)? 0 : 1;
+#define SWAPINIT(a, es) swaptype = ((uintptr_t)(a) % sizeof(long)) ||   \
+	((es) % sizeof(long)) ? 2 : ((es) == sizeof(long)) ? 0 : 1
 
 static inline void
 swapfunc (char *a,

--- a/scripts/cross-clang-riscv64-unknown-elf.txt
+++ b/scripts/cross-clang-riscv64-unknown-elf.txt
@@ -1,5 +1,6 @@
 [binaries]
 c = ['clang', '-target', 'riscv64-unknown-elf' ]
+c_ld = '/usr/bin/riscv64-unknown-elf-ld'
 ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'
 nm = 'riscv64-unknown-elf-nm'
@@ -15,3 +16,5 @@ endian = 'little'
 [properties]
 c_args = [ '-nostdlib', '-Wdouble-promotion']
 needs_exe_wrapper = true
+skip_sanity_check = true
+has_link_defsym = true

--- a/scripts/cross-clang-rv32imafdc-unknown-elf.txt
+++ b/scripts/cross-clang-rv32imafdc-unknown-elf.txt
@@ -27,7 +27,10 @@ c_link_args = [
 	'-m32',
 	'-target', 'riscv32-unknown-elf',
 	'-march=rv32imafdc',
+	'-Wl,-melf32lriscv',
 	'-nostdlib',
 	'-L/usr/lib/gcc/riscv64-unknown-elf/8.3.0/rv32imafdc/ilp32d'
 	]
 needs_exe_wrapper = true
+skip_sanity_check = true
+has_link_defsym = true

--- a/test/libc-testsuite/qsort.c
+++ b/test/libc-testsuite/qsort.c
@@ -35,6 +35,28 @@ static int icmp(const void *a, const void *b)
 	return *(int*)a - *(int*)b;
 }
 
+struct three {
+    unsigned char b[3];
+};
+
+#define i3(x)                                                    \
+        { (unsigned char) ((x) >> 16), (unsigned char) ((x) >> 8),      \
+                        (unsigned char) ((x) >> 0) }
+
+static int tcmp(const void *av, const void *bv)
+{
+    const struct three *a = av, *b = bv;
+    int c;
+    int i;
+
+    for (i = 0; i < 3; i++) {
+        c = (int) a->b[i] - (int) b->b[i];
+        if (c)
+            return c;
+    }
+    return 0;
+}
+
 #define FAIL(m) do {                                            \
         printf(__FILE__ ":%d: %s failed\n", __LINE__, m);       \
         err++;                                                  \
@@ -61,6 +83,12 @@ int test_qsort(void)
 		848405, 3434, 3434344, 3535, 93994, 2230404, 4334
 	};
 
+        struct three t[] = {
+                i3(879045), i3(394), i3(99405644), i3(33434), i3(232323), i3(4334), i3(5454),
+                i3(343), i3(45545), i3(454), i3(324), i3(22), i3(34344), i3(233), i3(45345), i3(343),
+                i3(848405), i3(3434), i3(3434344), i3(3535), i3(93994), i3(2230404), i3(4334)
+        };
+
 	qsort(s, sizeof(s)/sizeof(char *), sizeof(char *), scmp);
 	for (i=0; i<(int) (sizeof(s)/sizeof(char *)-1); i++) {
 		if (strcmp(s[i], s[i+1]) > 0) {
@@ -80,6 +108,17 @@ int test_qsort(void)
 			break;
 		}
 	}
+
+        qsort(t, sizeof(t)/sizeof(t[0]), sizeof(t[0]), tcmp);
+	for (i=0; i<(int)(sizeof(t)/sizeof(t[0])-1); i++) {
+                if (tcmp(&t[i], &t[i+1]) > 0) {
+			FAIL("three byte sort");
+			for (i=0; i<(int)(sizeof(t)/sizeof(t[0])); i++)
+                                printf("\t0x%02x%02x%02x\n", t[i].b[0], t[i].b[1], t[i].b[2]);
+			break;
+		}
+	}
+
 
 	return err;
 }


### PR DESCRIPTION
qsort's pointer alignment test was using pointer subtraction to convert a pointer to an integer. Replace this with a simple cast to uintptr_t instead, which (while probably still undefined behavior), at least isn't called out explicitly in the ISO spec, and doesn't trigger a warning from clang?