### PR TITLE
Stop using c_args properties in cross files

### DIFF
--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -21,50 +21,57 @@ picolibc:
     * ARM 32-bit, almost all targets (qemu)
     * ARM 64-bit
 
- 3. Verify that COPYING.picolibc includes information
+ 3. Use glibc test suite for RISC-V and ARM 32-bit
+
+ 4. Test c++ builds using hello-world example on ARM
+
+ 5. Verify that COPYING.picolibc includes information
     about the current source files
 
- 4. Add release notes to README.md
+ 6. Add release notes to README.md
  
- 5. Update meson.build file with new version number
+ 7. Update meson.build file with new version number
 
- 6. Commit release notes and meson.build
+ 8. Commit release notes and meson.build
 
 	$ git commit -m'Version <version>' README.md meson.build
 
- 7. Use native configuration to build release:
+ 9. Use native configuration to build release:
 
 	$ mkdir -p builds/build-native
 	$ cd builds/build-native
         $ ../../scripts/do-native-configure
 	$ ninja dist
 
- 8. Use arm configuration to build bits for the Arm embedded toolkit:
+ 10. Use arm configuration to build bits for the Arm embedded toolkit:
 
-        $ mkdir -p builds/build-arm
-        $ cd builds/build-arm
+        $ mkdir -p builds/build-arm-tk builds/build-arm-tk-release
+        $ cd builds/build-arm-tk
         $ PATH=$ARM_TK/bin:$PATH ../../scripts/do-arm-configure -Dsysroot-install=true
-        $ PATH=$ARM_TK/bin:$PATH DESTDIR=$PWD/dist ninja install
-        $ cd dist/$ARM_TK
+        $ PATH=$ARM_TK/bin:$PATH DESTDIR=$PWD/../dist ninja install
+	$ cd ../build-arm-tk-release
+	$ PATH=$ARM_TK/bin:$PATH ../../scripts/do-arm-configure -Dsysroot-install=true -Dbuild-type-subdir=release --buildtype=release
+        $ PATH=$ARM_TK/bin:$PATH DESTDIR=$PWD/../dist ninja install
+        $ cd ../dist/$ARM_TK
         $ zip -r picolibc-<version>-<arm-et-version>.zip .
         $ scp picolibc-<version>-<arm-et-version>.zip keithp.com:/var/www/picolibc/dist/gnu-arm-embedded
 
- 9. Tag release
+ 11. Tag release
 
 	$ git tag -m'Version <version>' <version> main
 
- 10. Push tag and branch to repositories
+ 12. Push tag and branch to repositories
 
 	$ git push origin main <version>
 
