### PR TITLE
Update build.md, syncing with meson_options, add locking.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ use Picolibc:
  * [Operating System Support](doc/os.md).
  * [Printf and Scanf in Picolibc](doc/printf.md)
  * [Thread Local Storage](doc/tls.md)
+ * [Re-entrancy and Locking](doc/locking.md)
  * [Picolibc as embedded source](doc/embedsource.md)
  * [Releasing Picolibc](doc/releasing.md)
  * [Copyright and license information](COPYING.picolibc)

--- a/doc/build.md
+++ b/doc/build.md
@@ -41,6 +41,7 @@ These options control some general build configuration values.
 | picolib                     | true    | Include picolib bits for tls and sbrk support                                        |
 | picocrt                     | true    | Build crt0.o (C startup function)                                                    |
 | semihost                    | true    | Build the semihost library (libsemihost.a)                                           |
+| fake-semihost               | false   | Create a fake semihost library to allow tests to link                                |
 | specsdir                    | auto    | Where to install the .specs file (default is in the GCC directory)                   |
 | sysroot-install             | false   | Install in GCC sysroot location (requires sysroot in GCC)                            |
 | tests                       | false   | Enable tests                                                                         |
@@ -56,7 +57,9 @@ types and formats.
 | Option                      | Default | Description                                                                          |
 | ------                      | ------- | -----------                                                                          |
 | io-c99-formats              | true    | Enable C99 support in IO functions like printf/scanf                                 |
-| io-long-long                | false   | Enable long long type support in IO functions like printf/scanf.		       |
+| io-long-long                | false   | Enable long long type support in IO functions like printf/scanf. For tiny-stdio, this only affects the integer-only versions, the full version always includes long long support. |
+| io-pos-args                 | false   | Enable printf-family positional arg support. For tiny-stdio, this only affects the integer-only versions, the full version always includes positional argument support. |
+
 
 `long long` support is always enabled for the tinystdio full
 printf/scanf modes, the `io-long-long` option adds them to the limited
@@ -80,9 +83,9 @@ definitions which use the same POSIX I/O functions.
 | ------                      | ------- | -----------                                                                          |
 | atomic-ungetc               | true    | Make getc/ungetc re-entrant using atomic operations                                  |
 | io-float-exact              | true    | Provide round-trip support in float/string conversions                               |
-| io-long-long                | false   | Include long-long support in integer-only printf function                            |
 | posix-io                    | true    | Provide fopen/fdopen using POSIX I/O (requires open, close, read, write, lseek)      |
 | posix-console               | false   | Use POSIX I/O for stdin/stdout/stderr                                                |
+| format-default              | double  | Sets the default printf/scanf style ('double', 'float' or 'integer')                 |
 
 ### Options when using legacy stdio bits
 
@@ -101,7 +104,6 @@ configuration
 | newlib-global-stdio-streams | false   | Enable global stdio streams                                                          |
 | newlib-have-fcntl           | false   | System has fcntl function available                                                  |
 | newlib-io-float             | false   | Enable printf/scanf family float support                                             |
-| newlib-io-pos-args          | false   | Enable printf-family positional arg support                                          |
 | newlib-io-long-double       | false   | Enable long double type support in IO functions printf/scanf                         |
 | newlib-nano-formatted-io    | false   | Use nano version formatted IO                                                        |
 | newlib-reent-small          | false   | Enable small reentrant struct support                                                |
@@ -119,6 +121,8 @@ These options control which character sets are supported by iconv.
 | newlib-iconv-from-encodings | <empty> | Comma-separated list of "from" iconv encodings to be built-in (default iconv-encodings) |
 | newlib-iconv-to-encodings   | <empty> | Comma-separated list of "to" iconv encodings to be built-in (default iconv-encodings) |
 | newlib-iconv-external-ccs   | false   | Use file system to store iconv tables. Requires fopen. (default built-in to memory)  |
+| newlib-iconv-dir            | libdir/locale | Directory to install external CCS files. Only used with newlib-iconv-external-ccs=true |
+| newlib-iconv-runtime-dir    | newlib-iconv-dir | Directory to read external CCS files from at runtime. |
 
 Thes options control how much Locale support is included in the
 library. By default, picolibc only supports the 'C' locale.
@@ -142,6 +146,11 @@ at startup and shutdown times.
 | newlib-initfini             | true    | Support _init() and _fini() functions in picocrt                                     |
 | newlib-initfini-array       | true    | Use .init_array and .fini_array sections in picocrt                                  |
 | newlib-register-fini        | false   | Enable finalization function registration using atexit                               |
