### PR TITLE
Set default EL/IX to '4'. Set _ELIX_LEVEL

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -739,6 +739,7 @@ conf_data.set('_MB_CAPABLE', newlib_mb)
 conf_data.set('_MB_LEN_MAX', newlib_mb ? '8' : '1')
 conf_data.set('__SINGLE_THREAD__', get_option('newlib-multithread') == false)
 conf_data.set('_ICONV_ENABLE_EXTERNAL_CCS', newlib_iconv_external_ccs)
+conf_data.set('_ELIX_LEVEL', newlib_elix_level)
 if newlib_iconv_external_ccs
   conf_data.set_quoted('ICONV_DEFAULT_NLSPATH', newlib_iconv_runtime_dir)
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -130,7 +130,7 @@ option('format-default', type: 'combo', choices: ['double', 'float', 'integer'],
 #
 # Options applying to only legacy stdio
 #
-option('newlib-elix-level', type: 'integer', value: 2,
+option('newlib-elix-level', type: 'integer', value: 4,
        description: 'desired elix library level (0-4)')
 option('newlib-fseek-optimization', type: 'boolean', value: false,
        description: 'enable fseek optimization')

--- a/newlib/libc/stdio/fopencookie.c
+++ b/newlib/libc/stdio/fopencookie.c
@@ -105,6 +105,7 @@ fcreader (struct _reent *ptr,
 {
   int result;
   fccookie *c = (fccookie *) cookie;
+  (void) ptr;
   errno = 0;
   if ((result = c->readfn (c->cookie, buf, n)) < 0 && errno)
     __errno_r(ptr) = errno;
@@ -146,6 +147,7 @@ fcseeker (struct _reent *ptr,
   _off64_t offset = (_off64_t) pos;
 #endif /* __LARGE64_FILES */
 
+  (void) ptr;
   errno = 0;
   if (c->seekfn (c->cookie, &offset, whence) < 0 && errno)
     __errno_r(ptr) = errno;
@@ -166,8 +168,9 @@ fcseeker64 (struct _reent *ptr,
        _fpos64_t pos,
        int whence)
 {
-  _off64_t offset;
+  _off64_t offset = (_off64_t) pos;
   fccookie *c = (fccookie *) cookie;
+  (void) ptr;
   errno = 0;
   if (c->seekfn (c->cookie, &offset, whence) < 0 && errno)
     __errno_r(ptr) = errno;
@@ -181,6 +184,7 @@ fccloser (struct _reent *ptr,
 {
   int result = 0;
   fccookie *c = (fccookie *) cookie;
+  (void) ptr;
   if (c->closefn)
     {
       errno = 0;
@@ -202,6 +206,7 @@ _fopencookie_r (struct _reent *ptr,
   int flags;
   int dummy;
 
+  (void) ptr;
   if ((flags = __sflags (ptr, mode, &dummy)) == 0)
     return NULL;
   if (((flags & (__SRD | __SRW)) && !functions.read)

--- a/newlib/libc/stdio/funopen.c
+++ b/newlib/libc/stdio/funopen.c
@@ -112,6 +112,7 @@ funreader (struct _reent *ptr,
 {
   int result;
   funcookie *c = (funcookie *) cookie;
+  (void) ptr;
   errno = 0;
   if ((result = c->readfn (c->cookie, buf, n)) < 0 && errno)
     __errno_r(ptr) = errno;
@@ -126,6 +127,7 @@ funwriter (struct _reent *ptr,
 {
   int result;
   funcookie *c = (funcookie *) cookie;
+  (void) ptr;
   errno = 0;
   if ((result = c->writefn (c->cookie, buf, n)) < 0 && errno)
     __errno_r(ptr) = errno;
@@ -155,6 +157,7 @@ funseeker (struct _reent *ptr,
       result = -1;
     }
 #endif /* __LARGE64_FILES */
+  (void) ptr;
   return result;
 }
 
@@ -167,6 +170,7 @@ funseeker64 (struct _reent *ptr,
 {
   _fpos64_t result;
   funcookie *c = (funcookie *) cookie;
+  (void) ptr;
   errno = 0;
   if ((result = c->seekfn (c->cookie, off, whence)) < 0 && errno)
     __errno_r(ptr) = errno;
@@ -180,6 +184,7 @@ funcloser (struct _reent *ptr,
 {
   int result = 0;
   funcookie *c = (funcookie *) cookie;
+  (void) ptr;
   if (c->closefn)
     {
       errno = 0;

--- a/newlib/libc/stdio/open_memstream.c
+++ b/newlib/libc/stdio/open_memstream.c
@@ -102,6 +102,7 @@ memwriter (struct _reent *ptr,
   memstream *c = (memstream *) cookie;
   char *cbuf = *c->pbuf;
 
+  (void) ptr;
   /* size_t is unsigned, but off_t is signed.  Don't let stream get so
      big that user cannot do ftello.  */
   if (sizeof (OFF_T) == sizeof (size_t) && (ssize_t) (c->pos + n) < 0)
@@ -155,6 +156,7 @@ memseeker (struct _reent *ptr,
   memstream *c = (memstream *) cookie;
   OFF_T offset = (OFF_T) pos;
 
+  (void) ptr;
   if (whence == SEEK_CUR)
     offset += c->pos;
   else if (whence == SEEK_END)
@@ -164,7 +166,7 @@ memseeker (struct _reent *ptr,
       __errno_r(ptr) = EINVAL;
       offset = -1;
     }
-  else if ((size_t) offset != offset)
+  else if ((OFF_T) (size_t) offset != offset)
     {
       __errno_r(ptr) = ENOSPC;
       offset = -1;
@@ -222,6 +224,7 @@ memseeker64 (struct _reent *ptr,
   _off64_t offset = (_off64_t) pos;
   memstream *c = (memstream *) cookie;
 
+  (void) ptr;
   if (whence == SEEK_CUR)
     offset += c->pos;
   else if (whence == SEEK_END)
@@ -231,7 +234,7 @@ memseeker64 (struct _reent *ptr,
       __errno_r(ptr) = EINVAL;
       offset = -1;
     }
-  else if ((size_t) offset != offset)
+  else if ((_off64_t) (size_t) offset != offset)
     {
       __errno_r(ptr) = ENOSPC;
       offset = -1;
@@ -279,6 +282,7 @@ memcloser (struct _reent *ptr,
   memstream *c = (memstream *) cookie;
   char *buf;
 
+  (void) ptr;
   /* Be nice and try to reduce any unused memory.  */
   buf = realloc (*c->pbuf,
 		    c->wide > 0 ? (*c->psize + 1) * sizeof (wchar_t)

--- a/newlib/libc/stdio/swprintf.c
+++ b/newlib/libc/stdio/swprintf.c
@@ -580,7 +580,7 @@ _swprintf_r (struct _reent *ptr,
   if (size > 0)  {
     *(wchar_t *)f._p = L'\0';	/* terminate the string */
   }
-  if(ret >= size)  {
+  if(ret >= 0 && (size_t) ret >= size)  {
     /* _svfwprintf_r() returns how many wide characters it would have printed
      * if there were enough space.  Return an error if too big to fit in str,
      * unlike snprintf, which returns the size needed.  */
@@ -620,7 +620,7 @@ swprintf (wchar_t *__restrict str,
   if (size > 0)  {
     *(wchar_t *)f._p = L'\0';	/* terminate the string */
   }
-  if(ret >= size)  {
+  if(ret >= 0 && (size_t) ret >= size)  {
     /* _svfwprintf_r() returns how many wide characters it would have printed
      * if there were enough space.  Return an error if too big to fit in str,
      * unlike snprintf, which returns the size needed.  */

--- a/newlib/libc/stdio/vswprintf.c
+++ b/newlib/libc/stdio/vswprintf.c
@@ -56,7 +56,7 @@ _vswprintf_r (struct _reent *ptr,
   if (size > 0)  {
     *(wchar_t *)f._p = L'\0';	/* terminate the string */
   }
-  if(ret >= size)  {
+  if(ret >= 0 && (size_t) ret >= size)  {
     /* _svfwprintf_r() returns how many wide characters it would have printed
      * if there were enough space.  Return an error if too big to fit in str,
      * unlike snprintf, which returns the size needed.  */

--- a/newlib/testsuite/newlib.stdio/swprintf.c
+++ b/newlib/testsuite/newlib.stdio/swprintf.c
@@ -11,7 +11,7 @@
 #include <wchar.h>
 #include "check.h"
 
-int main()
+int main(void)
 {
 #if defined(INTEGER_ONLY) || defined(NO_FLOATING_POINT)
 


### PR DESCRIPTION
EL/IX is a RedHat specification for embedded library API levels, which
newlib uses. When that value was migrated to picolibc, the default
value was set to 2, while newlib uses '4'. And some code depends on
_ELIX_LEVEL being set to that value.

Signed-off-by: Keith Packard <keithp@keithp.com>