### PR TITLE
m68k: Don't use unaligned access on m68010 memcpy

### DIFF
--- a/newlib/libc/machine/m68k/memcpy.S
+++ b/newlib/libc/machine/m68k/memcpy.S
@@ -15,7 +15,7 @@
 
 #include "m68kasm.h"
 
-#if defined (__mcoldfire__) || defined (__mc68010__) || defined (__mc68020__) || defined (__mc68030__) || defined (__mc68040__) || defined (__mc68060__)
+#if defined (__mcoldfire__) || defined (__mc68020__) || defined (__mc68030__) || defined (__mc68040__) || defined (__mc68060__)
 # define MISALIGNED_OK 1
 #else
 # define MISALIGNED_OK 0


### PR DESCRIPTION
It's a stretch to call misaligned writes "OK" on 68010. It supports
them in _software_, if and only if the operating system provides an
address error handler that knows how to emulate the
access. Newlib/picolibc does not provide this, and even if it did,
vectoring to a software emulation routine for every single
word/longword access is WAY slower than just copying byte for
byte. The 68010 should probably be removed from this.

Closes #286 

Reported by: Alexis Lockwood
Signed-off-by: Keith Packard <keithp@keithp.com>