### PR TITLE
AVR support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -36,7 +36,7 @@ project('picolibc', 'c',
 	default_options: [
 	  'buildtype=minsize',
 	  'debug=true',
-	  'c_std=c18',
+	  'c_std=c11',
 	  'b_staticpic=false',
           'warning_level=2',
 	],

--- a/newlib/libc/machine/avr/meson.build
+++ b/newlib/libc/machine/avr/meson.build
@@ -1,0 +1,46 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2022 Ayke van Laethem
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+srcs_machine = [
+]
+
+foreach target : targets
+	value = get_variable('target_' + target)
+	set_variable('lib_machine' + target,
+		static_library('machine' + target,
+			srcs_machine,
+			pic: false,
+			include_directories: inc,
+			c_args: value[1] + arg_fnobuiltin))
+endforeach

--- a/newlib/libm/common/sf_getpayload.c
+++ b/newlib/libm/common/sf_getpayload.c
@@ -49,7 +49,7 @@ float getpayloadf(const float *x)
 
 #ifdef _DOUBLE_IS_32BITS
 
-double getpayload(double *x)
+double getpayload(const double *x)
 {
     return (float) getpayloadf((float *) x);
 }

--- a/newlib/libm/math/s_lgamma.c
+++ b/newlib/libm/math/s_lgamma.c
@@ -35,8 +35,12 @@
 
 #include "fdlibm.h"
 
+#ifndef _DOUBLE_IS_32BITS
+
 double
 lgamma(double x)
 {
     return lgamma_r(x, &__signgam);
 }
+
+#endif /* defined(_DOUBLE_IS_32BITS) */

--- a/newlib/libm/test/test.h
+++ b/newlib/libm/test/test.h
@@ -30,6 +30,7 @@
    If that is not the case, please insert documentation here describing why
    they're needed.  */
 
+#ifndef _DOUBLE_IS_32BITS
 #ifdef __IEEE_BIG_ENDIAN
 
 typedef union 
@@ -108,6 +109,7 @@ typedef union
 } __ieee_double_shape_type;
 
 #endif /* __IEEE_LITTLE_ENDIAN */
+#endif /* defined(_DOUBLE_IS_32BITS) */
 
 #ifdef __IEEE_BIG_ENDIAN
 

--- a/newlib/testsuite/newlib.string/tstring.c
+++ b/newlib/testsuite/newlib.string/tstring.c
@@ -10,7 +10,7 @@
 #include <stdlib.h>
 
 #ifndef MAX_1
-#ifdef __SPU__
+#if defined(__AVR__) || defined(__SPU__)
 #define MAX_1 11000
 #else
 #define MAX_1 33000

--- a/scripts/cross-avr.txt
+++ b/scripts/cross-avr.txt
@@ -1,0 +1,21 @@
+[binaries]
+# Meson 0.53.2 doesn't use any cflags when doing basic compiler tests,
+# so we have to add -nostdlib to the compiler configuration itself or
+# early compiler tests will fail. This can be removed when picolibc
+# requires at least version 0.54.2 of meson.
+c = ['avr-gcc', '-nostdlib']
+ar = 'avr-ar'
+as = 'avr-as'
+nm = 'avr-nm'
+strip = 'avr-strip'
+# only needed to run tests
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-avr "$@"', 'run-avr']
+
+[host_machine]
+system = 'none'
+cpu_family = 'avr'
+cpu = 'avr'
+endian = 'little'
+
+[properties]
+skip_sanity_check = true

--- a/scripts/do-avr-configure
+++ b/scripts/do-avr-configure
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2019 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+exec "$(dirname "$0")"/do-configure avr -Dtests=true "$@"


### PR DESCRIPTION
This is my attempt at properly supporting AVR in picolibc. I'm first just taking a stab at compiling it before even trying to test it. This is not at all finished, just something to ask how to continue.

1. C version

The avr-gcc version included in Debian is version 5.4.0, a rather ancient version. It doesn't support `-std=c18`. Can I somehow change the language version for AVR only?

2. Target names

It appears like meson (?) auto-detects the available targets, but there are some problems with it.

```
WARNING: Target "avr25/libdummyhost" has a path separator in its name.
This is not supported, it can cause unexpected failures and will become
a hard error in the future.
WARNING: Target "avr3/libdummyhost" has a path separator in its name.
This is not supported, it can cause unexpected failures and will become
a hard error in the future.
WARNING: Target "avr31/libdummyhost" has a path separator in its name.
This is not supported, it can cause unexpected failures and will become
a hard error in the future.
[...etc]
```

