### PR TITLE
scripts: Support meson 0.53.2 by adjust exe_wrappers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -969,7 +969,18 @@ if tests_enable_stack_protector
   endif
 endif
 
-test_env = environment()
+# Meson version 0.53.2 doesn't check for the skip_sanity_check value
+# before attempting to run test fragments during configuration. That
+# means the exe_wrapper value needs to handle being run at that
+# point. To support this, the exe_wrapper becomes a script which
+# checks for a environment variable (PICOLIBC_TEST) and exits
+# indicating success if that is not present.
+#
+# This was fixed in meson version 0.54.2, so this can be removed from
+# here and the sample cross scripts once picolibc requires a version
+# of meson newer than that.
+
+test_env = environment({'PICOLIBC_TEST' : '1'})
 test_env.prepend('PATH', meson.source_root() / 'scripts')
 
 # CompCert needs the '-WUl,' prefix to correctly pass the --spec parameters to the linker

--- a/scripts/cross-aarch64-linux-gnu.txt
+++ b/scripts/cross-aarch64-linux-gnu.txt
@@ -6,7 +6,7 @@ ld = 'aarch64-linux-gnu-ld'
 nm = 'aarch64-linux-gnu-nm'
 strip = 'aarch64-linux-gnu-strip'
 # only needed to run tests
-exe_wrapper = ['env', 'run-aarch64']
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-aarch64 "$@"', 'run-aarch64']
 
 [host_machine]
 system = 'linux'

--- a/scripts/cross-aarch64-linux-gnu.txt
+++ b/scripts/cross-aarch64-linux-gnu.txt
@@ -1,5 +1,9 @@
 [binaries]
-c = 'aarch64-linux-gnu-gcc'
+# Meson 0.53.2 doesn't use any cflags when doing basic compiler tests,
+# so we have to add -nostdlib to the compiler configuration itself or
+# early compiler tests will fail. This can be removed when picolibc
+# requires at least version 0.54.2 of meson.
+c = ['aarch64-linux-gnu-gcc', '-nostdlib']
 ar = 'aarch64-linux-gnu-ar'
 as = 'aarch64-linux-gnu-as'
 ld = 'aarch64-linux-gnu-ld'

--- a/scripts/cross-aarch64-zephyr-elf.txt
+++ b/scripts/cross-aarch64-zephyr-elf.txt
@@ -5,7 +5,7 @@ as = 'aarch64-zephyr-elf-as'
 nm = 'aarch64-zephyr-elf-nm'
 strip = 'aarch64-zephyr-elf-strip'
 # only needed to run tests
-exe_wrapper = ['env', 'run-aarch64']
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-aarch64 "$@"', 'run-aarch64']
 
 [host_machine]
 system = 'none'

--- a/scripts/cross-aarch64-zephyr-elf.txt
+++ b/scripts/cross-aarch64-zephyr-elf.txt
@@ -1,5 +1,9 @@
 [binaries]
-c = 'aarch64-zephyr-elf-gcc'
+# Meson 0.53.2 doesn't use any cflags when doing basic compiler tests,
+# so we have to add -nostdlib to the compiler configuration itself or
+# early compiler tests will fail. This can be removed when picolibc
+# requires at least version 0.54.2 of meson.
+c = ['aarch64-zephyr-elf-gcc', '-nostdlib']
 ar = 'aarch64-zephyr-elf-ar'
 as = 'aarch64-zephyr-elf-as'
 nm = 'aarch64-zephyr-elf-nm'

--- a/scripts/cross-arm-none-eabi.txt
+++ b/scripts/cross-arm-none-eabi.txt
@@ -5,7 +5,7 @@ as = 'arm-none-eabi-as'
 nm = 'arm-none-eabi-nm'
 strip = 'arm-none-eabi-strip'
 # only needed to run tests
-exe_wrapper = ['env', 'run-arm']
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-arm "$@"', 'run-arm']
 
 [host_machine]
 system = 'none'

--- a/scripts/cross-arm-none-eabi.txt
+++ b/scripts/cross-arm-none-eabi.txt
@@ -1,5 +1,9 @@
 [binaries]
-c = 'arm-none-eabi-gcc'
+# Meson 0.53.2 doesn't use any cflags when doing basic compiler tests,
+# so we have to add -nostdlib to the compiler configuration itself or
+# early compiler tests will fail. This can be removed when picolibc
+# requires at least version 0.54.2 of meson.
+c = ['arm-none-eabi-gcc', '-nostdlib']
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eabi-as'
 nm = 'arm-none-eabi-nm'

