### PR TITLE
x86: Note that asm code doesn't require executable stack

### DIFF
--- a/newlib/libc/machine/i386/memchr.S
+++ b/newlib/libc/machine/i386/memchr.S
@@ -133,3 +133,7 @@ L20:
 	leave
 #endif
 	ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/newlib/libc/machine/i386/memcmp.S
+++ b/newlib/libc/machine/i386/memcmp.S
@@ -102,3 +102,7 @@ L4:
 	leave
 #endif
 	ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/newlib/libc/machine/i386/memcpy.S
+++ b/newlib/libc/machine/i386/memcpy.S
@@ -84,3 +84,7 @@ SYM (memcpy):
 	leave
 #endif
 	ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/newlib/libc/machine/i386/memmove.S
+++ b/newlib/libc/machine/i386/memmove.S
@@ -171,3 +171,7 @@ SYM (memmove):
 	leave
 #endif
 	ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/newlib/libc/machine/i386/memset.S
+++ b/newlib/libc/machine/i386/memset.S
@@ -107,3 +107,7 @@ SYM (memset):
 	leave
 #endif
 	ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/newlib/libc/machine/i386/setjmp.S
+++ b/newlib/libc/machine/i386/setjmp.S
@@ -130,3 +130,7 @@ SYM (longjmp):
 #endif
 
 	ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/newlib/libc/machine/i386/strchr.S
+++ b/newlib/libc/machine/i386/strchr.S
@@ -195,3 +195,7 @@ L27:
 #endif /* !__OPTIMIZE_SIZE__ */
 
 #endif /* __iamcu__ */
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/newlib/libc/machine/i386/strlen.S
+++ b/newlib/libc/machine/i386/strlen.S
@@ -100,3 +100,7 @@ L15:
 	popl edi
 	leave
 	ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/newlib/libc/machine/x86_64/memcpy.S
+++ b/newlib/libc/machine/x86_64/memcpy.S
@@ -111,3 +111,7 @@ quadword_copy:
   andq    $7, rcx
   rep     movsb                   /* Copy the remaining bytes */
   ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/newlib/libc/machine/x86_64/memset.S
+++ b/newlib/libc/machine/x86_64/memset.S
@@ -86,3 +86,6 @@ quadword_set:
   movq    r9, rax
   ret
 
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/newlib/libc/machine/x86_64/setjmp.S
+++ b/newlib/libc/machine/x86_64/setjmp.S
@@ -55,3 +55,7 @@ SYM (longjmp):
   __STI
 
   ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/picocrt/machine/i386/crt0.S
+++ b/picocrt/machine/i386/crt0.S
@@ -118,3 +118,7 @@ gdt:
 	.quad 0x00CF9B000000FFFF        # 0x10: ring 0 32-bit code segment
 	.quad 0x00CF93000000FFFF        # 0x18: ring 0 data segment
 gdt_end:
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/picocrt/machine/x86_64/crt0.S
+++ b/picocrt/machine/x86_64/crt0.S
@@ -168,3 +168,7 @@ level2pt:
 	page256(base), \
 	page256((base)+256)
 	.quad page512(0)
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif


### PR DESCRIPTION
Current GCC compiler bits for Linux complain when assembly code
doesn't explicitly note that it doesn't require an executable
stack. As both x86 test builds use the Linux toolchain, they've
started complaining. Add these notes, even though it really doesn't
matter to us.

Signed-off-by: Keith Packard <keithp@keithp.com>