### PR TITLE
Fix HAVE defines in picolibc.h (with other small fixes)

### DIFF
--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -21,50 +21,57 @@ picolibc:
     * ARM 32-bit, almost all targets (qemu)
     * ARM 64-bit
 
- 3. Verify that COPYING.picolibc includes information
+ 3. Use glibc test suite for RISC-V and ARM 32-bit
+
+ 4. Test c++ builds using hello-world example on ARM
+
+ 5. Verify that COPYING.picolibc includes information
     about the current source files
 
- 4. Add release notes to README.md
+ 6. Add release notes to README.md
  
- 5. Update meson.build file with new version number
+ 7. Update meson.build file with new version number
 
- 6. Commit release notes and meson.build
+ 8. Commit release notes and meson.build
 
 	$ git commit -m'Version <version>' README.md meson.build
 
- 7. Use native configuration to build release:
+ 9. Use native configuration to build release:
 
 	$ mkdir -p builds/build-native
 	$ cd builds/build-native
         $ ../../scripts/do-native-configure
 	$ ninja dist
 
- 8. Use arm configuration to build bits for the Arm embedded toolkit:
+ 10. Use arm configuration to build bits for the Arm embedded toolkit:
 
-        $ mkdir -p builds/build-arm
-        $ cd builds/build-arm
+        $ mkdir -p builds/build-arm-tk builds/build-arm-tk-release
+        $ cd builds/build-arm-tk
         $ PATH=$ARM_TK/bin:$PATH ../../scripts/do-arm-configure -Dsysroot-install=true
-        $ PATH=$ARM_TK/bin:$PATH DESTDIR=$PWD/dist ninja install
-        $ cd dist/$ARM_TK
+        $ PATH=$ARM_TK/bin:$PATH DESTDIR=$PWD/../dist ninja install
+	$ cd ../build-arm-tk-release
+	$ PATH=$ARM_TK/bin:$PATH ../../scripts/do-arm-configure -Dsysroot-install=true -Dbuild-type-subdir=release --buildtype=release
+        $ PATH=$ARM_TK/bin:$PATH DESTDIR=$PWD/../dist ninja install
+        $ cd ../dist/$ARM_TK
         $ zip -r picolibc-<version>-<arm-et-version>.zip .
         $ scp picolibc-<version>-<arm-et-version>.zip keithp.com:/var/www/picolibc/dist/gnu-arm-embedded
 
- 9. Tag release
+ 11. Tag release
 
 	$ git tag -m'Version <version>' <version> main
 
- 10. Push tag and branch to repositories
+ 12. Push tag and branch to repositories
 
 	$ git push origin main <version>
 
- 11. Upload release to web site:
+ 13. Upload release to web site:
 
 	$ scp build-native/meson-dist/* keithp.com:/var/www/picolibc/dist
 
- 12. Create new release on github site, pasting in relevant README.md
+ 14. Create new release on github site, pasting in relevant README.md
      section. Upload release tar and arm embedded toolkit zip files.
 
- 13. Email release message to mailing list. Paste in README.md section
+ 15. Email release message to mailing list. Paste in README.md section
      about the new release.
 
 ## Debian Packages

--- a/meson.build
+++ b/meson.build
@@ -685,7 +685,7 @@ int main(void) { return foo(@0@); }
 '''
   builtin_code = builtin_template.format(builtin[1], builtin[2])
   have_current_builtin = cc.links(builtin_code, name : 'test for __' + builtin[0], args: core_c_args)
-  conf_data.set('HAVE_' + builtin[0].to_upper(), have_current_builtin, description: 'The compiler supports __' + builtin[0])
+  conf_data.set('_HAVE_' + builtin[0].to_upper(), have_current_builtin, description: 'The compiler supports __' + builtin[0])
 endforeach
 
 NEWLIB_VERSION='4.1.0'
@@ -737,7 +737,7 @@ conf_data.set('_REENT_GLOBAL_ATEXIT', get_option('newlib-global-atexit'))
 conf_data.set('_FVWRITE_IN_STREAMIO', newlib_fvwrite_in_streamio)
 conf_data.set('_FSEEK_OPTIMIZATION', newlib_fseek_optimization)
 conf_data.set('_WIDE_ORIENT', newlib_wide_orient)
-conf_data.set('HAVE_FCNTL', newlib_have_fcntl)
+conf_data.set('_HAVE_FCNTL', newlib_have_fcntl)
 conf_data.set('_NANO_MALLOC', newlib_nano_malloc)
 conf_data.set('_UNBUF_STREAM_OPT', get_option('newlib-unbuf-stream-opt'))
 conf_data.set('_LITE_EXIT', lite_exit)
@@ -755,14 +755,14 @@ conf_data.set('_HAVE_INITFINI_ARRAY', get_option('newlib-initfini-array'), descr
 conf_data.set('_HAVE_INIT_FINI', get_option('newlib-initfini'), description: 'Support _init() and _fini() functions')
 conf_data.set('NEWLIB_TLS', thread_local_storage, description: 'use thread local storage')
 conf_data.set('PICOLIBC_TLS', thread_local_storage, description: 'use thread local storage')
-conf_data.set('HAVE_PICOLIBC_TLS_API', thread_local_storage, description: '_set_tls and _init_tls functions available')
+conf_data.set('_HAVE_PICOLIBC_TLS_API', thread_local_storage, description: '_set_tls and _init_tls functions available')
 conf_data.set('POSIX_IO', posix_io, description: 'Use open/close/read/write in tinystdio')
 conf_data.set('ATOMIC_UNGETC', atomic_ungetc, description: 'Use atomics for fgetc/ungetc for re-entrancy')
-conf_data.set('HAVE_BITFIELDS_IN_PACKED_STRUCTS', have_bitfields_in_packed_structs, description: 'Use bitfields in packed structs')
-conf_data.set('HAVE_BUILTIN_MUL', have_builtin_mul_overflow, description: 'Compiler has __builtin_mul_overflow')
-conf_data.set('HAVE_COMPLEX', have_complex, description: 'Compiler supports _Complex')
-conf_data.set('HAVE_BUILTIN_EXPECT', have_builtin_expect, description: 'Compiler has __builtin_expect')
-conf_data.set('HAVE_ALLOC_SIZE', have_alloc_size, description: 'The compiler REALLY has the attribute __alloc_size__')
+conf_data.set('_HAVE_BITFIELDS_IN_PACKED_STRUCTS', have_bitfields_in_packed_structs, description: 'Use bitfields in packed structs')
+conf_data.set('_HAVE_BUILTIN_MUL_OVERFLOW', have_builtin_mul_overflow, description: 'Compiler has __builtin_mul_overflow')
+conf_data.set('_HAVE_COMPLEX', have_complex, description: 'Compiler supports _Complex')
+conf_data.set('_HAVE_BUILTIN_EXPECT', have_builtin_expect, description: 'Compiler has __builtin_expect')
+conf_data.set('_HAVE_ALLOC_SIZE', have_alloc_size, description: 'The compiler REALLY has the attribute __alloc_size__')
 conf_data.set('_HAVE_ATTRIBUTE_ALWAYS_INLINE',
 	      cc.has_function_attribute('always_inline'),
 	      description: 'The compiler supports the always_inline function attribute')
@@ -950,7 +950,7 @@ if tinystdio
   subdir('dummyhost')
 endif
 
-conf_data.set('HAVE_SEMIHOST', has_semihost, description: 'Semihost APIs supported')
+conf_data.set('_HAVE_SEMIHOST', has_semihost, description: 'Semihost APIs supported')
 
 # By default, tests don't require any special arguments
 
@@ -1020,7 +1020,7 @@ if enable_tests
   subdir('test')
 endif
 
-conf_data.set('HAVE_IEEEFP_FUNCS', has_ieeefp_funcs, description: 'IEEE fp funcs available')
+conf_data.set('_HAVE_IEEEFP_FUNCS', has_ieeefp_funcs, description: 'IEEE fp funcs available')
 
 configure_file(output : 'picolibc.h',
 	       configuration: conf_data,

--- a/meson.build
+++ b/meson.build
@@ -47,8 +47,18 @@ project('picolibc', 'c',
 
 targets = []
 
-cc = meson.get_compiler('c')
 fs = import('fs')
+
+cc = meson.get_compiler('c')
+
+# these options are required for all C compiler operations, including
+# detecting many C compiler features, as we cannot expect there
+# to be a working C library on the system.
+
+core_c_args = []
+if not get_option('use-stdlib')
+  core_c_args += cc.get_supported_arguments(['-nostdlib'])
+endif
 
 # Find the picolibc name for the host cpu. Provide
 # for some common aliases
@@ -112,7 +122,7 @@ long double test()
 	 return ld;
 }
 '''
-have_long_double = cc.compiles(long_double_code, name : 'long double check')
+have_long_double = cc.compiles(long_double_code, name : 'long double check', args: core_c_args)
 
 long_double_size_code = '''
 #include <float.h>
@@ -130,10 +140,10 @@ char size_test[__LDBL_MANT_DIG__ == 113 ? 1 : -1];
 '''
 
 if have_long_double
-  long_double_equals_double = cc.compiles(long_double_size_code, name : 'long double same as double')
+  long_double_equals_double = cc.compiles(long_double_size_code, name : 'long double same as double', args: core_c_args)
   if not long_double_equals_double
-    long_double_mant_is_64 = cc.compiles(long_double_mant_64_code, name : 'long double mantissa is 64 bits')
-    long_double_mant_is_113 = cc.compiles(long_double_mant_113_code, name : 'long double mantissa is 113 bits')
+    long_double_mant_is_64 = cc.compiles(long_double_mant_64_code, name : 'long double mantissa is 64 bits', args: core_c_args)
+    long_double_mant_is_113 = cc.compiles(long_double_mant_113_code, name : 'long double mantissa is 113 bits', args: core_c_args)
   endif
 endif
 
@@ -161,7 +171,7 @@ newlib_nano_malloc = get_option('newlib-nano-malloc')
 lite_exit = get_option('lite-exit')
 
 newlib_elix_level = get_option('newlib-elix-level')
-c_args = ['-include', '@0@/@1@'.format(meson.current_build_dir(), 'picolibc.h')]
+c_args = ['-include', '@0@/@1@'.format(meson.current_build_dir(), 'picolibc.h')] + core_c_args
 native_c_args = ['-DNO_NEWLIB']
 
 # Disable ssp and fortify source while building picolibc (it's enabled
@@ -384,7 +394,7 @@ thread_local_storage = false
 if get_option('thread-local-storage') == 'auto'
   # We assume that _set_tls() is defined in the arch specific tls.c
   if fs.is_file('newlib/libc/picolib/machine' / host_cpu_family / 'tls.c')
-    thread_local_storage = not cc.has_function('__emutls_get_address', args: ['-nostdlib', '-lgcc'])
+    thread_local_storage = not cc.has_function('__emutls_get_address', args: core_c_args + ['-lgcc'])
   endif
 else
   thread_local_storage = get_option('thread-local-storage') == 'true'
@@ -541,7 +551,7 @@ bitfields_in_packed_structs_code = '''
 struct test { int part: 24; } __attribute__((packed));
 unsigned int foobar (const struct test *p) { return p->part; }
 '''
-have_bitfields_in_packed_structs = cc.compiles(bitfields_in_packed_structs_code, name : 'packed structs may contain bitfields')
+have_bitfields_in_packed_structs = cc.compiles(bitfields_in_packed_structs_code, name : 'packed structs may contain bitfields', args: core_c_args)
 
 # CompCert does not have __builtin_mul_overflow
 builtin_mul_overflow_code = '''
@@ -550,13 +560,13 @@ int overflows (size_t a, size_t b) { size_t x; return __builtin_mul_overflow(a, 
 volatile size_t aa = 42;
 int main (void) { return overflows(aa, aa); }
 '''
-have_builtin_mul_overflow = cc.links(builtin_mul_overflow_code, name : 'has __builtin_mul_overflow')
+have_builtin_mul_overflow = cc.links(builtin_mul_overflow_code, name : 'has __builtin_mul_overflow', args: core_c_args)
 
 # CompCert does not support _Complex
 complex_code = '''
 float _Complex test(float _Complex z) { return z; }
 '''
-have_complex = cc.compiles(complex_code, name : 'supports _Complex')
+have_complex = cc.compiles(complex_code, name : 'supports _Complex', args: core_c_args)
 
 # CompCert does not have __builtin_expect
 builtin_expect_code = '''
@@ -565,7 +575,9 @@ int main (void) {
   return __builtin_expect(a, 1);
 }
 '''
-have_builtin_expect = cc.links(builtin_expect_code, name : 'has __builtin_expect')
+have_builtin_expect = cc.links(builtin_expect_code, name : 'has __builtin_expect', args: core_c_args)
+
+werror_c_args = core_c_args + cc.get_supported_arguments('-Werror')
 
 # CompCert uses the GCC preprocessor, which causes to
 #  > #if __has_attribute(__alloc_size__)
@@ -574,20 +586,14 @@ alloc_size_code = '''
 void *foobar(int) __attribute__((__alloc_size__(1)));
 void *foobar2(int, int) __attribute__((__alloc_size__(1, 2)));
 '''
-have_alloc_size = cc.compiles(alloc_size_code, name : 'attribute __alloc_size__', args : (cc.has_argument('-Werror') ? '-Werror' : ''))
+have_alloc_size = cc.compiles(alloc_size_code, name : 'attribute __alloc_size__', args : werror_c_args)
 
 # attributes constructor/destructor are a GNU extension - if the compiler doesn't have them, don't test them.
 attr_ctor_dtor_code = '''
 void __attribute__((constructor(101))) ctor (void) {}
 void __attribute__((destructor(101))) dtor (void) {}
 '''
-have_attr_ctor_dtor = cc.compiles(attr_ctor_dtor_code, name : 'attributes constructor/destructor', args : (cc.has_argument('-Werror') ? '-Werror' : ''))
-
-# Add c_args from the cross file. This
-# means that the command line values get
-# added to the cross file values instead of
-# replacing them.
-c_args += meson.get_cross_property('c_args', [])
+have_attr_ctor_dtor = cc.compiles(attr_ctor_dtor_code, name : 'attributes constructor/destructor', args : werror_c_args)
 
 if enable_multilib
   used_libs = []
@@ -678,7 +684,7 @@ static int foo(@1@ i __attribute__((unused))) { return 0; }
 int main(void) { return foo(@0@); }
 '''
   builtin_code = builtin_template.format(builtin[1], builtin[2])
-  have_current_builtin = cc.links(builtin_code, name : 'test for __' + builtin[0])
+  have_current_builtin = cc.links(builtin_code, name : 'test for __' + builtin[0], args: core_c_args)
   conf_data.set('HAVE_' + builtin[0].to_upper(), have_current_builtin, description: 'The compiler supports __' + builtin[0])
 endforeach
 
@@ -694,7 +700,7 @@ conf_data.set('_HAVE_CC_INHIBIT_LOOP_TO_LIBCALL',
 conf_data.set('_HAVE_NO_BUILTIN_ATTRIBUTE',
 	      cc.compiles('int __attribute__((no_builtin)) foo(int x) { return x + 1; }',
 			  name : 'no_builtin attribute',
-			  args : (cc.has_argument('-Werror=attributes') ? '-Werror=attributes' : '')),
+			  args : werror_c_args),
 	      description: 'Compiler attribute to prevent the optimizer from adding new builtin calls')
 
 conf_data.set('_HAVE_LONG_DOUBLE', have_long_double,
@@ -979,7 +985,7 @@ if has_semihost
   else
     custom_script = cpu_family_script
   endif
-  test_link_args = ['-nostartfiles', '-nostdlib',
+  test_link_args = ['-nostartfiles',
                     '-T', meson.current_source_dir() / custom_script,
                     '-T', '@0@'.format(picolibc_ld), '-lgcc']
   test_linker_files = files(custom_script) + [picolibc_ld]

--- a/meson.build
+++ b/meson.build
@@ -965,6 +965,9 @@ if tests_enable_stack_protector
   endif
 endif
 
+test_env = environment()
+test_env.prepend('PATH', meson.source_root() / 'scripts')
+
 # CompCert needs the '-WUl,' prefix to correctly pass the --spec parameters to the linker
 specs_prefix = ''
 if cc.get_id() == 'ccomp'

--- a/meson.build
+++ b/meson.build
@@ -571,8 +571,8 @@ have_builtin_expect = cc.links(builtin_expect_code, name : 'has __builtin_expect
 #  > #if __has_attribute(__alloc_size__)
 # produce a wrong result. So test if the compiler has that attribute
 alloc_size_code = '''
-void *foobar(size_t) __attribute__((__alloc_size__(1)));
-void *foobar2(size_t, size_t) __attribute__((__alloc_size__(1, 2)));
+void *foobar(int) __attribute__((__alloc_size__(1)));
+void *foobar2(int, int) __attribute__((__alloc_size__(1, 2)));
 '''
 have_alloc_size = cc.compiles(alloc_size_code, name : 'attribute __alloc_size__', args : (cc.has_argument('-Werror') ? '-Werror' : ''))
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -74,6 +74,9 @@ option('picoexit', type: 'boolean', value: true,
 option('fortify-source', type: 'combo', choices: ['none', '1', '2'], value: 'none',
        description: 'Set _FORTIFY_SOURCE=<value>')
 
+option('use-stdlib', type: 'boolean', value: false,
+       description: 'Do not bypass the standard system library with -nostdlib (useful for native testing)')
+
 #
 # Testing options
 #

--- a/newlib/libc/ctype/categories.c
+++ b/newlib/libc/ctype/categories.c
@@ -12,7 +12,7 @@ struct _category {
   uint_least32_t first: 24;
   uint_least16_t delta;
 }
-#ifdef HAVE_BITFIELDS_IN_PACKED_STRUCTS
+#ifdef _HAVE_BITFIELDS_IN_PACKED_STRUCTS
 __attribute__((packed))
 #endif
 ;

--- a/newlib/libc/ctype/towctrans_l.c
+++ b/newlib/libc/ctype/towctrans_l.c
@@ -45,7 +45,7 @@ static struct caseconv_entry {
   uint_least32_t mode: 2;
   int_least32_t delta: 17;
 }
-#ifdef HAVE_BITFIELDS_IN_PACKED_STRUCTS
+#ifdef _HAVE_BITFIELDS_IN_PACKED_STRUCTS
 __attribute__((packed))
 #endif
 caseconv_table [] = {

--- a/newlib/libc/include/alloca.h
+++ b/newlib/libc/include/alloca.h
@@ -11,7 +11,7 @@
 
 #undef alloca
 
-#ifdef HAVE_BUILTIN_ALLOCA
+#ifdef _HAVE_BUILTIN_ALLOCA
 #define alloca(size) __builtin_alloca(size)
 #else
 void * alloca (size_t);

--- a/newlib/libc/include/sys/cdefs.h
+++ b/newlib/libc/include/sys/cdefs.h
@@ -100,7 +100,7 @@
  * not have it). In that case, transparently replace all
  * occurences of that builtin with just the condition:
  */