+| crt-runtime-size            | false   | Compute .data/.bss sizes at runtime rather than linktime                             |
+
+The crt-runtime-size option exists for targets where the link can't
+handle a symbol that is the difference between two other symbols,
+e.g. m68k.
 
 ### Thread local storage support
 
@@ -157,6 +166,7 @@ As a separate option, you can make `errno` not use TLS if necessary.
 | thread-local-storage        | auto    | Use TLS for global variables. Default is automatic based on compiler support         |
 | tls-model                   | local-exec | Select TLS model (global-dynamic, local-dynamic, initial-exec or local-exec)      |
 | newlib-global-errno         | false   | Use single global errno even when thread-local-storage=true                          |
+| errno-function              | <empty> | If set, names a function which returns the address of errno. 'auto' will try to auto-detect. |
 
 ### Malloc option
 
@@ -177,13 +187,13 @@ protecting when accessed by multiple threads. The largest set of these
 are the legacy stdio code, but there are other functions that can use
 locking, e.g. when newlib-global-atexit is enabled, calls to atexit
 need to lock the shared global data structure if they may be called
-from multiple threads at the same time. By default, all of this is
-disabled as it would require underlying system support.
+from multiple threads at the same time. By default, these are enabled
+and use the retargetable API defined in [locking.md](locking.md).
 
 | Option                      | Default | Description                                                                          |
 | ------                      | ------- | -----------                                                                          |
-| newlib-retargetable-locking | false   | Allow locking routines to be retargeted at link time                                 |
-| newlib-multithread          | false   | Enable support for multiple threads                                                  |
+| newlib-retargetable-locking | true    | Allow locking routines to be retargeted at link time                                 |
+| newlib-multithread          | true    | Enable support for multiple threads                                                  |
 
 
 ### Legacy newlib options
@@ -202,22 +212,28 @@ newlib environments.
 ### Math library options
 
 There are two versions of many libm functions, old ones from SunPro
-and new ones from ARM. The new ones are usually better for current
-hardware, except that the float-valued functions use double-precision
-computations. On systems with HW double support, that's likely a good
-choice. On sytems without HW double support, that's going to pull in SW
-double code.
+and new ones from ARM. The new ones are generally faster for targets
+with hardware double support, except that the new float-valued
+functions use double-precision computations. On sytems without
+hardware double support, that's going to pull in soft double
+code. Measurements show the old routines are generally more accurate,
+which is why they are enabled by default.
 
 POSIX requires many of the math functions to set errno when exceptions
 occur; disabling that makes them only support fenv() exception
-reporting.
+reporting, which is what IEEE floating point and ANSI C standards
+require.
 
 | Option                      | Default | Description                                             |
 | ------                      | ------- | -----------                                             |
-| newlib-obsolete-math        | auto    | Use old code for both float and double valued functions |
+| newlib-obsolete-math        | true    | Use old code for both float and double valued functions |
 | newlib-obsolete-math-float  | auto    | Use old code for float-valued functions                 |
 | newlib-obsolete-math-double | auto    | Use old code for double-valued functions                |
 | want-math-errno             | false   | Set errno when exceptions occur                         |
+
+newlib-obsolete-math provides the default value for the
+newlib-obsolete-math-float and newlib-obsolete-math-double parameters;
+those control the compilation of the individual fucntions.
 
 ## Building for embedded RISC-V and ARM systems
 

