### PR TITLE
Add '-Dbuild-type-subdir' to meson and '--picolibc-buildtype' to gcc

### DIFF
--- a/dummyhost/meson.build
+++ b/dummyhost/meson.build
@@ -40,7 +40,7 @@ srcs_dummyhost = [
 foreach target : targets
   value = get_variable('target_' + target)
 
-  instdir = join_paths(get_option('libdir'), value[0])
+  instdir = join_paths(lib_dir, value[0])
 
   if target == ''
     libdummyhost_name = 'dummyhost'

--- a/meson.build
+++ b/meson.build
@@ -395,9 +395,11 @@ if sysroot_install
   endif
 endif
 
-lib_dir = prefix / get_option('libdir')
+build_type_subdir = get_option('build-type-subdir')
 
-include_dir = prefix / get_option('includedir')
+lib_dir = prefix / get_option('libdir') / build_type_subdir
+
+include_dir = prefix / get_option('includedir') / build_type_subdir
 
 newlib_iconv_dir = get_option('newlib-iconv-dir')
 if newlib_iconv_dir == ''
@@ -410,7 +412,10 @@ if newlib_iconv_runtime_dir == ''
 endif
 
 specs_dir_option = get_option('specsdir')
-if specs_dir_option == ''
+if build_type_subdir != ''
+  specs_install = false
+  specs_dir = ''
+elif specs_dir_option == ''
   search_cmds = cc.cmd_array() + ['-print-search-dirs']
   install_dir=run_command(search_cmds, check : true).stdout().split('\n')[0]
   # Meson 0.56 adds a 'substring' method which can be used here

--- a/meson.build
+++ b/meson.build
@@ -395,7 +395,9 @@ if sysroot_install
   endif
 endif
 
-lib_dir = join_paths(prefix, get_option('libdir'))
+lib_dir = prefix / get_option('libdir')
+
+include_dir = prefix / get_option('includedir')
 
 newlib_iconv_dir = get_option('newlib-iconv-dir')
 if newlib_iconv_dir == ''
@@ -863,8 +865,6 @@ inc_dirs = [stdio_inc_dir, '.', 'newlib/libc/include']
 
 inc = include_directories(inc_dirs)
 
-includedir = join_paths(prefix, get_option('includedir'))
-
 # We don't need '-fdata-sections' currently as there aren't any
 # files with data used in separate code paths. This works around
 # versions of gcc for RISC-V which have a bug that mis-names
@@ -975,7 +975,7 @@ conf_data.set('HAVE_IEEEFP_FUNCS', has_ieeefp_funcs, description: 'IEEE fp funcs
 
 configure_file(output : 'picolibc.h',
 	       configuration: conf_data,
-	       install_dir: includedir)
+	       install_dir: include_dir)
 
 # Usage as an embedded subproject:
 # If picolibc is embedded into the source as a subproject,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -47,6 +47,9 @@ option('multilib', type: 'boolean', value: true,
 option('multilib-list', type: 'array', value: [],
        description: 'List of multilib configurations to build for')
 
+option('build-type-subdir', type: 'string',
+       description: 'Build-type subdir. Also skips installing .specs file')
+
 option('picolib', type: 'boolean', value: true,
        description: 'Include pico lib bits')
 

--- a/newlib/libc/include/machine/meson.build
+++ b/newlib/libc/include/machine/meson.build
@@ -64,5 +64,5 @@ endforeach
 
 install_headers(
   inc_machine_headers,
-  subdir:'machine'
+  install_dir: include_dir / 'machine'
 )

--- a/newlib/libc/include/meson.build
+++ b/newlib/libc/include/meson.build
@@ -105,4 +105,5 @@ if not tinystdio
   inc_headers += ['reent.h']
 endif
 
-install_headers(inc_headers)
+install_headers(inc_headers,
+		install_dir: include_dir)

--- a/newlib/libc/include/ssp/meson.build
+++ b/newlib/libc/include/ssp/meson.build
@@ -44,4 +44,4 @@ inc_ssp_headers = [
 ]
 
 install_headers(inc_ssp_headers,
-		subdir:'ssp')
+		install_dir: include_dir / 'ssp')

--- a/newlib/libc/include/sys/meson.build
+++ b/newlib/libc/include/sys/meson.build
@@ -87,5 +87,4 @@ foreach file : inc_sys_headers_all
 endforeach
 
 install_headers(inc_sys_headers,
-		subdir:'sys'
-	       )
+		install_dir: include_dir / 'sys')

--- a/newlib/libc/machine/aarch64/sys/meson.build
+++ b/newlib/libc/machine/aarch64/sys/meson.build
@@ -37,5 +37,4 @@ inc_sys_headers_machine = [
 ]
 
 install_headers(inc_sys_headers_machine,
-		subdir:'sys'
-	       )
+		install_dir: include_dir / 'sys')

--- a/newlib/libc/machine/arm/machine/meson.build
+++ b/newlib/libc/machine/arm/machine/meson.build
@@ -40,5 +40,4 @@ inc_machine_headers_machine = [
 ]
 
 install_headers(inc_machine_headers_machine,
-		subdir:'machine'
-	       )
+		install_dir: include_dir / 'machine')