-#ifndef HAVE_BUILTIN_EXPECT
+#ifndef _HAVE_BUILTIN_EXPECT
 #define __builtin_expect(cond, exp) (cond)
 #endif
 
@@ -258,7 +258,7 @@
 #define	__section(x)	__attribute__((__section__(x)))
 #endif
 
-#ifdef HAVE_ALLOC_SIZE
+#ifdef _HAVE_ALLOC_SIZE
 #define	__alloc_size(x)	__attribute__((__alloc_size__(x)))
 #define	__alloc_size2(n, x)	__attribute__((__alloc_size__(n, x)))
 #else

--- a/newlib/libc/machine/aarch64/machine/math.h
+++ b/newlib/libc/machine/aarch64/machine/math.h
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2022 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _MACHINE_MATH_H_
+#define _MACHINE_MATH_H_
+
+#define _HAVE_FAST_FMA 1
+#define _HAVE_FAST_FMAF 1
+
+#if defined(_HAVE_ATTRIBUTE_ALWAYS_INLINE) && defined(_HAVE_ATTRIBUTE_GNU_INLINE)
+#define __declare_aarch64_macro(type) extern __inline type __attribute((gnu_inline, always_inline))
+
+#ifdef _WANT_MATH_ERRNO
+#include <errno.h>
+#endif
+
+__declare_aarch64_macro(double)
+sqrt (double x)
+{
+    double result;
+#ifdef _WANT_MATH_ERRNO
+    if (isless(x, 0.0))
+        errno = EDOM;
+#endif
+    __asm__ __volatile__ ("fsqrt\t%d0, %d1" : "=w" (result) : "w" (x));
+    return result;
+}
+
+__declare_aarch64_macro(float)
+sqrtf (float x)
+{
+    float result;
+#ifdef _WANT_MATH_ERRNO
+    if (isless(x, 0.0f))
+        errno = EDOM;
+#endif
+    __asm__ __volatile__ ("fsqrt\t%s0, %s1" : "=w" (result) : "w" (x));
+    return result;
+}
+
+__declare_aarch64_macro(double)
+fma (double x, double y, double z)
+{
+    double result;
+    __asm__ __volatile__ ("fmadd\t%d0, %d1, %d2, %d3" : "=w" (result) : "w" (x), "w" (y), "w" (z));
+    return result;
+}
+
+__declare_aarch64_macro(float)
+fmaf (float x, float y, float z)
+{
+    float result;
+    __asm__ __volatile__ ("fmadd\t%s0, %s1, %s2, %s3" : "=w" (result) : "w" (x), "w" (y), "w" (z));
+    return result;
+}
+
+#endif
+
+#endif /* _MACHINE_MATH_H_ */