- 11. Upload release to web site:
+ 13. Upload release to web site:
 
 	$ scp build-native/meson-dist/* keithp.com:/var/www/picolibc/dist
 
- 12. Create new release on github site, pasting in relevant README.md
+ 14. Create new release on github site, pasting in relevant README.md
      section. Upload release tar and arm embedded toolkit zip files.
 
- 13. Email release message to mailing list. Paste in README.md section
+ 15. Email release message to mailing list. Paste in README.md section
      about the new release.
 
 ## Debian Packages

--- a/meson.build
+++ b/meson.build
@@ -47,8 +47,18 @@ project('picolibc', 'c',
 
 targets = []
 
-cc = meson.get_compiler('c')
 fs = import('fs')
+
+cc = meson.get_compiler('c')
+
+# these options are required for all C compiler operations, including
+# detecting many C compiler features, as we cannot expect there
+# to be a working C library on the system.
+
+core_c_args = []
+if not get_option('use-stdlib')
+  core_c_args += cc.get_supported_arguments(['-nostdlib'])
+endif
 
 # Find the picolibc name for the host cpu. Provide
 # for some common aliases
@@ -112,7 +122,7 @@ long double test()
 	 return ld;
 }
 '''
-have_long_double = cc.compiles(long_double_code, name : 'long double check')
+have_long_double = cc.compiles(long_double_code, name : 'long double check', args: core_c_args)
 
 long_double_size_code = '''
 #include <float.h>
@@ -130,10 +140,10 @@ char size_test[__LDBL_MANT_DIG__ == 113 ? 1 : -1];
 '''
 
 if have_long_double
-  long_double_equals_double = cc.compiles(long_double_size_code, name : 'long double same as double')
+  long_double_equals_double = cc.compiles(long_double_size_code, name : 'long double same as double', args: core_c_args)
   if not long_double_equals_double
-    long_double_mant_is_64 = cc.compiles(long_double_mant_64_code, name : 'long double mantissa is 64 bits')
-    long_double_mant_is_113 = cc.compiles(long_double_mant_113_code, name : 'long double mantissa is 113 bits')
+    long_double_mant_is_64 = cc.compiles(long_double_mant_64_code, name : 'long double mantissa is 64 bits', args: core_c_args)
+    long_double_mant_is_113 = cc.compiles(long_double_mant_113_code, name : 'long double mantissa is 113 bits', args: core_c_args)
   endif
 endif
 
@@ -161,7 +171,7 @@ newlib_nano_malloc = get_option('newlib-nano-malloc')
 lite_exit = get_option('lite-exit')
 
 newlib_elix_level = get_option('newlib-elix-level')
-c_args = ['-include', '@0@/@1@'.format(meson.current_build_dir(), 'picolibc.h')]
+c_args = ['-include', '@0@/@1@'.format(meson.current_build_dir(), 'picolibc.h')] + core_c_args
 native_c_args = ['-DNO_NEWLIB']
 
 # Disable ssp and fortify source while building picolibc (it's enabled
@@ -384,7 +394,7 @@ thread_local_storage = false
 if get_option('thread-local-storage') == 'auto'
   # We assume that _set_tls() is defined in the arch specific tls.c
   if fs.is_file('newlib/libc/picolib/machine' / host_cpu_family / 'tls.c')
-    thread_local_storage = not cc.has_function('__emutls_get_address', args: ['-nostdlib', '-lgcc'])
+    thread_local_storage = not cc.has_function('__emutls_get_address', args: core_c_args + ['-lgcc'])
   endif
 else
   thread_local_storage = get_option('thread-local-storage') == 'true'
@@ -541,7 +551,7 @@ bitfields_in_packed_structs_code = '''
 struct test { int part: 24; } __attribute__((packed));
 unsigned int foobar (const struct test *p) { return p->part; }
 '''
-have_bitfields_in_packed_structs = cc.compiles(bitfields_in_packed_structs_code, name : 'packed structs may contain bitfields')
+have_bitfields_in_packed_structs = cc.compiles(bitfields_in_packed_structs_code, name : 'packed structs may contain bitfields', args: core_c_args)
 
 # CompCert does not have __builtin_mul_overflow
 builtin_mul_overflow_code = '''
@@ -550,13 +560,13 @@ int overflows (size_t a, size_t b) { size_t x; return __builtin_mul_overflow(a, 
 volatile size_t aa = 42;
 int main (void) { return overflows(aa, aa); }
 '''
-have_builtin_mul_overflow = cc.links(builtin_mul_overflow_code, name : 'has __builtin_mul_overflow')
+have_builtin_mul_overflow = cc.links(builtin_mul_overflow_code, name : 'has __builtin_mul_overflow', args: core_c_args)
 
 # CompCert does not support _Complex
 complex_code = '''
 float _Complex test(float _Complex z) { return z; }
 '''
-have_complex = cc.compiles(complex_code, name : 'supports _Complex')
+have_complex = cc.compiles(complex_code, name : 'supports _Complex', args: core_c_args)
 
 # CompCert does not have __builtin_expect
 builtin_expect_code = '''
@@ -565,7 +575,9 @@ int main (void) {
   return __builtin_expect(a, 1);
 }
 '''
-have_builtin_expect = cc.links(builtin_expect_code, name : 'has __builtin_expect')
+have_builtin_expect = cc.links(builtin_expect_code, name : 'has __builtin_expect', args: core_c_args)
+
+werror_c_args = core_c_args + cc.get_supported_arguments('-Werror')
 
 # CompCert uses the GCC preprocessor, which causes to
 #  > #if __has_attribute(__alloc_size__)
@@ -574,20 +586,14 @@ alloc_size_code = '''
 void *foobar(int) __attribute__((__alloc_size__(1)));
 void *foobar2(int, int) __attribute__((__alloc_size__(1, 2)));
 '''
-have_alloc_size = cc.compiles(alloc_size_code, name : 'attribute __alloc_size__', args : (cc.has_argument('-Werror') ? '-Werror' : ''))
+have_alloc_size = cc.compiles(alloc_size_code, name : 'attribute __alloc_size__', args : werror_c_args)
 
 # attributes constructor/destructor are a GNU extension - if the compiler doesn't have them, don't test them.
 attr_ctor_dtor_code = '''
 void __attribute__((constructor(101))) ctor (void) {}
 void __attribute__((destructor(101))) dtor (void) {}
 '''
-have_attr_ctor_dtor = cc.compiles(attr_ctor_dtor_code, name : 'attributes constructor/destructor', args : (cc.has_argument('-Werror') ? '-Werror' : ''))
-
-# Add c_args from the cross file. This
-# means that the command line values get
-# added to the cross file values instead of
-# replacing them.
-c_args += meson.get_cross_property('c_args', [])
+have_attr_ctor_dtor = cc.compiles(attr_ctor_dtor_code, name : 'attributes constructor/destructor', args : werror_c_args)
 
 if enable_multilib
   used_libs = []
@@ -678,7 +684,7 @@ static int foo(@1@ i __attribute__((unused))) { return 0; }
 int main(void) { return foo(@0@); }
 '''
   builtin_code = builtin_template.format(builtin[1], builtin[2])
-  have_current_builtin = cc.links(builtin_code, name : 'test for __' + builtin[0])
+  have_current_builtin = cc.links(builtin_code, name : 'test for __' + builtin[0], args: core_c_args)
   conf_data.set('HAVE_' + builtin[0].to_upper(), have_current_builtin, description: 'The compiler supports __' + builtin[0])
 endforeach
 
@@ -694,7 +700,7 @@ conf_data.set('_HAVE_CC_INHIBIT_LOOP_TO_LIBCALL',
 conf_data.set('_HAVE_NO_BUILTIN_ATTRIBUTE',
 	      cc.compiles('int __attribute__((no_builtin)) foo(int x) { return x + 1; }',
 			  name : 'no_builtin attribute',
-			  args : (cc.has_argument('-Werror=attributes') ? '-Werror=attributes' : '')),
+			  args : werror_c_args),
 	      description: 'Compiler attribute to prevent the optimizer from adding new builtin calls')
 
 conf_data.set('_HAVE_LONG_DOUBLE', have_long_double,
@@ -979,7 +985,7 @@ if has_semihost
   else
     custom_script = cpu_family_script
   endif
-  test_link_args = ['-nostartfiles', '-nostdlib',
+  test_link_args = ['-nostartfiles',
                     '-T', meson.current_source_dir() / custom_script,
                     '-T', '@0@'.format(picolibc_ld), '-lgcc']
   test_linker_files = files(custom_script) + [picolibc_ld]

--- a/meson.build
+++ b/meson.build
@@ -965,6 +965,9 @@ if tests_enable_stack_protector
   endif
 endif
 
+test_env = environment()
+test_env.prepend('PATH', meson.source_root() / 'scripts')
+
 # CompCert needs the '-WUl,' prefix to correctly pass the --spec parameters to the linker
 specs_prefix = ''
 if cc.get_id() == 'ccomp'

--- a/meson.build
+++ b/meson.build
@@ -571,8 +571,8 @@ have_builtin_expect = cc.links(builtin_expect_code, name : 'has __builtin_expect
 #  > #if __has_attribute(__alloc_size__)
 # produce a wrong result. So test if the compiler has that attribute
 alloc_size_code = '''
-void *foobar(size_t) __attribute__((__alloc_size__(1)));
-void *foobar2(size_t, size_t) __attribute__((__alloc_size__(1, 2)));
+void *foobar(int) __attribute__((__alloc_size__(1)));
+void *foobar2(int, int) __attribute__((__alloc_size__(1, 2)));
 '''
 have_alloc_size = cc.compiles(alloc_size_code, name : 'attribute __alloc_size__', args : (cc.has_argument('-Werror') ? '-Werror' : ''))
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -74,6 +74,9 @@ option('picoexit', type: 'boolean', value: true,
 option('fortify-source', type: 'combo', choices: ['none', '1', '2'], value: 'none',
        description: 'Set _FORTIFY_SOURCE=<value>')
 
+option('use-stdlib', type: 'boolean', value: false,
+       description: 'Do not bypass the standard system library with -nostdlib (useful for native testing)')
+
 #
 # Testing options
 #

--- a/newlib/libm/test/meson.build
+++ b/newlib/libm/test/meson.build
@@ -155,7 +155,7 @@ foreach target : targets
 		  link_args: value[1] + double_printf_link_args + test_link_args,
 		  include_directories: inc),
        depends: bios_bin,
-       env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+       env: test_env)
 endforeach
 
 if enable_native_tests

--- a/newlib/testsuite/newlib.iconv/meson.build
+++ b/newlib/testsuite/newlib.iconv/meson.build
@@ -72,6 +72,6 @@ foreach target : targets
 		    link_with: _libs,
 		    include_directories: test_inc),
 	 depends: [iconv_data_link, bios_bin],
-	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+	 env: test_env)
   endforeach
 endforeach

--- a/newlib/testsuite/newlib.locale/meson.build
+++ b/newlib/testsuite/newlib.locale/meson.build
@@ -46,5 +46,5 @@ foreach test : tests
 		  link_with: [lib_c, lib_semihost, lib_crt],
 		  include_directories: inc),
        depends: bios_bin,
-       env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+       env: test_env)
 endforeach

--- a/newlib/testsuite/newlib.search/meson.build
+++ b/newlib/testsuite/newlib.search/meson.build
@@ -65,6 +65,6 @@ foreach target : targets
 		    link_with: _libs,
 		    include_directories: test_inc),
          depends: bios_bin,
-	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+	 env: test_env)
   endforeach
 endforeach

--- a/newlib/testsuite/newlib.stdio/meson.build
+++ b/newlib/testsuite/newlib.stdio/meson.build
@@ -69,6 +69,6 @@ foreach target : targets
 		    link_with: _libs,
 		    include_directories: test_inc),
 	 depends: bios_bin,
-	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+	 env: test_env)
   endforeach
 endforeach

--- a/newlib/testsuite/newlib.stdlib/meson.build
+++ b/newlib/testsuite/newlib.stdlib/meson.build
@@ -65,6 +65,6 @@ foreach target : targets
 		    link_with: _libs,
 		    include_directories: test_inc),
          depends: bios_bin,
-	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+	 env: test_env)
   endforeach
 endforeach

--- a/newlib/testsuite/newlib.string/meson.build
+++ b/newlib/testsuite/newlib.string/meson.build
@@ -65,6 +65,6 @@ foreach target : targets
 		    link_with: _libs,
 		    include_directories: test_inc),
          depends: bios_bin,
-	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+	 env: test_env)
   endforeach
 endforeach

--- a/newlib/testsuite/newlib.wctype/meson.build
+++ b/newlib/testsuite/newlib.wctype/meson.build
@@ -67,6 +67,6 @@ foreach target : targets
 		    link_with: _libs,
 		    include_directories: test_inc),
          depends: bios_bin,
-	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+	 env: test_env)
   endforeach
 endforeach

--- a/picocrt/meson.build
+++ b/picocrt/meson.build
@@ -74,7 +74,7 @@ foreach target : targets
 	     install : true,
 	     install_dir : instdir,
 	     c_args : value[1] + arg_fnobuiltin + ['-ffreestanding'],
-	     link_args : value[1] + ['-r', '-ffreestanding', '-nostdlib'])
+	     link_args : value[1] + ['-r', '-ffreestanding'])
 
   # Tests link against this because using the .o isn't supported under meson
   set_variable('lib_crt' + target,
@@ -91,7 +91,7 @@ foreach target : targets
              install : true,
              install_dir : instdir,
              c_args : value[1] + arg_fnobuiltin + ['-ffreestanding', '-DCRT0_EXIT'],
-             link_args : value[1] + ['-r', '-ffreestanding', '-nostdlib'])
+             link_args : value[1] + ['-r', '-ffreestanding'])
 
   # Tests link against this because using the .o isn't supported under meson
   set_variable('lib_crt_hosted' + target,
@@ -108,7 +108,7 @@ foreach target : targets
              install : true,
              install_dir : instdir,
              c_args : value[1] + arg_fnobuiltin + ['-ffreestanding', '-DCONSTRUCTORS=0'],
-             link_args : value[1] + ['-r', '-ffreestanding', '-nostdlib'])
+             link_args : value[1] + ['-r', '-ffreestanding'])
 
   # Tests link against this because using the .o isn't supported under meson
   set_variable('lib_crt_minimal' + target,
@@ -127,7 +127,7 @@ foreach target : targets
                install : true,
                install_dir : instdir,
                c_args : value[1] + arg_fnobuiltin + ['-ffreestanding', '-DCRT0_EXIT', '-DCRT0_SEMIHOST'],
-               link_args : value[1] + ['-r', '-ffreestanding', '-nostdlib'])
+               link_args : value[1] + ['-r', '-ffreestanding'])
 
     # Tests link against this because using the .o isn't supported under meson
     set_variable('lib_crt_semihost' + target,

--- a/picolibc.specs.in
+++ b/picolibc.specs.in
@@ -10,7 +10,7 @@
 @TLSMODEL@ %(picolibc_cc1) @CC1_SPEC@
 
 *cc1plus:
--isystem %{-picolibc-prefix=*:%*/@INCLUDEDIR@; -picolibc-buildtype=*:@PREFIX@/@INCLUDEDIR@/%*; @PREFIX@/@INCLUDEDIR@} -idirafter %{-picolibc-prefix=*:%*/@INCLUDEDIR@; -picolibc-buildtype=*:@PREFIX@/@INCLUDEDIR@/%*; :@PREFIX@/@INCLUDEDIR@} @TLSMODEL@ %(picolibc_cc1plus) @CC1_SPEC@ @CC1PLUS_SPEC@
+-isystem %{-picolibc-prefix=*:%*/@INCLUDEDIR@; -picolibc-buildtype=*:@PREFIX@/@INCLUDEDIR@/%*; :@PREFIX@/@INCLUDEDIR@} -idirafter %{-picolibc-prefix=*:%*/@INCLUDEDIR@; -picolibc-buildtype=*:@PREFIX@/@INCLUDEDIR@/%*; :@PREFIX@/@INCLUDEDIR@} @TLSMODEL@ %(picolibc_cc1plus) @CC1_SPEC@ @CC1PLUS_SPEC@
 
 *link:
 @SPECS_PRINTF@ -L%{-picolibc-prefix=*:%*/@LIBDIR@/%M; -picolibc-buildtype=*:@PREFIX@/@LIBDIR@/%*/%M; :@PREFIX@/@LIBDIR@/%M} -L%{-picolibc-prefix=*:%*/@LIBDIR@; -picolibc-buildtype=*:@PREFIX@/@LIBDIR@/%*; :@PREFIX@/@LIBDIR@} %{!T:-T@PICOLIBC_LD@} %(picolibc_link) --gc-sections @LINK_SPEC@