--- a/newlib/libc/machine/arm/sys/meson.build
+++ b/newlib/libc/machine/arm/sys/meson.build
@@ -37,5 +37,4 @@ inc_sys_headers_machine = [
 ]
 
 install_headers(inc_sys_headers_machine,
-		subdir:'sys'
-	       )
+		install_dir: include_dir / 'sys')

--- a/newlib/libc/machine/i386/machine/meson.build
+++ b/newlib/libc/machine/i386/machine/meson.build
@@ -37,5 +37,4 @@ inc_machine_headers_machine = [
 ]
 
 install_headers(inc_machine_headers_machine,
-		subdir:'machine'
-	       )
+		install_dir: include_dir / 'machine')

--- a/newlib/libc/machine/riscv/machine/meson.build
+++ b/newlib/libc/machine/riscv/machine/meson.build
@@ -37,5 +37,4 @@ inc_machine_headers_machine = [
 ]
 
 install_headers(inc_machine_headers_machine,
-		subdir:'machine'
-	       )
+		install_dir: include_dir / 'machine')

--- a/newlib/libc/machine/riscv/sys/meson.build
+++ b/newlib/libc/machine/riscv/sys/meson.build
@@ -37,5 +37,4 @@ inc_sys_headers_machine = [
 ]
 
 install_headers(inc_sys_headers_machine,
-		subdir:'sys'
-	       )
+		install_dir: include_dir / 'sys')

--- a/newlib/libc/machine/shared_x86/sys/meson.build
+++ b/newlib/libc/machine/shared_x86/sys/meson.build
@@ -37,6 +37,5 @@ inc_sys_headers_machine = [
 ]
 
 install_headers(inc_sys_headers_machine,
-		subdir:'sys'
-	       )
+		install_dir: include_dir / 'sys')
 

--- a/newlib/libc/machine/xtensa/machine/meson.build
+++ b/newlib/libc/machine/xtensa/machine/meson.build
@@ -37,5 +37,4 @@ inc_machine_headers_machine = [
 ]
 
 install_headers(inc_machine_headers_machine,
-		subdir:'machine'
-	       )
+		install_dir: include_dir / 'machine')

--- a/newlib/libc/machine/xtensa/sys/meson.build
+++ b/newlib/libc/machine/xtensa/sys/meson.build
@@ -37,5 +37,4 @@ inc_sys_headers_machine = [
 ]
 
 install_headers(inc_sys_headers_machine,
-		subdir:'sys'
-	       )
+		install_dir: include_dir / 'sys')