--- a/newlib/libc/machine/aarch64/machine/meson.build
+++ b/newlib/libc/machine/aarch64/machine/meson.build
@@ -1,8 +1,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
-# Copyright © 2019 Keith Packard, 
-# Copyright © 2020 Anthony Anderson
+# Copyright © 2022 Keith Packard
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -33,50 +32,11 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-
-srcs_machine = [
-    'memchr-stub.c',
-    'memchr.S',
-    'memcmp-stub.c',
-    'memcmp.S',
-    'memcpy-stub.c',
-    'memcpy.S',
-    'memmove-stub.c',
-    'memmove.S',
-    'memset-stub.c',
-    'memset.S',
-    'rawmemchr-stub.c',
-    'rawmemchr.S',
-    'setjmp.S',
-    'stpcpy-stub.c',
-    'stpcpy.S',
-    'strchr-stub.c',
-    'strchr.S',
-    'strchrnul-stub.c',
-    'strchrnul.S',
-    'strcmp-stub.c',
-    'strcmp.S',
-    'strcpy-stub.c',
-    'strcpy.S',
-    'strlen-stub.c',
-    'strlen.S',
-    'strncmp-stub.c',
-    'strncmp.S',
-    'strnlen-stub.c',
-    'strnlen.S',
-    'strchr-stub.c',
-    'strchr.S'
+inc_machine_headers_machine = [
+  '_types.h',
+  'fenv-fp.h',
+  'math.h',
 ]
 
-subdir('sys')
-subdir('machine')
-
-foreach target : targets
-    value = get_variable('target_' + target)
-    set_variable('lib_machine' + target,
-        static_library('machine' + target,
-            srcs_machine,
-            pic: false,
-            include_directories: inc,
-            c_args: value[1] + arg_fnobuiltin))
-endforeach
+install_headers(inc_machine_headers_machine,
+		install_dir: include_dir / 'machine')

--- a/newlib/libc/machine/aarch64/sys/fenv.h
+++ b/newlib/libc/machine/aarch64/sys/fenv.h
@@ -31,10 +31,6 @@
 
 #include <sys/_types.h>
 
-#ifndef	__fenv_static
-#define	__fenv_static	static
-#endif
-
 typedef	__uint64_t	fenv_t;
 typedef	__uint64_t	fexcept_t;
 
@@ -70,5 +66,10 @@ typedef	__uint64_t	fexcept_t;
 
 #define	__mrs_fpsr(__r)	__asm __volatile("mrs %0, fpsr" : "=r" (__r))
 #define	__msr_fpsr(__r)	__asm __volatile("msr fpsr, %0" : : "r" (__r))
+
+#ifndef	__fenv_static
+#define	__fenv_static	static
+#include <machine/fenv-fp.h>
+#endif
 
 #endif	/* !_FENV_H_ */

--- a/newlib/libc/machine/arm/machine/math.h
+++ b/newlib/libc/machine/arm/machine/math.h
@@ -38,6 +38,14 @@
 #ifndef _MACHINE_MATH_H_
 #define _MACHINE_MATH_H_
 
+# if (__ARM_FEATURE_FMA && (__ARM_FP & 8))
+#define _HAVE_FAST_FMA  1
+#endif
+
+#if (__ARM_FEATURE_FMA && (__ARM_FP & 4))
+#define _HAVE_FAST_FMAF 1
+#endif
+
 #if defined(_HAVE_ATTRIBUTE_ALWAYS_INLINE) && defined(_HAVE_ATTRIBUTE_GNU_INLINE)
 #define __declare_arm_macro(type) extern __inline type __attribute((gnu_inline, always_inline))
 
@@ -133,13 +141,15 @@ trunc (double x)
 }
 #endif /* __ARM_ARCH >= 8 */
 
-#if HAVE_FAST_FMA
+#if _HAVE_FAST_FMA
+
 __declare_arm_macro(double)
 fma (double x, double y, double z)
 {
   __asm__ volatile ("vfma.f64 %P0, %P1, %P2" : "+w" (z) : "w" (x), "w" (y));
   return z;
 }
+
 #endif
 
 #endif /* (__ARM_FP & 0x8) && !defined(__SOFTFP__) */
@@ -232,7 +242,7 @@ truncf (float x)
 }
 #endif /* __ARM_ARCH >= 8 */
 
-#if HAVE_FAST_FMAF
+#if _HAVE_FAST_FMAF
 
 __declare_arm_macro(float)
 fmaf (float x, float y, float z)
@@ -240,6 +250,7 @@ fmaf (float x, float y, float z)
   __asm__ volatile ("vfma.f32 %0, %1, %2" : "+t" (z) : "t" (x), "t" (y));
   return z;
 }
+
 #endif
 
 #endif /* (__ARM_FP & 0x4) && !defined(__SOFTFP__) */