--- a/scripts/cross-aarch64-linux-gnu.txt
+++ b/scripts/cross-aarch64-linux-gnu.txt
@@ -5,7 +5,8 @@ as = 'aarch64-linux-gnu-as'
 ld = 'aarch64-linux-gnu-ld'
 nm = 'aarch64-linux-gnu-nm'
 strip = 'aarch64-linux-gnu-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-aarch64 "$@"', 'run-arm']
+# only needed to run tests
+exe_wrapper = ['env', 'run-aarch64']
 
 [host_machine]
 system = 'linux'
@@ -14,8 +15,6 @@ cpu = 'aarch64'
 endian = 'little'
 
 [properties]
-c_args = '-fno-pic -mpc-relative-literal-loads'
-needs_exe_wrapper = true
 skip_sanity_check = true
 link_spec = '--build-id=none'
 specs_extra = ['*libgcc:', '-lgcc']

--- a/scripts/cross-aarch64-linux-gnu.txt
+++ b/scripts/cross-aarch64-linux-gnu.txt
@@ -14,9 +14,8 @@ cpu = 'aarch64'
 endian = 'little'
 
 [properties]
-c_args = ['-mpc-relative-literal-loads', '-nostdlib', '-fno-pic', '-static']
+c_args = '-fno-pic -mpc-relative-literal-loads'
 needs_exe_wrapper = true
 skip_sanity_check = true
 link_spec = '--build-id=none'