--- a/scripts/cross-arm-zephyr-eabi.txt
+++ b/scripts/cross-arm-zephyr-eabi.txt
@@ -5,7 +5,7 @@ as = 'arm-zephyr-eabi-as'
 nm = 'arm-zephyr-eabi-nm'
 strip = 'arm-zephyr-eabi-strip'
 # only needed to run tests
-exe_wrapper = ['env', 'run-arm']
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-arm "$@"', 'run-arm']
 
 [host_machine]
 system = 'zephyr'

--- a/scripts/cross-arm-zephyr-eabi.txt
+++ b/scripts/cross-arm-zephyr-eabi.txt
@@ -1,5 +1,9 @@
 [binaries]
-c = 'arm-zephyr-eabi-gcc'
+# Meson 0.53.2 doesn't use any cflags when doing basic compiler tests,
+# so we have to add -nostdlib to the compiler configuration itself or
+# early compiler tests will fail. This can be removed when picolibc
+# requires at least version 0.54.2 of meson.
+c = ['arm-zephyr-eabi-gcc', '-nostdlib']
 ar = 'arm-zephyr-eabi-ar'
 as = 'arm-zephyr-eabi-as'
 nm = 'arm-zephyr-eabi-nm'

--- a/scripts/cross-clang-riscv64-unknown-elf.txt
+++ b/scripts/cross-clang-riscv64-unknown-elf.txt
@@ -1,5 +1,9 @@
 [binaries]
-c = ['clang', '-target', 'riscv64-unknown-elf', '-mcmodel=medany']
+# Meson 0.53.2 doesn't use any cflags when doing basic compiler tests,
+# so we have to add -nostdlib to the compiler configuration itself or
+# early compiler tests will fail. This can be removed when picolibc
+# requires at least version 0.54.2 of meson.
+c = ['clang', '-target', 'riscv64-unknown-elf', '-mcmodel=medany', '-nostdlib']
 c_ld = '/usr/bin/riscv64-unknown-elf-ld'
 ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'

--- a/scripts/cross-clang-riscv64-unknown-elf.txt
+++ b/scripts/cross-clang-riscv64-unknown-elf.txt
@@ -6,7 +6,7 @@ as = 'riscv64-unknown-elf-as'
 nm = 'riscv64-unknown-elf-nm'
 strip = 'riscv64-unknown-elf-strip'
 # only needed to run tests
-exe_wrapper = ['env', 'run-riscv']
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-riscv "$@"', 'run-riscv']
 
 [host_machine]
 system = 'none'

--- a/scripts/cross-clang-rv32imafdc-unknown-elf.txt
+++ b/scripts/cross-clang-rv32imafdc-unknown-elf.txt
@@ -1,5 +1,9 @@
 [binaries]
-c = ['clang', '-m32', '-target', 'riscv32-unknown-elf', '-march=rv32imafdc']
+# Meson 0.53.2 doesn't use any cflags when doing basic compiler tests,
+# so we have to add -nostdlib to the compiler configuration itself or
+# early compiler tests will fail. This can be removed when picolibc
+# requires at least version 0.54.2 of meson.
+c = ['clang', '-m32', '-target', 'riscv32-unknown-elf', '-march=rv32imafdc', '-nostdlib']
 c_ld = '/usr/bin/riscv64-unknown-elf-ld'
 ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'

--- a/scripts/cross-clang-rv32imafdc-unknown-elf.txt
+++ b/scripts/cross-clang-rv32imafdc-unknown-elf.txt
@@ -6,7 +6,7 @@ as = 'riscv64-unknown-elf-as'
 nm = 'riscv64-unknown-elf-nm'
 strip = 'riscv64-unknown-elf-strip'
 # only needed to run tests
-exe_wrapper = ['env', 'run-rv32imafdc']
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-rv32imafdc "$@"', 'run-rv32imafdc']
 
 [host_machine]
 system = 'none'

--- a/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
@@ -1,5 +1,9 @@
 [binaries]
-c = ['clang', '-m32', '-target', 'thumbv7e-none-eabi', '-mcpu=cortex-m7', '-mfloat-abi=hard']
+# Meson 0.53.2 doesn't use any cflags when doing basic compiler tests,
+# so we have to add -nostdlib to the compiler configuration itself or
+# early compiler tests will fail. This can be removed when picolibc
+# requires at least version 0.54.2 of meson.
+c = ['clang', '-m32', '-target', 'thumbv7e-none-eabi', '-mcpu=cortex-m7', '-mfloat-abi=hard', '-nostdlib']
 c_ld = '/usr/bin/arm-none-eabi-ld'
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eab-as'