--- a/newlib/libc/machine/nvptx/assert.c
+++ b/newlib/libc/machine/nvptx/assert.c
@@ -17,7 +17,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#ifndef HAVE_ASSERT_FUNC
+#ifndef _HAVE_ASSERT_FUNC
 /* func can be NULL, in which case no function information is given.  */
 void
 __assert_func (const char *file,
@@ -28,7 +28,7 @@ __assert_func (const char *file,
   abort();
   /* NOTREACHED */
 }
-#endif /* HAVE_ASSERT_FUNC */
+#endif /* _HAVE_ASSERT_FUNC */
 
 void
 __assert (const char *file,

--- a/newlib/libc/machine/riscv/machine/math.h
+++ b/newlib/libc/machine/riscv/machine/math.h
@@ -75,6 +75,10 @@
 /* We always need the fclass functions */
 
 #if __riscv_flen >= 64
+
+/* anything with a 64-bit FPU has FMA */
+#define _HAVE_FAST_FMA 1
+
 __declare_riscv_macro_fclass(long)
 _fclass_d(double x)
 {
@@ -85,6 +89,10 @@ _fclass_d(double x)
 #endif
 
 #if __riscv_flen >= 32
+
+/* anything with a 32-bit FPU has FMAF */
+#define _HAVE_FAST_FMAF 1
+
 __declare_riscv_macro_fclass(long)
 _fclass_f(float x)
 {
@@ -193,7 +201,6 @@ sqrt (double x)
 	return result;
 }
 
-#if HAVE_FAST_FMA
 __declare_riscv_macro(double)
 fma (double x, double y, double z)
 {
@@ -201,7 +208,6 @@ fma (double x, double y, double z)
 	__asm__ volatile("fmadd.d %0, %1, %2, %3" : "=f" (result) : "f" (x), "f" (y), "f" (z));
 	return result;
 }
-#endif
 
 #endif /* __riscv_flen >= 64 */
 
@@ -296,8 +302,6 @@ sqrtf (float x)
 	return result;
 }
 
-
-#if defined(HAVE_FAST_FMAF)
 __declare_riscv_macro(float)
 fmaf (float x, float y, float z)
 {
@@ -305,7 +309,6 @@ fmaf (float x, float y, float z)
 	__asm__ volatile("fmadd.s %0, %1, %2, %3" : "=f" (result) : "f" (x), "f" (y), "f" (z));
 	return result;
 }
-#endif
 
 #endif /* __riscv_flen >= 32 */
 

--- a/newlib/libc/misc/ffs.c
+++ b/newlib/libc/misc/ffs.c
@@ -58,16 +58,16 @@ No supporting OS subroutines are required.  */
  * builtin to implement ffs here. Instead, fall back to the ctz code
  * instead.
  */
-#if defined(HAVE_BUILTIN_FFS) && defined(__GNUC__) && __INT_WIDTH__ != __LONG_WIDTH__
-#undef HAVE_BUILTIN_FFS
+#if defined(_HAVE_BUILTIN_FFS) && defined(__GNUC__) && __INT_WIDTH__ != __LONG_WIDTH__
+#undef _HAVE_BUILTIN_FFS
 #endif
 
 int
 ffs(int i)
 {
-#ifdef HAVE_BUILTIN_FFS
+#ifdef _HAVE_BUILTIN_FFS
 	return (__builtin_ffs(i));
-#elif defined(HAVE_BUILTIN_CTZ)
+#elif defined(_HAVE_BUILTIN_CTZ)
 	if (i == 0)
 		return 0;
 	return __builtin_ctz((unsigned int)i) + 1;

--- a/newlib/libc/search/hash.c
+++ b/newlib/libc/search/hash.c
@@ -160,7 +160,7 @@ __hash_open (const char *file,
 #endif
 			new_table = 1;
 
-#ifdef HAVE_FCNTL
+#ifdef _HAVE_FCNTL
 		(void)fcntl(hashp->fp, F_SETFD, 1);
 #endif
 	}

--- a/newlib/libc/search/hash_page.c
+++ b/newlib/libc/search/hash_page.c
@@ -858,7 +858,7 @@ open_temp(HTAB *hashp)
 	(void)sigprocmask(SIG_BLOCK, &set, &oset);
 	if ((hashp->fp = mkstemp(namestr)) != -1) {
 		(void)unlink(namestr);
-#ifdef HAVE_FCNTL
+#ifdef _HAVE_FCNTL
 		(void)fcntl(hashp->fp, F_SETFD, 1);
 #endif
 	}

--- a/newlib/libc/stdio/fdopen.c
+++ b/newlib/libc/stdio/fdopen.c
@@ -59,7 +59,7 @@ _fdopen_r (struct _reent *ptr,
 {
   register FILE *fp;
   int flags, oflags;
-#ifdef HAVE_FCNTL
+#ifdef _HAVE_FCNTL
   int fdflags, fdmode;
 #endif
 
@@ -67,7 +67,7 @@ _fdopen_r (struct _reent *ptr,
     return 0;
 
   /* make sure the mode the user wants is a subset of the actual mode */
-#ifdef HAVE_FCNTL
+#ifdef _HAVE_FCNTL
   if ((fdflags = fcntl (fd, F_GETFL, 0)) < 0)
     return 0;
   fdmode = fdflags & O_ACCMODE;
@@ -88,7 +88,7 @@ _fdopen_r (struct _reent *ptr,
      streams.  Someone may later clear O_APPEND on fileno(fp), but the
      stream must still remain in append mode.  Rely on __sflags
      setting __SAPP properly.  */
-#ifdef HAVE_FCNTL
+#ifdef _HAVE_FCNTL
   if ((oflags & O_APPEND) && !(fdflags & O_APPEND))
     fcntl (fd, F_SETFL, fdflags | O_APPEND);
 #endif

--- a/newlib/libc/stdio/findfp.c
+++ b/newlib/libc/stdio/findfp.c
@@ -102,7 +102,7 @@ stdout_init(FILE *ptr)
      we will default to line buffered mode here.  Technically, POSIX
      requires both stdin and stdout to be line-buffered, but tradition
      leaves stdin alone on systems without fcntl.  */
-#ifdef HAVE_FCNTL
+#ifdef _HAVE_FCNTL
   std (ptr, __SWR, 1);
 #else
   std (ptr, __SWR | __SLBF, 1);

--- a/newlib/libc/stdio/freopen.c
+++ b/newlib/libc/stdio/freopen.c
@@ -141,7 +141,7 @@ _freopen_r (struct _reent *ptr,
     }
   else
     {
-#ifdef HAVE_FCNTL
+#ifdef _HAVE_FCNTL
       int oldflags;
       /*
        * Reuse the file descriptor, but only if the new access mode is

--- a/newlib/libc/stdio64/fdopen64.c
+++ b/newlib/libc/stdio64/fdopen64.c
@@ -43,7 +43,7 @@ _fdopen64_r (struct _reent *ptr,
 {
   register FILE *fp;
   int flags, oflags;
-#ifdef HAVE_FCNTL
+#ifdef _HAVE_FCNTL
   int fdflags, fdmode;
 #endif
 
@@ -51,7 +51,7 @@ _fdopen64_r (struct _reent *ptr,
     return 0;
 
   /* make sure the mode the user wants is a subset of the actual mode */
-#ifdef HAVE_FCNTL
+#ifdef _HAVE_FCNTL
   if ((fdflags = fcntl (fd, F_GETFL, 0)) < 0)
     return 0;
   fdmode = fdflags & O_ACCMODE;
@@ -72,7 +72,7 @@ _fdopen64_r (struct _reent *ptr,
      streams.  Someone may later clear O_APPEND on fileno(fp), but the
      stream must still remain in append mode.  Rely on __sflags
      setting __SAPP properly.  */
-#ifdef HAVE_FCNTL
+#ifdef _HAVE_FCNTL
   if ((oflags & O_APPEND) && !(fdflags & O_APPEND))
     fcntl (fd, F_SETFL, fdflags | O_APPEND);
 #endif

--- a/newlib/libc/stdio64/freopen64.c
+++ b/newlib/libc/stdio64/freopen64.c
@@ -143,7 +143,7 @@ _freopen64_r (struct _reent *ptr,
     }
   else
     {
-#ifdef HAVE_FCNTL
+#ifdef _HAVE_FCNTL
       int oldflags;
       /*
        * Reuse the file descriptor, but only if the new access mode is

--- a/newlib/libc/stdlib/assert.c
+++ b/newlib/libc/stdlib/assert.c
@@ -51,7 +51,7 @@ Supporting OS subroutines required (only if enabled): <<close>>, <<fstat>>,
 #include <stdlib.h>
 #include <stdio.h>
 
-#ifndef HAVE_ASSERT_FUNC
+#ifndef _HAVE_ASSERT_FUNC
 /* func can be NULL, in which case no function information is given.  */
 void
 __assert_func (const char *file,
@@ -66,7 +66,7 @@ __assert_func (const char *file,
   abort();
   /* NOTREACHED */
 }
-#endif /* HAVE_ASSERT_FUNC */
+#endif /* _HAVE_ASSERT_FUNC */
 
 void
 __assert (const char *failedexpr,

--- a/newlib/libc/stdlib/mallocr.c
+++ b/newlib/libc/stdlib/mallocr.c
@@ -407,7 +407,7 @@ extern void __malloc_unlock();
 
 #ifndef INTERNAL_SIZE_T
 #define INTERNAL_SIZE_T size_t
-#elif !defined(HAVE_BUILTIN_MUL_OVERFLOW)
+#elif !defined(_HAVE_BUILTIN_MUL_OVERFLOW)
 #error Compiler does not support __builtin_mul_overflow, hence INTERNAL_SIZE_T cannot be set
 #endif
 

--- a/newlib/libc/stdlib/mul_overflow.h
+++ b/newlib/libc/stdlib/mul_overflow.h
@@ -1,4 +1,4 @@
-#ifdef HAVE_BUILTIN_MUL_OVERFLOW
+#ifdef _HAVE_BUILTIN_MUL_OVERFLOW
 // gcc should use the correct one here
 #define mul_overflow __builtin_mul_overflow
 #else

--- a/newlib/libc/string/ffsl.c
+++ b/newlib/libc/string/ffsl.c
@@ -29,9 +29,9 @@
 int
 ffsl(long i)
 {
-#ifdef HAVE_BUILTIN_FFSL
+#ifdef _HAVE_BUILTIN_FFSL
 	return (__builtin_ffsl(i));
-#elif defined(HAVE_BUILTIN_CTZL)
+#elif defined(_HAVE_BUILTIN_CTZL)
 	if (i == 0)
 		return 0;
 	return __builtin_ctzl((unsigned long)i) + 1;

--- a/newlib/libc/string/ffsll.c
+++ b/newlib/libc/string/ffsll.c
@@ -29,9 +29,9 @@
 int
 ffsll(long long i)
 {
-#ifdef HAVE_BUILTIN_FFSLL
+#ifdef _HAVE_BUILTIN_FFSLL
 	return (__builtin_ffsll(i));
-#elif defined(HAVE_BUILTIN_CTZLL)
+#elif defined(_HAVE_BUILTIN_CTZLL)
 	if (i == 0)
 		return 0;
 	return __builtin_ctzll((unsigned long long)i) + 1;

--- a/newlib/libc/tinystdio/vfprintf.c
+++ b/newlib/libc/tinystdio/vfprintf.c
@@ -222,7 +222,6 @@ skip_to_arg(const char *fmt_orig, my_va_list *ap, int target_argno)
 		  case '0':
 		    continue;
 		  case '+':
-		    FALLTHROUGH;
 		  case ' ':
 		    continue;
 		  case '-':

--- a/newlib/libm/common/isinfl.c
+++ b/newlib/libm/common/isinfl.c
@@ -31,7 +31,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <math.h>
 #include "local.h"
 
-#if defined(_LDBL_EQ_DBL) || defined(HAVE_BUILTIN_ISINFL)
+#if defined(_LDBL_EQ_DBL) || defined(_HAVE_BUILTIN_ISINFL)
 /* On platforms where long double is as wide as double.  */
 int
 isinfl (long double x)

--- a/newlib/libm/common/isnanl.c
+++ b/newlib/libm/common/isnanl.c
@@ -31,7 +31,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <math.h>
 #include "local.h"
 
-#if defined(_LDBL_EQ_DBL) || defined(HAVE_BUILTIN_ISNANL)
+#if defined(_LDBL_EQ_DBL) || defined(_HAVE_BUILTIN_ISNANL)
 /* On platforms where long double is as wide as double.  */
 int
 isnanl (long double x)

--- a/newlib/libm/common/log.c
+++ b/newlib/libm/common/log.c
@@ -146,7 +146,7 @@ log (double x)
 
   /* log(x) = log1p(z/c-1) + log(c) + k*Ln2.  */
   /* r ~= z/c - 1, |r| < 1/(2*N).  */
-#if HAVE_FAST_FMA
+#if _HAVE_FAST_FMA
   /* rounding error: 0x1p-55/N.  */
   r = fma (z, invc, -1.0);
 #else

--- a/newlib/libm/common/log2.c
+++ b/newlib/libm/common/log2.c
@@ -72,7 +72,7 @@ double
       if (WANT_ROUNDING && unlikely (ix == asuint64 (1.0)))
 	return 0;
       r = x - 1.0;
-#if HAVE_FAST_FMA
+#if _HAVE_FAST_FMA
       hi = r * InvLn2hi;
       lo = r * InvLn2lo + fma (r, InvLn2hi, -hi);
 #else
@@ -123,7 +123,7 @@ double
 
   /* log2(x) = log2(z/c) + log2(c) + k.  */
   /* r ~= z/c - 1, |r| < 1/(2*N).  */
-#if HAVE_FAST_FMA
+#if _HAVE_FAST_FMA
   /* rounding error: 0x1p-55/N.  */
   r = fma (z, invc, -1.0);
   t1 = r * InvLn2hi;

--- a/newlib/libm/common/log2_data.c
+++ b/newlib/libm/common/log2_data.c
@@ -160,7 +160,7 @@ that logc + poly(z/c - 1) has small error, however near x == 1 when
 {0x1.767dcf99eff8cp-1, 0x1.ce0a43dbf4000p-2},
 #endif
 },
-#if !HAVE_FAST_FMA
+#if !_HAVE_FAST_FMA
 .tab2 = {
 # if N == 64
 {0x1.6200012b90a8ep-1, 0x1.904ab0644b605p-55},
@@ -229,6 +229,6 @@ that logc + poly(z/c - 1) has small error, however near x == 1 when
 {0x1.5dfffebfc3481p+0, -0x1.180902e30e93ep-54},
 # endif
 },
-#endif /* !HAVE_FAST_FMA */
+#endif /* !_HAVE_FAST_FMA */
 };
 #endif /* __OBSOLETE_MATH_DOUBLE */

--- a/newlib/libm/common/log_data.c
+++ b/newlib/libm/common/log_data.c
@@ -333,7 +333,7 @@ that logc + poly(z/c - 1) has small error, however near x == 1 when
 {0x1.756cadbd6130cp-1, 0x1.432eee32fe000p-2},
 #endif
 },
-#if !HAVE_FAST_FMA
+#if !_HAVE_FAST_FMA
 .tab2 = {
 # if N == 64
 {0x1.61ffff94c4fecp-1, -0x1.9fe4fc998f325p-56},
@@ -531,6 +531,6 @@ that logc + poly(z/c - 1) has small error, however near x == 1 when
 {0x1.5efffe7b87a89p+0, -0x1.47eb780ed6904p-54},
 #endif
 },
-#endif /* !HAVE_FAST_FMA */
+#endif /* !_HAVE_FAST_FMA */
 };
 #endif /* __OBSOLETE_MATH_DOUBLE */

--- a/newlib/libm/common/math_config.h
+++ b/newlib/libm/common/math_config.h
@@ -66,7 +66,7 @@
 # define NOINLINE
 #endif
 
-#ifdef HAVE_BUILTIN_EXPECT
+#ifdef _HAVE_BUILTIN_EXPECT
 # define likely(x) __builtin_expect (!!(x), 1)
 # define unlikely(x) __builtin_expect (x, 0)
 #else

--- a/newlib/libm/common/math_config.h
+++ b/newlib/libm/common/math_config.h
@@ -92,23 +92,6 @@
 # endif
 #endif
 
-/* Compiler can inline fma as a single instruction.  */
-#ifndef HAVE_FAST_FMA
-# if __aarch64__ || (__ARM_FEATURE_FMA && (__ARM_FP & 8)) || __riscv_flen >= 64
-#   define HAVE_FAST_FMA 1
-# else
-#   define HAVE_FAST_FMA 0
-# endif
-#endif
-
-#ifndef HAVE_FAST_FMAF
-# if HAVE_FAST_FMA || (__ARM_FEATURE_FMA && (__ARM_FP & 4)) || __riscv_flen >= 32
-#  define HAVE_FAST_FMAF 1
-# else
-#  define HAVE_FAST_FMAF 0
-# endif
-#endif
-
 #if HAVE_FAST_ROUND
 /* When set, the roundtoint and converttoint functions are provided with
    the semantics documented below.  */
@@ -580,7 +563,7 @@ extern const struct log_data
   double poly[LOG_POLY_ORDER - 1]; /* First coefficient is 1.  */
   double poly1[LOG_POLY1_ORDER - 1];
   struct {double invc, logc;} tab[1 << LOG_TABLE_BITS];
-#if !HAVE_FAST_FMA
+#if !_HAVE_FAST_FMA
   struct {double chi, clo;} tab2[1 << LOG_TABLE_BITS];
 #endif
 } __log_data HIDDEN;
@@ -595,7 +578,7 @@ extern const struct log2_data
   double poly[LOG2_POLY_ORDER - 1];
   double poly1[LOG2_POLY1_ORDER - 1];
   struct {double invc, logc;} tab[1 << LOG2_TABLE_BITS];
-#if !HAVE_FAST_FMA
+#if !_HAVE_FAST_FMA
   struct {double chi, clo;} tab2[1 << LOG2_TABLE_BITS];
 #endif
 } __log2_data HIDDEN;

--- a/newlib/libm/common/pow.c
+++ b/newlib/libm/common/pow.c
@@ -81,7 +81,7 @@ log_inline (uint64_t ix, double_t *tail)
 
   /* Note: 1/c is j/N or j/N/2 where j is an integer in [N,2N) and
      |z/c - 1| < 1/N, so r = z/c - 1 is exactly representible.  */
-#if HAVE_FAST_FMA
+#if _HAVE_FAST_FMA
   r = fma (z, invc, -1.0);
 #else
   /* Split z such that rhi, rlo and rhi*rhi are exact and |rlo| <= |r|.  */
@@ -104,7 +104,7 @@ log_inline (uint64_t ix, double_t *tail)
   ar2 = r * ar;
   ar3 = r * ar2;
   /* k*Ln2 + log(c) + r + A[0]*r*r.  */
-#if HAVE_FAST_FMA
+#if _HAVE_FAST_FMA
   hi = t2 + ar2;
   lo3 = fma (ar, r, -ar2);
   lo4 = t2 - hi + ar2;
@@ -383,7 +383,7 @@ pow (double x, double y)
   double_t lo;
   double_t hi = log_inline (ix, &lo);
   double_t ehi, elo;
-#if HAVE_FAST_FMA
+#if _HAVE_FAST_FMA
   ehi = y * hi;
   elo = y * lo + fma (y, hi, -ehi);
 #else

--- a/newlib/libm/common/s_fma.c
+++ b/newlib/libm/common/s_fma.c
@@ -44,7 +44,7 @@ ANSI C, POSIX.
 
 #include "fdlibm.h"
 
-#if !HAVE_FAST_FMA
+#if !_HAVE_FAST_FMA
 
 #ifndef _DOUBLE_IS_32BITS
 
@@ -63,4 +63,4 @@ ANSI C, POSIX.
 
 #endif /* _DOUBLE_IS_32BITS */
 
-#endif /* !HAVE_FAST_FMA */
+#endif /* !_HAVE_FAST_FMA */

--- a/newlib/libm/common/sf_fma.c
+++ b/newlib/libm/common/sf_fma.c
@@ -6,7 +6,7 @@
 
 #include "fdlibm.h"
 
-#if !HAVE_FAST_FMAF
+#if !_HAVE_FAST_FMAF
 
 #ifdef __STDC__
 	float fmaf(float x, float y, float z)

--- a/newlib/libm/common/sl_finite.c
+++ b/newlib/libm/common/sl_finite.c
@@ -9,7 +9,7 @@
 #define _DEFAULT_SOURCE
 #include <math.h>
 
-#if defined(_LDBL_EQ_DBL) || defined(HAVE_BUILTIN_FINITEL) || defined(HAVE_BUILTIN_ISFINITE)
+#if defined(_LDBL_EQ_DBL) || defined(_HAVE_BUILTIN_FINITEL) || defined(_HAVE_BUILTIN_ISFINITE)
 int
 finitel (long double x)
 {
@@ -21,10 +21,10 @@ finitel (long double x)
      Some architectures for example have an 80-bit long double whereas
      others use 128-bits.  We use macros and comiler builtin functions
      to avoid specific knowledge of the long double format.  */
-#ifdef HAVE_BUILTIN_FINITEL
+#ifdef _HAVE_BUILTIN_FINITEL
   return __builtin_finitel (x);
 #endif
-#ifdef HAVE_BUILTIN_ISFINITE
+#ifdef _HAVE_BUILTIN_ISFINITE
   return __builtin_isfinite (x);
 #endif
 #endif

--- a/newlib/libm/machine/arm/s_fma_arm.c
+++ b/newlib/libm/machine/arm/s_fma_arm.c
@@ -36,7 +36,7 @@
 #include <math.h>
 #include "math_config.h"
 
-#if HAVE_FAST_FMA
+#if _HAVE_FAST_FMA
 
 double
 fma (double x, double y, double z)

--- a/newlib/libm/machine/arm/sf_fma_arm.c
+++ b/newlib/libm/machine/arm/sf_fma_arm.c
@@ -36,7 +36,7 @@
 #include <math.h>
 #include "math_config.h"
 
-#if HAVE_FAST_FMAF
+#if _HAVE_FAST_FMAF
 
 float
 fmaf (float x, float y, float z)

--- a/newlib/libm/machine/riscv/s_fma.c
+++ b/newlib/libm/machine/riscv/s_fma.c
@@ -36,7 +36,7 @@
 #include <math.h>
 #include "math_config.h"
 
-#if HAVE_FAST_FMA
+#if _HAVE_FAST_FMA
 
 double
 fma (double x, double y, double z)

--- a/newlib/libm/machine/riscv/s_fma_riscv.c
+++ b/newlib/libm/machine/riscv/s_fma_riscv.c
@@ -36,7 +36,7 @@
 #include <math.h>
 #include "math_config.h"
 
-#if HAVE_FAST_FMA
+#if _HAVE_FAST_FMA
 
 double
 fma (double x, double y, double z)

--- a/newlib/libm/machine/riscv/sf_fma.c
+++ b/newlib/libm/machine/riscv/sf_fma.c
@@ -36,7 +36,7 @@
 #include <math.h>
 #include "math_config.h"
 
-#if HAVE_FAST_FMAF
+#if _HAVE_FAST_FMAF
 
 float
 fmaf (float x, float y, float z)

--- a/newlib/libm/machine/riscv/sf_fma_riscv.c
+++ b/newlib/libm/machine/riscv/sf_fma_riscv.c
@@ -36,7 +36,7 @@
 #include <math.h>
 #include "math_config.h"
 
-#if HAVE_FAST_FMAF
+#if _HAVE_FAST_FMAF
 
 float
 fmaf (float x, float y, float z)

--- a/newlib/libm/test/meson.build
+++ b/newlib/libm/test/meson.build
@@ -155,7 +155,7 @@ foreach target : targets
 		  link_args: value[1] + double_printf_link_args + test_link_args,
 		  include_directories: inc),
        depends: bios_bin,
-       env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+       env: test_env)
 endforeach
 
 if enable_native_tests

--- a/newlib/libm/test/test.c
+++ b/newlib/libm/test/test.c
@@ -46,7 +46,7 @@ main (int ac,
   int is = 1;
   int math= 1;
   int cvt = 1;
-#ifdef HAVE_IEEEFP_FUNCS
+#ifdef _HAVE_IEEEFP_FUNCS
   int ieee= 1;
 #endif
   int vector=0;
@@ -64,7 +64,7 @@ main (int ac,
      math= 0;
     if (strcmp(av[i],"-nocvt") == 0)
      cvt = 0;
-#ifdef HAVE_IEEEFP_FUNCS
+#ifdef _HAVE_IEEEFP_FUNCS
     if (strcmp(av[i],"-noiee") == 0)
      ieee= 0;
 #endif
@@ -84,7 +84,7 @@ main (int ac,
    test_math(vector);
   if (is)
    test_is();
-#ifdef HAVE_IEEEFP_FUNCS
+#ifdef _HAVE_IEEEFP_FUNCS
   if (ieee)
    test_ieee();
 #endif

--- a/newlib/testsuite/newlib.iconv/meson.build
+++ b/newlib/testsuite/newlib.iconv/meson.build
@@ -72,6 +72,6 @@ foreach target : targets
 		    link_with: _libs,
 		    include_directories: test_inc),
 	 depends: [iconv_data_link, bios_bin],
-	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+	 env: test_env)
   endforeach
 endforeach

--- a/newlib/testsuite/newlib.locale/meson.build
+++ b/newlib/testsuite/newlib.locale/meson.build
@@ -46,5 +46,5 @@ foreach test : tests
 		  link_with: [lib_c, lib_semihost, lib_crt],
 		  include_directories: inc),
        depends: bios_bin,
-       env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+       env: test_env)
 endforeach

--- a/newlib/testsuite/newlib.search/meson.build
+++ b/newlib/testsuite/newlib.search/meson.build
@@ -65,6 +65,6 @@ foreach target : targets
 		    link_with: _libs,
 		    include_directories: test_inc),
          depends: bios_bin,
-	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+	 env: test_env)
   endforeach
 endforeach

--- a/newlib/testsuite/newlib.stdio/meson.build
+++ b/newlib/testsuite/newlib.stdio/meson.build
@@ -69,6 +69,6 @@ foreach target : targets
 		    link_with: _libs,
 		    include_directories: test_inc),
 	 depends: bios_bin,
-	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+	 env: test_env)
   endforeach
 endforeach

--- a/newlib/testsuite/newlib.stdlib/meson.build
+++ b/newlib/testsuite/newlib.stdlib/meson.build
@@ -65,6 +65,6 @@ foreach target : targets
 		    link_with: _libs,
 		    include_directories: test_inc),
          depends: bios_bin,
-	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+	 env: test_env)
   endforeach
 endforeach

