### PR TITLE
Add POSIX definitions to sys/features.h when building under Zephyr

### DIFF
--- a/newlib/libc/include/sys/features.h
+++ b/newlib/libc/include/sys/features.h
@@ -400,6 +400,30 @@ extern "C" {
 # define _POSIX_VERSION 199009L
 #endif
 
+#ifdef __ZEPHYR__
+#define _POSIX_VERSION				200809L
+#define _POSIX2_VERSION				200809L
+#define _POSIX_CLOCK_SELECTION                  200809L
+#define _POSIX_FSYNC                            200809L
+#define _POSIX_MEMLOCK                          200809L
+#define _POSIX_MEMLOCK_RANGE                    200809L
+#define _POSIX_MONOTONIC_CLOCK                  200809L
+#define _POSIX_NO_TRUNC                         200809L
+#define _POSIX_REALTIME_SIGNALS                 200809L
+#define _POSIX_SEMAPHORES                       200809L
+#define _POSIX_SHARED_MEMORY_OBJECTS            200809L
+#define _POSIX_SYNCHRONIZED_IO                  200809L
+#define _POSIX_THREAD_ATTR_STACKADDR            200809L
+#define _POSIX_THREAD_ATTR_STACKSIZE            200809L
+#define _POSIX_THREAD_CPUTIME                   200809L
+#define _POSIX_THREAD_PRIO_INHERIT              200809L
+#define _POSIX_THREAD_PRIO_PROTECT              200809L
+#define _POSIX_THREAD_PRIORITY_SCHEDULING       200809L
+#define _POSIX_THREAD_SPORADIC_SERVER           200809L
+#define _POSIX_TIMEOUTS                         200809L
+#define _POSIX_TIMERS                           200809L
+#endif /* __ZEPHYR__ */
+
 #ifdef __CYGWIN__
 
 #if __POSIX_VISIBLE >= 200809


### PR DESCRIPTION
Zephyr exposes a bunch of POSIX functions which are supposed to be
defined in C library headers. Add a section to features.h that sets
the flags necessary to make those headers include definitions for the
necessary functions.

Signed-off-by: Keith Packard <keithp@keithp.com>