--- a/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
@@ -6,7 +6,7 @@ as = 'arm-none-eab-as'
 nm = 'arm-none-eab-nm'
 strip = 'arm-none-eabi-strip'
 # only needed to run tests
-exe_wrapper = ['env', 'run-thumbv7e']
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-thumbv7e "$@"', 'run-thumbv7e']
 
 [host_machine]
 system = 'none'

--- a/scripts/cross-clang-thumbv7m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7m-none-eabi.txt
@@ -1,5 +1,9 @@
 [binaries]
-c = ['clang', '-m32', '-target', 'thumbv7m-none-eabi', '-mfloat-abi=soft']
+# Meson 0.53.2 doesn't use any cflags when doing basic compiler tests,
+# so we have to add -nostdlib to the compiler configuration itself or
+# early compiler tests will fail. This can be removed when picolibc
+# requires at least version 0.54.2 of meson.
+c = ['clang', '-m32', '-target', 'thumbv7m-none-eabi', '-mfloat-abi=soft', '-nostdlib']
 c_ld = '/usr/bin/arm-none-eabi-ld'
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eab-as'

--- a/scripts/cross-clang-thumbv7m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7m-none-eabi.txt
@@ -6,7 +6,7 @@ as = 'arm-none-eab-as'
 nm = 'arm-none-eab-nm'
 strip = 'arm-none-eabi-strip'
 # only needed to run tests
-exe_wrapper = ['env', 'run-thumbv7m']
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-thumbv7m "$@"', 'run-thumbv7m']
 
 [host_machine]
 system = 'none'

--- a/scripts/cross-cortex-a9-none-eabi.txt
+++ b/scripts/cross-cortex-a9-none-eabi.txt
@@ -1,5 +1,9 @@
 [binaries]
-c = ['arm-none-eabi-gcc', '-mcpu=cortex-a9']
+# Meson 0.53.2 doesn't use any cflags when doing basic compiler tests,
+# so we have to add -nostdlib to the compiler configuration itself or
+# early compiler tests will fail. This can be removed when picolibc
+# requires at least version 0.54.2 of meson.
+c = ['arm-none-eabi-gcc', '-mcpu=cortex-a9', '-nostdlib']
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eabi-as'
 nm = 'arm-none-eabi-nm'

--- a/scripts/cross-cortex-a9-none-eabi.txt
+++ b/scripts/cross-cortex-a9-none-eabi.txt
@@ -5,7 +5,7 @@ as = 'arm-none-eabi-as'
 nm = 'arm-none-eabi-nm'
 strip = 'arm-none-eabi-strip'
 # only needed to run tests
-exe_wrapper = ['env', 'run-cortex-a9']
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-cortex-a9 "$@"', 'run-cortex-a9']
 
 [host_machine]
 system = 'none'

--- a/scripts/cross-i686-linux-gnu.txt
+++ b/scripts/cross-i686-linux-gnu.txt
@@ -1,5 +1,9 @@
 [binaries]