--- a/newlib/testsuite/newlib.string/meson.build
+++ b/newlib/testsuite/newlib.string/meson.build
@@ -65,6 +65,6 @@ foreach target : targets
 		    link_with: _libs,
 		    include_directories: test_inc),
          depends: bios_bin,
-	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+	 env: test_env)
   endforeach
 endforeach

--- a/newlib/testsuite/newlib.wctype/meson.build
+++ b/newlib/testsuite/newlib.wctype/meson.build
@@ -67,6 +67,6 @@ foreach target : targets
 		    link_with: _libs,
 		    include_directories: test_inc),
          depends: bios_bin,
-	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+	 env: test_env)
   endforeach
 endforeach

--- a/picocrt/meson.build
+++ b/picocrt/meson.build
@@ -74,7 +74,7 @@ foreach target : targets
 	     install : true,
 	     install_dir : instdir,
 	     c_args : value[1] + arg_fnobuiltin + ['-ffreestanding'],
-	     link_args : value[1] + ['-r', '-ffreestanding', '-nostdlib'])
+	     link_args : value[1] + ['-r', '-ffreestanding'])
 
   # Tests link against this because using the .o isn't supported under meson
   set_variable('lib_crt' + target,
@@ -91,7 +91,7 @@ foreach target : targets
              install : true,
              install_dir : instdir,
              c_args : value[1] + arg_fnobuiltin + ['-ffreestanding', '-DCRT0_EXIT'],
-             link_args : value[1] + ['-r', '-ffreestanding', '-nostdlib'])
+             link_args : value[1] + ['-r', '-ffreestanding'])
 
   # Tests link against this because using the .o isn't supported under meson
   set_variable('lib_crt_hosted' + target,
@@ -108,7 +108,7 @@ foreach target : targets
              install : true,
              install_dir : instdir,
              c_args : value[1] + arg_fnobuiltin + ['-ffreestanding', '-DCONSTRUCTORS=0'],
-             link_args : value[1] + ['-r', '-ffreestanding', '-nostdlib'])
+             link_args : value[1] + ['-r', '-ffreestanding'])
 
   # Tests link against this because using the .o isn't supported under meson
   set_variable('lib_crt_minimal' + target,
@@ -127,7 +127,7 @@ foreach target : targets
                install : true,
                install_dir : instdir,
                c_args : value[1] + arg_fnobuiltin + ['-ffreestanding', '-DCRT0_EXIT', '-DCRT0_SEMIHOST'],
-               link_args : value[1] + ['-r', '-ffreestanding', '-nostdlib'])
+               link_args : value[1] + ['-r', '-ffreestanding'])
 
     # Tests link against this because using the .o isn't supported under meson
     set_variable('lib_crt_semihost' + target,

--- a/picolibc.specs.in
+++ b/picolibc.specs.in
@@ -10,7 +10,7 @@
 @TLSMODEL@ %(picolibc_cc1) @CC1_SPEC@
 
 *cc1plus:
--isystem %{-picolibc-prefix=*:%*/@INCLUDEDIR@; -picolibc-buildtype=*:@PREFIX@/@INCLUDEDIR@/%*; @PREFIX@/@INCLUDEDIR@} -idirafter %{-picolibc-prefix=*:%*/@INCLUDEDIR@; -picolibc-buildtype=*:@PREFIX@/@INCLUDEDIR@/%*; :@PREFIX@/@INCLUDEDIR@} @TLSMODEL@ %(picolibc_cc1plus) @CC1_SPEC@ @CC1PLUS_SPEC@
+-isystem %{-picolibc-prefix=*:%*/@INCLUDEDIR@; -picolibc-buildtype=*:@PREFIX@/@INCLUDEDIR@/%*; :@PREFIX@/@INCLUDEDIR@} -idirafter %{-picolibc-prefix=*:%*/@INCLUDEDIR@; -picolibc-buildtype=*:@PREFIX@/@INCLUDEDIR@/%*; :@PREFIX@/@INCLUDEDIR@} @TLSMODEL@ %(picolibc_cc1plus) @CC1_SPEC@ @CC1PLUS_SPEC@
 
 *link:
 @SPECS_PRINTF@ -L%{-picolibc-prefix=*:%*/@LIBDIR@/%M; -picolibc-buildtype=*:@PREFIX@/@LIBDIR@/%*/%M; :@PREFIX@/@LIBDIR@/%M} -L%{-picolibc-prefix=*:%*/@LIBDIR@; -picolibc-buildtype=*:@PREFIX@/@LIBDIR@/%*; :@PREFIX@/@LIBDIR@} %{!T:-T@PICOLIBC_LD@} %(picolibc_link) --gc-sections @LINK_SPEC@

--- a/scripts/cross-aarch64-linux-gnu.txt
+++ b/scripts/cross-aarch64-linux-gnu.txt
@@ -5,7 +5,8 @@ as = 'aarch64-linux-gnu-as'
 ld = 'aarch64-linux-gnu-ld'
 nm = 'aarch64-linux-gnu-nm'
 strip = 'aarch64-linux-gnu-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-aarch64 "$@"', 'run-arm']