-cc1_spec = '-fno-pic -mpc-relative-literal-loads'
 specs_extra = ['*libgcc:', '-lgcc']

--- a/scripts/cross-aarch64-zephyr-elf.txt
+++ b/scripts/cross-aarch64-zephyr-elf.txt
@@ -13,6 +13,5 @@ cpu = 'aarch64'
 endian = 'little'
 
 [properties]
-c_args = [ '-nostdlib' ]
 needs_exe_wrapper = true
 skip_sanity_check = true

--- a/scripts/cross-aarch64-zephyr-elf.txt
+++ b/scripts/cross-aarch64-zephyr-elf.txt
@@ -4,7 +4,8 @@ ar = 'aarch64-zephyr-elf-ar'
 as = 'aarch64-zephyr-elf-as'
 nm = 'aarch64-zephyr-elf-nm'
 strip = 'aarch64-zephyr-elf-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-aarch64 "$@"', 'run-aarch64']
+# only needed to run tests
+exe_wrapper = ['env', 'run-aarch64']
 
 [host_machine]
 system = 'none'
@@ -13,5 +14,4 @@ cpu = 'aarch64'
 endian = 'little'
 
 [properties]
-needs_exe_wrapper = true
 skip_sanity_check = true

--- a/scripts/cross-arm-none-eabi.txt
+++ b/scripts/cross-arm-none-eabi.txt
@@ -4,7 +4,8 @@ ar = 'arm-none-eabi-ar'
 as = 'arm-none-eabi-as'
 nm = 'arm-none-eabi-nm'
 strip = 'arm-none-eabi-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-arm "$@"', 'run-arm']
+# only needed to run tests
+exe_wrapper = ['env', 'run-arm']
 
 [host_machine]
 system = 'none'
@@ -13,5 +14,4 @@ cpu = 'arm'
 endian = 'little'
 
 [properties]
-needs_exe_wrapper = true
 skip_sanity_check = true

--- a/scripts/cross-arm-none-eabi.txt
+++ b/scripts/cross-arm-none-eabi.txt
@@ -13,6 +13,5 @@ cpu = 'arm'
 endian = 'little'
 
 [properties]
-c_args = [ '-nostdlib', '-fno-common']
 needs_exe_wrapper = true
 skip_sanity_check = true

--- a/scripts/cross-arm-zephyr-eabi.txt
+++ b/scripts/cross-arm-zephyr-eabi.txt
@@ -13,6 +13,5 @@ cpu = 'arm'
 endian = 'little'
 
 [properties]
-c_args = [ '-nostdlib', '-fno-common' ]
 needs_exe_wrapper = true
 skip_sanity_check = true

--- a/scripts/cross-arm-zephyr-eabi.txt
+++ b/scripts/cross-arm-zephyr-eabi.txt
@@ -4,7 +4,8 @@ ar = 'arm-zephyr-eabi-ar'
 as = 'arm-zephyr-eabi-as'
 nm = 'arm-zephyr-eabi-nm'
 strip = 'arm-zephyr-eabi-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-arm "$@"', 'run-arm']
+# only needed to run tests
+exe_wrapper = ['env', 'run-arm']
 
 [host_machine]
 system = 'zephyr'
@@ -13,5 +14,4 @@ cpu = 'arm'
 endian = 'little'
 
 [properties]
-needs_exe_wrapper = true
 skip_sanity_check = true

--- a/scripts/cross-clang-riscv64-unknown-elf.txt
+++ b/scripts/cross-clang-riscv64-unknown-elf.txt
@@ -5,7 +5,8 @@ ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'
 nm = 'riscv64-unknown-elf-nm'
 strip = 'riscv64-unknown-elf-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-riscv "$@"', 'run-riscv']
+# only needed to run tests
+exe_wrapper = ['env', 'run-riscv']
 
 [host_machine]
 system = 'none'
@@ -16,6 +17,5 @@ endian = 'little'
 [properties]
 c_args = ['-Werror=double-promotion']
 c_link_args = ['-L/usr/lib/gcc/riscv64-unknown-elf/8.3.0/rv64imac/lp64/']
-needs_exe_wrapper = true
 skip_sanity_check = true
 has_link_defsym = true

--- a/scripts/cross-clang-riscv64-unknown-elf.txt
+++ b/scripts/cross-clang-riscv64-unknown-elf.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = ['clang', '-target', 'riscv64-unknown-elf' ]
+c = ['clang', '-target', 'riscv64-unknown-elf', '-mcmodel=medany']
 c_ld = '/usr/bin/riscv64-unknown-elf-ld'
 ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'
@@ -14,13 +14,8 @@ cpu = 'riscv'
 endian = 'little'
 
 [properties]