Where should I look to fix these issues?

3. Large arrays in iconv

Because AVR is a 16-bit system, many arrays in the code are too large. For example:

```
avr-gcc -nostdlib -Inewlib/libavr25/libc.a.p -Inewlib -I../newlib -Inewlib/libm/common -I../newlib/libm/common -Inewlib/libc/machine/avr -I../newlib/libc/machine/avr -Inewlib/libc/tinystdio -I../newlib/libc/tinystdio -I. -I.. -Inewlib/libc/include -I../newlib/libc/include -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=c11 -Os -g -ffunction-sections -include /home/ayke/src/github.com/tinygo-org/tinygo/lib/picolibc/build/picolibc.h -nostdlib -fno-common -frounding-math -fsignaling-nans -fno-stack-protector -U_FORTIFY_SOURCE -DFORMAT_DEFAULT_DOUBLE -Werror=implicit-function-declaration -Werror=vla -Warray-bounds -Wold-style-definition -Wno-missing-braces -Wno-implicit-int -Wno-return-type -mmcu=avr25 -D_LIBC -MD -MQ newlib/libavr25/libc.a.p/libc_iconv_ccs_big5.c.o -MF newlib/libavr25/libc.a.p/libc_iconv_ccs_big5.c.o.d -o newlib/libavr25/libc.a.p/libc_iconv_ccs_big5.c.o -c ../newlib/libc/iconv/ccs/big5.c
../newlib/libc/iconv/ccs/big5.c:8411:1: error: size of variable 'from_ucs_size_big5' is too large
 from_ucs_size_big5[] =
 ^
```

I can work around that using `-Dnewlib-iconv-external-ccs=true`. Is there a way to make this the default for AVR?

4. Large arrays in tests

Many tests contain large arrays, which are too large for AVR. Any suggestions how to deal with those? Example:

```
avr-gcc -nostdlib -Inewlib/libm/test/math_test.p -Inewlib/libm/test -I../newlib/libm/test -Inewlib/libm/common -I../newlib/libm/common -Inewlib/libc/machine/avr -I../newlib/libc/machine/avr -Inewlib/libc/tinystdio -I../newlib/libc/tinystdio -I. -I.. -Inewlib/libc/include -I../newlib/libc/include -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=c11 -Os -g -ffunction-sections -include /home/ayke/src/github.com/tinygo-org/tinygo/lib/picolibc/build/picolibc.h -nostdlib -fno-common -frounding-math -fsignaling-nans -fno-stack-protector -Werror=implicit-function-declaration -Werror=vla -Warray-bounds -Wold-style-definition -Wno-missing-braces -Wno-implicit-int -Wno-return-type -DPICOLIBC_DOUBLE_PRINTF_SCANF -include /home/ayke/src/github.com/tinygo-org/tinygo/lib/picolibc/build/picolibc.h -nostdlib -fno-common -frounding-math -fsignaling-nans -fno-stack-protector -U_FORTIFY_SOURCE -DFORMAT_DEFAULT_DOUBLE -Werror=implicit-function-declaration -Werror=vla -Warray-bounds -Wold-style-definition -Wno-missing-braces -Wno-implicit-int -Wno-return-type -fno-builtin -fstack-protector-all -fstack-protector-strong -DTESTS_ENABLE_STACK_PROTECTOR --specs /home/ayke/src/github.com/tinygo-org/tinygo/lib/picolibc/build/test.specs -MD -MQ newlib/libm/test/math_test.p/sprint_ivec.c.o -MF newlib/libm/test/math_test.p/sprint_ivec.c.o.d -o newlib/libm/test/math_test.p/sprint_ivec.c.o -c ../newlib/libm/test/sprint_ivec.c
[...]
../newlib/libm/test/sprint_ivec.c:19:17: error: size of variable 'sprint_ints' is too large
 sprint_int_type sprint_ints[] = 
```

5. `double` support

`avr-gcc` by default doesn't support `double`, instead treating it as an alias for `float`. Should we keep it that way in picolibc?
(Note: I very much dislike this behavior in avr-gcc and use 64-bit double in TinyGo even on AVR).