+# only needed to run tests
+exe_wrapper = ['env', 'run-aarch64']
 
 [host_machine]
 system = 'linux'
@@ -14,8 +15,6 @@ cpu = 'aarch64'
 endian = 'little'
 
 [properties]
-c_args = '-fno-pic -mpc-relative-literal-loads'
-needs_exe_wrapper = true
 skip_sanity_check = true
 link_spec = '--build-id=none'
 specs_extra = ['*libgcc:', '-lgcc']

--- a/scripts/cross-aarch64-linux-gnu.txt
+++ b/scripts/cross-aarch64-linux-gnu.txt
@@ -14,9 +14,8 @@ cpu = 'aarch64'
 endian = 'little'
 
 [properties]
-c_args = ['-mpc-relative-literal-loads', '-nostdlib', '-fno-pic', '-static']
+c_args = '-fno-pic -mpc-relative-literal-loads'
 needs_exe_wrapper = true
 skip_sanity_check = true
 link_spec = '--build-id=none'
-cc1_spec = '-fno-pic -mpc-relative-literal-loads'
 specs_extra = ['*libgcc:', '-lgcc']

--- a/scripts/cross-aarch64-zephyr-elf.txt
+++ b/scripts/cross-aarch64-zephyr-elf.txt
@@ -13,6 +13,5 @@ cpu = 'aarch64'
 endian = 'little'
 
 [properties]
-c_args = [ '-nostdlib' ]
 needs_exe_wrapper = true
 skip_sanity_check = true

--- a/scripts/cross-aarch64-zephyr-elf.txt
+++ b/scripts/cross-aarch64-zephyr-elf.txt
@@ -4,7 +4,8 @@ ar = 'aarch64-zephyr-elf-ar'
 as = 'aarch64-zephyr-elf-as'
 nm = 'aarch64-zephyr-elf-nm'
 strip = 'aarch64-zephyr-elf-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-aarch64 "$@"', 'run-aarch64']
+# only needed to run tests
+exe_wrapper = ['env', 'run-aarch64']
 
 [host_machine]
 system = 'none'
@@ -13,5 +14,4 @@ cpu = 'aarch64'
 endian = 'little'
 
 [properties]
-needs_exe_wrapper = true
 skip_sanity_check = true

--- a/scripts/cross-arm-none-eabi.txt
+++ b/scripts/cross-arm-none-eabi.txt
@@ -4,7 +4,8 @@ ar = 'arm-none-eabi-ar'
 as = 'arm-none-eabi-as'
 nm = 'arm-none-eabi-nm'
 strip = 'arm-none-eabi-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-arm "$@"', 'run-arm']
+# only needed to run tests
+exe_wrapper = ['env', 'run-arm']
 
 [host_machine]
 system = 'none'
@@ -13,5 +14,4 @@ cpu = 'arm'
 endian = 'little'
 
 [properties]
-needs_exe_wrapper = true
 skip_sanity_check = true

--- a/scripts/cross-arm-none-eabi.txt
+++ b/scripts/cross-arm-none-eabi.txt
@@ -13,6 +13,5 @@ cpu = 'arm'
 endian = 'little'
 
 [properties]
-c_args = [ '-nostdlib', '-fno-common']
 needs_exe_wrapper = true
 skip_sanity_check = true

--- a/scripts/cross-arm-zephyr-eabi.txt
+++ b/scripts/cross-arm-zephyr-eabi.txt
@@ -13,6 +13,5 @@ cpu = 'arm'
 endian = 'little'
 
 [properties]
-c_args = [ '-nostdlib', '-fno-common' ]
 needs_exe_wrapper = true
 skip_sanity_check = true

--- a/scripts/cross-arm-zephyr-eabi.txt
+++ b/scripts/cross-arm-zephyr-eabi.txt
@@ -4,7 +4,8 @@ ar = 'arm-zephyr-eabi-ar'
 as = 'arm-zephyr-eabi-as'
 nm = 'arm-zephyr-eabi-nm'
 strip = 'arm-zephyr-eabi-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-arm "$@"', 'run-arm']
+# only needed to run tests
+exe_wrapper = ['env', 'run-arm']
 
 [host_machine]
 system = 'zephyr'
@@ -13,5 +14,4 @@ cpu = 'arm'
 endian = 'little'
 
 [properties]
-needs_exe_wrapper = true
 skip_sanity_check = true

--- a/scripts/cross-clang-riscv64-unknown-elf.txt
+++ b/scripts/cross-clang-riscv64-unknown-elf.txt
@@ -5,7 +5,8 @@ ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'
 nm = 'riscv64-unknown-elf-nm'
 strip = 'riscv64-unknown-elf-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-riscv "$@"', 'run-riscv']
+# only needed to run tests
+exe_wrapper = ['env', 'run-riscv']
 
 [host_machine]
 system = 'none'
@@ -16,6 +17,5 @@ endian = 'little'
 [properties]
 c_args = ['-Werror=double-promotion']
 c_link_args = ['-L/usr/lib/gcc/riscv64-unknown-elf/8.3.0/rv64imac/lp64/']
-needs_exe_wrapper = true
 skip_sanity_check = true
 has_link_defsym = true

--- a/scripts/cross-clang-riscv64-unknown-elf.txt
+++ b/scripts/cross-clang-riscv64-unknown-elf.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = ['clang', '-target', 'riscv64-unknown-elf' ]
+c = ['clang', '-target', 'riscv64-unknown-elf', '-mcmodel=medany']
 c_ld = '/usr/bin/riscv64-unknown-elf-ld'
 ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'
@@ -14,13 +14,8 @@ cpu = 'riscv'
 endian = 'little'
 
 [properties]
-c_args = [ '-nostdlib', '-Wdouble-promotion', '-mcmodel=medany']
-c_link_args = [
-	'-nostdlib',
-	'-mcmodel=medany',
-	'-L/usr/lib/gcc/riscv64-unknown-elf/8.3.0/rv64imac/lp64/'
-	]
-
+c_args = ['-Werror=double-promotion']
+c_link_args = ['-L/usr/lib/gcc/riscv64-unknown-elf/8.3.0/rv64imac/lp64/']
 needs_exe_wrapper = true
 skip_sanity_check = true
 has_link_defsym = true

--- a/scripts/cross-clang-rv32imafdc-unknown-elf.txt
+++ b/scripts/cross-clang-rv32imafdc-unknown-elf.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = 'clang'
+c = ['clang', '-m32', '-target', 'riscv32-unknown-elf', '-march=rv32imafdc']
 c_ld = '/usr/bin/riscv64-unknown-elf-ld'
 ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'
@@ -14,23 +14,8 @@ cpu = 'riscv'
 endian = 'little'
 
 [properties]
-c_args = [
-	'-m32',
-	'-target', 'riscv32-unknown-elf',
-	'-march=rv32imafdc',
-	'-Wdouble-promotion',
-	'-Werror=double-promotion',
-        '-Wno-unsupported-floating-point-opt',
-        '-std=c17',
-	]
-c_link_args = [
-	'-m32',
-	'-target', 'riscv32-unknown-elf',
-	'-march=rv32imafdc',
-	'-Wl,-melf32lriscv',
-	'-nostdlib',
-	'-L/usr/lib/gcc/riscv64-unknown-elf/8.3.0/rv32imafdc/ilp32d'
-	]
+c_args = ['-Werror=double-promotion']
+c_link_args = ['-Wl,-melf32lriscv', '-L/usr/lib/gcc/riscv64-unknown-elf/8.3.0/rv32imafdc/ilp32d']
 needs_exe_wrapper = true
 skip_sanity_check = true
 has_link_defsym = true

--- a/scripts/cross-clang-rv32imafdc-unknown-elf.txt
+++ b/scripts/cross-clang-rv32imafdc-unknown-elf.txt
@@ -5,7 +5,8 @@ ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'
 nm = 'riscv64-unknown-elf-nm'
 strip = 'riscv64-unknown-elf-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-rv32imafdc "$@"', 'run-rv32imafdc']
+# only needed to run tests
+exe_wrapper = ['env', 'run-rv32imafdc']
 
 [host_machine]
 system = 'none'
@@ -16,6 +17,5 @@ endian = 'little'
 [properties]
 c_args = ['-Werror=double-promotion']
 c_link_args = ['-Wl,-melf32lriscv', '-L/usr/lib/gcc/riscv64-unknown-elf/8.3.0/rv32imafdc/ilp32d']
-needs_exe_wrapper = true
 skip_sanity_check = true
 has_link_defsym = true

--- a/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
@@ -5,7 +5,8 @@ ar = 'arm-none-eabi-ar'
 as = 'arm-none-eab-as'
 nm = 'arm-none-eab-nm'
 strip = 'arm-none-eabi-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-thumbv7e "$@"', 'run-thumbv7e']
+# only needed to run tests
+exe_wrapper = ['env', 'run-thumbv7e']
 
 [host_machine]
 system = 'none'
@@ -16,5 +17,4 @@ endian = 'little'
 [properties]
 c_args = [ '-Werror=double-promotion', '-Wno-unsupported-floating-point-opt' ]
 c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+dp/hard/']
-needs_exe_wrapper = true
 skip_sanity_check = true

--- a/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = 'clang'
+c = ['clang', '-m32', '-target', 'thumbv7e-none-eabi', '-mcpu=cortex-m7', '-mfloat-abi=hard']
 c_ld = '/usr/bin/arm-none-eabi-ld'
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eab-as'
@@ -14,22 +14,7 @@ cpu = 'arm'
 endian = 'little'
 
 [properties]
-c_args = [
-	'-m32',
-	'-target', 'thumbv7e-none-eabi',
-	'-mcpu=cortex-m7',
-	'-mfloat-abi=hard',
-	'-Wdouble-promotion',
-	'-Werror=double-promotion',
-        '-Wno-unsupported-floating-point-opt',
-        '-std=c17',
-	]
-c_link_args = [
-	'-m32',
-	'-target', 'thumbv7e-none-eabi',
-	'-mcpu=cortex-m7',
-	'-mfloat-abi=hard',
-	'-nostdlib',
-	'-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+dp/hard/'
-	]
+c_args = [ '-Werror=double-promotion', '-Wno-unsupported-floating-point-opt' ]
+c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+dp/hard/']
 needs_exe_wrapper = true