--- a/doc/locking.md
+++ b/doc/locking.md
@@ -1,0 +1,112 @@
+# Locking in Picolibc
+
+By default, picolibc is built with threading support, including
+various locks, enabled. However, picolibc has no scheduling support to
+control thread execution. That means it can't provide real
+implementations of the underlying locking primitives. Instead, it
+provides dummy functions sufficient for picolibc to work in a single
+threaded environment.
+
+If you are using picolibc in a re-entrant environment, like an RTOS
+with threading support, you will need to provide an implementation of
+this API on top of the scheduling primitives provided by the
+environment.
+
+## Where Picolibc uses locking
+
+Picolibc has a single global lock for APIs that share global
+data. That includes:
+
+ * malloc family
+ * onexit/atexit
+ * arc4random
+ * functions using timezones (localtime, et al)
+ * legacy stdio struct reent globals
+
+Tinystdio (the default stdio) uses per-file locks for the buffered
+POSIX file backend, but it doesn't require any locks for the bulk of
+the implementation. It uses atomic exchanges to handle the one
+reentrancy issue related to ungetc/getc.
+
+The legacy stdio implementation is full of locking, and has per-file
+locks for every operation.
+
+## Configuration options controlling locking
+
+There are two configuration options related to locking:
+
+ * newlib-retargetable-locking. When 'true', locking operations are
+   enabled and performed by the retargetable locking API described below.
+
+ * newlib-multithread. When 'true', the library is built with
+   multithreading support enabled and uses the locking operations.
+
+Picolibc inherits these options from newlib, and they're so
+interrelated as to make them effectively co-dependent, so users must
+set them to the same value.
+
+## Retargetable locking API
+
+When newlib-multithread and newlib-retargetable-locking are enabled
+enabled, Picolibc uses the following interface. Picolibc provides
+stubs for all of these functions that do not perform locking, so a
+single threaded application can still use a library compiled to enable
+locking. An application needing locking would provide a real
+implementation of the API.
+
+This API requires recursive mutexes; if the underlying implementation
+only provides non-recursive mutexes, a suitable wrapper implementing
+recursive mutexes will be required for the recursive APIs. All APIs
+involving recursive mutexes contain `recursive` in their names.
+
+In this section, *the locking implementation* refers to the external
+implementation of this API.
+
+### `struct __lock; typedef struct __lock *_LOCK_T;`
+
+This struct is only referenced by picolibc, not defined. The
+locking implementation may define it as necessary.
+
+### `extern struct __lock __libc_recursive_mutex;`
+
+This is the single global lock used for most libc locking. It must be
+defined in the locking implementation in such a way as to not require
+any runtime initialization.
+
+### `void __retarget_lock_init(_LOCK_T *lock)`
+
+This is used by tinystdio to initialize the lock in a newly allocated
+FILE.
+
+### `void __retarget_lock_acquire(_LOCK_T lock)`
+
+Acquire a non-recursive mutex. A thread will only acquire the mutex once.
+
+### `void __retarget_lock_release(_LOCK_T lock)`
+
+Release a non-recursive mutex.
+
+### `void __retarget_lock_close(_LOCK_T lock)`
+
+This is used by tinystdio to de-initialize a lock from a FILE which is
+being closed.
+
+### `void __retarget_lock_init_recursive(_LOCK_T *lock)`
+
+This is used by the legacy stdio code to initialize the lock in a
+newly allocated FILE.
+
+### `void __retarget_lock_acquire_recursive(_LOCK_T lock)`
+
+Acquire a recursive mutex. A thread may acquire a recursive
+mutex multiple times.
+
+### `void __retarget_lock_release_recursive(_LOCK_T lock)`
+
+Acquire a recursive mutex. A thread thread must release the mutex as
+many times as it has acquired it before the mutex is unlocked.
+
+### `void __retarget_lock_close_recursive(_LOCK_T lock)`
+
+This is used by the legacy stdio code to de-initialize a lock from a
+FILE which is being closed.

--- a/doc/locking.md
+++ b/doc/locking.md
@@ -1,16 +1,11 @@
 # Locking in Picolibc
 
-By default, picolibc is built with threading support, including
-various locks, enabled. However, picolibc has no scheduling support to
-control thread execution. That means it can't provide real
-implementations of the underlying locking primitives. Instead, it
-provides dummy functions sufficient for picolibc to work in a single
-threaded environment.
-
-If you are using picolibc in a re-entrant environment, like an RTOS
-with threading support, you will need to provide an implementation of
-this API on top of the scheduling primitives provided by the
-environment.
+When newlib-multithread and newlib-retargetable-locking are enabled,
+Picolibc uses the following locking API. Picolibc provides stubs for
+all of these functions that do not actually perform any locking, so
+that a single-threaded application can still use a Picolibc compiled
+with locking enabled. An application needing locking must provide a
+real implementation of the locking API.
 
 ## Where Picolibc uses locking
 

--- a/meson.build
+++ b/meson.build
@@ -693,6 +693,10 @@ NEWLIB_MAJOR_VERSION=4
 NEWLIB_MINOR_VERSION=1
 NEWLIB_PATCHLEVEL_VERSION=0
 
+if get_option('newlib-retargetable-locking') != get_option('newlib-multithread')
+  error('newlib-retargetable-locking and newlib-multithread must be set to the same value')
+endif
+
 conf_data.set('_HAVE_CC_INHIBIT_LOOP_TO_LIBCALL',
 	      cc.has_argument('-fno-tree-loop-distribute-patterns'),
 	      description: 'Compiler flag to prevent detecting memcpy/memset patterns')


### PR DESCRIPTION
build.md had lagged behind changes to meson_options.txt and the section on locking needed expanding to define the API used by the library.

Closes #266 