--- a/newlib/libc/stdio/meson.build
+++ b/newlib/libc/stdio/meson.build
@@ -33,9 +33,8 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 subdir('sys')
-install_headers(
-  'stdio.h'
-)
+install_headers('stdio.h',
+		install_dir: include_dir)
 
 general_srcs_stdio = [
   'clearerr.c',

--- a/newlib/libc/stdio/sys/meson.build
+++ b/newlib/libc/stdio/sys/meson.build
@@ -46,7 +46,5 @@ foreach file : inc_stdio_sys_headers_all
   endif
 endforeach
 
-install_headers(
-  inc_stdio_sys_headers,
-  subdir:'sys'
-)
+install_headers(inc_stdio_sys_headers,
+		install_dir: include_dir / 'sys')

--- a/newlib/libc/tinystdio/meson.build
+++ b/newlib/libc/tinystdio/meson.build
@@ -177,9 +177,9 @@ hdrs_tinystdio = [
     'xtoa_fast.h',
 ]
 
-install_headers(
-  'stdio.h'
-)
+install_headers('stdio.h',
+		install_dir: include_dir
+	       )
 
 srcs_tinystdio_use = []
 foreach file : srcs_tinystdio

--- a/newlib/meson.build
+++ b/newlib/meson.build
@@ -55,7 +55,7 @@ foreach target : targets
     libsrcs_target += get_variable('src_' + libname + target, [])
   endforeach
 
-  instdir = join_paths(get_option('libdir'), value[0])
+  instdir = join_paths(lib_dir, value[0])
 
   if target == ''
     libc_name = 'c'

--- a/picocrt/meson.build
+++ b/picocrt/meson.build
@@ -45,7 +45,7 @@ endif
 foreach target : targets
   value = get_variable('target_' + target)
 
-  instdir = join_paths(get_option('libdir'), value[0])
+  instdir = join_paths(lib_dir, value[0])
 
   if target == ''
     crt_name = 'crt0.o'

--- a/picolibc.specs.in
+++ b/picolibc.specs.in
@@ -4,16 +4,16 @@
 %rename cc1plus	picolibc_cc1plus
 
 *cpp:
--isystem %{-picolibc-prefix=*:%*/@INCLUDEDIR@;:@PREFIX@/@INCLUDEDIR@} %(picolibc_cpp)
+-isystem %{-picolibc-prefix=*:%*/@INCLUDEDIR@; -picolibc-buildtype=*:@PREFIX@/@INCLUDEDIR/%*; :@PREFIX@/@INCLUDEDIR@} %(picolibc_cpp)
 
 *cc1:
 @TLSMODEL@ %(picolibc_cc1) @CC1_SPEC@
 
 *cc1plus:
--isystem %{-picolibc-prefix=*:%*/@INCLUDEDIR@;:@PREFIX@/@INCLUDEDIR@} -idirafter %{-picolibc-prefix=*:%*/@INCLUDEDIR@;:@PREFIX@/@INCLUDEDIR@} @TLSMODEL@ %(picolibc_cc1plus) @CC1_SPEC@ @CC1PLUS_SPEC@
+-isystem %{-picolibc-prefix=*:%*/@INCLUDEDIR@; -picolibc-buildtype=*:@PREFIX@/@INCLUDEDIR@/%*; @PREFIX@/@INCLUDEDIR@} -idirafter %{-picolibc-prefix=*:%*/@INCLUDEDIR@; -picolibc-buildtype=*:@PREFIX@/@INCLUDEDIR@/%*; :@PREFIX@/@INCLUDEDIR@} @TLSMODEL@ %(picolibc_cc1plus) @CC1_SPEC@ @CC1PLUS_SPEC@
 
 *link:
-@SPECS_PRINTF@ -L%{-picolibc-prefix=*:%*/@LIBDIR@/%M;:@PREFIX@/@LIBDIR@/%M} -L%{-picolibc-prefix=*:%*/@LIBDIR@;:@PREFIX@/@LIBDIR@} %{!T:-T@PICOLIBC_LD@} %(picolibc_link) --gc-sections @LINK_SPEC@
+@SPECS_PRINTF@ -L%{-picolibc-prefix=*:%*/@LIBDIR@/%M; -picolibc-buildtype=*:@PREFIX@/@LIBDIR@/%*/%M; :@PREFIX@/@LIBDIR@/%M} -L%{-picolibc-prefix=*:%*/@LIBDIR@; -picolibc-buildtype=*:@PREFIX@/@LIBDIR@/%*; :@PREFIX@/@LIBDIR@} %{!T:-T@PICOLIBC_LD@} %(picolibc_link) --gc-sections @LINK_SPEC@
 
 *lib:
 --start-group %(libgcc) @ADDITIONAL_LIBS@ -lc %{-oslib=*:-l%*} --end-group
@@ -22,5 +22,5 @@
 @CRTEND@
 
 *startfile:
-%{-picolibc-prefix=*:%*/@LIBDIR@/%M/crt0%{-crt0=*:-%*%O;:%O}%s;:@PREFIX@/@LIBDIR@/%M/crt0%{-crt0=*:-%*%O;:%O}%s} @CRTBEGIN@
+%{-picolibc-prefix=*:%*/@LIBDIR@/%M/crt0%{-crt0=*:-%*%O;:%O}%s; -picolibc-buildtype=*:@PREFIX@/@LIBDIR@/%*/%M/crt0%{-crt0=*:-%*%O;:%O}%s; :@PREFIX@/@LIBDIR@/%M/crt0%{-crt0=*:-%*%O;:%O}%s} @CRTBEGIN@
 @SPECS_EXTRA@

--- a/semihost/fake/meson.build
+++ b/semihost/fake/meson.build
@@ -48,7 +48,7 @@ has_semihost = true
 foreach target : targets
   value = get_variable('target_' + target)
 
-  instdir = join_paths(get_option('libdir'), value[0])
+  instdir = join_paths(lib_dir, value[0])
 
   if target == ''
     libsemihost_name = 'semihost'

--- a/semihost/machine/i386/meson.build
+++ b/semihost/machine/i386/meson.build
@@ -50,7 +50,7 @@ objcopy = find_program('objcopy', required: false)
 foreach target : targets
   value = get_variable('target_' + target)
 
-  instdir = join_paths(get_option('libdir'), value[0])
+  instdir = join_paths(lib_dir, value[0])
 
   if target == ''
     libsemihost_name = 'semihost'

--- a/semihost/meson.build
+++ b/semihost/meson.build
@@ -98,9 +98,9 @@ if src_semihost != []
     src_semihost += 'mapstdio.c'
   endif
 
-  install_headers(
-    'semihost.h'
-  )
+  install_headers('semihost.h',
+		  install_dir: include_dir
+		 )
 
   inc = [inc, include_directories('.')]
 
@@ -111,7 +111,7 @@ if src_semihost != []
   foreach target : targets
     value = get_variable('target_' + target)
 
-    instdir = join_paths(get_option('libdir'), value[0])
+    instdir = join_paths(lib_dir, value[0])
 
     if target == ''
       libsemihost_name = 'semihost'


### PR DESCRIPTION
These two options let picolibc be built with multiple configuration options and
installed in the same target directory. At application compile time, the build type
can be selected via the GCC --picolibc-buildtype option which selects which target
path to use for headers and binaries.
    
Signed-off-by: Keith Packard <keithp@keithp.com>

This will allow pre-built binaries to include both minsize and release builds so that developers can choose which version to use instead of having to rebuild picolibc for each application.

Closes #258 