-c_args = [ '-nostdlib', '-Wdouble-promotion', '-mcmodel=medany']
-c_link_args = [
-	'-nostdlib',
-	'-mcmodel=medany',
-	'-L/usr/lib/gcc/riscv64-unknown-elf/8.3.0/rv64imac/lp64/'
-	]
-
+c_args = ['-Werror=double-promotion']
+c_link_args = ['-L/usr/lib/gcc/riscv64-unknown-elf/8.3.0/rv64imac/lp64/']
 needs_exe_wrapper = true
 skip_sanity_check = true
 has_link_defsym = true

--- a/scripts/cross-clang-rv32imafdc-unknown-elf.txt
+++ b/scripts/cross-clang-rv32imafdc-unknown-elf.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = 'clang'
+c = ['clang', '-m32', '-target', 'riscv32-unknown-elf', '-march=rv32imafdc']
 c_ld = '/usr/bin/riscv64-unknown-elf-ld'
 ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'
@@ -14,23 +14,8 @@ cpu = 'riscv'
 endian = 'little'
 
 [properties]
-c_args = [
-	'-m32',
-	'-target', 'riscv32-unknown-elf',
-	'-march=rv32imafdc',
-	'-Wdouble-promotion',
-	'-Werror=double-promotion',
-        '-Wno-unsupported-floating-point-opt',
-        '-std=c17',
-	]
-c_link_args = [
-	'-m32',
-	'-target', 'riscv32-unknown-elf',
-	'-march=rv32imafdc',
-	'-Wl,-melf32lriscv',
-	'-nostdlib',
-	'-L/usr/lib/gcc/riscv64-unknown-elf/8.3.0/rv32imafdc/ilp32d'
-	]
+c_args = ['-Werror=double-promotion']
+c_link_args = ['-Wl,-melf32lriscv', '-L/usr/lib/gcc/riscv64-unknown-elf/8.3.0/rv32imafdc/ilp32d']
 needs_exe_wrapper = true
 skip_sanity_check = true
 has_link_defsym = true

--- a/scripts/cross-clang-rv32imafdc-unknown-elf.txt
+++ b/scripts/cross-clang-rv32imafdc-unknown-elf.txt
@@ -5,7 +5,8 @@ ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'
 nm = 'riscv64-unknown-elf-nm'
 strip = 'riscv64-unknown-elf-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-rv32imafdc "$@"', 'run-rv32imafdc']
+# only needed to run tests
+exe_wrapper = ['env', 'run-rv32imafdc']
 
 [host_machine]
 system = 'none'
@@ -16,6 +17,5 @@ endian = 'little'
 [properties]
 c_args = ['-Werror=double-promotion']
 c_link_args = ['-Wl,-melf32lriscv', '-L/usr/lib/gcc/riscv64-unknown-elf/8.3.0/rv32imafdc/ilp32d']
-needs_exe_wrapper = true
 skip_sanity_check = true
 has_link_defsym = true

--- a/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
@@ -5,7 +5,8 @@ ar = 'arm-none-eabi-ar'
 as = 'arm-none-eab-as'
 nm = 'arm-none-eab-nm'
 strip = 'arm-none-eabi-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-thumbv7e "$@"', 'run-thumbv7e']
+# only needed to run tests
+exe_wrapper = ['env', 'run-thumbv7e']
 
 [host_machine]
 system = 'none'
@@ -16,5 +17,4 @@ endian = 'little'
 [properties]
 c_args = [ '-Werror=double-promotion', '-Wno-unsupported-floating-point-opt' ]
 c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+dp/hard/']
-needs_exe_wrapper = true
 skip_sanity_check = true

--- a/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = 'clang'
+c = ['clang', '-m32', '-target', 'thumbv7e-none-eabi', '-mcpu=cortex-m7', '-mfloat-abi=hard']
 c_ld = '/usr/bin/arm-none-eabi-ld'
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eab-as'
@@ -14,22 +14,7 @@ cpu = 'arm'
 endian = 'little'
 
 [properties]
-c_args = [
-	'-m32',
-	'-target', 'thumbv7e-none-eabi',
-	'-mcpu=cortex-m7',
-	'-mfloat-abi=hard',
-	'-Wdouble-promotion',
-	'-Werror=double-promotion',
-        '-Wno-unsupported-floating-point-opt',
-        '-std=c17',
-	]
-c_link_args = [
-	'-m32',
-	'-target', 'thumbv7e-none-eabi',
-	'-mcpu=cortex-m7',
-	'-mfloat-abi=hard',
-	'-nostdlib',
-	'-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+dp/hard/'
-	]
+c_args = [ '-Werror=double-promotion', '-Wno-unsupported-floating-point-opt' ]
+c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+dp/hard/']
 needs_exe_wrapper = true
+skip_sanity_check = true

--- a/scripts/cross-clang-thumbv7m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7m-none-eabi.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = 'clang'
+c = ['clang', '-m32', '-target', 'thumbv7m-none-eabi', '-mfloat-abi=soft']
 c_ld = '/usr/bin/arm-none-eabi-ld'
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eab-as'
@@ -14,20 +14,6 @@ cpu = 'arm'
 endian = 'little'
 
 [properties]
-c_args = [
-	'-m32',
-	'-target', 'thumbv7m-none-eabi',
-	'-mfloat-abi=soft',
-	'-Wdouble-promotion',
-	'-Werror=double-promotion',
-        '-Wno-unsupported-floating-point-opt',
-        '-std=c17',
-	]
-c_link_args = [
-	'-m32',
-	'-target', 'thumbv7m-none-eabi',
-	'-mfloat-abi=soft',
-	'-nostdlib',
-	'-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7-m/nofp/',
-	]
+c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt']
+c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7-m/nofp/']
 needs_exe_wrapper = true

--- a/scripts/cross-clang-thumbv7m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7m-none-eabi.txt
@@ -5,7 +5,8 @@ ar = 'arm-none-eabi-ar'
 as = 'arm-none-eab-as'
 nm = 'arm-none-eab-nm'
 strip = 'arm-none-eabi-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-thumbv7m "$@"', 'run-thumbv7m']
+# only needed to run tests
+exe_wrapper = ['env', 'run-thumbv7m']
 
 [host_machine]
 system = 'none'
@@ -16,5 +17,4 @@ endian = 'little'
 [properties]
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt']
 c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7-m/nofp/']
-needs_exe_wrapper = true
 skip_sanity_check = true

--- a/scripts/cross-clang-thumbv7m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7m-none-eabi.txt
@@ -17,3 +17,4 @@ endian = 'little'
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt']
 c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7-m/nofp/']
 needs_exe_wrapper = true
+skip_sanity_check = true

