### PR TITLE
More glibc testing adventures

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -161,10 +161,13 @@ lite_exit = get_option('lite-exit')
 
 newlib_elix_level = get_option('newlib-elix-level')
 c_args = ['-include', '@0@/@1@'.format(meson.current_build_dir(), 'picolibc.h')]
+native_c_args = ['-DNO_NEWLIB']
 
 # Disable ssp and fortify source while building picolibc (it's enabled
 # by default by the ubuntu native compiler)
-c_args += cc.get_supported_arguments(['-fno-common', '-frounding-math', '-Wno-unsupported-floating-point-opt', '-fno-stack-protector'])
+c_flags = cc.get_supported_arguments(['-fno-common', '-frounding-math', '-fsignaling-nans', '-Wno-unsupported-floating-point-opt', '-fno-stack-protector'])
+c_args += c_flags
+native_c_args += c_flags
 
 # Select a fortify source option
 fortify_source = get_option('fortify-source')
@@ -521,7 +524,9 @@ picolibcpp_ld = configure_file(input: 'picolibc.ld.in',
 # Not all compilers necessarily support all warnings; only use these which are:
 c_warnings = ['-Werror=implicit-function-declaration', '-Werror=vla', '-Warray-bounds', '-Wold-style-definition']
 disabled_warnings = ['-Wno-missing-braces', '-Wno-implicit-int', '-Wno-return-type', '-Wno-unused-command-line-argument']
-c_args += cc.get_supported_arguments(c_warnings, disabled_warnings)
+c_flags = cc.get_supported_arguments(c_warnings, disabled_warnings)
+c_args += c_flags
+native_c_args += c_flags
 
 # CompCert does not support bitfields in packed structs, so avoid using this optimization
 bitfields_in_packed_structs_code = '''
@@ -936,6 +941,7 @@ conf_data.set('HAVE_SEMIHOST', has_semihost, description: 'Semihost APIs support
 
 # disable compiler built-ins so we reach the library equivalents
 test_c_args = c_args + arg_fnobuiltin
+native_c_args += arg_fnobuiltin
 if tests_enable_stack_protector
   if cc.has_argument('-fstack-protector-all') and cc.has_argument('-fstack-protector-strong')
     test_c_args += ['-fstack-protector-all', '-fstack-protector-strong', '-DTESTS_ENABLE_STACK_PROTECTOR']

--- a/newlib/libc/include/machine/ieeefp.h
+++ b/newlib/libc/include/machine/ieeefp.h
@@ -80,6 +80,10 @@ warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
 #if (defined(__arm__) || defined(__thumb__)) && !defined(__MAVERICK__)
+/* arm with hard fp and soft dp cannot use new float code */
+# if (__ARM_FP & 4) && !(__ARM_FP & 8)
+#  define __OBSOLETE_MATH_DEFAULT_FLOAT 1
+# endif
 /* ARM traditionally used big-endian words; and within those words the
    byte ordering was big or little endian depending upon the target.
    Modern floating-point formats are naturally ordered; in this case
@@ -89,11 +93,6 @@ warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #  define __IEEE_LITTLE_ENDIAN
 # else
 #  define __IEEE_BIG_ENDIAN
-# endif
-# if __ARM_FP & 0x8
-#  define __OBSOLETE_MATH_DEFAULT_FLOAT 0
-# else
-#  define __OBSOLETE_MATH_DEFAULT_FLOAT 1
 # endif
 #else
 # define __IEEE_BIG_ENDIAN
@@ -112,7 +111,6 @@ warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #else
 #define __IEEE_BIG_ENDIAN
 #endif
-#define __OBSOLETE_MATH_DEFAULT_FLOAT 0
 #ifdef __ARM_FP
 # define _SUPPORTS_ERREXCEPT
 #endif
@@ -220,11 +218,6 @@ warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #endif
 #ifdef __riscv_flen
 # define _SUPPORTS_ERREXCEPT
-#endif
-#if __riscv_flen >= 64
-# define __OBSOLETE_MATH_DEFAULT_FLOAT 0
-#else
-# define __OBSOLETE_MATH_DEFAULT_FLOAT 1
 #endif
 #endif
 
@@ -532,38 +525,28 @@ warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #define __OBSOLETE_MATH_DEFAULT 0
 #endif
 
-#ifndef __OBSOLETE_MATH_DEFAULT_FLOAT
-# ifdef __OBSOLETE_MATH_DEFAULT
-#  define __OBSOLETE_MATH_DEFAULT_FLOAT __OBSOLETE_MATH_DEFAULT
-# else
-/* Use old math code by default for single-precision functions.  */
-#  define __OBSOLETE_MATH_DEFAULT_FLOAT 1
-# endif
-#endif
-
-#ifndef __OBSOLETETE_MATH_DEFAULT_DOUBLE
-# ifdef __OBSOLETE_MATH_DEFAULT
-#  define __OBSOLETE_MATH_DEFAULT_DOUBLE __OBSOLETE_MATH_DEFAULT
-# else
-/* Use new math code by default for double-precision functions. */
-#  define __OBSOLETE_MATH_DEFAULT_DOUBLE 0
-# endif
-#endif
-
 #ifndef __OBSOLETE_MATH_DEFAULT
-/* Use old math code by default.  */
 #define __OBSOLETE_MATH_DEFAULT 1
 #endif
+
 #ifndef __OBSOLETE_MATH
 #define __OBSOLETE_MATH __OBSOLETE_MATH_DEFAULT
 #endif
 
 #ifndef __OBSOLETE_MATH_FLOAT
+#ifdef __OBSOLETE_MATH_DEFAULT_FLOAT
 #define __OBSOLETE_MATH_FLOAT __OBSOLETE_MATH_DEFAULT_FLOAT
+#else
+#define __OBSOLETE_MATH_FLOAT __OBSOLETE_MATH
+#endif
 #endif
 
 #ifndef __OBSOLETE_MATH_DOUBLE
+#ifdef __OBSOLETE_MATH_DEFAULT_DOUBLE
 #define __OBSOLETE_MATH_DOUBLE __OBSOLETE_MATH_DEFAULT_DOUBLE
+#else
+#define __OBSOLETE_MATH_DOUBLE __OBSOLETE_MATH
+#endif
 #endif
 
 #ifndef __IEEE_BIG_ENDIAN

--- a/newlib/libc/include/math.h
+++ b/newlib/libc/include/math.h
@@ -338,7 +338,7 @@ int __issignalingl(long double d);
 	                              __signbitd((double) (__x)))
 #endif
 
-#if __GNUC_PREREQ (2, 97)
+#if __GNUC_PREREQ (2, 97) && !(defined(__riscv) && defined(__clang__))
 #define isgreater(__x,__y)	(__builtin_isgreater (__x, __y))
 #define isgreaterequal(__x,__y)	(__builtin_isgreaterequal (__x, __y))
 #define isless(__x,__y)		(__builtin_isless (__x, __y))

--- a/newlib/libc/include/math.h
+++ b/newlib/libc/include/math.h
@@ -251,6 +251,8 @@ extern int __fpclassifyf (float);
 extern int __fpclassifyd (double);
 extern int __signbitf (float);
 extern int __signbitd (double);
+extern int __finite (double);
+extern int __finitef (float);
 
 /* Note: isinf and isnan were once functions in newlib that took double
  *       arguments.  C99 specifies that these names are reserved for macros
@@ -277,14 +279,13 @@ extern int __signbitd (double);
     #define isnan(__x) (__builtin_isnan (__x))
   #endif
   #define isnormal(__x) (__builtin_isnormal (__x))
+  #define issubnormal(__x) (__builtin_issubnormal (__x))
 #else
   #define fpclassify(__x) \
 	  ((sizeof(__x) == sizeof(float))  ? __fpclassifyf(__x) : \
 	  __fpclassifyd((double) (__x)))
   #ifndef isfinite
-    #define isfinite(__y) \
-	    (__extension__ ({int __cy = fpclassify(__y); \
-			     __cy != FP_INFINITE && __cy != FP_NAN;}))
+    #define isfinite(__x) ((sizeof(__x) == sizeof(float)) ? __finitef(__x) : __finite(__x))
   #endif
   #ifndef isinf
     #define isinf(__x) (fpclassify(__x) == FP_INFINITE)
@@ -293,6 +294,7 @@ extern int __signbitd (double);
     #define isnan(__x) (fpclassify(__x) == FP_NAN)
   #endif
   #define isnormal(__x) (fpclassify(__x) == FP_NORMAL)
+  #define issubnormal(__x) (fpclassify(__x) == FP_SUBNORMAL)
 #endif
 
 #ifndef issignaling

--- a/newlib/libc/include/math.h
+++ b/newlib/libc/include/math.h
@@ -263,9 +263,12 @@ extern int __finitef (float);
 
 /*
  * GCC bug 66462 raises INVALID exception when __builtin_fpclassify is
- * passed snan, so we cannot use it when building with snan support
+ * passed snan, so we cannot use it when building with snan support.
+ * clang doesn't appear to have an option to control snan behavior, and
+ * it's builtin fpclassify also raises INVALID for snan, so always use
+ * our version for that.
  */
-#if (__GNUC_PREREQ (4, 4) || defined(__clang__)) && !defined(__SUPPORT_SNAN__)
+#if __GNUC_PREREQ (4, 4) && !defined(__SUPPORT_SNAN__) && !defined(__clang__)
   #define fpclassify(__x) (__builtin_fpclassify (FP_NAN, FP_INFINITE, \
 						 FP_NORMAL, FP_SUBNORMAL, \
 						 FP_ZERO, __x))

--- a/newlib/libc/include/math.h
+++ b/newlib/libc/include/math.h
@@ -259,7 +259,11 @@ extern int __signbitd (double);
  *       taking double arguments still exist for compatibility purposes
  *       (prototypes for them are earlier in this header).  */
 
-#if __GNUC_PREREQ (4, 4) || defined(__clang__)
+/*
+ * GCC bug 66462 raises INVALID exception when __builtin_fpclassify is
+ * passed snan, so we cannot use it when building with snan support
+ */
+#if (__GNUC_PREREQ (4, 4) || defined(__clang__)) && !defined(__SUPPORT_SNAN__)
   #define fpclassify(__x) (__builtin_fpclassify (FP_NAN, FP_INFINITE, \
 						 FP_NORMAL, FP_SUBNORMAL, \
 						 FP_ZERO, __x))

--- a/newlib/libc/include/math.h
+++ b/newlib/libc/include/math.h
@@ -375,7 +375,9 @@ extern double cbrt (double);
 extern double nextafter (double, double);
 extern double rint (double);
 extern double scalbn (double, int);
+extern double scalb (double, double);
 extern double getpayload(const double *x);
+extern double significand (double);
 
 extern double exp2 (double);
 extern double scalbln (double, long int);
@@ -474,9 +476,11 @@ extern float cbrtf (float);
 extern float nextafterf (float, float);
 extern float rintf (float);
 extern float scalbnf (float, int);
+extern float scalbf (float, float);
 extern float log1pf (float);
 extern float expm1f (float);
 extern float getpayloadf(const float *x);
+extern float significandf (float);
 
 #ifndef _REENT_ONLY
 extern float acoshf (float);

--- a/newlib/libc/machine/arm/machine/math.h
+++ b/newlib/libc/machine/arm/machine/math.h
@@ -68,6 +68,14 @@ sqrt(double x)
 	return result;
 }
 
+__declare_arm_macro(double)
+fabs(double x)
+{
+    double result;
+    __asm__ ("vabs.f64\t%P0, %P1" : "=w" (result) : "w" (x));
+    return result;
+}
+
 #if __ARM_ARCH >= 8
 __declare_arm_macro(double)
 ceil (double x)
@@ -157,6 +165,14 @@ sqrtf(float x)
 	__asm__ volatile ("vsqrt.f32 %0, %1" : "=&w" (result) : "w" (x) : "cc", "memory");
 #endif
 	return result;
+}
+
+__declare_arm_macro(float)
+fabsf(float x)
+{
+    float result;
+    __asm__ ("vabs.f32\t%0, %1" : "=t" (result) : "t" (x));
+    return result;
 }
 
 #if __ARM_ARCH >= 8

--- a/newlib/libc/machine/arm/machine/math.h
+++ b/newlib/libc/machine/arm/machine/math.h
@@ -56,7 +56,7 @@ sqrt(double x)
 {
 	double result;
 #ifdef _WANT_MATH_ERRNO
-        if (x < 0)
+        if (isless(x, 0.0))
             errno = EDOM;
 #endif
 #if __ARM_ARCH >= 6
@@ -140,7 +140,7 @@ sqrtf(float x)
 {
 	float result;
 #ifdef _WANT_MATH_ERRNO
-        if (x < 0)
+        if (isless(x, 0.0f))
             errno = EDOM;
 #endif
 #if __ARM_ARCH >= 6

--- a/newlib/libc/machine/arm/machine/math.h
+++ b/newlib/libc/machine/arm/machine/math.h
@@ -60,10 +60,10 @@ sqrt(double x)
             errno = EDOM;
 #endif
 #if __ARM_ARCH >= 6
-	__asm__("vsqrt.f64 %P0, %P1" : "=w" (result) : "w" (x));
+	__asm__ volatile ("vsqrt.f64 %P0, %P1" : "=w" (result) : "w" (x));
 #else
 	/* VFP9 Erratum 760019, see GCC sources "gcc/config/arm/vfp.md" */
-	__asm__("vsqrt.f64 %P0, %P1" : "=&w" (result) : "w" (x));
+        __asm__ volatile ("vsqrt.f64 %P0, %P1" : "=&w" (result) : "w" (x));
 #endif
 	return result;
 }
@@ -129,7 +129,7 @@ trunc (double x)
 __declare_arm_macro(double)
 fma (double x, double y, double z)
 {
-  __asm__("vfma.f64 %P0, %P1, %P2" : "+w" (z) : "w" (x), "w" (y));
+  __asm__ volatile ("vfma.f64 %P0, %P1, %P2" : "+w" (z) : "w" (x), "w" (y));
   return z;
 }
 #endif
@@ -151,10 +151,10 @@ sqrtf(float x)
             errno = EDOM;
 #endif
 #if __ARM_ARCH >= 6
-	__asm__("vsqrt.f32 %0, %1" : "=w" (result) : "w" (x));
+	__asm__ volatile ("vsqrt.f32 %0, %1" : "=w" (result) : "w" (x));
 #else
 	/* VFP9 Erratum 760019, see GCC sources "gcc/config/arm/vfp.md" */
-	__asm__("vsqrt.f32 %0, %1" : "=&w" (result) : "w" (x));
+	__asm__ volatile ("vsqrt.f32 %0, %1" : "=&w" (result) : "w" (x) : "cc", "memory");
 #endif
 	return result;
 }
@@ -221,7 +221,7 @@ truncf (float x)
 __declare_arm_macro(float)
 fmaf (float x, float y, float z)
 {
-  __asm__("vfma.f32 %0, %1, %2" : "+t" (z) : "t" (x), "t" (y));
+  __asm__ volatile ("vfma.f32 %0, %1, %2" : "+t" (z) : "t" (x), "t" (y));
   return z;
 }
 #endif

--- a/newlib/libc/machine/arm/machine/math.h
+++ b/newlib/libc/machine/arm/machine/math.h
@@ -88,9 +88,16 @@ floor (double x)
 __declare_arm_macro(double)
 nearbyint (double x)
 {
-  double result;
-  __asm__ volatile ("vrintr.f64\t%P0, %P1" : "=w" (result) : "w" (x));
-  return result;
+    if (isnan(x)) return x + x;
+#if defined(FE_INEXACT)
+    fenv_t env;
+    fegetenv(&env);
+#endif
+    __asm__ volatile ("vrintr.f64\t%P0, %P1" : "=w" (x) : "w" (x));
+#if defined(FE_INEXACT)
+    fesetenv(&env);
+#endif
+    return x;
 }
 
 __declare_arm_macro(double)
@@ -172,9 +179,16 @@ floorf (float x)
 __declare_arm_macro(float)
 nearbyintf (float x)
 {
-  float result;
-  __asm__ volatile ("vrintr.f32\t%0, %1" : "=t" (result) : "t" (x));
-  return result;
+    if (isnan(x)) return x + x;
+#if defined(FE_INEXACT)
+    fenv_t env;
+    fegetenv(&env);
+#endif
+    __asm__ volatile ("vrintr.f32\t%0, %1" : "=t" (x) : "t" (x));
+#if defined(FE_INEXACT)
+    fesetenv(&env);
+#endif
+    return x;
 }
 
 __declare_arm_macro(float)

--- a/newlib/libc/machine/riscv/machine/math.h
+++ b/newlib/libc/machine/riscv/machine/math.h
@@ -121,6 +121,9 @@ __declare_riscv_macro(double)
 fmax (double x, double y)
 {
 	double result;
+        if (issignaling(x) || issignaling(y))
+            return x + y;
+
 	__asm__ volatile("fmax.d\t%0, %1, %2" : "=f" (result) : "f" (x), "f" (y));
 	return result;
 }
@@ -129,6 +132,9 @@ __declare_riscv_macro(double)
 fmin (double x, double y)
 {
 	double result;
+        if (issignaling(x) || issignaling(y))
+            return x + y;
+
 	__asm__ volatile("fmin.d\t%0, %1, %2" : "=f" (result) : "f" (x), "f" (y));
 	return result;
 }
@@ -222,6 +228,9 @@ __declare_riscv_macro(float)
 fmaxf (float x, float y)
 {
 	float result;
+        if (issignaling(x) || issignaling(y))
+            return x + y;
+
 	__asm__ volatile("fmax.s\t%0, %1, %2" : "=f" (result) : "f" (x), "f" (y));
 	return result;
 }
@@ -230,6 +239,9 @@ __declare_riscv_macro(float)
 fminf (float x, float y)
 {
 	float result;
+        if (issignaling(x) || issignaling(y))
+            return x + y;
+
 	__asm__ volatile("fmin.s\t%0, %1, %2" : "=f" (result) : "f" (x), "f" (y));
 	return result;
 }

--- a/newlib/libc/machine/riscv/machine/math.h
+++ b/newlib/libc/machine/riscv/machine/math.h
@@ -180,7 +180,7 @@ sqrt (double x)
 {
 	double result;
 #ifdef _WANT_MATH_ERRNO
-        if (x < 0)
+        if (isless(x, 0.0))
             errno = EDOM;
 #endif
 	__asm__("fsqrt.d %0, %1" : "=f" (result) : "f" (x));
@@ -277,7 +277,7 @@ sqrtf (float x)
 {
 	float result;
 #ifdef _WANT_MATH_ERRNO
-        if (x < 0)
+        if (isless(x, 0.0f))
             errno = EDOM;
 #endif
 	__asm__("fsqrt.s %0, %1" : "=f" (result) : "f" (x));

--- a/newlib/libc/machine/riscv/machine/math.h
+++ b/newlib/libc/machine/riscv/machine/math.h
@@ -79,7 +79,7 @@ __declare_riscv_macro_fclass(long)
 _fclass_d(double x)
 {
 	long fclass;
-	__asm __volatile ("fclass.d\t%0, %1" : "=r" (fclass) : "f" (x));
+	__asm__ ("fclass.d\t%0, %1" : "=r" (fclass) : "f" (x));
 	return fclass;
 }
 #endif
@@ -89,7 +89,7 @@ __declare_riscv_macro_fclass(long)
 _fclass_f(float x)
 {
 	long fclass;
-	__asm __volatile ("fclass.s\t%0, %1" : "=r" (fclass) : "f" (x));
+	__asm__ ("fclass.s\t%0, %1" : "=r" (fclass) : "f" (x));
 	return fclass;
 }
 #endif
@@ -121,7 +121,7 @@ __declare_riscv_macro(double)
 fmax (double x, double y)
 {
 	double result;
-	__asm__("fmax.d\t%0, %1, %2" : "=f" (result) : "f" (x), "f" (y));
+	__asm__ volatile("fmax.d\t%0, %1, %2" : "=f" (result) : "f" (x), "f" (y));
 	return result;
 }
 
@@ -129,7 +129,7 @@ __declare_riscv_macro(double)
 fmin (double x, double y)
 {
 	double result;
-	__asm__("fmin.d\t%0, %1, %2" : "=f" (result) : "f" (x), "f" (y));
+	__asm__ volatile("fmin.d\t%0, %1, %2" : "=f" (result) : "f" (x), "f" (y));
 	return result;
 }
 
@@ -183,7 +183,7 @@ sqrt (double x)
         if (isless(x, 0.0))
             errno = EDOM;
 #endif
-	__asm__("fsqrt.d %0, %1" : "=f" (result) : "f" (x));
+	__asm__ volatile("fsqrt.d %0, %1" : "=f" (result) : "f" (x));
 	return result;
 }
 
@@ -192,7 +192,7 @@ __declare_riscv_macro(double)
 fma (double x, double y, double z)
 {
 	double result;
-	__asm__("fmadd.d %0, %1, %2, %3" : "=f" (result) : "f" (x), "f" (y), "f" (z));
+	__asm__ volatile("fmadd.d %0, %1, %2, %3" : "=f" (result) : "f" (x), "f" (y), "f" (z));
 	return result;
 }
 #endif
@@ -222,7 +222,7 @@ __declare_riscv_macro(float)
 fmaxf (float x, float y)
 {
 	float result;
-	__asm__("fmax.s\t%0, %1, %2" : "=f" (result) : "f" (x), "f" (y));
+	__asm__ volatile("fmax.s\t%0, %1, %2" : "=f" (result) : "f" (x), "f" (y));
 	return result;
 }
 
@@ -230,7 +230,7 @@ __declare_riscv_macro(float)
 fminf (float x, float y)
 {
 	float result;
-	__asm__("fmin.s\t%0, %1, %2" : "=f" (result) : "f" (x), "f" (y));
+	__asm__ volatile("fmin.s\t%0, %1, %2" : "=f" (result) : "f" (x), "f" (y));
 	return result;
 }
 
@@ -280,7 +280,7 @@ sqrtf (float x)
         if (isless(x, 0.0f))
             errno = EDOM;
 #endif
-	__asm__("fsqrt.s %0, %1" : "=f" (result) : "f" (x));
+	__asm__ volatile("fsqrt.s %0, %1" : "=f" (result) : "f" (x));
 	return result;
 }
 
@@ -290,15 +290,16 @@ __declare_riscv_macro(float)
 fmaf (float x, float y, float z)
 {
 	float result;
-	__asm__("fmadd.s %0, %1, %2, %3" : "=f" (result) : "f" (x), "f" (y), "f" (z));
+	__asm__ volatile("fmadd.s %0, %1, %2, %3" : "=f" (result) : "f" (x), "f" (y), "f" (z));
 	return result;
 }
 #endif
 
 #endif /* __riscv_flen >= 32 */
 
-#undef declare_riscv_macro
+#undef __declare_riscv_macro
+#undef __declare_riscv_mcaro_fclass
 
-#endif /* defined(declare_riscv_macro) */
+#endif /* __riscv_flen */
 
 #endif /* _MACHINE_MATH_H_ */

--- a/newlib/libc/stdlib/getopt.c
+++ b/newlib/libc/stdlib/getopt.c
@@ -201,23 +201,24 @@ getopt_internal (int argc, char *const argv[], const char *shortopts,
   int arg_next = 0;
   int initial_colon = 0;
 
-  /* first, deal with silly parameters and easy stuff */
-  if (argc == 0 || argv == 0 || (shortopts == 0 && longopts == 0)
-      || data->optind >= argc || argv[data->optind] == 0)
-    return EOF;
-  if (strcmp (argv[data->optind], "--") == 0)
-    {
-      data->optind++;
-      return EOF;
-    }
-
   /* if this is our first time through */
-  if (data->optind == 0)
+  if (data->optind <= 0)
     {
       data->optind = 1;
       data->optwhere = 1;
       data->permute_from = 0;
       data->num_nonopts = 0;
+    }
+
+  /* first, deal with silly parameters and easy stuff */
+  if (argc == 0 || argv == 0 || (shortopts == 0 && longopts == 0)
+      || data->optind >= argc || argv[data->optind] == 0)
+    return EOF;
+
+  if (strcmp (argv[data->optind], "--") == 0)
+    {
+      data->optind++;
+      return EOF;
     }
 
   /* define ordering */

--- a/newlib/libc/tinystdio/fcvtf_r.c
+++ b/newlib/libc/tinystdio/fcvtf_r.c
@@ -54,7 +54,7 @@ fcvtf_r (float invalue,
     int ftoa_decimal = ndecimal;
     char *digits = ftoa.digits;
 
-    if (!isfinite(invalue)) {
+    if (!__finitef(invalue)) {
         ndigit = 3;
         ntrailing = 0;
         *sign = invalue < 0;

--- a/newlib/libm/common/fdlibm.h
+++ b/newlib/libm/common/fdlibm.h
@@ -165,11 +165,6 @@
 
 #define X_TLOSS		1.41484755040568800000e+16 
 
-/* Functions that are not documented, and are not in <math.h>.  */
-
-extern double scalb (double, double);
-extern double significand (double);
-
 extern __int32_t __rem_pio2 (double,double*);
 
 /* fdlibm kernel function */
@@ -177,10 +172,6 @@ extern double __kernel_sin (double,double,int);
 extern double __kernel_cos (double,double);
 extern double __kernel_tan (double,double,int);
 extern int    __kernel_rem_pio2 (double*,double*,int,int,int,const __int32_t*);
-
-/* Undocumented float functions.  */
-extern float scalbf (float, float);
-extern float significandf (float);
 
 extern __int32_t __rem_pio2f (float,float*);
 

--- a/newlib/libm/common/math_config.h
+++ b/newlib/libm/common/math_config.h
@@ -572,4 +572,10 @@ __math_xflow (uint32_t sign, double y);
 HIDDEN float
 __math_xflowf (uint32_t sign, float y);
 
+HIDDEN double
+__math_lgamma_r (double y, int *signgamp, int *divzero);
+
+HIDDEN float
+__math_lgammaf_r (float y, int *signgamp, int *divzero);
+
 #endif

--- a/newlib/libm/common/math_config.h
+++ b/newlib/libm/common/math_config.h
@@ -380,8 +380,20 @@ HIDDEN double __math_divzero (uint32_t);
 
 /* Invalid input unless it is a quiet NaN.  */
 HIDDEN float __math_invalidf (float);
+/* set invalid exception */
+#if defined(FE_INVALID) && !defined(PICOLIBC_FLOAT_NOEXECPT)
+HIDDEN void __math_set_invalidf(void);
+#else
+#define __math_set_invalidf()   ((void) 0)
+#endif
 /* Invalid input unless it is a quiet NaN.  */
 HIDDEN double __math_invalid (double);
+/* set invalid exception */
+#if defined(FE_INVALID) && !defined(PICOLIBC_DOUBLE_NOEXECPT)
+HIDDEN void __math_set_invalid(void);
+#else
+#define __math_set_invalid()    ((void) 0)
+#endif
 
 /* Error handling using output checking, only for errno setting.  */
 
@@ -428,7 +440,7 @@ double __math_inexact(double);
 void __math_set_inexact(void);
 #else
 #define __math_inexact(val) (val)
-#define __math_set_inexact()
+#define __math_set_inexact()    ((void) 0)
 #endif
 
 #if defined(FE_INEXACT) && !defined(PICOLIBC_FLOAT_NOEXECPT)
@@ -436,7 +448,7 @@ float __math_inexactf(float val);
 void __math_set_inexactf(void);
 #else
 #define __math_inexactf(val) (val)
-#define __math_set_inexactf()
+#define __math_set_inexactf()   ((void) 0)
 #endif
 
 /* Shared between expf, exp2f and powf.  */

--- a/newlib/libm/common/math_config.h
+++ b/newlib/libm/common/math_config.h
@@ -334,6 +334,22 @@ force_eval_double (double x)
   (void) y;
 }
 
+/* Clang doesn't appear to suppor precise exceptions on
+ * many targets. We introduce barriers for that compiler
+ * to force evaluation order where needed
+ */
+#ifdef __clang__
+#define clang_barrier_double(x) opt_barrier_double(x)
+#define clang_barrier_float(x) opt_barrier_float(x)
+#define clang_force_double(x) force_eval_double(x)
+#define clang_force_float(x) force_eval_float(x)
+#else
+#define clang_barrier_double(x) (x)
+#define clang_barrier_float(x) (x)
+#define clang_force_double(x) (x)
+#define clang_force_float(x) (x)
+#endif
+
 /* Evaluate an expression as the specified type, normally a type
    cast should be enough, but compilers implement non-standard
    excess-precision handling, so when FLT_EVAL_METHOD != 0 then

--- a/newlib/libm/common/math_err_invalid.c
+++ b/newlib/libm/common/math_err_invalid.c
@@ -38,3 +38,11 @@ __math_invalid (double x)
     x = pick_double_except(VAL / VAL, VAL);
     return __math_with_errno (x, EDOM);
 }
+
+#ifndef __math_set_invalid
+HIDDEN void
+__math_set_invalid(void)
+{
+    force_eval_double(pick_double_except(VAL / VAL, VAL));
+}
+#endif

--- a/newlib/libm/common/math_errf_invalidf.c
+++ b/newlib/libm/common/math_errf_invalidf.c
@@ -39,3 +39,11 @@ __math_invalidf (float x)
     x = pick_float_except(VAL / VAL, VAL);
     return __math_with_errnof (x, EDOM);
 }
+
+#ifndef __math_set_invalidf
+HIDDEN void
+__math_set_invalidf(void)
+{
+    force_eval_float(pick_float_except(VAL / VAL, VAL));
+}
+#endif

--- a/newlib/libm/common/nexttowardf.c
+++ b/newlib/libm/common/nexttowardf.c
@@ -59,18 +59,12 @@ nexttowardf (float x, long double y)
   }
   e = ux & 0x7f800000;
   /* raise overflow if ux.value is infinite and x is finite */
-  if (e == 0x7f800000) {
-    volatile float force_eval;
-    force_eval = x + x;
-    (void) force_eval;
-  }
+  if (e == 0x7f800000)
+    return check_oflowf(opt_barrier_float(x+x));
   /* raise underflow if ux.value is subnormal or zero */
-  if (e == 0) {
-    volatile float force_eval;
-    force_eval = x*x + asfloat(ux)*asfloat(ux);
-    (void) force_eval;
-  }
-  return asfloat(ux);
+  if (e == 0)
+    force_eval_float(x*x + asfloat(ux)*asfloat(ux));
+  return check_uflowf(asfloat(ux));
 }
 
 #endif // _LDBL_EQ_DBL

--- a/newlib/libm/common/nexttowardf.c
+++ b/newlib/libm/common/nexttowardf.c
@@ -37,8 +37,17 @@ nexttowardf (float x, long double y)
   uint32_t ux;
   uint32_t e;
 
-  if (isnan(x) || isnan(y))
-    return (long double) x + y;
+  /*
+   * We can't do this if y isn't nan as that might raise INEXACT doing
+   * long double -> float conversion, and we don't want to do this
+   * in long double for machines without long double HW as we won't
+   * get any exceptions in that case.
+   */
+  if (isnan(y))
+      return x + (issignaling(y) ? __builtin_nansf("") : (float) y);
+  if (isnan(x))
+      return x + x;
+
   if ((long double) x == y)
     return y;
   ux = asuint(x);

--- a/newlib/libm/common/s_finite.c
+++ b/newlib/libm/common/s_finite.c
@@ -20,16 +20,25 @@
 
 #ifndef _DOUBLE_IS_32BITS
 
-#ifdef __STDC__
-	int finite(double x)
-#else
-	int finite(x)
-	double x;
-#endif
+int finite(double x)
 {
 	__int32_t hx;
 	GET_HIGH_WORD(hx,x);
 	return  (int)((__uint32_t)((hx&0x7fffffff)-0x7ff00000)>>31);
 }
+
+#if defined(HAVE_ALIAS_ATTRIBUTE)
+#ifndef __clang__
+#pragma GCC diagnostic ignored "-Wmissing-attributes"
+#endif
+__strong_reference(finite, __finite);
+#else
+
+int __finite(double x)
+{
+    return finite(x);
+}
+
+#endif
 
 #endif /* _DOUBLE_IS_32BITS */

--- a/newlib/libm/common/s_fmax.c
+++ b/newlib/libm/common/s_fmax.c
@@ -33,20 +33,18 @@ ANSI C, POSIX.
 
 #ifndef _DOUBLE_IS_32BITS
 
-#ifdef __STDC__
-	double fmax(double x, double y)
-#else
-	double fmax(x,y)
-	double x;
-	double y;
-#endif
+double fmax(double x, double y)
 {
-  if (__fpclassifyd(x) == FP_NAN)
-    return y;
-  if (__fpclassifyd(y) == FP_NAN)
-    return x;
-  
-  return x > y ? x : y;
+    if (issignaling(x) || issignaling(y))
+        return x + y;
+
+    if (isnan(x))
+        return y;
+
+    if (isnan(y))
+        return x;
+
+    return x > y ? x : y;
 }
 
 #endif /* _DOUBLE_IS_32BITS */

--- a/newlib/libm/common/s_fmin.c
+++ b/newlib/libm/common/s_fmin.c
@@ -33,20 +33,18 @@ ANSI C, POSIX.
 
 #ifndef _DOUBLE_IS_32BITS
 
-#ifdef __STDC__
-	double fmin(double x, double y)
-#else
-	double fmin(x,y)
-	double x;
-	double y;
-#endif
+double fmin(double x, double y)
 {
-  if (__fpclassifyd(x) == FP_NAN)
-    return y;
-  if (__fpclassifyd(y) == FP_NAN)
-    return x;
-  
-  return x < y ? x : y;
+    if (issignaling(x) || issignaling(y))
+        return x + y;
+
+    if (isnan(x))
+        return y;
+
+    if (isnan(y))
+        return x;
+
+    return x < y ? x : y;
 }
 
 #endif /* _DOUBLE_IS_32BITS */

--- a/newlib/libm/common/s_lround.c
+++ b/newlib/libm/common/s_lround.c
@@ -96,7 +96,7 @@ long int lround(double x)
 	/* 64bit long: shift amt in [32,42] */
         result = ((long int) msw << (exponent_less_1023 - 20))
 		/* 64bit long: shift amt in [0,10] */
-                | (lsw << (exponent_less_1023 - 52));
+            | ((long int) lsw << (exponent_less_1023 - 52));
       else
         {
 	  /* 32bit long: exponent_less_1023 in [20,30] */

--- a/newlib/libm/common/s_nearbyint.c
+++ b/newlib/libm/common/s_nearbyint.c
@@ -51,14 +51,18 @@ SEEALSO
 
 #ifndef _DOUBLE_IS_32BITS
 
-#ifdef __STDC__
-	double nearbyint(double x)
-#else
-	double nearbyint(x)
-	double x;
-#endif
+double nearbyint(double x)
 {
-  return rint(x);
+    if (isnan(x)) return x + x;
+#if defined(FE_INEXACT) && !defined(PICOLIBC_DOUBLE_NOEXECPT)
+    fenv_t env;
+    fegetenv(&env);
+#endif
+    x = rint(x);
+#if defined(FE_INEXACT) && !defined(PICOLIBC_DOUBLE_NOEXECPT)
+    fesetenv(&env);
+#endif
+    return x;
 }
 
 #endif /* _DOUBLE_IS_32BITS */

--- a/newlib/libm/common/s_rint.c
+++ b/newlib/libm/common/s_rint.c
@@ -116,8 +116,14 @@ TWO52[2]={
 		}
 	    }
 	} else if (j0>51) {
-	    if(j0==0x400) return x+x;	/* inf or NaN */
-	    else return x;		/* x is integral */
+            /*
+             * Use barrier to avoid overflow on clang which would
+             * otherwise always do this add on arm and use a
+             * conditional move instead of a branch for the if
+             */
+            if (j0 == 0x400)
+                return opt_barrier_double(x+x);
+            return x;
 	} else {
 	    i = ((__uint32_t)(0xffffffff))>>(j0-20);
 	    if((i1&i)==0) return x;	/* x is integral */

--- a/newlib/libm/common/s_scalbln.c
+++ b/newlib/libm/common/s_scalbln.c
@@ -31,7 +31,8 @@ twom54  =  5.55111512312578270212e-17; /* 0x3C900000, 0x00000000 */
 
 double scalbln (double x, long int n)
 {
-	__int32_t k,hx,lx;
+	__int32_t hx,lx;
+        long int k;
 	EXTRACT_WORDS(hx,lx,x);
         k = (hx&0x7ff00000)>>20;		/* extract exponent */
         if (k==0) {				/* 0 or subnormal x */

--- a/newlib/libm/common/s_scalbln.c
+++ b/newlib/libm/common/s_scalbln.c
@@ -27,16 +27,9 @@ static const double
 static double
 #endif
 two54   =  1.80143985094819840000e+16, /* 0x43500000, 0x00000000 */
-twom54  =  5.55111512312578270212e-17, /* 0x3C900000, 0x00000000 */
-huge   = 1.0e+300,
-tiny   = 1.0e-300;
+twom54  =  5.55111512312578270212e-17; /* 0x3C900000, 0x00000000 */
 
-#ifdef __STDC__
-	double scalbln (double x, long int n)
-#else
-	double scalbln (x,n)
-	double x; long int n;
-#endif
+double scalbln (double x, long int n)
 {
 	__int32_t k,hx,lx;
 	EXTRACT_WORDS(hx,lx,x);
@@ -46,19 +39,19 @@ tiny   = 1.0e-300;
 	    x *= two54;
 	    GET_HIGH_WORD(hx,x);
 	    k = ((hx&0x7ff00000)>>20) - 54;
+            if (n< -50000) return __math_uflow(hx < 0); /*underflow*/
 	    }
         if (k==0x7ff) return x+x;		/* NaN or Inf */
         k = k+n;
         if (n> 50000 || k >  0x7fe)
-	  return huge*copysign(huge,x); /* overflow  */
-	if (n< -50000) return tiny*copysign(tiny,x); /*underflow*/
+            return __math_oflow(hx<0);          /* overflow  */
         if (k > 0) 				/* normal result */
 	    {SET_HIGH_WORD(x,(hx&0x800fffff)|(k<<20)); return x;}
         if (k <= -54)
-	  return tiny*copysign(tiny,x); 	/*underflow*/
+            return __math_uflow(hx < 0); 	/*underflow*/
         k += 54;				/* subnormal result */
 	SET_HIGH_WORD(x,(hx&0x800fffff)|(k<<20));
-        return x*twom54;
+        return check_uflow(x*twom54);
 }
 
 #endif /* _DOUBLE_IS_32BITS */

--- a/newlib/libm/common/s_scalbn.c
+++ b/newlib/libm/common/s_scalbn.c
@@ -65,20 +65,11 @@ SEEALSO
 
 #ifndef _DOUBLE_IS_32BITS
 
-#ifdef __STDC__
 static const double
-#else
-static double
-#endif
 two54   =  1.80143985094819840000e+16, /* 0x43500000, 0x00000000 */
 twom54  =  5.55111512312578270212e-17; /* 0x3C900000, 0x00000000 */
 
-#ifdef __STDC__
-	double scalbn (double x, int n)
-#else
-	double scalbn (x,n)
-	double x; int n;
-#endif
+double scalbn (double x, int n)
 {
 	__int32_t  k,hx,lx;
 	EXTRACT_WORDS(hx,lx,x);
@@ -101,7 +92,7 @@ twom54  =  5.55111512312578270212e-17; /* 0x3C900000, 0x00000000 */
 	    return __math_uflow(hx<0); 	        /*underflow*/
         k += 54;				/* subnormal result */
 	SET_HIGH_WORD(x,(hx&0x800fffff)|(k<<20));
-        return x*twom54;
+        return check_uflow(x*twom54);
 }
 
 #if defined(HAVE_ALIAS_ATTRIBUTE)

--- a/newlib/libm/common/s_scalbn.c
+++ b/newlib/libm/common/s_scalbn.c
@@ -65,11 +65,20 @@ SEEALSO
 
 #ifndef _DOUBLE_IS_32BITS
 
+#ifdef __STDC__
 static const double
+#else
+static double
+#endif
 two54   =  1.80143985094819840000e+16, /* 0x43500000, 0x00000000 */
 twom54  =  5.55111512312578270212e-17; /* 0x3C900000, 0x00000000 */
 
-double ldexp (double x, int n)
+#ifdef __STDC__
+	double scalbn (double x, int n)
+#else
+	double scalbn (x,n)
+	double x; int n;
+#endif
 {
 	__int32_t  k,hx,lx;
 	EXTRACT_WORDS(hx,lx,x);
@@ -81,7 +90,7 @@ double ldexp (double x, int n)
 	    k = ((hx&0x7ff00000)>>20) - 54; 
             if (n< -50000) return __math_uflow(hx<0); 	/*underflow*/
 	    }
-        if (k==0x7ff) return x;		        /* NaN or Inf */
+        if (k==0x7ff) return x+x;		/* NaN or Inf */
         if (n > 50000) 	/* in case integer overflow in n+k */
             return __math_oflow(hx<0);	        /*overflow*/
         k = k+n; 
@@ -95,12 +104,19 @@ double ldexp (double x, int n)
         return x*twom54;
 }
 
+#if defined(HAVE_ALIAS_ATTRIBUTE)
+#ifndef __clang__
+#pragma GCC diagnostic ignored "-Wmissing-attributes"
+#endif
+__strong_reference(scalbn, ldexp);
+#else
+
 double
-scalbn(double value, int exp)
+ldexp(double value, int exp)
 {
-    if (isnan(value))
-        return value + value;
-    return ldexp(value, exp);
+    return scalbn(value, exp);
 }
+
+#endif
 
 #endif /* _DOUBLE_IS_32BITS */

--- a/newlib/libm/common/sf_finite.c
+++ b/newlib/libm/common/sf_finite.c
@@ -20,12 +20,7 @@
 
 #include "fdlibm.h"
 
-#ifdef __STDC__
-	int finitef(float x)
-#else
-	int finitef(x)
-	float x;
-#endif
+int finitef(float x)
 {
 	__int32_t ix;
 	GET_FLOAT_WORD(ix,x);
@@ -33,16 +28,30 @@
 	return (FLT_UWORD_IS_FINITE(ix));
 }
 
+#if defined(HAVE_ALIAS_ATTRIBUTE)
+#ifndef __clang__
+#pragma GCC diagnostic ignored "-Wmissing-attributes"
+#endif
+__strong_reference(finitef, __finitef);
+#else
+
+int
+__finitef(float x)
+{
+    return finitef(x);
+}
+#endif
+
 #ifdef _DOUBLE_IS_32BITS
 
-#ifdef __STDC__
-	int finite(double x)
-#else
-	int finite(x)
-	double x;
-#endif
+int finite(double x)
 {
 	return finitef((float) x);
+}
+
+int __finite(double x)
+{
+    return finitef((float) x);
 }
 
 #endif /* defined(_DOUBLE_IS_32BITS) */

--- a/newlib/libm/common/sf_fmax.c
+++ b/newlib/libm/common/sf_fmax.c
@@ -6,33 +6,25 @@
 
 #include "fdlibm.h"
 
-#ifdef __STDC__
-	float fmaxf(float x, float y)
-#else
-	float fmaxf(x,y)
-	float x;
-	float y;
-#endif
+float fmaxf(float x, float y)
 {
-  if (__fpclassifyf(x) == FP_NAN)
-    return y;
-  if (__fpclassifyf(y) == FP_NAN)
-    return x;
-  
-  return x > y ? x : y;
+    if (issignaling(x) || issignaling(y))
+        return x + y;
+
+    if (isnan(x))
+        return y;
+
+    if (isnan(y))
+        return x;
+
+    return x > y ? x : y;
 }
 
 #ifdef _DOUBLE_IS_32BITS
 
-#ifdef __STDC__
-	double fmax(double x, double y)
-#else
-	double fmax(x,y)
-	double x;
-	double y;
-#endif
+double fmax(double x, double y)
 {
-  return (double) fmaxf((float) x, (float) y);
+    return (double) fmaxf((float) x, (float) y);
 }
 
 #endif /* defined(_DOUBLE_IS_32BITS) */

--- a/newlib/libm/common/sf_fmin.c
+++ b/newlib/libm/common/sf_fmin.c
@@ -6,33 +6,25 @@
 
 #include "fdlibm.h"
 
-#ifdef __STDC__
-	float fminf(float x, float y)
-#else
-	float fminf(x,y)
-	float x;
-	float y;
-#endif
+float fminf(float x, float y)
 {
-  if (__fpclassifyf(x) == FP_NAN)
-    return y;
-  if (__fpclassifyf(y) == FP_NAN)
-    return x;
-  
-  return x < y ? x : y;
+    if (issignaling(x) || issignaling(y))
+        return x + y;
+
+    if (isnan(x))
+        return y;
+
+    if (isnan(y))
+        return x;
+
+    return x < y ? x : y;
 }
 
 #ifdef _DOUBLE_IS_32BITS
 
-#ifdef __STDC__
-	double fmin(double x, double y)
-#else
-	double fmin(x,y)
-	double x;
-	double y;
-#endif
+double fmin(double x, double y)
 {
-  return (double) fminf((float) x, (float) y);
+    return (double) fminf((float) x, (float) y);
 }
 
 #endif /* defined(_DOUBLE_IS_32BITS) */

--- a/newlib/libm/common/sf_lrint.c
+++ b/newlib/libm/common/sf_lrint.c
@@ -22,12 +22,9 @@
  */
 
 #include "fdlibm.h"
+#include <limits.h>
 
-#ifdef __STDC__
 static const float
-#else
-static float 
-#endif
 /* Adding a float, x, to 2^23 will cause the result to be rounded based on
    the fractional part of x, according to the implementation's current rounding
    mode.  2^23 is the smallest float that can be represented using all 23 significant
@@ -37,12 +34,7 @@ TWO23[2]={
  -8.3886080000e+06, /* 0xcb000000 */
 };
 
-#ifdef __STDC__
-	long int lrintf(float x)
-#else
-	long int lrintf(x)
-	float x;
-#endif
+long int lrintf(float x)
 {
   __int32_t j0,sx;
   __uint32_t i0;
@@ -57,30 +49,32 @@ TWO23[2]={
 
   /* Extract exponent field. */
   j0 = ((i0 & 0x7f800000) >> 23) - 127;
-  
+
   if (j0 < (int)(sizeof (long int) * 8) - 1)
     {
-      if (j0 < -1)
-        return 0;
-      else if (j0 >= 23)
+      if (j0 >= 23)
         result = (long int) ((i0 & 0x7fffff) | 0x800000) << (j0 - 23);
       else
         {
           w = TWO23[sx] + x;
           t = w - TWO23[sx];
           GET_FLOAT_WORD (i0, t);
-          /* Detect the all-zeros representation of plus and
-             minus zero, which fails the calculation below. */
-          if ((i0 & ~(1L << 31)) == 0)
-              return 0;
           j0 = ((i0 >> 23) & 0xff) - 0x7f;
           i0 &= 0x7fffff;
           i0 |= 0x800000;
-          result = i0 >> (23 - j0);
+          if (j0 < 0)
+            result = 0;
+          else
+            result = i0 >> (23 - j0);
         }
     }
   else
     {
+      if (x != LONG_MIN)
+      {
+        __math_set_invalidf();
+        return sx ? LONG_MIN : LONG_MAX;
+      }
       return (long int) x;
     }
   return sx ? -result : result;
@@ -88,12 +82,7 @@ TWO23[2]={
 
 #ifdef _DOUBLE_IS_32BITS
 
-#ifdef __STDC__
-	long int lrint(double x)
-#else
-	long int lrint(x)
-	double x;
-#endif
+long int lrint(double x)
 {
   return lrintf((float) x);
 }

--- a/newlib/libm/common/sf_lround.c
+++ b/newlib/libm/common/sf_lround.c
@@ -11,12 +11,7 @@
 
 #include "fdlibm.h"
 
-#ifdef __STDC__
-	long int lroundf(float x)
-#else
-	long int lroundf(x)
-	float x;
-#endif
+long int lroundf(float x)
 {
   __int32_t exponent_less_127;
   __uint32_t w;
@@ -49,12 +44,7 @@
 
 #ifdef _DOUBLE_IS_32BITS
 
-#ifdef __STDC__
-	long int lround(double x)
-#else
-	long int lround(x)
-	double x;
-#endif
+long int lround(double x)
 {
 	return lroundf((float) x);
 }

--- a/newlib/libm/common/sf_nearbyint.c
+++ b/newlib/libm/common/sf_nearbyint.c
@@ -13,26 +13,25 @@
 #include <math.h>
 #include "fdlibm.h"
 
-#ifdef __STDC__
-	float nearbyintf(float x)
-#else
-	float nearbyintf(x)
-	float x;
-#endif
+float nearbyintf(float x)
 {
-  return rintf(x);
+    if (isnan(x)) return x + x;
+#if defined(FE_INEXACT) && !defined(PICOLIBC_DOUBLE_NOEXECPT)
+    fenv_t env;
+    fegetenv(&env);
+#endif
+    x = rintf(x);
+#if defined(FE_INEXACT) && !defined(PICOLIBC_DOUBLE_NOEXECPT)
+    fesetenv(&env);
+#endif
+    return x;
 }
 
 #ifdef _DOUBLE_IS_32BITS
 
-#ifdef __STDC__
-	double nearbyint(double x)
-#else
-	double nearbyint(x)
-	double x;
-#endif
+double nearbyint(double x)
 {
-  return (double) nearbyintf((float) x);
+    return (double) nearbyintf((float) x);
 }
 
 #endif /* defined(_DOUBLE_IS_32BITS) */

--- a/newlib/libm/common/sf_nextafter.c
+++ b/newlib/libm/common/sf_nextafter.c
@@ -15,12 +15,7 @@
 
 #include "fdlibm.h"
 
-#ifdef __STDC__
-	float nextafterf(float x, float y)
-#else
-	float nextafterf(x,y)
-	float x,y;
-#endif
+float nextafterf(float x, float y)
 {
 	__int32_t	hx,hy,ix,iy;
 
@@ -32,11 +27,11 @@
 	if(FLT_UWORD_IS_NAN(ix) ||
 	   FLT_UWORD_IS_NAN(iy))
 	   return x+y;
-	if(x==y) return x;		/* x=y, return x */
+	if(x==y) return y;		/* x=y, return y */
 	if(FLT_UWORD_IS_ZERO(ix)) {		/* x == 0 */
 	    SET_FLOAT_WORD(x,(hy&0x80000000)|FLT_UWORD_MIN);
-	    y = x*x;
-	    if(y==x) return y; else return x;	/* raise underflow flag */
+	    force_eval_float(x*x);             /* raise underflow flag */
+            return x;
 	}
 	if(hx>=0) {				/* x > 0 */
 	    if(hx>hy) {				/* x > y, x -= ulp */
@@ -52,26 +47,17 @@
 	    }
 	}
 	hy = hx&0x7f800000;
-	if(hy>FLT_UWORD_MAX) return x+x;	/* overflow  */
+	if(hy>FLT_UWORD_MAX) return check_oflowf(x+x);	/* overflow  */
 	if(hy<0x00800000) {		/* underflow */
-	    y = x*x;
-	    if(y!=x) {		/* raise underflow flag */
-	        SET_FLOAT_WORD(y,hx);
-		return y;
-	    }
+            force_eval_float(x*x);      /* raise underflow flag */
 	}
 	SET_FLOAT_WORD(x,hx);
-	return x;
+	return check_uflowf(x);
 }
 
 #ifdef _DOUBLE_IS_32BITS
 
-#ifdef __STDC__
-	double nextafter(double x, double y)
-#else
-	double nextafter(x,y)
-	double x,y;
-#endif
+double nextafter(double x, double y)
 {
 	return (double) nextafterf((float) x, (float) x);
 }

--- a/newlib/libm/common/sf_pow.c
+++ b/newlib/libm/common/sf_pow.c
@@ -187,11 +187,13 @@ powf (float x, float y)
 	      x2 = -x2;
 	      sign_bias = 1;
 	    }
+          if (!(iy & 0x80000000))
+              return opt_barrier_float(x2);
 #if WANT_ERRNO
-	  if (2 * ix == 0 && iy & 0x80000000)
-	    return __math_divzerof (sign_bias);
+          if (2 * ix == 0)
+              return __math_divzerof (sign_bias);
 #endif
-	  return iy & 0x80000000 ? 1 / x2 : x2;
+          return 1 / x2;
 	}
       /* x and y are non-zero finite.  */
       if (ix & 0x80000000)

--- a/newlib/libm/common/sf_remquo.c
+++ b/newlib/libm/common/sf_remquo.c
@@ -55,7 +55,7 @@ remquof(float x, float y, int *quo)
 	    q = 0;
 	    goto fixup;	/* |x|<|y| return x or x-y */
 	} else if(hx==hy) {
-	    *quo = 1;
+	    *quo = (sxy ? -1 : 1);
 	    return Zero[(__uint32_t)sx>>31];	/* |x|=|y| return x*0*/
 	}
 

--- a/newlib/libm/common/sf_rint.c
+++ b/newlib/libm/common/sf_rint.c
@@ -60,7 +60,8 @@ TWO23[2]={
 		if((i0&i)!=0) i0 = (i0&(~i))|((0x200000)>>j0);
 	    }
 	} else {
-	    if(!FLT_UWORD_IS_FINITE(ix)) return x+x; /* inf or NaN */
+	    if(!FLT_UWORD_IS_FINITE(ix))
+                return opt_barrier_float(x+x); /* inf or NaN */
 	    else
 	      return x;		/* x is integral */
 	}

--- a/newlib/libm/common/sf_scalbln.c
+++ b/newlib/libm/common/sf_scalbln.c
@@ -21,49 +21,40 @@ static const float
 static float
 #endif
 two25   =  3.355443200e+07,	/* 0x4c000000 */
-twom25  =  2.9802322388e-08,	/* 0x33000000 */
-huge   = 1.0e+30,
-tiny   = 1.0e-30;
+twom25  =  2.9802322388e-08;	/* 0x33000000 */
 
-#ifdef __STDC__
-	float scalblnf (float x, long int n)
-#else
-	float scalblnf (x,n)
-	float x; long int n;
-#endif
+float scalblnf (float x, long int n)
 {
 	__int32_t k,ix;
+        uint32_t hx;
+
 	GET_FLOAT_WORD(ix,x);
-        k = (ix&0x7f800000)>>23;		/* extract exponent */
+	hx = ix&0x7fffffff;
+        k = hx>>23;		                /* extract exponent */
         if (k==0) {				/* 0 or subnormal x */
-            if ((ix&0x7fffffff)==0) return x; /* +-0 */
+            if (hx == 0) return x;              /* +-0 */
 	    x *= two25;
 	    GET_FLOAT_WORD(ix,x);
 	    k = ((ix&0x7f800000)>>23) - 25;
+            if (n< -50000)
+                return __math_uflowf(ix<0); 	/*underflow*/
 	    }
         if (k==0xff) return x+x;		/* NaN or Inf */
         k = k+n;
         if (n> 50000 || k >  0xfe)
-	  return huge*copysignf(huge,x); /* overflow  */
-	if (n< -50000)
-	  return tiny*copysignf(tiny,x);	/*underflow*/
+            return __math_oflowf(ix < 0);       /* overflow  */
         if (k > 0) 				/* normal result */
 	    {SET_FLOAT_WORD(x,(ix&0x807fffff)|(k<<23)); return x;}
         if (k <= -25)
-	    return tiny*copysignf(tiny,x);	/*underflow*/
+	    return __math_uflowf(ix < 0);	/*underflow*/
         k += 25;				/* subnormal result */
 	SET_FLOAT_WORD(x,(ix&0x807fffff)|(k<<23));
-        return x*twom25;
+        return check_uflowf(x*twom25);
 }
 
 #ifdef _DOUBLE_IS_32BITS
 
-#ifdef __STDC__
-	double scalbln (double x, long int n)
-#else
-	double scalbln (x,n)
-	double x; long int n;
-#endif
+double scalbln (double x, long int n)
 {
 	return (double) scalblnf((float) x, n);
 }

--- a/newlib/libm/common/sf_scalbln.c
+++ b/newlib/libm/common/sf_scalbln.c
@@ -25,8 +25,9 @@ twom25  =  2.9802322388e-08;	/* 0x33000000 */
 
 float scalblnf (float x, long int n)
 {
-	__int32_t k,ix;
+	__int32_t ix;
         uint32_t hx;
+        long int k;
 
 	GET_FLOAT_WORD(ix,x);
 	hx = ix&0x7fffffff;

--- a/newlib/libm/common/sf_scalbn.c
+++ b/newlib/libm/common/sf_scalbn.c
@@ -23,11 +23,20 @@
 #define OVERFLOW_INT 30000
 #endif
 
+#ifdef __STDC__
 static const float
+#else
+static float
+#endif
 two25   =  3.355443200e+07,	/* 0x4c000000 */
 twom25  =  2.9802322388e-08;	/* 0x33000000 */
 
-float ldexpf (float x, int n)
+#ifdef __STDC__
+	float scalbnf (float x, int n)
+#else
+	float scalbnf (x,n)
+	float x; int n;
+#endif
 {
 	__int32_t  k,ix;
 	__uint32_t hx;
@@ -60,25 +69,47 @@ float ldexpf (float x, int n)
         return x*twom25;
 }
 
+#if defined(HAVE_ALIAS_ATTRIBUTE)
+#ifndef __clang__
+#pragma GCC diagnostic ignored "-Wmissing-attributes"
+#endif
+__strong_reference(scalbnf, ldexpf);
+#else
+
 float
-scalbnf(float value, int exp)
+ldexpf(float value, int exp)
 {
-    if (isnanf(value))
-        return value + value;
-    return ldexpf(value, exp);
+    return scalbnf(value, exp);
 }
+
+#endif
 
 #ifdef _DOUBLE_IS_32BITS
 
-double scalbn(double x, int n)
+#ifdef __STDC__
+	double scalbn(double x, int n)
+#else
+	double scalbn(x,n)
+	double x;
+	int n;
+#endif
 {
 	return (double) scalbnf((float) x, n);
 }
 
+#if defined(HAVE_ALIAS_ATTRIBUTE)
+#ifndef __clang__
+#pragma GCC diagnostic ignored "-Wmissing-attributes"
+#endif
+__strong_reference(scalbn, ldexp);
+#else
+
 double
 ldexp(double value, int exp)
 {
-    return (double) ldexpf((float) value, exp);
+    return scalbn(value, exp);
 }
+
+#endif
 
 #endif /* defined(_DOUBLE_IS_32BITS) */

--- a/newlib/libm/machine/aarch64/s_nearbyint.c
+++ b/newlib/libm/machine/aarch64/s_nearbyint.c
@@ -29,7 +29,14 @@
 double
 nearbyint (double x)
 {
-  double result;
-  __asm__("frinti\t%d0, %d1" : "=w" (result) : "w" (x));
-  return result;
+    if (isnan(x)) return x + x;
+#if defined(FE_INEXACT)
+    fenv_t env;
+    fegetenv(&env);
+#endif
+    __asm__("frinti\t%d0, %d1" : "=w" (x) : "w" (x));
+#if defined(FE_INEXACT)
+    fesetenv(&env);
+#endif
+    return x;
 }

--- a/newlib/libm/machine/aarch64/s_sqrt.c
+++ b/newlib/libm/machine/aarch64/s_sqrt.c
@@ -31,7 +31,7 @@ sqrt (double x)
 {
   double result;
 #ifdef _WANT_MATH_ERRNO
-  if (x < 0)
+  if (isless(x, 0.0))
       return __math_invalid(x);
 #endif
   __asm__("fsqrt\t%d0, %d1" : "=w" (result) : "w" (x));

--- a/newlib/libm/machine/aarch64/sf_nearbyint.c
+++ b/newlib/libm/machine/aarch64/sf_nearbyint.c
@@ -29,7 +29,14 @@
 float
 nearbyintf (float x)
 {
-  float result;
-  __asm__("frinti\t%s0, %s1" : "=w" (result) : "w" (x));
-  return result;
+    if (isnan(x)) return x + x;
+#if defined(FE_INEXACT)
+    fenv_t env;
+    fegetenv(&env);
+#endif
+    __asm__("frinti\t%s0, %s1" : "=w" (x) : "w" (x));
+#if defined(FE_INEXACT)
+    fesetenv(&env);
+#endif
+    return x;
 }

--- a/newlib/libm/machine/aarch64/sf_sqrt.c
+++ b/newlib/libm/machine/aarch64/sf_sqrt.c
@@ -31,7 +31,7 @@ sqrtf (float x)
 {
   float result;
 #ifdef _WANT_MATH_ERRNO
-  if (x < 0)
+  if (isless(x, 0.0f))
       return __math_invalidf(x);
 #endif
   __asm__("fsqrt\t%s0, %s1" : "=w" (result) : "w" (x));

--- a/newlib/libm/machine/arm/meson.build
+++ b/newlib/libm/machine/arm/meson.build
@@ -49,6 +49,8 @@ srcs_libm_machine = [
   'feupdateenv.c',
   's_ceil.c',
   'sf_ceil.c',
+  's_fabs.c',
+  'sf_fabs.c',
   'sf_floor.c',
   's_floor.c',
   'sf_nearbyint.c',

--- a/newlib/libm/machine/arm/s_fabs.c
+++ b/newlib/libm/machine/arm/s_fabs.c
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2022 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#if (__ARM_FP & 0x8) && !defined(__SOFTFP__)
+#include "fdlibm.h"
+
+double
+fabs(double x)
+{
+	double result;
+	__asm__("vabs.f64 %P0, %P1" : "=w" (result) : "w" (x));
+	return result;
+}
+
+#else
+#include "../../math/s_fabs.c"
+#endif

--- a/newlib/libm/machine/arm/s_nearbyint.c
+++ b/newlib/libm/machine/arm/s_nearbyint.c
@@ -30,9 +30,16 @@
 double
 nearbyint (double x)
 {
-  double result;
-  __asm__ volatile ("vrintr.f64\t%P0, %P1" : "=w" (result) : "w" (x));
-  return result;
+    if (isnan(x)) return x + x;
+#if defined(FE_INEXACT)
+    fenv_t env;
+    fegetenv(&env);
+#endif
+    __asm__ volatile ("vrintr.f64\t%P0, %P1" : "=w" (x) : "w" (x));
+#if defined(FE_INEXACT)
+    fesetenv(&env);
+#endif
+    return x;
 }
 
 #else

--- a/newlib/libm/machine/arm/s_sqrt.c
+++ b/newlib/libm/machine/arm/s_sqrt.c
@@ -32,7 +32,7 @@ sqrt(double x)
 {
 	double result;
 #ifdef _WANT_MATH_ERRNO
-        if (x < 0)
+        if (isless(x, 0.0))
             return __math_invalid(x);
 #endif
 #if __ARM_ARCH >= 6

--- a/newlib/libm/machine/arm/sf_fabs.c
+++ b/newlib/libm/machine/arm/sf_fabs.c
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2022 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#if (__ARM_FP & 0x4) && !defined(__SOFTFP__)
+#include "fdlibm.h"
+
+float
+fabsf(float x)
+{
+	float result;
+	__asm__("vabs.f32 %0, %1" : "=t" (result) : "t" (x));
+	return result;
+}
+
+#else
+#include "../../math/sf_fabs.c"
+#endif

--- a/newlib/libm/machine/arm/sf_nearbyint.c
+++ b/newlib/libm/machine/arm/sf_nearbyint.c
@@ -30,9 +30,16 @@
 float
 nearbyintf (float x)
 {
-  float result;
-  __asm__ volatile ("vrintr.f32\t%0, %1" : "=t" (result) : "t" (x));
-  return result;
+    if (isnan(x)) return x + x;
+#if defined(FE_INEXACT)
+    fenv_t env;
+    fegetenv(&env);
+#endif
+    __asm__ volatile ("vrintr.f32\t%0, %1" : "=t" (x) : "t" (x));
+#if defined(FE_INEXACT)
+    fesetenv(&env);
+#endif
+    return x;
 }
 
 #else

--- a/newlib/libm/machine/arm/sf_sqrt.c
+++ b/newlib/libm/machine/arm/sf_sqrt.c
@@ -33,7 +33,7 @@ sqrtf(float x)
 {
 	float result;
 #ifdef _WANT_MATH_ERRNO
-        if (x < 0)
+        if (isless(x, 0.0f))
             errno = EDOM;
 #endif
 #if __ARM_ARCH >= 6

--- a/newlib/libm/machine/riscv/s_finite.c
+++ b/newlib/libm/machine/riscv/s_finite.c
@@ -45,6 +45,21 @@ int finite(double x)
 	long fclass = _fclass_d (x);
 	return (fclass & (FCLASS_INF | FCLASS_NAN)) == 0;
 }
+
+#if defined(HAVE_ALIAS_ATTRIBUTE)
+#ifndef __clang__
+#pragma GCC diagnostic ignored "-Wmissing-attributes"
+#endif
+__strong_reference(finite, __finite);
+#else
+
+int __finite(double x)
+{
+    return finite(x);
+}
+
+#endif
+
 #else
 #include "../../common/s_finite.c"
 #endif

--- a/newlib/libm/machine/riscv/s_fmax.c
+++ b/newlib/libm/machine/riscv/s_fmax.c
@@ -40,9 +40,12 @@
 double
 fmax (double x, double y)
 {
-  double result;
-  __asm__("fmax.d\t%0, %1, %2" : "=f" (result) : "f" (x), "f" (y));
-  return result;
+    double result;
+    if (issignaling(x) || issignaling(y))
+        return x + y;
+
+    __asm__("fmax.d\t%0, %1, %2" : "=f" (result) : "f" (x), "f" (y));
+    return result;
 }
 #else
 #include "../../common/s_fmax.c"

--- a/newlib/libm/machine/riscv/s_fmin.c
+++ b/newlib/libm/machine/riscv/s_fmin.c
@@ -40,9 +40,12 @@
 double
 fmin (double x, double y)
 {
-  double result;
-  __asm__("fmin.d\t%0, %1, %2" : "=f" (result) : "f" (x), "f" (y));
-  return result;
+    double result;
+    if (issignaling(x) || issignaling(y))
+        return x + y;
+
+    __asm__("fmin.d\t%0, %1, %2" : "=f" (result) : "f" (x), "f" (y));
+    return result;
 }
 
 #else

--- a/newlib/libm/machine/riscv/s_sqrt.c
+++ b/newlib/libm/machine/riscv/s_sqrt.c
@@ -41,7 +41,7 @@ sqrt (double x)
 {
 	double result;
 #ifdef _WANT_MATH_ERRNO
-        if (x < 0)
+        if (isless(x, 0.0))
             return __math_invalid(x);
 #endif
 	__asm__("fsqrt.d %0, %1" : "=f" (result) : "f" (x));

--- a/newlib/libm/machine/riscv/sf_finite.c
+++ b/newlib/libm/machine/riscv/sf_finite.c
@@ -42,6 +42,21 @@ int finitef(float x)
 	long fclass = _fclass_f (x);
 	return (fclass & (FCLASS_INF | FCLASS_NAN)) == 0;
 }
+
+#if defined(HAVE_ALIAS_ATTRIBUTE)
+#ifndef __clang__
+#pragma GCC diagnostic ignored "-Wmissing-attributes"
+#endif
+__strong_reference(finitef, __finitef);
+#else
+
+int
+__finitef(float x)
+{
+    return finitef(x);
+}
+#endif
+
 #else
 #include "../../common/sf_finite.c"
 #endif

--- a/newlib/libm/machine/riscv/sf_fmax.c
+++ b/newlib/libm/machine/riscv/sf_fmax.c
@@ -40,9 +40,12 @@
 float
 fmaxf (float x, float y)
 {
-  float result;
-  __asm__("fmax.s\t%0, %1, %2" : "=f" (result) : "f" (x), "f" (y));
-  return result;
+    float result;
+    if (issignaling(x) || issignaling(y))
+        return x + y;
+
+    __asm__("fmax.s\t%0, %1, %2" : "=f" (result) : "f" (x), "f" (y));
+    return result;
 }
 
 #else

--- a/newlib/libm/machine/riscv/sf_fmin.c
+++ b/newlib/libm/machine/riscv/sf_fmin.c
@@ -40,9 +40,12 @@
 float
 fminf (float x, float y)
 {
-  float result;
-  __asm__("fmin.s\t%0, %1, %2" : "=f" (result) : "f" (x), "f" (y));
-  return result;
+    float result;
+    if (issignaling(x) || issignaling(y))
+        return x + y;
+
+    __asm__("fmin.s\t%0, %1, %2" : "=f" (result) : "f" (x), "f" (y));
+    return result;
 }
 
 #else

--- a/newlib/libm/machine/riscv/sf_sqrt.c
+++ b/newlib/libm/machine/riscv/sf_sqrt.c
@@ -41,7 +41,7 @@ sqrtf (float x)
 {
 	float result;
 #ifdef _WANT_MATH_ERRNO
-        if (x < 0)
+        if (isless(x, 0.0f))
             return __math_invalidf(x);
 #endif
 	__asm__("fsqrt.s %0, %1" : "=f" (result) : "f" (x));

--- a/newlib/libm/math/s_ceil.c
+++ b/newlib/libm/math/s_ceil.c
@@ -24,8 +24,6 @@
 
 #ifndef _DOUBLE_IS_32BITS
 
-static const double huge = 1.0e300;
-
 double
 ceil(double x)
 {
@@ -34,26 +32,22 @@ ceil(double x)
     EXTRACT_WORDS(i0, i1, x);
     j0 = ((i0 >> 20) & 0x7ff) - 0x3ff;
     if (j0 < 20) {
-        if (j0 < 0) { /* raise inexact if x != 0 */
-            if (huge + x > 0.0) { /* return 0*sign(x) if |x|<1 */
-                if (i0 < 0) {
-                    i0 = 0x80000000;
-                    i1 = 0;
-                } else if ((i0 | i1) != 0) {
-                    i0 = 0x3ff00000;
-                    i1 = 0;
-                }
+        if (j0 < 0) {
+            if (i0 < 0) {
+                i0 = 0x80000000;
+                i1 = 0;
+            } else if ((i0 | i1) != 0) {
+                i0 = 0x3ff00000;
+                i1 = 0;
             }
         } else {
             i = (0x000fffff) >> j0;
             if (((i0 & i) | i1) == 0)
                 return x; /* x is integral */
-            if (huge + x > 0.0) { /* raise inexact flag */
-                if (i0 > 0)
-                    i0 += (0x00100000) >> j0;
-                i0 &= (~i);
-                i1 = 0;
-            }
+            if (i0 > 0)
+                i0 += (0x00100000) >> j0;
+            i0 &= (~i);
+            i1 = 0;
         }
     } else if (j0 > 51) {
         if (j0 == 0x400)
@@ -64,19 +58,17 @@ ceil(double x)
         i = ((__uint32_t)(0xffffffff)) >> (j0 - 20);
         if ((i1 & i) == 0)
             return x; /* x is integral */
-        if (huge + x > 0.0) { /* raise inexact flag */
-            if (i0 > 0) {
-                if (j0 == 20)
-                    i0 += 1;
-                else {
-                    j = i1 + (1 << (52 - j0));
-                    if (j < i1)
-                        i0 += 1; /* got a carry */
-                    i1 = j;
-                }
+        if (i0 > 0) {
+            if (j0 == 20)
+                i0 += 1;
+            else {
+                j = i1 + (1 << (52 - j0));
+                if (j < i1)
+                    i0 += 1; /* got a carry */
+                i1 = j;
             }
-            i1 &= (~i);
         }
+        i1 &= (~i);
     }
     INSERT_WORDS(x, i0, i1);
     return x;

--- a/newlib/libm/math/s_floor.c
+++ b/newlib/libm/math/s_floor.c
@@ -66,8 +66,6 @@ PORTABILITY
 
 #ifndef _DOUBLE_IS_32BITS
 
-static const double huge = 1.0e300;
-
 double
 floor(double x)
 {
@@ -76,25 +74,21 @@ floor(double x)
     EXTRACT_WORDS(i0, i1, x);
     j0 = ((i0 >> 20) & 0x7ff) - 0x3ff;
     if (j0 < 20) {
-        if (j0 < 0) { /* raise inexact if x != 0 */
-            if (huge + x > 0.0) { /* return 0*sign(x) if |x|<1 */
-                if (i0 >= 0) {
-                    i0 = i1 = 0;
-                } else if (((i0 & 0x7fffffff) | i1) != 0) {
-                    i0 = 0xbff00000;
-                    i1 = 0;
-                }
+        if (j0 < 0) {
+            if (i0 >= 0) {
+                i0 = i1 = 0;
+            } else if (((i0 & 0x7fffffff) | i1) != 0) {
+                i0 = 0xbff00000;
+                i1 = 0;
             }
         } else {
             i = (0x000fffff) >> j0;
             if (((i0 & i) | i1) == 0)
                 return x; /* x is integral */
-            if (huge + x > 0.0) { /* raise inexact flag */
-                if (i0 < 0)
-                    i0 += (0x00100000) >> j0;
-                i0 &= (~i);
-                i1 = 0;
-            }
+            if (i0 < 0)
+                i0 += (0x00100000) >> j0;
+            i0 &= (~i);
+            i1 = 0;
         }
     } else if (j0 > 51) {
         if (j0 == 0x400)
@@ -105,19 +99,17 @@ floor(double x)
         i = ((__uint32_t)(0xffffffff)) >> (j0 - 20);
         if ((i1 & i) == 0)
             return x; /* x is integral */
-        if (huge + x > 0.0) { /* raise inexact flag */
-            if (i0 < 0) {
-                if (j0 == 20)
-                    i0 += 1;
-                else {
-                    j = i1 + (1 << (52 - j0));
-                    if (j < i1)
-                        i0 += 1; /* got a carry */
-                    i1 = j;
-                }
+        if (i0 < 0) {
+            if (j0 == 20)
+                i0 += 1;
+            else {
+                j = i1 + (1 << (52 - j0));
+                if (j < i1)
+                    i0 += 1; /* got a carry */
+                i1 = j;
             }
-            i1 &= (~i);
         }
+        i1 &= (~i);
     }
     INSERT_WORDS(x, i0, i1);
     return x;

--- a/newlib/libm/math/s_fmod.c
+++ b/newlib/libm/math/s_fmod.c
@@ -40,7 +40,7 @@ fmod(double x, double y)
 
     /* purge off exception values */
     if (isnan(x) || isnan(y)) /* x or y nan, return nan */
-        return (double)NAN;
+        return x + y;
 
     if (isinf(x)) /* x == inf, domain error */
         return __math_invalid(x);

--- a/newlib/libm/math/s_frexp.c
+++ b/newlib/libm/math/s_frexp.c
@@ -80,7 +80,7 @@ frexp(double x, int *eptr)
     ix = 0x7fffffff & hx;
     *eptr = 0;
     if (ix >= 0x7ff00000 || ((ix | lx) == 0))
-        return x; /* 0,inf,nan */
+        return x + x; /* 0,inf,nan */
     if (ix < 0x00100000) { /* subnormal */
         x *= two54;
         GET_HIGH_WORD(hx, x);

--- a/newlib/libm/math/s_pow.c
+++ b/newlib/libm/math/s_pow.c
@@ -183,7 +183,7 @@ pow(double x, double y)
                 z = one / z; /* z = (1/|x|) */
             if (hx < 0) {
                 if (((ix - 0x3ff00000) | yisint) == 0) {
-                    z = (z - z) / (z - z); /* (-1)**non-int is NaN */
+                    return __math_invalid(x); /* (-1)**non-int is NaN */
                 } else if (yisint == 1)
                     z = -z; /* (x<0)**odd = -(|x|**odd) */
             }
@@ -216,10 +216,14 @@ pow(double x, double y)
                 return (hy > 0) ? __math_oflow(0) : __math_uflow(0);
         }
         /* over/underflow if x is not close to one */
-        if (ix < 0x3fefffff)
-            return (hy < 0) ? __math_oflow(0) : __math_uflow(0);
-        if (ix > 0x3ff00000)
-            return (hy > 0) ? __math_oflow(0) : __math_uflow(0);
+        if (ix < 0x3fefffff) {
+            int sign = yisint & ((__uint32_t)hx>>31);
+            return (hy < 0) ? __math_oflow(sign) : __math_uflow(sign);
+        }
+        if (ix > 0x3ff00000) {
+            int sign = yisint & ((__uint32_t)hx>>31);
+            return (hy > 0) ? __math_oflow(sign) : __math_uflow(sign);
+        }
         /* now |1-x| is tiny <= 2**-20, suffice to compute
 	   log(x) by x-x^2/2+x^3/3-x^4/4 */
         t = ax - 1; /* t has 20 trailing zeros */

--- a/newlib/libm/math/s_scalb.c
+++ b/newlib/libm/math/s_scalb.c
@@ -24,12 +24,16 @@
 double
 scalb(double x, double fn)
 {
-    if (isnan(fn))
-        return fn + fn;
+    if (isnan(fn) || isnan(x))
+        return x + fn;
 
     if (isinf(fn)) {
         if ((x == 0.0 && fn > 0.0) || (isinf(x) && fn < 0.0))
             return __math_invalid(fn);
+        if (fn > 0.0)
+            return fn*x;
+        else
+            return x/(-fn);
     }
 
     if (rint(fn) != fn)

--- a/newlib/libm/math/s_tgamma.c
+++ b/newlib/libm/math/s_tgamma.c
@@ -26,7 +26,7 @@ tgamma(double x)
     int signgam_local;
     int divzero = 0;
 
-    if (isless(x, 0.0) && rint(x) == x)
+    if (isless(x, 0.0) && clang_barrier_double(rint(x)) == x)
         return __math_invalid(x);
 
     double y = exp(__math_lgamma_r(x, &signgam_local, &divzero));

--- a/newlib/libm/math/s_tgamma.c
+++ b/newlib/libm/math/s_tgamma.c
@@ -24,14 +24,15 @@ double
 tgamma(double x)
 {
     int signgam_local;
+    int divzero = 0;
 
-    if (x < 0.0 && floor(x) == x)
+    if (isless(x, 0.0) && rint(x) == x)
         return __math_invalid(x);
 
-    double y = exp(lgamma_r(x, &signgam_local));
+    double y = exp(__math_lgamma_r(x, &signgam_local, &divzero));
     if (signgam_local < 0)
         y = -y;
-    if (!finite(y) && finite(x))
+    if (isinf(y) && finite(x) && !divzero)
         return __math_oflow(signgam_local < 0);
     return y;
 }

--- a/newlib/libm/math/sf_ceil.c
+++ b/newlib/libm/math/sf_ceil.c
@@ -15,8 +15,6 @@
 
 #include "fdlibm.h"
 
-static const float huge = 1.0e30;
-
 float
 ceilf(float x)
 {
@@ -26,23 +24,19 @@ ceilf(float x)
     ix = (i0 & 0x7fffffff);
     j0 = (ix >> 23) - 0x7f;
     if (j0 < 23) {
-        if (j0 < 0) { /* raise inexact if x != 0 */
-            if (huge + x > (float)0.0) { /* return 0*sign(x) if |x|<1 */
-                if (i0 < 0) {
-                    i0 = 0x80000000;
-                } else if (!FLT_UWORD_IS_ZERO(ix)) {
-                    i0 = 0x3f800000;
-                }
+        if (j0 < 0) {
+            if (i0 < 0) {
+                i0 = 0x80000000;
+            } else if (!FLT_UWORD_IS_ZERO(ix)) {
+                i0 = 0x3f800000;
             }
         } else {
             i = (0x007fffff) >> j0;
             if ((i0 & i) == 0)
                 return x; /* x is integral */
-            if (huge + x > (float)0.0) { /* raise inexact flag */
-                if (i0 > 0)
-                    i0 += (0x00800000) >> j0;
-                i0 &= (~i);
-            }
+            if (i0 > 0)
+                i0 += (0x00800000) >> j0;
+            i0 &= (~i);
         }
     } else {
         if (!FLT_UWORD_IS_FINITE(ix))

--- a/newlib/libm/math/sf_floor.c
+++ b/newlib/libm/math/sf_floor.c
@@ -24,8 +24,6 @@
 
 #include "fdlibm.h"
 
-static const float huge = 1.0e30;
-
 float
 floorf(float x)
 {
@@ -36,22 +34,18 @@ floorf(float x)
     j0 = (ix >> 23) - 0x7f;
     if (j0 < 23) {
         if (j0 < 0) { /* raise inexact if x != 0 */
-            if (huge + x > (float)0.0) { /* return 0*sign(x) if |x|<1 */
-                if (i0 >= 0) {
-                    i0 = 0;
-                } else if (!FLT_UWORD_IS_ZERO(ix)) {
-                    i0 = 0xbf800000;
-                }
+            if (i0 >= 0) {
+                i0 = 0;
+            } else if (!FLT_UWORD_IS_ZERO(ix)) {
+                i0 = 0xbf800000;
             }
         } else {
             i = (0x007fffff) >> j0;
             if ((i0 & i) == 0)
                 return x; /* x is integral */
-            if (huge + x > (float)0.0) { /* raise inexact flag */
-                if (i0 < 0)
-                    i0 += (0x00800000) >> j0;
-                i0 &= (~i);
-            }
+            if (i0 < 0)
+                i0 += (0x00800000) >> j0;
+            i0 &= (~i);
         }
     } else {
         if (!FLT_UWORD_IS_FINITE(ix))

--- a/newlib/libm/math/sf_fmod.c
+++ b/newlib/libm/math/sf_fmod.c
@@ -39,7 +39,7 @@ fmodf(float x, float y)
 
     /* purge off exception values */
     if (isnan(x) || isnan(y)) /* x or y nan, return nan */
-        return (float)NAN;
+        return x + y;
 
     if (isinf(x)) /* x == inf, domain error */
         return __math_invalidf(x);

--- a/newlib/libm/math/sf_frexp.c
+++ b/newlib/libm/math/sf_frexp.c
@@ -25,7 +25,7 @@ frexpf(float x, int *eptr)
     ix = 0x7fffffff & hx;
     *eptr = 0;
     if (!FLT_UWORD_IS_FINITE(ix) || FLT_UWORD_IS_ZERO(ix))
-        return x; /* 0,inf,nan */
+        return x + x; /* 0,inf,nan */
     if (FLT_UWORD_IS_SUBNORMAL(ix)) { /* subnormal */
         x *= two25;
         GET_FLOAT_WORD(hx, x);

--- a/newlib/libm/math/sf_scalb.c
+++ b/newlib/libm/math/sf_scalb.c
@@ -19,12 +19,16 @@
 float
 scalbf(float x, float fn)
 {
-    if (isnan(fn))
-        return fn + fn;
+    if (isnan(fn) || isnan(x))
+        return x + fn;
 
     if (isinf(fn)) {
         if ((x == 0.0f && fn > 0.0f) || (isinf(x) && fn < 0.0f))
             return __math_invalidf(fn);
+        if (fn > 0.0f)
+            return fn*x;
+        else
+            return x/(-fn);
     }
 
     if (rintf(fn) != fn)

--- a/newlib/libm/math/sf_tgamma.c
+++ b/newlib/libm/math/sf_tgamma.c
@@ -26,14 +26,15 @@ float
 tgammaf(float x)
 {
     int signgam_local;
+    int divzero = 0;
 
-    if (x < 0.0f && floorf(x) == x)
+    if (isless(x, 0.0f) && rintf(x) == x)
         return __math_invalidf(x);
 
-    float y = expf(lgammaf_r(x, &signgam_local));
+    float y = expf(__math_lgammaf_r(x, &signgam_local, &divzero));
     if (signgam_local < 0)
         y = -y;
-    if (!finitef(y) && finitef(x))
+    if (isinff(y) && finitef(x) && !divzero)
         return __math_oflowf(signgam_local < 0);
     return y;
 }

--- a/newlib/libm/math/sf_tgamma.c
+++ b/newlib/libm/math/sf_tgamma.c
@@ -28,7 +28,7 @@ tgammaf(float x)
     int signgam_local;
     int divzero = 0;
 
-    if (isless(x, 0.0f) && rintf(x) == x)
+    if (isless(x, 0.0f) && clang_barrier_float(rintf(x)) == x)
         return __math_invalidf(x);
 
     float y = expf(__math_lgammaf_r(x, &signgam_local, &divzero));

--- a/newlib/libm/math/srf_lgamma.c
+++ b/newlib/libm/math/srf_lgamma.c
@@ -144,7 +144,7 @@ sin_pif(float x)
 }
 
 float
-lgammaf_r(float x, int *signgamp)
+__math_lgammaf_r(float x, int *signgamp, int *divzero)
 {
     float t, y, z, nadj = 0.0, p, p1, p2, p3, q, r, w;
     __int32_t i, hx, ix;
@@ -159,6 +159,7 @@ lgammaf_r(float x, int *signgamp)
     if (ix == 0) {
         if (hx < 0)
             *signgamp = -1;
+        *divzero = 1;
         return __math_divzerof(0);
     }
     if (ix < 0x1c800000) { /* |x|<2**-70, return -log(|x|) */
@@ -169,11 +170,15 @@ lgammaf_r(float x, int *signgamp)
             return -logf(x);
     }
     if (hx < 0) {
-        if (ix >= 0x4b000000) /* |x|>=2**23, must be -integer */
+        if (ix >= 0x4b000000) { /* |x|>=2**23, must be -integer */
+            *divzero = 1;
             return __math_divzerof(0);
+        }
         t = sin_pif(x);
-        if (t == zero)
+        if (t == zero) {
+            *divzero = 1;
             return __math_divzerof(0);
+        }
         nadj = logf(pi / fabsf(t * x));
         if (t < zero)
             *signgamp = -1;
@@ -271,4 +276,11 @@ lgammaf_r(float x, int *signgamp)
     if (hx < 0)
         r = nadj - r;
     return check_oflowf(r);
+}
+
+float
+lgammaf_r(float x, int *signgamp)
+{
+    int divzero = 0;
+    return __math_lgammaf_r(x, signgamp, &divzero);
 }

--- a/newlib/libm/test/math.c
+++ b/newlib/libm/test/math.c
@@ -677,6 +677,8 @@ test_math (int vector)
   test_modff(vector);
   test_pow_vec(vector);
   test_powf_vec(vector);
+  test_scalb(vector);
+  test_scalbf(vector);
   test_scalbn(vector);
   test_scalbnf(vector);
   test_sin(vector);

--- a/newlib/libm/test/meson.build
+++ b/newlib/libm/test/meson.build
@@ -164,7 +164,7 @@ if enable_native_tests
   if native_lib_m.found()
     test('math-native',
 	 executable('math_test_native', math_test_src,
-		    c_args: c_args + ['-DNO_NEWLIB'],
+		    c_args: native_c_args,
 		    dependencies: native_lib_m))
   endif
 endif

--- a/newlib/libm/test/meson.build
+++ b/newlib/libm/test/meson.build
@@ -96,6 +96,7 @@ math_test_src = [
   'modff_vec.c',
   'pow_vec.c',
   'powf_vec.c',
+  'scalb_vec.c',
   'scalbn_vec.c',
   'sinf_vec.c',
   'sinhf_vec.c',

--- a/newlib/libm/test/scalb_vec.c
+++ b/newlib/libm/test/scalb_vec.c
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2021 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "test.h"
+
+one_line_type scalb_vec[] = {
+    { 64, 0, 123, __LINE__, 0x3ff00000, 0x00000000, 0x3ff00000, 0x00000000, 0x00000000, 0x00000000 }, /* 1 = f(1, 0); */
+    { 64, 0, 123, __LINE__, 0x7ff00000, 0x00000000, 0x3ff00000, 0x00000000, 0x40c38800, 0x00000000 }, /* +inf = f(1, 10000); */
+    { 64, 0, 123, __LINE__, 0x7ff00000, 0x00000000, 0x3ff00000, 0x00000000, 0x41dfffff, 0xffc00000 }, /* +inf = f(1, 0x7fffffff); */
+    { 0 },
+};
+
+void test_scalb(int m) { run_vector_1(m, scalb_vec, (void*)scalb,"scalb","ddd"); }
+void test_scalbf(int m) { run_vector_1(m, scalb_vec, (void*)scalbf,"scalbf","fff"); }

--- a/newlib/libm/test/test.h
+++ b/newlib/libm/test/test.h
@@ -482,6 +482,12 @@ void
 test_powf_vec(int vector);
 
 void
+test_scalb(int vector);
+
+void
+test_scalbf(int vector);
+
+void
 test_scalbn(int vector);
 
 void

--- a/test/math_errhandling.c
+++ b/test/math_errhandling.c
@@ -76,7 +76,7 @@ e_to_str(int e)
 	if (e == (FE_UNDERFLOW|FE_INEXACT))
 		return "FE_UNDERFLOW|FE_INEXACT";
 #endif
-	static char buf[3][50];
+	static char buf[3][128];
         static int i = 0;
         buf[i][0] = '\0';
         while (e) {
@@ -117,9 +117,15 @@ e_to_str(int e)
                 v = tmp;
                 e = 0;
             }
+#define check_add(s) do {                                               \
+                if (strlen(buf[i]) + strlen(s) + 1 > sizeof(buf[i]))    \
+                    printf("exception buf overflow %s + %s\n", buf[i], s); \
+                else                                                    \
+                    strcat(buf[i], s);                                  \
+            } while(0)
             if (buf[i][0])
-                strcat(buf[i], " | ");
-            strcat(buf[i], v);
+                check_add(" | ");
+            check_add(v);
         }
         char *ret = buf[i];
         i = (i + 1) % 3;

--- a/test/math_errhandling_tests.c
+++ b/test/math_errhandling_tests.c
@@ -253,6 +253,17 @@ long makemathname(test_ilogb_snan)(void) { return makemathname(ilogb)(makemathna
 long makemathname(test_ilogb_inf)(void) { return makemathname(ilogb)(makemathname(infval)); }
 long makemathname(test_ilogb_neginf)(void) { return makemathname(ilogb)(-makemathname(infval)); }
 
+long makemathname(test_fpclassify_snan)(void) { return fpclassify(makemathname(snanval)); }
+long makemathname(test_fpclassify_nan)(void) { return fpclassify(makemathname(qnanval)); }
+long makemathname(test_fpclassify_inf)(void) { return fpclassify(makemathname(infval)); }
+long makemathname(test_fpclassify_neginf)(void) { return fpclassify(-makemathname(infval)); }
+long makemathname(test_fpclassify_zero)(void) { return fpclassify(makemathname(zero)); }
+long makemathname(test_fpclassify_negzero)(void) { return fpclassify(-makemathname(zero)); }
+long makemathname(test_fpclassify_small)(void) { return fpclassify(makemathname(small)); }
+long makemathname(test_fpclassify_negsmall)(void) { return fpclassify(-makemathname(small)); }
+long makemathname(test_fpclassify_two)(void) { return fpclassify(makemathname(two)); }
+long makemathname(test_fpclassify_negtwo)(void) { return fpclassify(-makemathname(two)); }
+
 FLOAT_T makemathname(test_j0_inf)(void) { return makemathname(j0)(makemathname(infval)); }
 FLOAT_T makemathname(test_j0_qnan)(void) { return makemathname(j0)(makemathname(qnanval)); }
 FLOAT_T makemathname(test_j0_snan)(void) { return makemathname(j0)(makemathname(snanval)); }
@@ -1021,6 +1032,17 @@ struct {
 	int	except;
 	int	errno_expect;
 } makemathname(itests)[] = {
+        TEST(fpclassify_snan, FP_NAN, 0, 0),
+        TEST(fpclassify_nan, FP_NAN, 0, 0),
+        TEST(fpclassify_inf, FP_INFINITE, 0, 0),
+        TEST(fpclassify_neginf, FP_INFINITE, 0, 0),
+        TEST(fpclassify_zero, FP_ZERO, 0, 0),
+        TEST(fpclassify_negzero, FP_ZERO, 0, 0),
+        TEST(fpclassify_small, FP_SUBNORMAL, 0, 0),
+        TEST(fpclassify_negsmall, FP_SUBNORMAL, 0, 0),
+        TEST(fpclassify_two, FP_NORMAL, 0, 0),
+        TEST(fpclassify_negtwo, FP_NORMAL, 0, 0),
+
         TEST(ilogb_0, FP_ILOGB0, FE_INVALID, EDOM),
         TEST(ilogb_qnan, FP_ILOGBNAN, FE_INVALID, EDOM),
         TEST(ilogb_inf, INT_MAX, FE_INVALID, EDOM),

--- a/test/math_errhandling_tests.c
+++ b/test/math_errhandling_tests.c
@@ -586,8 +586,10 @@ FLOAT_T makemathname(test_scalbn_tiny)(void) { return makemathname(scalbn)(makem
  * to NAN on load, so you can't ever return a sNAN value successfully.
  */
 #define sNAN_RET        NAN
+#define sNAN_EXCEPTION  FE_INVALID
 #else
 #define sNAN_RET        sNAN
+#define sNAN_EXCEPTION  0
 #endif
 
 struct {
@@ -704,7 +706,7 @@ struct {
 	TEST(expm1_negbig, -(FLOAT_T)1.0, FE_INEXACT, 0),
 
         TEST(fabs_qnan, (FLOAT_T)NAN, 0, 0),
-        TEST(fabs_snan, (FLOAT_T)sNAN_RET, 0, 0),
+        TEST(fabs_snan, (FLOAT_T)sNAN_RET, sNAN_EXCEPTION, 0),
         TEST(fabs_0, (FLOAT_T)0.0, 0, 0),
         TEST(fabs_neg0, (FLOAT_T)0.0, 0, 0),
         TEST(fabs_inf, (FLOAT_T)INFINITY, 0, 0),

--- a/test/math_errhandling_tests.c
+++ b/test/math_errhandling_tests.c
@@ -1101,7 +1101,16 @@ makemathname(run_tests)(void) {
 			++result;
 		}
 		if (math_errhandling & EXCEPTION_TEST) {
-			if ((except & makemathname(tests)[t].except) != makemathname(tests)[t].except) {
+                    int expect_except = makemathname(tests)[t].except;
+                    int mask = FE_ALL_EXCEPT;
+
+                    /* underflow can be set for inexact operations */
+                    if (expect_except & FE_INEXACT)
+                        mask &= ~FE_UNDERFLOW;
+                    else
+                        mask &= ~FE_INEXACT;
+
+                    if ((except & (expect_except | mask)) != expect_except) {
                                 PRINT;
 				printf("\texceptions supported. %s returns %s instead of %s\n",
                                        makemathname(tests)[t].name, e_to_str(except), e_to_str(makemathname(tests)[t].except));

--- a/test/math_errhandling_tests.c
+++ b/test/math_errhandling_tests.c
@@ -788,7 +788,7 @@ struct {
 
         TEST(ldexp_1_0, (FLOAT_T)1.0, 0, 0),
         TEST(ldexp_qnan_0, (FLOAT_T)NAN, 0, 0),
-        TEST(ldexp_snan_0, (FLOAT_T)sNAN_RET, 0, 0),
+        TEST(ldexp_snan_0, (FLOAT_T)NAN, FE_INVALID, 0),
         TEST(ldexp_inf_0, (FLOAT_T)INFINITY, 0, 0),
         TEST(ldexp_neginf_0, -(FLOAT_T)INFINITY, 0, 0),
         TEST(ldexp_1_negbig, (FLOAT_T)0.0, FE_UNDERFLOW, ERANGE),

--- a/test/math_errhandling_tests.c
+++ b/test/math_errhandling_tests.c
@@ -1174,7 +1174,16 @@ makemathname(run_tests)(void) {
 			++result;
 		}
 		if (math_errhandling & EXCEPTION_TEST) {
-			if ((except & makemathname(itests)[t].except) != makemathname(itests)[t].except) {
+                        int expect_except = makemathname(itests)[t].except;
+                        int mask = FE_ALL_EXCEPT;
+
+                        /* underflow can be set for inexact operations */
+                        if (expect_except & FE_INEXACT)
+                                mask &= ~FE_UNDERFLOW;
+                        else
+                                mask &= ~FE_INEXACT;
+
+                        if ((except & (expect_except | mask)) != expect_except) {
                                 IPRINT;
 				printf("\texceptions supported. %s returns %s instead of %s\n",
                                        makemathname(itests)[t].name, e_to_str(except), e_to_str(makemathname(itests)[t].except));

--- a/test/math_errhandling_tests.c
+++ b/test/math_errhandling_tests.c
@@ -321,8 +321,8 @@ FLOAT_T makemathname(test_tgamma_big)(void) { return makemathname(tgamma)(makema
 FLOAT_T makemathname(test_tgamma_negbig)(void) { return makemathname(tgamma)(makemathname(-big)); }
 FLOAT_T makemathname(test_tgamma_inf)(void) { return makemathname(tgamma)(makemathname(infval)); }
 FLOAT_T makemathname(test_tgamma_neginf)(void) { return makemathname(tgamma)(-makemathname(infval)); }
-FLOAT_T makemathname(test_tgamma_small)(void) { return makemathname(tgamma)(small); }
-FLOAT_T makemathname(test_tgamma_negsmall)(void) { return makemathname(tgamma)(-small); }
+FLOAT_T makemathname(test_tgamma_small)(void) { return makemathname(tgamma)(makemathname(small)); }
+FLOAT_T makemathname(test_tgamma_negsmall)(void) { return makemathname(tgamma)(-makemathname(small)); }
 
 FLOAT_T makemathname(test_lgamma_qnan)(void) { return makemathname(lgamma)(makemathname(qnanval)); }
 FLOAT_T makemathname(test_lgamma_snan)(void) { return makemathname(lgamma)(makemathname(snanval)); }
@@ -990,11 +990,8 @@ struct {
 	TEST(tgamma_neginf, (FLOAT_T)NAN, FE_INVALID, EDOM),
 	TEST(tgamma_qnan, (FLOAT_T)NAN, 0, 0),
 	TEST(tgamma_snan, (FLOAT_T)NAN, FE_INVALID, 0),
-#if !defined(TEST_FLOAT) || defined(__PICOLIBC__)
-	/* glibc has a bug with this test using float */
 	TEST(tgamma_small, (FLOAT_T)INFINITY, FE_OVERFLOW, ERANGE),
 	TEST(tgamma_negsmall, -(FLOAT_T)INFINITY, FE_OVERFLOW, ERANGE),
-#endif
 
         TEST(y0_inf, (FLOAT_T)0.0, 0, 0),
         TEST(y0_qnan, (FLOAT_T)NAN, 0, 0),

--- a/test/math_errhandling_tests.c
+++ b/test/math_errhandling_tests.c
@@ -284,6 +284,24 @@ FLOAT_T makemathname(test_ldexp_neginf_0)(void) { return makemathname(ldexp)(-ma
 FLOAT_T makemathname(test_ldexp_1_negbig)(void) { return makemathname(ldexp)(makemathname(one), -(__DBL_MAX_EXP__ * 100)); }
 FLOAT_T makemathname(test_ldexp_1_big)(void) { return makemathname(ldexp)(makemathname(one),(__DBL_MAX_EXP__ * 100)); }
 
+FLOAT_T makemathname(test_rint_qnan)(void) { return makemathname(rint)(makemathname(qnanval)); }
+FLOAT_T makemathname(test_rint_snan)(void) { return makemathname(rint)(makemathname(snanval)); }
+FLOAT_T makemathname(test_rint_inf)(void) { return makemathname(rint)(makemathname(infval)); }
+FLOAT_T makemathname(test_rint_neginf)(void) { return makemathname(rint)(-makemathname(infval)); }
+FLOAT_T makemathname(test_rint_big)(void) { return makemathname(rint)(makemathname(big)); }
+FLOAT_T makemathname(test_rint_negbig)(void) { return makemathname(rint)(-makemathname(big)); }
+FLOAT_T makemathname(test_rint_half)(void) { return makemathname(rint)(makemathname(half)); }
+FLOAT_T makemathname(test_rint_neghalf)(void) { return makemathname(rint)(makemathname(half)); }
+
+FLOAT_T makemathname(test_nearbyint_qnan)(void) { return makemathname(nearbyint)(makemathname(qnanval)); }
+FLOAT_T makemathname(test_nearbyint_snan)(void) { return makemathname(nearbyint)(makemathname(snanval)); }
+FLOAT_T makemathname(test_nearbyint_inf)(void) { return makemathname(nearbyint)(makemathname(infval)); }
+FLOAT_T makemathname(test_nearbyint_neginf)(void) { return makemathname(nearbyint)(-makemathname(infval)); }
+FLOAT_T makemathname(test_nearbyint_big)(void) { return makemathname(nearbyint)(makemathname(big)); }
+FLOAT_T makemathname(test_nearbyint_negbig)(void) { return makemathname(nearbyint)(-makemathname(big)); }
+FLOAT_T makemathname(test_nearbyint_half)(void) { return makemathname(nearbyint)(makemathname(half)); }
+FLOAT_T makemathname(test_nearbyint_neghalf)(void) { return makemathname(nearbyint)(makemathname(half)); }
+
 long makemathname(test_lrint_qnan)(void) { makemathname(lrint)(makemathname(qnanval)); return 0; }
 long makemathname(test_lrint_snan)(void) { makemathname(lrint)(makemathname(snanval)); return 0; }
 long makemathname(test_lrint_inf)(void) { makemathname(lrint)(makemathname(infval)); return 0; }
@@ -858,6 +876,15 @@ struct {
         TEST(logb_inf, (FLOAT_T)INFINITY, 0, 0),
         TEST(logb_neginf, (FLOAT_T)INFINITY, 0, 0),
 
+        TEST(nearbyint_qnan, (FLOAT_T) NAN, 0, 0),
+        TEST(nearbyint_snan, (FLOAT_T) NAN, FE_INVALID, 0),
+        TEST(nearbyint_inf, (FLOAT_T)INFINITY, 0, 0),
+        TEST(nearbyint_neginf, -(FLOAT_T)INFINITY, 0, 0),
+        TEST(nearbyint_big, BIG, 0, 0),
+        TEST(nearbyint_negbig, -BIG, 0, 0),
+        TEST(nearbyint_half, 0.0, 0, 0),
+        TEST(nearbyint_neghalf, -0.0, 0, 0),
+
 	TEST(pow_neg_half, (FLOAT_T)NAN, FE_INVALID, EDOM),
 	TEST(pow_big, (FLOAT_T)INFINITY, FE_OVERFLOW, ERANGE),
 	TEST(pow_negbig, (FLOAT_T)-INFINITY, FE_OVERFLOW, ERANGE),
@@ -923,6 +950,15 @@ struct {
         TEST(remainder_2_0, (FLOAT_T)NAN, FE_INVALID, EDOM),
         TEST(remainder_1_2, (FLOAT_T)1.0, 0, 0),
         TEST(remainder_neg1_2, -(FLOAT_T)1.0, 0, 0),
+
+        TEST(rint_qnan, (FLOAT_T) NAN, 0, 0),
+        TEST(rint_snan, (FLOAT_T) NAN, FE_INVALID, 0),
+        TEST(rint_inf, (FLOAT_T)INFINITY, 0, 0),
+        TEST(rint_neginf, -(FLOAT_T)INFINITY, 0, 0),
+        TEST(rint_big, BIG, 0, 0),
+        TEST(rint_negbig, -BIG, 0, 0),
+        TEST(rint_half, 0.0, FE_INEXACT, 0),
+        TEST(rint_neghalf, -0.0, FE_INEXACT, 0),
 
         TEST(scalb_1_1, (FLOAT_T)2.0, 0, 0),
         TEST(scalb_1_half, (FLOAT_T)NAN, FE_INVALID, EDOM),

--- a/test/meson.build
+++ b/test/meson.build
@@ -297,27 +297,27 @@ if enable_native_tests
   if native_lib_m.found()
     test('math_errhandling_native',
 	 executable('math_errhandling_native', 'math_errhandling.c',
-		    c_args: ['-DNO_NEWLIB'],
+		    c_args: native_c_args,
 		    dependencies: native_lib_m))
     test('rounding-mode_native',
 	 executable('rounding-mode_native',
 		    ['rounding-mode.c', 'rounding-mode-sub.c'],
-		    c_args: test_c_args + ['-DNO_NEWLIB'],
+		    c_args: native_c_args,
 		    dependencies: native_lib_m))
     test('printf-tests_native',
 	 executable('printf-tests_native',
 		    'printf-tests.c',
-		    c_args: ['-DNO_NEWLIB'],
+		    c_args: native_c_args,
 		    dependencies: native_lib_m))
     test('printf_scanf_native',
 	 executable('printf_scanf_native',
 		    'printf_scanf.c',
-		    c_args: ['-DNO_NEWLIB'],
+		    c_args: native_c_args,
 		    dependencies: native_lib_m))
     test('test-efcvt_native',
 	 executable('test-efcvt_native',
 		    'test-efcvt.c',
-		    c_args: ['-DNO_NEWLIB'],
+		    c_args: native_c_args,
 		    dependencies: native_lib_m))
   endif
 endif


### PR DESCRIPTION
Here's another series of fixes to address bugs found when picolibc is run against the glibc test suite. Almost all of these are fixes to address math functions which raise the wrong exceptions. On significant change is to address GCC bug 66462, which has been unfixed since 2015 and causes the builtin versions of fpclassify and friends to raise FE_INVALID when passed an sNaN value.

To help validate these changes in the picolibc test suite, I adjusted the test system to require more precise exception matching; now unexpected exceptions are flagged as errors instead of being ignored.

With these fixes, picolibc now passes 136 of the glibc tests.