+skip_sanity_check = true

--- a/scripts/cross-clang-thumbv7m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7m-none-eabi.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = 'clang'
+c = ['clang', '-m32', '-target', 'thumbv7m-none-eabi', '-mfloat-abi=soft']
 c_ld = '/usr/bin/arm-none-eabi-ld'
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eab-as'
@@ -14,20 +14,6 @@ cpu = 'arm'
 endian = 'little'
 
 [properties]
-c_args = [
-	'-m32',
-	'-target', 'thumbv7m-none-eabi',
-	'-mfloat-abi=soft',
-	'-Wdouble-promotion',
-	'-Werror=double-promotion',
-        '-Wno-unsupported-floating-point-opt',
-        '-std=c17',
-	]
-c_link_args = [
-	'-m32',
-	'-target', 'thumbv7m-none-eabi',
-	'-mfloat-abi=soft',
-	'-nostdlib',
-	'-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7-m/nofp/',
-	]
+c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt']
+c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7-m/nofp/']
 needs_exe_wrapper = true

--- a/scripts/cross-clang-thumbv7m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7m-none-eabi.txt
@@ -5,7 +5,8 @@ ar = 'arm-none-eabi-ar'
 as = 'arm-none-eab-as'
 nm = 'arm-none-eab-nm'
 strip = 'arm-none-eabi-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-thumbv7m "$@"', 'run-thumbv7m']
+# only needed to run tests
+exe_wrapper = ['env', 'run-thumbv7m']
 
 [host_machine]
 system = 'none'
@@ -16,5 +17,4 @@ endian = 'little'
 [properties]
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt']
 c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7-m/nofp/']
-needs_exe_wrapper = true
 skip_sanity_check = true

--- a/scripts/cross-clang-thumbv7m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7m-none-eabi.txt
@@ -17,3 +17,4 @@ endian = 'little'
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt']
 c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7-m/nofp/']
 needs_exe_wrapper = true
+skip_sanity_check = true

--- a/scripts/cross-cortex-a9-none-eabi.txt
+++ b/scripts/cross-cortex-a9-none-eabi.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = 'arm-none-eabi-gcc'
+c = ['arm-none-eabi-gcc', '-mcpu=cortex-a9']
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eabi-as'
 nm = 'arm-none-eabi-nm'
@@ -13,12 +13,5 @@ cpu = 'cortex-a9'
 endian = 'little'
 
 [properties]
-c_args = [
-	'-mcpu=cortex-a9',
-	]
-c_link_args = [
-	'-mcpu=cortex-a9',
-	'-nostdlib',
-	]
 needs_exe_wrapper = true
 test_link_script = 'scripts/test-cortex-a9.ld'

--- a/scripts/cross-cortex-a9-none-eabi.txt
+++ b/scripts/cross-cortex-a9-none-eabi.txt
@@ -15,3 +15,4 @@ endian = 'little'
 [properties]
 needs_exe_wrapper = true
 test_link_script = 'scripts/test-cortex-a9.ld'
+skip_sanity_check = true

--- a/scripts/cross-cortex-a9-none-eabi.txt
+++ b/scripts/cross-cortex-a9-none-eabi.txt
@@ -4,7 +4,8 @@ ar = 'arm-none-eabi-ar'
 as = 'arm-none-eabi-as'
 nm = 'arm-none-eabi-nm'
 strip = 'arm-none-eabi-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-cortex-a9 "$@"', 'run-cortex-a9']
+# only needed to run tests
+exe_wrapper = ['env', 'run-cortex-a9']
 
 [host_machine]
 system = 'none'
@@ -13,6 +14,4 @@ cpu = 'cortex-a9'
 endian = 'little'
 
 [properties]
-needs_exe_wrapper = true
-test_link_script = 'scripts/test-cortex-a9.ld'
 skip_sanity_check = true

--- a/scripts/cross-i686-linux-gnu.txt
+++ b/scripts/cross-i686-linux-gnu.txt
@@ -1,10 +1,11 @@
 [binaries]
-c = ['i686-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2']
+c = ['i686-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2', '-fno-pic', '-fno-PIE', '-static']
 ar = 'i686-linux-gnu-ar'
 as = 'i686-linux-gnu-as'
 nm = 'i686-linux-gnu-nm'
 strip = 'i686-linux-gnu-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-i386 "$@"', 'run-i386']
+# only needed to run tests
+exe_wrapper = ['env', 'run-i386']
 
 [host_machine]
 system='linux'
@@ -13,8 +14,6 @@ cpu='i386'
 endian='little'
 
 [properties]
-c_args = ['-fno-pic', '-fno-PIE', '-static']
-ld_args = ['-Wl,--build-id=none']
 skip_sanity_check = true
 needs_exe_wrapper = true
 link_spec = '--build-id=none'

--- a/scripts/cross-i686-linux-gnu.txt
+++ b/scripts/cross-i686-linux-gnu.txt
@@ -1,8 +1,7 @@
 [binaries]
-c = ['i686-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2', '-nostdlib', '-fno-pic', '-fno-PIE', '-static']
+c = ['i686-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2']
 ar = 'i686-linux-gnu-ar'
 as = 'i686-linux-gnu-as'
-ld = ['i686-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2', '-nostdlib', '-fno-pic', '-fno-PIE', '-static']
 nm = 'i686-linux-gnu-nm'
 strip = 'i686-linux-gnu-strip'
 exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-i386 "$@"', 'run-i386']
@@ -14,6 +13,8 @@ cpu='i386'
 endian='little'
 
 [properties]
+c_args = ['-fno-pic', '-fno-PIE', '-static']
+ld_args = ['-Wl,--build-id=none']
 skip_sanity_check = true
 needs_exe_wrapper = true
 link_spec = '--build-id=none'

--- a/scripts/cross-m68k-linux-gnu.txt
+++ b/scripts/cross-m68k-linux-gnu.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = 'm68k-linux-gnu-gcc'
+c = ['m68k-linux-gnu-gcc', '-march=68020']
 ar = 'm68k-linux-gnu-ar'
 as = 'm68k-linux-gnu-as'
 ld = 'm68k-linux-gnu-ld'
@@ -13,7 +13,5 @@ cpu = '68020'
 endian = 'big'
 
 [properties]
-c_args = [ '-nostdlib', '-march=68020' ]
-c_link_args = [ '-nostdlib', '-march=68020', '-lgcc' ]
 link_spec = '--build-id=none'
 skip_sanity_check = true

--- a/scripts/cross-powerpc64-linux-gnu.txt
+++ b/scripts/cross-powerpc64-linux-gnu.txt
@@ -1,11 +1,8 @@
 [binaries]
 c = 'powerpc64-linux-gnu-gcc'
 ar = 'powerpc64-linux-gnu-ar'
-as = 'powerpc64-linux-gnu-as'
-ld = 'powerpc64-linux-gnu-ld'
 nm = 'powerpc64-linux-gnu-nm'
 strip = 'powerpc64-linux-gnu-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-powerpc64 "$@"', 'run-powerpc64']
 
 [host_machine]
 system = 'linux'
@@ -14,7 +11,7 @@ cpu = 'ppc64'
 endian = 'big'
 
 [properties]
-c_args = ['-nostdlib', '-fno-pic', '-static']
+c_args = ['-fno-pic', '-static']
 needs_exe_wrapper = true
 skip_sanity_check = true
 link_spec = '--build-id=none'

--- a/scripts/cross-powerpc64-linux-gnu.txt
+++ b/scripts/cross-powerpc64-linux-gnu.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = 'powerpc64-linux-gnu-gcc'
+c = ['powerpc64-linux-gnu-gcc', '-fno-pic', '-static']
 ar = 'powerpc64-linux-gnu-ar'
 nm = 'powerpc64-linux-gnu-nm'
 strip = 'powerpc64-linux-gnu-strip'
@@ -11,9 +11,4 @@ cpu = 'ppc64'
 endian = 'big'
 
 [properties]
-c_args = ['-fno-pic', '-static']
-needs_exe_wrapper = true
 skip_sanity_check = true
-link_spec = '--build-id=none'
-cc1_spec = '-fno-pic'
-specs_extra = ['*libgcc:', '-lgcc']

--- a/scripts/cross-powerpc64le-linux-gnu.txt
+++ b/scripts/cross-powerpc64le-linux-gnu.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = 'powerpc64le-linux-gnu-gcc'
+c = ['powerpc64le-linux-gnu-gcc', '-fno-pic', '-static']
 ar = 'powerpc64le-linux-gnu-ar'
 as = 'powerpc64le-linux-gnu-as'
 nm = 'powerpc64le-linux-gnu-nm'
@@ -12,8 +12,4 @@ cpu = 'ppc64'
 endian = 'little'
 
 [properties]
-c_args = ['-fno-pic', '-static']
 skip_sanity_check = true
-link_spec = '--build-id=none'
-cc1_spec = '-fno-pic'
-specs_extra = ['*libgcc:', '-lgcc']

--- a/scripts/cross-powerpc64le-linux-gnu.txt
+++ b/scripts/cross-powerpc64le-linux-gnu.txt
@@ -2,10 +2,8 @@
 c = 'powerpc64le-linux-gnu-gcc'
 ar = 'powerpc64le-linux-gnu-ar'
 as = 'powerpc64le-linux-gnu-as'
-ld = 'powerpc64le-linux-gnu-ld'
 nm = 'powerpc64le-linux-gnu-nm'
 strip = 'powerpc64le-linux-gnu-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-powerpc64le "$@"', 'run-powerpc64le']
 
 [host_machine]
 system = 'linux'
@@ -14,8 +12,7 @@ cpu = 'ppc64'
 endian = 'little'
 
 [properties]
-c_args = ['-nostdlib', '-fno-pic', '-static']
-needs_exe_wrapper = true
+c_args = ['-fno-pic', '-static']
 skip_sanity_check = true
 link_spec = '--build-id=none'
 cc1_spec = '-fno-pic'

--- a/scripts/cross-riscv64-unknown-elf.txt
+++ b/scripts/cross-riscv64-unknown-elf.txt
@@ -13,7 +13,7 @@ cpu = 'riscv'
 endian = 'little'
 
 [properties]
-c_args = [ '-nostdlib', '-msave-restore', '-fno-common' ]
+c_args = [ '-msave-restore' ]
 # default multilib is 64 bit
 c_args_ = [ '-mcmodel=medany' ]
 needs_exe_wrapper = true

--- a/scripts/cross-riscv64-unknown-elf.txt
+++ b/scripts/cross-riscv64-unknown-elf.txt
@@ -4,7 +4,8 @@ ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'
 strip = 'riscv64-unknown-elf-strip'
 nm = 'riscv64-unknown-elf-nm'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-riscv "$@"', 'run-riscv']
+# only needed to run tests
+exe_wrapper = ['env', 'run-riscv']
 
 [host_machine]
 system = 'unknown'
@@ -13,8 +14,8 @@ cpu = 'riscv'
 endian = 'little'
 
 [properties]
+# this uses shorter but slower function entry code
 c_args = [ '-msave-restore' ]
 # default multilib is 64 bit
 c_args_ = [ '-mcmodel=medany' ]
-needs_exe_wrapper = true
 skip_sanity_check = true