--- a/scripts/cross-cortex-a9-none-eabi.txt
+++ b/scripts/cross-cortex-a9-none-eabi.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = 'arm-none-eabi-gcc'
+c = ['arm-none-eabi-gcc', '-mcpu=cortex-a9']
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eabi-as'
 nm = 'arm-none-eabi-nm'
@@ -13,12 +13,5 @@ cpu = 'cortex-a9'
 endian = 'little'
 
 [properties]
-c_args = [
-	'-mcpu=cortex-a9',
-	]
-c_link_args = [
-	'-mcpu=cortex-a9',
-	'-nostdlib',
-	]
 needs_exe_wrapper = true
 test_link_script = 'scripts/test-cortex-a9.ld'

--- a/scripts/cross-cortex-a9-none-eabi.txt
+++ b/scripts/cross-cortex-a9-none-eabi.txt
@@ -15,3 +15,4 @@ endian = 'little'
 [properties]
 needs_exe_wrapper = true
 test_link_script = 'scripts/test-cortex-a9.ld'
+skip_sanity_check = true

--- a/scripts/cross-cortex-a9-none-eabi.txt
+++ b/scripts/cross-cortex-a9-none-eabi.txt
@@ -4,7 +4,8 @@ ar = 'arm-none-eabi-ar'
 as = 'arm-none-eabi-as'
 nm = 'arm-none-eabi-nm'
 strip = 'arm-none-eabi-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-cortex-a9 "$@"', 'run-cortex-a9']
+# only needed to run tests
+exe_wrapper = ['env', 'run-cortex-a9']
 
 [host_machine]
 system = 'none'
@@ -13,6 +14,4 @@ cpu = 'cortex-a9'
 endian = 'little'
 
 [properties]
-needs_exe_wrapper = true
-test_link_script = 'scripts/test-cortex-a9.ld'
 skip_sanity_check = true

--- a/scripts/cross-i686-linux-gnu.txt
+++ b/scripts/cross-i686-linux-gnu.txt
@@ -1,10 +1,11 @@
 [binaries]
-c = ['i686-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2']
+c = ['i686-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2', '-fno-pic', '-fno-PIE', '-static']
 ar = 'i686-linux-gnu-ar'
 as = 'i686-linux-gnu-as'
 nm = 'i686-linux-gnu-nm'
 strip = 'i686-linux-gnu-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-i386 "$@"', 'run-i386']
+# only needed to run tests
+exe_wrapper = ['env', 'run-i386']
 
 [host_machine]
 system='linux'
@@ -13,8 +14,6 @@ cpu='i386'
 endian='little'
 
 [properties]
-c_args = ['-fno-pic', '-fno-PIE', '-static']
-ld_args = ['-Wl,--build-id=none']
 skip_sanity_check = true
 needs_exe_wrapper = true
 link_spec = '--build-id=none'

--- a/scripts/cross-i686-linux-gnu.txt
+++ b/scripts/cross-i686-linux-gnu.txt
@@ -1,8 +1,7 @@
 [binaries]
-c = ['i686-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2', '-nostdlib', '-fno-pic', '-fno-PIE', '-static']
+c = ['i686-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2']
 ar = 'i686-linux-gnu-ar'
 as = 'i686-linux-gnu-as'
-ld = ['i686-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2', '-nostdlib', '-fno-pic', '-fno-PIE', '-static']
 nm = 'i686-linux-gnu-nm'
 strip = 'i686-linux-gnu-strip'
 exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-i386 "$@"', 'run-i386']
@@ -14,6 +13,8 @@ cpu='i386'
 endian='little'
 
 [properties]
+c_args = ['-fno-pic', '-fno-PIE', '-static']
+ld_args = ['-Wl,--build-id=none']
 skip_sanity_check = true
 needs_exe_wrapper = true
 link_spec = '--build-id=none'

--- a/scripts/cross-m68k-linux-gnu.txt
+++ b/scripts/cross-m68k-linux-gnu.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = 'm68k-linux-gnu-gcc'
+c = ['m68k-linux-gnu-gcc', '-march=68020']
 ar = 'm68k-linux-gnu-ar'
 as = 'm68k-linux-gnu-as'
 ld = 'm68k-linux-gnu-ld'
@@ -13,7 +13,5 @@ cpu = '68020'
 endian = 'big'
 
 [properties]
-c_args = [ '-nostdlib', '-march=68020' ]
-c_link_args = [ '-nostdlib', '-march=68020', '-lgcc' ]
 link_spec = '--build-id=none'
 skip_sanity_check = true

--- a/scripts/cross-powerpc64-linux-gnu.txt
+++ b/scripts/cross-powerpc64-linux-gnu.txt
@@ -1,11 +1,8 @@
 [binaries]
 c = 'powerpc64-linux-gnu-gcc'
 ar = 'powerpc64-linux-gnu-ar'
-as = 'powerpc64-linux-gnu-as'
-ld = 'powerpc64-linux-gnu-ld'
 nm = 'powerpc64-linux-gnu-nm'
 strip = 'powerpc64-linux-gnu-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-powerpc64 "$@"', 'run-powerpc64']
 
 [host_machine]
 system = 'linux'
@@ -14,7 +11,7 @@ cpu = 'ppc64'
 endian = 'big'
 
 [properties]
-c_args = ['-nostdlib', '-fno-pic', '-static']
+c_args = ['-fno-pic', '-static']
 needs_exe_wrapper = true
 skip_sanity_check = true
 link_spec = '--build-id=none'

--- a/scripts/cross-powerpc64-linux-gnu.txt
+++ b/scripts/cross-powerpc64-linux-gnu.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = 'powerpc64-linux-gnu-gcc'
+c = ['powerpc64-linux-gnu-gcc', '-fno-pic', '-static']
 ar = 'powerpc64-linux-gnu-ar'
 nm = 'powerpc64-linux-gnu-nm'
 strip = 'powerpc64-linux-gnu-strip'
@@ -11,9 +11,4 @@ cpu = 'ppc64'
 endian = 'big'
 
 [properties]
-c_args = ['-fno-pic', '-static']
-needs_exe_wrapper = true
 skip_sanity_check = true
-link_spec = '--build-id=none'
-cc1_spec = '-fno-pic'
-specs_extra = ['*libgcc:', '-lgcc']

--- a/scripts/cross-powerpc64le-linux-gnu.txt
+++ b/scripts/cross-powerpc64le-linux-gnu.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = 'powerpc64le-linux-gnu-gcc'
+c = ['powerpc64le-linux-gnu-gcc', '-fno-pic', '-static']
 ar = 'powerpc64le-linux-gnu-ar'
 as = 'powerpc64le-linux-gnu-as'
 nm = 'powerpc64le-linux-gnu-nm'