-c = ['i686-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2', '-fno-pic', '-fno-PIE', '-static']
+# Meson 0.53.2 doesn't use any cflags when doing basic compiler tests,
+# so we have to add -nostdlib to the compiler configuration itself or
+# early compiler tests will fail. This can be removed when picolibc
+# requires at least version 0.54.2 of meson.
+c = ['i686-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
 ar = 'i686-linux-gnu-ar'
 as = 'i686-linux-gnu-as'
 nm = 'i686-linux-gnu-nm'

--- a/scripts/cross-i686-linux-gnu.txt
+++ b/scripts/cross-i686-linux-gnu.txt
@@ -5,7 +5,7 @@ as = 'i686-linux-gnu-as'
 nm = 'i686-linux-gnu-nm'
 strip = 'i686-linux-gnu-strip'
 # only needed to run tests
-exe_wrapper = ['env', 'run-i386']
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-i386 "$@"', 'run-i386']
 
 [host_machine]
 system='linux'

--- a/scripts/cross-riscv64-unknown-elf.txt
+++ b/scripts/cross-riscv64-unknown-elf.txt
@@ -5,7 +5,7 @@ as = 'riscv64-unknown-elf-as'
 strip = 'riscv64-unknown-elf-strip'
 nm = 'riscv64-unknown-elf-nm'
 # only needed to run tests
-exe_wrapper = ['env', 'run-riscv']
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-riscv "$@"', 'run-riscv']
 
 [host_machine]
 system = 'unknown'

--- a/scripts/cross-riscv64-unknown-elf.txt
+++ b/scripts/cross-riscv64-unknown-elf.txt
@@ -1,5 +1,9 @@
 [binaries]
-c = 'riscv64-unknown-elf-gcc'
+# Meson 0.53.2 doesn't use any cflags when doing basic compiler tests,
+# so we have to add -nostdlib to the compiler configuration itself or
+# early compiler tests will fail. This can be removed when picolibc
+# requires at least version 0.54.2 of meson.
+c = ['riscv64-unknown-elf-gcc', '-nostdlib']
 ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'
 strip = 'riscv64-unknown-elf-strip'

--- a/scripts/cross-riscv64-zephyr-elf.txt
+++ b/scripts/cross-riscv64-zephyr-elf.txt
@@ -1,5 +1,9 @@
 [binaries]
-c = 'riscv64-zephyr-elf-gcc'
+# Meson 0.53.2 doesn't use any cflags when doing basic compiler tests,
+# so we have to add -nostdlib to the compiler configuration itself or
+# early compiler tests will fail. This can be removed when picolibc
+# requires at least version 0.54.2 of meson.
+c = ['riscv64-zephyr-elf-gcc', '-nostdlib']
 ar = 'riscv64-zephyr-elf-ar'
 as = 'riscv64-zephyr-elf-as'
 nm = 'riscv64-zephyr-elf-nm'

--- a/scripts/cross-riscv64-zephyr-elf.txt
+++ b/scripts/cross-riscv64-zephyr-elf.txt
@@ -5,7 +5,7 @@ as = 'riscv64-zephyr-elf-as'
 nm = 'riscv64-zephyr-elf-nm'
 strip = 'riscv64-zephyr-elf-strip'
 # only needed to run tests
-exe_wrapper = ['env', 'run-riscv']
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-riscv "$@"', 'run-riscv']
 
 [host_machine]
 system = 'zephyr'

--- a/scripts/cross-rv32imac.txt
+++ b/scripts/cross-rv32imac.txt
@@ -5,7 +5,7 @@ as = 'riscv64-unknown-elf-as'
 nm = 'riscv64-unknown-elf-nm'
 strip = 'riscv64-unknown-elf-strip'
 # only needed to run tests
-exe_wrapper = ['env', 'run-rv32imac']
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-rv32imac "$@"', 'run-rv32imac']
 
 [host_machine]
 system = 'unknown'

--- a/scripts/cross-x86_64-linux-gnu.txt
+++ b/scripts/cross-x86_64-linux-gnu.txt
@@ -1,5 +1,9 @@
 [binaries]
-c = ['x86_64-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2', '-fno-pic', '-fno-PIE', '-static']
+# Meson 0.53.2 doesn't use any cflags when doing basic compiler tests,
+# so we have to add -nostdlib to the compiler configuration itself or
+# early compiler tests will fail. This can be removed when picolibc
+# requires at least version 0.54.2 of meson.
+c = ['x86_64-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
 ar = 'x86_64-linux-gnu-ar'
 as = 'x86_64-linux-gnu-as'
 nm = 'x86_64-linux-gnu-nm'

--- a/scripts/cross-x86_64-linux-gnu.txt
+++ b/scripts/cross-x86_64-linux-gnu.txt
@@ -5,7 +5,7 @@ as = 'x86_64-linux-gnu-as'
 nm = 'x86_64-linux-gnu-nm'
 strip = 'x86_64-linux-gnu-strip'
 # only needed to run tests
-exe_wrapper = ['env', 'run-x86_64']
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-x86_64 "$@"', 'run-x86_64']
 
 [host_machine]
 system='linux'


### PR DESCRIPTION
Meson version 0.53.2 (at least) doesn't check for the
skip_sanity_check value before attempting to run test fragments during
configuration. That means the exe_wrapper value needs to handle being
run at that point. To support this, the exe_wrapper becomes a script
which checks for a environment variable (PICOLIBC_TEST) and exits
indicating success if that is not present.

Closes #270 

Signed-off-by: Keith Packard <keithp@keithp.com>