### PR TITLE
Compute memory region sizes at runtime

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -742,6 +742,9 @@ conf_data.set('_HAVE_ATTRIBUTE_ALWAYS_INLINE',
 conf_data.set('_HAVE_ATTRIBUTE_GNU_INLINE',
 	      cc.has_function_attribute('gnu_inline'),
 	      description: 'The compiler supports the gnu_inline function attribute')
+conf_data.set('__PICOLIBC_CRT_RUNTIME_SIZE',
+	      get_option('crt-runtime-size'),
+	      description: 'Compute static memory area sizes at runtime instead of link time')
 
 # Obsolete newlib options
 conf_data.set('_WANT_USE_LONG_TIME_T', get_option('newlib-long-time_t'), description: 'Obsoleted. Define time_t to long instead of using a 64-bit type')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -184,6 +184,8 @@ option('newlib-register-fini', type: 'boolean', value: false,
        description: 'enable finalization function registration using atexit')
 option('fake-semihost', type: 'boolean', value: false,
        description: 'create fake semihost library to link tests')
+option('crt-runtime-size', type: 'boolean', value: false,
+       description: 'compute crt memory space sizes at runtime')
 
 #
 # Malloc option

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -182,6 +182,8 @@ option('newlib-initfini-array', type: 'boolean', value: true,
        description: 'compiler supports INIT_ARRAY section types')
 option('newlib-register-fini', type: 'boolean', value: false,
        description: 'enable finalization function registration using atexit')
+option('fake-semihost', type: 'boolean', value: false,
+       description: 'create fake semihost library to link tests')
 
 #
 # Malloc option

--- a/newlib/libc/picolib/inittls.c
+++ b/newlib/libc/picolib/inittls.c
@@ -46,7 +46,16 @@
 
 extern char __tdata_source[];	/* Source of TLS initialization data (in ROM) */
 extern char __tdata_size[];	/* Size of TLS initized data */
+extern char __tbss_start[];     /* Start of static zero-initialized TLS data */
+extern char __tbss_end[];       /* End of static zero-initialized TLS data */
 extern char __tbss_size[];	/* Size of TLS zero-filled data */
+extern char __tdata_start[];    /* Start of static tdata area */
+extern char __tdata_end[];      /* End of static tdata area */
+
+#ifdef __PICOLIBC_CRT_RUNTIME_SIZE
+#define __tdata_size (__tdata_end - __tdata_start)
+#define __tbss_size (__tbss_end - __tbss_start)
+#endif
 
 void
 _init_tls(void *__tls)

--- a/newlib/libm/common/pow.c
+++ b/newlib/libm/common/pow.c
@@ -165,7 +165,11 @@ specialcase (double_t tmp, uint64_t sbits, uint64_t ki)
   /* Note: sbits is signed scale.  */
   scale = asdouble (sbits);
   y = scale + scale * tmp;
+#if FLT_EVAL_METHOD == 2
+#define fabs(x) fabsl(x)
+#endif
   if (fabs (y) < 1.0)
+#undef fabs
     {
       /* Round y to the right precision before scaling it into the subnormal
 	 range to avoid double rounding that can cause 0.5+E/2 ulp error where

--- a/picocrt/crt0.h
+++ b/picocrt/crt0.h
@@ -40,10 +40,19 @@
 
 extern char __data_source[];
 extern char __data_start[];
+extern char __data_end[];
 extern char __data_size[];
 extern char __bss_start[];
+extern char __bss_end[];
 extern char __bss_size[];
 extern char __tls_base[];
+extern char __tdata_end[];
+extern char __tls_end[];
+
+#ifdef __PICOLIBC_CRT_RUNTIME_SIZE
+#define __data_size (__data_end - __data_start)
+#define __bss_size (__bss_end - __bss_start)
+#endif
 
 /* These two functions must be defined in the architecture-specific
  * code

--- a/picolibc.ld.in
+++ b/picolibc.ld.in
@@ -162,9 +162,12 @@ SECTIONS
 	.tdata : ALIGN_WITH_INPUT {
 		*(.tdata .tdata.* .gnu.linkonce.td.*)
 		PROVIDE(__data_end = .);
+		PROVIDE(__tdata_end = .);
 	} >ram AT>flash :tls :ram_init
 	PROVIDE( __tls_base = ADDR(.tdata));
+	PROVIDE( __tdata_start = ADDR(.tdata));
 	PROVIDE( __tdata_source = LOADADDR(.tdata) );
+	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
 	PROVIDE( __tdata_size = SIZEOF(.tdata) );
 
 	PROVIDE( __edata = __data_end );
@@ -176,8 +179,10 @@ SECTIONS
 		*(.tbss .tbss.* .gnu.linkonce.tb.*)
 		*(.tcommon)
 		PROVIDE( __tls_end = . );
+		PROVIDE( __tbss_end = . );
 	} >ram AT>ram :tls :ram
 	PROVIDE( __bss_start = ADDR(.tbss));
+	PROVIDE( __tbss_start = ADDR(.tbss));
 	PROVIDE( __tbss_size = SIZEOF(.tbss) );
 	PROVIDE( __tls_size = __tls_end - __tls_base );
 
@@ -191,7 +196,7 @@ SECTIONS
 	 * so we create a special segment here just to make room
 	 */
 	.tbss_space (NOLOAD) : {
-		. = . + __tbss_size;
+		. = . + SIZEOF(.tbss);
 	} >ram AT>ram :ram
 
 	.bss (NOLOAD) : {

--- a/scripts/cross-m68k-linux-gnu.txt
+++ b/scripts/cross-m68k-linux-gnu.txt
@@ -9,10 +9,11 @@ strip = 'm68k-linux-gnu-strip'
 [host_machine]
 system = 'unknown'
 cpu_family = 'm68k'
-cpu = '68000'
+cpu = '68020'
 endian = 'big'
 
 [properties]
-c_args = [ '-nostdlib', '-march=68000']
-c_link_args = [ '-nostdlib', '-march=68000', '-lgcc' ]
+c_args = [ '-nostdlib', '-march=68020' ]
+c_link_args = [ '-nostdlib', '-march=68020', '-lgcc' ]
+link_spec = '--build-id=none'
 skip_sanity_check = true

--- a/scripts/do-m68k-configure
+++ b/scripts/do-m68k-configure
@@ -33,14 +33,4 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-ARCH=m68k-linux-gnu
-DIR=`dirname $0`
-meson "$DIR"/.. \
-	-Dtests=false \
-	-Dpicolib=false \
-	-Dposix-io=false \
-	-Dmultilib=false \
-	-Dincludedir=picolibc/$ARCH/include \
-	-Dlibdir=picolibc/$ARCH/lib \
-	--cross-file "$DIR"/cross-m68k.txt \
-	"$@"
+exec "$(dirname "$0")"/do-configure m68k-linux-gnu -Dtests=true -Dfake-semihost=true "$@"

--- a/scripts/test-m68k.ld
+++ b/scripts/test-m68k.ld
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2020 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+__flash =      0x00000000;
+__flash_size = 0x00400000;
+__ram =        0x00400000;
+__ram_size   = 0x00200000;
+__stack_size = 4k;

--- a/semihost/fake/fake_exit.c
+++ b/semihost/fake/fake_exit.c
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2022 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+void  _ATTRIBUTE((__noreturn__))
+_exit(int code)
+{
+        (void) code;
+	while(1) {
+        }
+}

--- a/semihost/fake/fake_io.c
+++ b/semihost/fake/fake_io.c
@@ -1,0 +1,65 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2022 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+static int
+fake_putc(char c, FILE *file)
+{
+	(void) file;
+        (void) c;
+	return c;
+}
+
+static int
+fake_getc(FILE *file)
+{
+	(void) file;
+	return EOF;
+}
+
+static FILE __stdio = FDEV_SETUP_STREAM(fake_putc, fake_getc, NULL, _FDEV_SETUP_RW);
+
+#ifdef __strong_reference
+#define STDIO_ALIAS(x) __strong_reference(stdin, x);
+#else
+#define STDIO_ALIAS(x) FILE *const x = &__stdio;
+#endif
+
+FILE *const stdin = &__stdio;
+STDIO_ALIAS(stdout);
+STDIO_ALIAS(stderr);

--- a/semihost/fake/fake_kill.c
+++ b/semihost/fake/fake_kill.c
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2022 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sys/types.h>
+#include <signal.h>
+#include <unistd.h>
+#include <errno.h>
+
+pid_t getpid(void) { return 1; }
+
+int kill(pid_t pid, int sig) { if (pid == 1) _exit(128 + sig); errno = ESRCH; return -1; }

--- a/semihost/fake/fake_stub.c
+++ b/semihost/fake/fake_stub.c
@@ -1,0 +1,113 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2022 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+
+_READ_WRITE_RETURN_TYPE
+read(int fd, void *buf, size_t count)
+{
+        (void) fd;
+        (void) buf;
+        (void) count;
+	return 0;
+}
+
+_READ_WRITE_RETURN_TYPE
+write(int fd, const void *buf, size_t count)
+{
+	const uint8_t *b = buf;
+	size_t c = count;
+
+        (void) fd;
+        (void) b;
+	while (c--) {
+	}
+	return count;
+}
+
+int
+open(const char *pathname, int flags, ...)
+{
+        (void) pathname;
+        (void) flags;
+	return -1;
+}
+
+int
+close(int fd)
+{
+        (void) fd;
+	return 0;
+}
+
+off_t lseek(int fd, off_t offset, int whence)
+{
+        (void) fd;
+        (void) offset;
+        (void) whence;
+	return (off_t) -1;
+}
+
+_off64_t lseek64(int fd, _off64_t offset, int whence)
+{
+	return (_off64_t) lseek(fd, (off_t) offset, whence);
+}
+
+int
+unlink(const char *pathname)
+{
+        (void) pathname;
+	return 0;
+}
+
+int
+fstat (int fd, struct stat *sbuf)
+{
+        (void) fd;
+        (void) sbuf;
+	return -1;
+}
+
+int
+isatty (int fd)
+{
+        (void) fd;
+	return 1;
+}

--- a/semihost/fake/meson.build
+++ b/semihost/fake/meson.build
@@ -1,0 +1,69 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2022 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+lib_semihost_srcs = [
+  'fake_exit.c',
+  'fake_kill.c',
+  'fake_stub.c',
+  ]
+
+if tinystdio
+  lib_semihost_srcs += 'fake_io.c'
+endif
+
+has_semihost = true
+
+foreach target : targets
+  value = get_variable('target_' + target)
+
+  instdir = join_paths(get_option('libdir'), value[0])
+
+  if target == ''
+    libsemihost_name = 'semihost'
+  else
+    libsemihost_name = join_paths(target, 'libsemihost')
+  endif
+
+  local_lib_semihost_target = static_library(libsemihost_name,
+				       lib_semihost_srcs,
+				       install : true,
+				       install_dir : instdir,
+				       include_directories : inc,
+				       c_args : value[1],
+				       pic: false)
+
+  set_variable('lib_semihost' + target, local_lib_semihost_target)
+
+endforeach

--- a/semihost/meson.build
+++ b/semihost/meson.build
@@ -129,3 +129,7 @@ if src_semihost != []
     
   endforeach
 endif
+
+if not has_semihost and get_option('fake-semihost')
+  subdir('fake')
+endif


### PR DESCRIPTION
This series adds a -Dcrt-runtime-size=true option which tells picolibc to compute the size of the bss, data, tbss and tdata segments at runtime by subtracting addresses rather than having the linker perform that subtraction at link time. This can be necessary if the toolchain doesn't deal with relocating the size values as 'addresses'.

Closes #246 