### PR TITLE
Shrink vfprintf integer handling code

### DIFF
--- a/newlib/libc/tinystdio/vfprintf.c
+++ b/newlib/libc/tinystdio/vfprintf.c
@@ -967,7 +967,7 @@ int vfprintf (FILE * stream, const char *fmt, va_list ap_orig)
 
                     flags &= ~FL_ALT;
 
-                    if ((flags & FL_PREC) && prec == 0 && x_s == 0)
+                    if (x_s == 0 && (flags & FL_PREC) && prec == 0)
                         buf_len = 0;
                     else
                         buf_len = __ultoa_invert (x_s, buf, 10) - buf;
@@ -1005,7 +1005,7 @@ int vfprintf (FILE * stream, const char *fmt, va_list ap_orig)
                     if (x == 0)
                         flags &= ~FL_ALT;
 
-                    if ((flags & FL_PREC) && prec == 0 && x == 0)
+                    if (x == 0 && (flags & FL_PREC) && prec == 0)
                         buf_len = 0;
                     else
                         buf_len = __ultoa_invert (x, buf, base) - buf;

--- a/newlib/libc/tinystdio/vfprintf.c
+++ b/newlib/libc/tinystdio/vfprintf.c
@@ -1001,10 +1001,12 @@ int vfprintf (FILE * stream, const char *fmt, va_list ap_orig)
 
                     arg_to_unsigned(ap, flags, x);
 
-                    if ((flags & FL_PREC) && prec == 0 && x == 0) {
-                        buf_len = 0;
+                    /* Zero gets no special alternate treatment */
+                    if (x == 0)
                         flags &= ~FL_ALT;
-                    }
+
+                    if ((flags & FL_PREC) && prec == 0 && x == 0)
+                        buf_len = 0;
                     else
                         buf_len = __ultoa_invert (x, buf, base) - buf;
                 }
@@ -1031,14 +1033,9 @@ int vfprintf (FILE * stream, const char *fmt, va_list ap_orig)
                 /* Alternate mode for octal/hex */
                 if (flags & FL_ALT) {
 
-                    /* Zero gets no special alternate treatment */
-                    if (buf[buf_len-1] == '0') {
-                        flags &= ~FL_ALT;
-                    } else {
+                    len += 1;
+                    if (c != '\0')
                         len += 1;
-                        if (c != '\0')
-                            len += 1;
-                    }
                 } else if (flags & (FL_NEGATIVE | FL_PLUS | FL_SPACE)) {
                     len += 1;
                 }


### PR DESCRIPTION
A short series that restructures the integer format handling code a bit to shrink it while (I hope) making it a bit clearer.

This reduced the text size on all 32-bit arm and all risc-v targets, from 16 to 104 bytes.

Here's complete data:
arm:
```
old 18752 new 18720 diff -32 test/printfi-tests
old 18528 new 18496 diff -32 test/printfi-tests_arm_v5te_hard
old 18528 new 18496 diff -32 test/printfi-tests_arm_v5te_softfp
old 13812 new 13796 diff -16 test/printfi-tests_thumb_nofp
old 13548 new 13532 diff -16 test/printfi-tests_thumb_v6_m_nofp
old 13972 new 13892 diff -80 test/printfi-tests_thumb_v7_a_fp_hard
old 13972 new 13892 diff -80 test/printfi-tests_thumb_v7_a_fp_softfp
old 13972 new 13908 diff -64 test/printfi-tests_thumb_v7_a_nofp
old 13972 new 13908 diff -64 test/printfi-tests_thumb_v7_a_simd_hard
old 13972 new 13908 diff -64 test/printfi-tests_thumb_v7_a_simd_softfp
old 13404 new 13340 diff -64 test/printfi-tests_thumb_v7e_m_dp_hard
old 13404 new 13340 diff -64 test/printfi-tests_thumb_v7e_m_dp_softfp
old 13404 new 13340 diff -64 test/printfi-tests_thumb_v7e_m_fp_hard
old 13404 new 13340 diff -64 test/printfi-tests_thumb_v7e_m_fp_softfp
old 13404 new 13340 diff -64 test/printfi-tests_thumb_v7e_m_nofp
old 13972 new 13908 diff -64 test/printfi-tests_thumb_v7_fp_hard
old 13972 new 13908 diff -64 test/printfi-tests_thumb_v7_fp_softfp
old 13404 new 13340 diff -64 test/printfi-tests_thumb_v7_m_nofp
old 13972 new 13908 diff -64 test/printfi-tests_thumb_v7_nofp
old 13316 new 13252 diff -64 test/printfi-tests_thumb_v7_r_fp_sp_hard
old 13316 new 13252 diff -64 test/printfi-tests_thumb_v7_r_fp_sp_softfp
old 13332 new 13268 diff -64 test/printfi-tests_thumb_v7ve_simd_hard
old 13332 new 13268 diff -64 test/printfi-tests_thumb_v7ve_simd_softfp
old 13388 new 13308 diff -80 test/printfi-tests_thumb_v8_1_m_main_mve_hard
old 13336 new 13256 diff -80 test/printfi-tests_thumb_v8_a_nofp
old 13336 new 13256 diff -80 test/printfi-tests_thumb_v8_a_simd_hard
old 13336 new 13256 diff -80 test/printfi-tests_thumb_v8_a_simd_softfp
old 13284 new 13252 diff -32 test/printfi-tests_thumb_v8_m_base_nofp
old 13420 new 13340 diff -80 test/printfi-tests_thumb_v8_m_main_dp_hard
old 13420 new 13340 diff -80 test/printfi-tests_thumb_v8_m_main_dp_softfp
old 13420 new 13340 diff -80 test/printfi-tests_thumb_v8_m_main_fp_hard
old 13420 new 13340 diff -80 test/printfi-tests_thumb_v8_m_main_fp_softfp
old 13404 new 13340 diff -64 test/printfi-tests_thumb_v8_m_main_nofp
```

