### PR TITLE
tinystdio: support 16-bit int type

### DIFF
--- a/newlib/libc/tinystdio/atof_ryu.c
+++ b/newlib/libc/tinystdio/atof_ryu.c
@@ -126,7 +126,7 @@ __atof_engine(uint32_t m10, int e10)
 
 	if (ieee_e2 > 0xfe) {
 		// Final IEEE exponent is larger than the maximum representable; return Infinity.
-		uint32_t ieee = (0xffu << FLOAT_MANTISSA_BITS);
+		uint32_t ieee = ((uint32_t)0xffu << FLOAT_MANTISSA_BITS);
 		return int32Bits2Float(ieee);
 	}
 
@@ -155,7 +155,7 @@ __atof_engine(uint32_t m10, int e10)
 #endif
 	uint32_t ieee_m2 = (m2 >> shift) + roundUp;
         assert(ieee_m2 <= (1u << (FLOAT_MANTISSA_BITS + 1)));
-        ieee_m2 &= (1u << FLOAT_MANTISSA_BITS) - 1;
+        ieee_m2 &= ((uint32_t)1u << FLOAT_MANTISSA_BITS) - 1;
         if (ieee_m2 == 0 && roundUp) {
             // Rounding up may overflow the mantissa.
             // In this case we move a trailing zero of the mantissa into the exponent.

--- a/newlib/libc/tinystdio/ftoa_engine.c
+++ b/newlib/libc/tinystdio/ftoa_engine.c
@@ -105,7 +105,7 @@ int __ftoa_engine(float val, struct ftoa *ftoa, int maxDigits, bool fmode, int m
 
     /* Read the sign, shift the exponent in place and delete it from frac.
      */
-    if (x.u & (1 << 31))
+    if (x.u & ((uint32_t)1 << 31))
         flags = FTOA_MINUS;
 
     uint8_t exp = x.u >> 23;

--- a/newlib/libc/tinystdio/ftoa_ryu.c
+++ b/newlib/libc/tinystdio/ftoa_ryu.c
@@ -69,7 +69,7 @@ f2d(const uint32_t ieeeMantissa, const uint32_t ieeeExponent, int max_digits, bo
 		m2 = ieeeMantissa;
 	} else {
 		e2 = (int32_t) ieeeExponent - FLOAT_BIAS - FLOAT_MANTISSA_BITS - 2;
-		m2 = (1u << FLOAT_MANTISSA_BITS) | ieeeMantissa;
+		m2 = ((uint32_t)1u << FLOAT_MANTISSA_BITS) | ieeeMantissa;
 	}
 	const bool even = (m2 & 1) == 0;
 	const bool acceptBounds = even;


### PR DESCRIPTION
This fixes a few issues in tinystdio where the code assumed the int type (which is the default for integer literals) is at least 32 bits.
It might not fix all issues, only the ones I hit when trying to get picolibc to work on AVR.