### PR TITLE
tinystdio: Ignore thousands separator flag

### DIFF
--- a/newlib/libc/tinystdio/vfprintf.c
+++ b/newlib/libc/tinystdio/vfprintf.c
@@ -228,6 +228,8 @@ skip_to_arg(const char *fmt_orig, my_va_list *ap, int target_argno)
 		    continue;
 		  case '#':
 		    continue;
+                  case '\'':
+                    continue;
 		}
 	    }
 
@@ -421,6 +423,12 @@ int vfprintf (FILE * stream, const char *fmt, va_list ap_orig)
 		  case '#':
 		    flags |= FL_ALT;
 		    continue;
+                  case '\'':
+                    /*
+                     * C/POSIX locale has an empty thousands_sep
+                     * value, so we can just ignore this character
+                     */
+                    continue;
 		}
 	    }
 

--- a/test/testcases.c
+++ b/test/testcases.c
@@ -158,6 +158,8 @@
     result |= test(__LINE__, " ", "%c", 32);
     result |= test(__LINE__, "$", "%c", 36);
     result |= test(__LINE__, "10", "%d", 10);
+
+    result |= test(__LINE__, "1000000", "%'d", 1000000);
     /* 72: anti-test */
     /* 73: anti-test */
     /* 74: excluded for C */


### PR DESCRIPTION
POSIX defines a thousands separator flag for printf, ', which causes
the current locale thousands separator to be placed between groups of
digits to make them easier to read. As tinystdio doesn't have any
locale support, and as the C/POSIX locale has an empty thousands
separator, we can "support" this feature by simply ignoring this flag.

Enabling this feature in a useful fashion will require either some
level of locale support or creating a custom API to control it.

Closes #273 

Signed-off-by: Keith Packard <keithp@keithp.com>