risc-v
```
old 18950 new 18854 diff -96 test/printfi-tests
old 17838 new 17790 diff -48 test/printfi-tests_rv32eac_ilp32e
old 20780 new 20764 diff -16 test/printfi-tests_rv32ea_ilp32e
old 20780 new 20764 diff -16 test/printfi-tests_rv32e_ilp32e
old 17662 new 17614 diff -48 test/printfi-tests_rv32emac_ilp32e
old 20524 new 20508 diff -16 test/printfi-tests_rv32em_ilp32e
old 16730 new 16650 diff -80 test/printfi-tests_rv32iac_ilp32
old 19192 new 19144 diff -48 test/printfi-tests_rv32iafd_ilp32d
old 19192 new 19144 diff -48 test/printfi-tests_rv32iaf_ilp32f
old 19152 new 19104 diff -48 test/printfi-tests_rv32ia_ilp32
old 19192 new 19144 diff -48 test/printfi-tests_rv32ifd_ilp32d
old 19192 new 19144 diff -48 test/printfi-tests_rv32if_ilp32f
old 19152 new 19104 diff -48 test/printfi-tests_rv32i_ilp32
old 16570 new 16506 diff -64 test/printfi-tests_rv32imac_ilp32
old 16818 new 16738 diff -80 test/printfi-tests_rv32imafc_ilp32f
old 16818 new 16738 diff -80 test/printfi-tests_rv32imafdc_ilp32d
old 18976 new 18928 diff -48 test/printfi-tests_rv32imaf_ilp32f
old 16818 new 16738 diff -80 test/printfi-tests_rv32imfc_ilp32f
old 18976 new 18928 diff -48 test/printfi-tests_rv32imfd_ilp32d
old 18976 new 18928 diff -48 test/printfi-tests_rv32imf_ilp32f
old 18936 new 18888 diff -48 test/printfi-tests_rv32im_ilp32
old 19110 new 19030 diff -80 test/printfi-tests_rv64iac_lp64
old 22180 new 22100 diff -80 test/printfi-tests_rv64iafd_lp64d
old 22180 new 22100 diff -80 test/printfi-tests_rv64iaf_lp64f
old 22140 new 22060 diff -80 test/printfi-tests_rv64ia_lp64
old 22180 new 22100 diff -80 test/printfi-tests_rv64ifd_lp64d
old 22180 new 22100 diff -80 test/printfi-tests_rv64if_lp64f
old 22140 new 22060 diff -80 test/printfi-tests_rv64i_lp64
old 18910 new 18814 diff -96 test/printfi-tests_rv64imac_lp64
old 18950 new 18854 diff -96 test/printfi-tests_rv64imafc_lp64f
old 18950 new 18854 diff -96 test/printfi-tests_rv64imafdc_lp64d
old 21908 new 21796 diff -112 test/printfi-tests_rv64imaf_lp64f
old 18950 new 18854 diff -96 test/printfi-tests_rv64imfc_lp64f
old 21908 new 21796 diff -112 test/printfi-tests_rv64imfd_lp64d
old 21908 new 21796 diff -112 test/printfi-tests_rv64imf_lp64f
old 21868 new 21756 diff -112 test/printfi-tests_rv64im_lp64
```