@@ -12,8 +12,4 @@ cpu = 'ppc64'
 endian = 'little'
 
 [properties]
-c_args = ['-fno-pic', '-static']
 skip_sanity_check = true
-link_spec = '--build-id=none'
-cc1_spec = '-fno-pic'
-specs_extra = ['*libgcc:', '-lgcc']

--- a/scripts/cross-powerpc64le-linux-gnu.txt
+++ b/scripts/cross-powerpc64le-linux-gnu.txt
@@ -2,10 +2,8 @@
 c = 'powerpc64le-linux-gnu-gcc'
 ar = 'powerpc64le-linux-gnu-ar'
 as = 'powerpc64le-linux-gnu-as'
-ld = 'powerpc64le-linux-gnu-ld'
 nm = 'powerpc64le-linux-gnu-nm'
 strip = 'powerpc64le-linux-gnu-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-powerpc64le "$@"', 'run-powerpc64le']
 
 [host_machine]
 system = 'linux'
@@ -14,8 +12,7 @@ cpu = 'ppc64'
 endian = 'little'
 
 [properties]
-c_args = ['-nostdlib', '-fno-pic', '-static']
-needs_exe_wrapper = true
+c_args = ['-fno-pic', '-static']
 skip_sanity_check = true
 link_spec = '--build-id=none'
 cc1_spec = '-fno-pic'

--- a/scripts/cross-riscv64-unknown-elf.txt
+++ b/scripts/cross-riscv64-unknown-elf.txt
@@ -13,7 +13,7 @@ cpu = 'riscv'
 endian = 'little'
 
 [properties]
-c_args = [ '-nostdlib', '-msave-restore', '-fno-common' ]
+c_args = [ '-msave-restore' ]
 # default multilib is 64 bit
 c_args_ = [ '-mcmodel=medany' ]
 needs_exe_wrapper = true

--- a/scripts/cross-riscv64-unknown-elf.txt
+++ b/scripts/cross-riscv64-unknown-elf.txt
@@ -4,7 +4,8 @@ ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'
 strip = 'riscv64-unknown-elf-strip'
 nm = 'riscv64-unknown-elf-nm'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-riscv "$@"', 'run-riscv']
+# only needed to run tests
+exe_wrapper = ['env', 'run-riscv']
 
 [host_machine]
 system = 'unknown'
@@ -13,8 +14,8 @@ cpu = 'riscv'
 endian = 'little'
 
 [properties]
+# this uses shorter but slower function entry code
 c_args = [ '-msave-restore' ]
 # default multilib is 64 bit
 c_args_ = [ '-mcmodel=medany' ]
-needs_exe_wrapper = true
 skip_sanity_check = true

--- a/scripts/cross-riscv64-zephyr-elf.txt
+++ b/scripts/cross-riscv64-zephyr-elf.txt
@@ -4,7 +4,8 @@ ar = 'riscv64-zephyr-elf-ar'
 as = 'riscv64-zephyr-elf-as'
 nm = 'riscv64-zephyr-elf-nm'
 strip = 'riscv64-zephyr-elf-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-riscv "$@"', 'run-riscv']
+# only needed to run tests
+exe_wrapper = ['env', 'run-riscv']
 
 [host_machine]
 system = 'zephyr'
@@ -13,5 +14,4 @@ cpu = 'riscv'
 endian = 'little'
 
 [properties]
-needs_exe_wrapper = true
 skip_sanity_check = true

--- a/scripts/cross-riscv64-zephyr-elf.txt
+++ b/scripts/cross-riscv64-zephyr-elf.txt
@@ -13,6 +13,5 @@ cpu = 'riscv'
 endian = 'little'
 
 [properties]
-c_args = [ '-nostdlib' ]
 needs_exe_wrapper = true
 skip_sanity_check = true

--- a/scripts/cross-rv32imac.txt
+++ b/scripts/cross-rv32imac.txt
@@ -4,7 +4,8 @@ ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'
 nm = 'riscv64-unknown-elf-nm'
 strip = 'riscv64-unknown-elf-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-rv32imac "$@"', 'run-rv32imac']
+# only needed to run tests
+exe_wrapper = ['env', 'run-rv32imac']
 
 [host_machine]
 system = 'unknown'
@@ -14,5 +15,4 @@ endian = 'little'
 
 [properties]
 c_args = ['-msave-restore']
-needs_exe_wrapper = true
 skip_sanity_check = true

--- a/scripts/cross-rv32imac.txt
+++ b/scripts/cross-rv32imac.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = 'riscv64-unknown-elf-gcc'
+c = ['riscv64-unknown-elf-gcc', '-march=rv32imac', '-mabi=ilp32']
 ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'
 nm = 'riscv64-unknown-elf-nm'
@@ -13,7 +13,6 @@ cpu = 'riscv32'
 endian = 'little'
 
 [properties]
-c_args = [ '-nostdlib', '-msave-restore', '-march=rv32imac', '-mabi=ilp32']
-c_link_args = [ '-nostdlib', '-msave-restore', '-march=rv32imac', '-mabi=ilp32']
+c_args = ['-msave-restore']
 needs_exe_wrapper = true
 skip_sanity_check = true

--- a/scripts/cross-x86_64-linux-gnu.txt
+++ b/scripts/cross-x86_64-linux-gnu.txt
@@ -1,9 +1,8 @@
 [binaries]
-c = ['x86_64-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2',
-        '-nostdlib', '-fno-pic', '-fno-PIE', '-static']
+c = ['x86_64-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2']
 ar = 'x86_64-linux-gnu-ar'
 as = 'x86_64-linux-gnu-as'
-ld = ['x86_64-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2', '-nostdlib', '-fno-pic', '-fno-PIE', '-static']
+ld = ['x86_64-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2']
 nm = 'x86_64-linux-gnu-nm'
 strip = 'x86_64-linux-gnu-strip'
 exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-x86_64 "$@"', 'run-x86_64']
@@ -15,6 +14,8 @@ cpu='x86_64'
 endian='little'
 
 [properties]
+c_args = ['-fno-pic', '-fno-PIE', '-static']
+ld_args = ['-fno-pic', '-fno-PIE', '-static']
 skip_sanity_check = true
 needs_exe_wrapper = true
 link_spec = '--build-id=none'

