### PR TITLE
Handle %p on ILP64 targets

### DIFF
--- a/newlib/libc/tinystdio/vfprintf.c
+++ b/newlib/libc/tinystdio/vfprintf.c
@@ -513,9 +513,9 @@ int vfprintf (FILE * stream, const char *fmt, va_list ap_orig)
 		continue;
             }
 
-#ifdef _WANT_IO_C99_FORMATS
-
 #define CHECK_LONGLONG(type) else if (sizeof(type) == sizeof(long long)) flags |= FL_LONG|FL_REPD_TYPE;
+
+#ifdef _WANT_IO_C99_FORMATS
 
 #define CHECK_INT_SIZE(letter, type)			\
 	    if (c == letter) {				\
@@ -985,6 +985,8 @@ int vfprintf (FILE * stream, const char *fmt, va_list ap_orig)
                         base = 8;
                     } else if (c == 'p') {
                         flags |= FL_ALT | FL_ALTHEX;
+                        if (sizeof(void *) > sizeof(int))
+                            flags |= FL_LONG;
                         base = 16;
                     } else if (TOLOW(c) == 'x') {
                         flags |= FL_ALTHEX;

--- a/newlib/libc/tinystdio/vfscanf.c
+++ b/newlib/libc/tinystdio/vfscanf.c
@@ -625,6 +625,9 @@ int vfscanf (FILE * stream, const char *fmt, va_list ap_orig)
 
 #if  SCANF_FLOAT
 	          case 'p':
+                      if (sizeof(void *) > sizeof(int))
+                          flags |= FL_LONG;
+                      FALLTHROUGH;
 		  case 'x':
 	          case 'X':
 		    flags |= FL_HEX;
@@ -657,6 +660,10 @@ int vfscanf (FILE * stream, const char *fmt, va_list ap_orig)
 		  case 'i':
 		    goto conv_int;
 
+                  case 'p':
+                      if (sizeof(void *) > sizeof(int))
+                          flags |= FL_LONG;
+                      FALLTHROUGH;
 		  default:			/* p,x,X	*/
 		    flags |= FL_HEX;
 		  conv_int:

--- a/test/printf_scanf.c
+++ b/test/printf_scanf.c
@@ -193,7 +193,7 @@ main(void)
 #define CHECK_RT(type, prefix) do {                                     \
         for (x = 0; x < (int) (sizeof(type) * 8); x++) {            \
                 type v = (type) (0x123456789abcdef0LL >> (64 - sizeof(type) * 8)) >> x; \
-                type r;                                                 \
+                type r = ~v;                                            \
                 VERIFY(prefix, "d");                                    \
                 VERIFY(prefix, "u");                                    \
                 VERIFY(prefix, "x");                                    \
@@ -217,6 +217,12 @@ main(void)
         CHECK_RT(size_t, "z");
         CHECK_RT(ptrdiff_t, "t");
 
+        {
+            static int i_addr = 12;
+            void *v = &i_addr;
+            void *r = (void *) -1;
+            VERIFY("", "p");
+        }
 #if defined(TINY_STDIO) || !defined(NO_FLOATING_POINT)
 #ifdef PICOLIBC_FLOAT_PRINTF_SCANF
 #define float_type float


### PR DESCRIPTION
%p needs to adjust parameter size on targets where sizeof(void *) > sizeof(int).