--- a/scripts/cross-riscv64-zephyr-elf.txt
+++ b/scripts/cross-riscv64-zephyr-elf.txt
@@ -4,7 +4,8 @@ ar = 'riscv64-zephyr-elf-ar'
 as = 'riscv64-zephyr-elf-as'
 nm = 'riscv64-zephyr-elf-nm'
 strip = 'riscv64-zephyr-elf-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-riscv "$@"', 'run-riscv']
+# only needed to run tests
+exe_wrapper = ['env', 'run-riscv']
 
 [host_machine]
 system = 'zephyr'
@@ -13,5 +14,4 @@ cpu = 'riscv'
 endian = 'little'
 
 [properties]
-needs_exe_wrapper = true
 skip_sanity_check = true

--- a/scripts/cross-riscv64-zephyr-elf.txt
+++ b/scripts/cross-riscv64-zephyr-elf.txt
@@ -13,6 +13,5 @@ cpu = 'riscv'
 endian = 'little'
 
 [properties]
-c_args = [ '-nostdlib' ]
 needs_exe_wrapper = true
 skip_sanity_check = true

--- a/scripts/cross-rv32imac.txt
+++ b/scripts/cross-rv32imac.txt
@@ -4,7 +4,8 @@ ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'
 nm = 'riscv64-unknown-elf-nm'
 strip = 'riscv64-unknown-elf-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-rv32imac "$@"', 'run-rv32imac']
+# only needed to run tests
+exe_wrapper = ['env', 'run-rv32imac']
 
 [host_machine]
 system = 'unknown'
@@ -14,5 +15,4 @@ endian = 'little'
 
 [properties]
 c_args = ['-msave-restore']
-needs_exe_wrapper = true
 skip_sanity_check = true

--- a/scripts/cross-rv32imac.txt
+++ b/scripts/cross-rv32imac.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = 'riscv64-unknown-elf-gcc'
+c = ['riscv64-unknown-elf-gcc', '-march=rv32imac', '-mabi=ilp32']
 ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'
 nm = 'riscv64-unknown-elf-nm'
@@ -13,7 +13,6 @@ cpu = 'riscv32'
 endian = 'little'
 
 [properties]
-c_args = [ '-nostdlib', '-msave-restore', '-march=rv32imac', '-mabi=ilp32']
-c_link_args = [ '-nostdlib', '-msave-restore', '-march=rv32imac', '-mabi=ilp32']
+c_args = ['-msave-restore']
 needs_exe_wrapper = true
 skip_sanity_check = true

--- a/scripts/cross-x86_64-linux-gnu.txt
+++ b/scripts/cross-x86_64-linux-gnu.txt
@@ -1,9 +1,8 @@
 [binaries]
-c = ['x86_64-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2',
-        '-nostdlib', '-fno-pic', '-fno-PIE', '-static']
+c = ['x86_64-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2']
 ar = 'x86_64-linux-gnu-ar'
 as = 'x86_64-linux-gnu-as'
-ld = ['x86_64-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2', '-nostdlib', '-fno-pic', '-fno-PIE', '-static']
+ld = ['x86_64-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2']
 nm = 'x86_64-linux-gnu-nm'
 strip = 'x86_64-linux-gnu-strip'
 exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-x86_64 "$@"', 'run-x86_64']
@@ -15,6 +14,8 @@ cpu='x86_64'
 endian='little'
 
 [properties]
+c_args = ['-fno-pic', '-fno-PIE', '-static']
+ld_args = ['-fno-pic', '-fno-PIE', '-static']
 skip_sanity_check = true
 needs_exe_wrapper = true
 link_spec = '--build-id=none'

--- a/scripts/cross-x86_64-linux-gnu.txt
+++ b/scripts/cross-x86_64-linux-gnu.txt
@@ -1,11 +1,11 @@
 [binaries]
-c = ['x86_64-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2']
+c = ['x86_64-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2', '-fno-pic', '-fno-PIE', '-static']
 ar = 'x86_64-linux-gnu-ar'
 as = 'x86_64-linux-gnu-as'
-ld = ['x86_64-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2']
 nm = 'x86_64-linux-gnu-nm'
 strip = 'x86_64-linux-gnu-strip'
-exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/scripts/run-x86_64 "$@"', 'run-x86_64']
+# only needed to run tests
+exe_wrapper = ['env', 'run-x86_64']
 
 [host_machine]
 system='linux'
@@ -14,8 +14,6 @@ cpu='x86_64'
 endian='little'
 
 [properties]
-c_args = ['-fno-pic', '-fno-PIE', '-static']
-ld_args = ['-fno-pic', '-fno-PIE', '-static']
 skip_sanity_check = true
 needs_exe_wrapper = true
 link_spec = '--build-id=none'

--- a/scripts/cross-xtensa-lx106-elf.txt
+++ b/scripts/cross-xtensa-lx106-elf.txt
@@ -12,5 +12,5 @@ cpu = 'xtensa'
 endian = 'little'
 
 [properties]
-c_args = ['-nostdlib', '-mlongcalls']
+c_args = ['-mlongcalls']
 skip_sanity_check = true

--- a/scripts/do-native-configure
+++ b/scripts/do-native-configure
@@ -49,6 +49,7 @@ meson setup \
 	-Dincludedir=lib/picolibc/include \
 	-Dlibdir=lib/picolibc/lib \
 	-Dspecsdir=none \
+	-Duse-stdlib=true \
 	-Dtests=true \
 	-Dc_args="-fsanitize=bounds -fsanitize-undefined-trap-on-error -Werror" \
 	"$@" \

--- a/semihost/machine/i386/meson.build
+++ b/semihost/machine/i386/meson.build
@@ -76,7 +76,7 @@ foreach target : targets
     bios_ld = '@0@/@1@'.format(meson.current_source_dir(), 'bios.ld')
     bios = executable('bios' + target, 'bios.S',
 		      c_args: value[1],
-		      link_args: ['-nostartfiles', '-nostdlib', '-Wl,--build-id=none', '-T', bios_ld])
+		      link_args: ['-nostartfiles', '-Wl,--build-id=none', '-T', bios_ld])
 
     bios_bin = custom_target('bios' + target + '.bin',
 		             build_by_default: true,

--- a/test/libc-testsuite/meson.build
+++ b/test/libc-testsuite/meson.build
@@ -94,6 +94,6 @@ foreach target : targets
 		    include_directories: inc),
          depends: bios_bin,
 	 timeout: timeout,
-	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+	 env: test_env)
   endforeach
 endforeach

--- a/test/math-funcs.c
+++ b/test/math-funcs.c
@@ -82,15 +82,15 @@ main(void)
 
     i1 = finite (d1);
     i1 = finitef (f1);
-#if defined(HAVE_BUILTIN_FINITEL) || defined(HAVE_BUILTIN_ISFINITE)
+#if defined(_HAVE_BUILTIN_FINITEL) || defined(_HAVE_BUILTIN_ISFINITE)
     i1 = finitel (l1);
 #endif
     i1 = isinff (f1);
     i1 = isnanf (f1);
-#ifdef HAVE_BUILTIN_ISINFL
+#ifdef _HAVE_BUILTIN_ISINFL
     i1 = isinfl (l1);
 #endif
-#ifdef HAVE_BUILTIN_ISNANL
+#ifdef _HAVE_BUILTIN_ISNANL
     i1 = isnanl (l1);
 #endif
     i1 = isinf (d1);

--- a/test/meson.build
+++ b/test/meson.build
@@ -73,7 +73,7 @@ foreach target : targets
 		  link_depends:  test_link_depends,
 		  include_directories: inc),
        depends: bios_bin,
-       env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+       env: test_env)
 
   t1 = 'printff_scanff'
   if target == ''
@@ -90,7 +90,7 @@ foreach target : targets
 		  link_depends:  test_link_depends,
 		  include_directories: inc),
        depends: bios_bin,
-       env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+       env: test_env)
 
   t1 = 'printf-tests'
   if target == ''
@@ -106,7 +106,7 @@ foreach target : targets
 		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
-       env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+       env: test_env)
 
   t1 = 'printff-tests'
   if target == ''
@@ -122,7 +122,7 @@ foreach target : targets
 		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
-       env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+       env: test_env)
 
   t1 = 'printfi-tests'
   if target == ''
@@ -138,7 +138,7 @@ foreach target : targets
 		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
-       env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+       env: test_env)
 
   t1 = 'try-ilp32'
   if target == ''
@@ -154,7 +154,7 @@ foreach target : targets
 		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
-       env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+       env: test_env)
 
   t1 = 'hosted-exit'
   if target == ''
@@ -170,7 +170,7 @@ foreach target : targets
 		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
-       env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+       env: test_env)
 
   test(t1 + '-fail' + target,
        executable(t1_name + '-fail', 'hosted-exit.c',
@@ -179,7 +179,7 @@ foreach target : targets
 		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
-       env: ['MESON_SOURCE_ROOT=' + meson.source_root()],
+       env: test_env,
        should_fail: true
       )
 
@@ -197,7 +197,7 @@ foreach target : targets
 		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
-       env: ['MESON_SOURCE_ROOT=' + meson.source_root()],
+       env: test_env,
        should_fail: true
       )
 
@@ -216,7 +216,7 @@ foreach target : targets
 		    link_with: _libs_minimal,
 		    include_directories: inc),
          depends: bios_bin,
-	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+	 env: test_env)
   endif
 
   t1 = 'rounding-mode'
@@ -233,7 +233,7 @@ foreach target : targets
 		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
-       env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+       env: test_env)
 
   t1 = 'test-except'
   t1_src = t1 + '.c'
@@ -251,7 +251,7 @@ foreach target : targets
 		  link_depends:  test_link_depends,
 		  include_directories: inc),
        depends: bios_bin,
-       env: ['MESON_SOURCE_ROOT=' + meson.source_root()],
+       env: test_env,
        should_fail: true
       )
 
@@ -305,7 +305,7 @@ foreach target : targets
 		    link_depends:  test_link_depends,
 		    include_directories: inc),
          depends: bios_bin,
-	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+	 env: test_env)
   endforeach
 
 endforeach

--- a/test/semihost/meson.build
+++ b/test/semihost/meson.build
@@ -102,7 +102,7 @@ foreach target : targets
 		    include_directories: inc),
 	 args: ['--', command_line],
          depends: bios_bin,
-	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()])
+	 env: test_env)
   endforeach
 
   foreach semihost_fail_test : semihost_fail_tests
@@ -121,7 +121,7 @@ foreach target : targets
 		    link_depends:  test_link_depends,
 		    include_directories: inc),
 	 args: ['--', command_line],
-	 env: ['MESON_SOURCE_ROOT=' + meson.source_root()],
+	 env: test_env,
 	 should_fail: true)
   endforeach
   

--- a/test/tls.c
+++ b/test/tls.c
@@ -105,7 +105,7 @@ main(void)
 
 	result = check_tls("pre-defined", false);
 
-#ifdef HAVE_PICOLIBC_TLS_API
+#ifdef _HAVE_PICOLIBC_TLS_API
 
 	void *tls = malloc(_tls_size());
 


### PR DESCRIPTION
Most of this series adds a leading underscore to the HAVE defines in picolibc.h to avoid conflicting with application symbols. There's also a piece which finally publishes aarch64 inline versions of a few math functions and code to restructure how the _HAVE_FAST_FMA symbols are computed so that they are visible in the installed library along with the inlines themselves.