--- a/scripts/cross-x86_64-linux-gnu.txt
+++ b/scripts/cross-x86_64-linux-gnu.txt
@@ -1,11 +1,11 @@
 [binaries]
-c = ['x86_64-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2']
+c = ['x86_64-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2', '-fno-pic', '-fno-PIE', '-static']
 ar = 'x86_64-linux-gnu-ar'
 as = 'x86_64-linux-gnu-as'
-ld = ['x86_64-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2']
 nm = 'x86_64-linux-gnu-nm'
 strip = 'x86_64-linux-gnu-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-x86_64 "$@"', 'run-x86_64']
+# only needed to run tests
+exe_wrapper = ['env', 'run-x86_64']
 
 [host_machine]
 system='linux'
@@ -14,8 +14,6 @@ cpu='x86_64'
 endian='little'
 
 [properties]
-c_args = ['-fno-pic', '-fno-PIE', '-static']
-ld_args = ['-fno-pic', '-fno-PIE', '-static']
 skip_sanity_check = true
 needs_exe_wrapper = true
 link_spec = '--build-id=none'

--- a/scripts/cross-xtensa-lx106-elf.txt
+++ b/scripts/cross-xtensa-lx106-elf.txt
@@ -12,5 +12,5 @@ cpu = 'xtensa'
 endian = 'little'
 
 [properties]
-c_args = ['-nostdlib', '-mlongcalls']
+c_args = ['-mlongcalls']
 skip_sanity_check = true

--- a/scripts/do-native-configure
+++ b/scripts/do-native-configure
@@ -49,6 +49,7 @@ meson setup \
 	-Dincludedir=lib/picolibc/include \
 	-Dlibdir=lib/picolibc/lib \
 	-Dspecsdir=none \
+	-Duse-stdlib=true \
 	-Dtests=true \
 	-Dc_args="-fsanitize=bounds -fsanitize-undefined-trap-on-error -Werror" \
 	"$@" \

--- a/semihost/machine/i386/meson.build
+++ b/semihost/machine/i386/meson.build
@@ -76,7 +76,7 @@ foreach target : targets
     bios_ld = '@0@/@1@'.format(meson.current_source_dir(), 'bios.ld')
     bios = executable('bios' + target, 'bios.S',
 		      c_args: value[1],
-		      link_args: ['-nostartfiles', '-nostdlib', '-Wl,--build-id=none', '-T', bios_ld])
+		      link_args: ['-nostartfiles', '-Wl,--build-id=none', '-T', bios_ld])
 
     bios_bin = custom_target('bios' + target + '.bin',
 		             build_by_default: true,

--- a/test/libc-testsuite/meson.build
+++ b/test/libc-testsuite/meson.build
@@ -94,6 +94,6 @@ foreach target : targets
 		    include_directories: inc),
          depends: bios_bin,
 	 timeout: timeout,
-	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+	 env: test_env)
   endforeach
 endforeach

--- a/test/meson.build
+++ b/test/meson.build
@@ -73,7 +73,7 @@ foreach target : targets
 		  link_depends:  test_link_depends,
 		  include_directories: inc),
        depends: bios_bin,
-       env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+       env: test_env)
 
   t1 = 'printff_scanff'
   if target == ''
@@ -90,7 +90,7 @@ foreach target : targets
 		  link_depends:  test_link_depends,
 		  include_directories: inc),
        depends: bios_bin,
-       env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+       env: test_env)
 
   t1 = 'printf-tests'
   if target == ''
@@ -106,7 +106,7 @@ foreach target : targets
 		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
-       env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+       env: test_env)
 
   t1 = 'printff-tests'
   if target == ''
@@ -122,7 +122,7 @@ foreach target : targets
 		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
-       env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+       env: test_env)
 
   t1 = 'printfi-tests'
   if target == ''
@@ -138,7 +138,7 @@ foreach target : targets
 		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
-       env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+       env: test_env)
 
   t1 = 'try-ilp32'
   if target == ''
@@ -154,7 +154,7 @@ foreach target : targets
 		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
-       env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+       env: test_env)
 
   t1 = 'hosted-exit'
   if target == ''
@@ -170,7 +170,7 @@ foreach target : targets
 		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
-       env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+       env: test_env)
 
   test(t1 + '-fail' + target,
        executable(t1_name + '-fail', 'hosted-exit.c',
@@ -179,7 +179,7 @@ foreach target : targets
 		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
-       env: ['MESON_SOURCE_ROOT=' + meson.source_root()],
+       env: test_env,
        should_fail: true
       )
 
@@ -197,7 +197,7 @@ foreach target : targets
 		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
-       env: ['MESON_SOURCE_ROOT=' + meson.source_root()],
+       env: test_env,
        should_fail: true
       )
 
@@ -216,7 +216,7 @@ foreach target : targets
 		    link_with: _libs_minimal,
 		    include_directories: inc),
          depends: bios_bin,
-	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+	 env: test_env)
   endif
 
   t1 = 'rounding-mode'
@@ -233,7 +233,7 @@ foreach target : targets
 		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
-       env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+       env: test_env)
 
   t1 = 'test-except'
   t1_src = t1 + '.c'
@@ -251,7 +251,7 @@ foreach target : targets
 		  link_depends:  test_link_depends,
 		  include_directories: inc),
        depends: bios_bin,
-       env: ['MESON_SOURCE_ROOT=' + meson.source_root()],
+       env: test_env,
        should_fail: true
       )
 
@@ -305,7 +305,7 @@ foreach target : targets
 		    link_depends:  test_link_depends,
 		    include_directories: inc),
          depends: bios_bin,
-	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+	 env: test_env)
   endforeach
 
 endforeach

--- a/test/semihost/meson.build
+++ b/test/semihost/meson.build
@@ -102,7 +102,7 @@ foreach target : targets
 		    include_directories: inc),
 	 args: ['--', command_line],
          depends: bios_bin,
-	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+	 env: test_env)
   endforeach
 
   foreach semihost_fail_test : semihost_fail_tests
@@ -121,7 +121,7 @@ foreach target : targets
 		    link_depends:  test_link_depends,
 		    include_directories: inc),
 	 args: ['--', command_line],
-	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()],
+	 env: test_env,
 	 should_fail: true)
   endforeach
   


### PR DESCRIPTION
These get overridden by any -Dc_args specified on the meson command
line, which breaks most of the cross compilation
environments. Instead, place all required c options in the 'c' and
'c_ld' commands specified in the [binaries] section.
    
Signed-off-by: Keith Packard <keithp@keithp.com>