### PR TITLE
tinystdio: Add explicit 'base' when parsing ints in scanf

### DIFF
--- a/newlib/libc/tinystdio/scanf_private.h
+++ b/newlib/libc/tinystdio/scanf_private.h
@@ -74,15 +74,12 @@ typedef unsigned int width_t;
 #define FL_LONGLONG 0x08        /* 'long long' type modifier    */
 #define FL_CHAR	    0x10	/* 'char' type modifier		*/
 #define FL_SHORT    0x20	/* 'short' type modifier	*/
-#define FL_OCT	    0x40	/* octal number			*/
-#define FL_DEC	    0x80	/* decimal number		*/
-#define FL_HEX	    0x100	/* hexidecimal number		*/
-#define FL_MINUS    0x200	/* minus flag (field or value)	*/
-#define FL_ANY	    0x400	/* any digit was read	        */
-#define FL_OVFL	    0x800	/* significand overflowed       */
-#define FL_DOT	    0x1000	/* decimal '.' was	        */
-#define FL_MEXP	    0x2000 	/* exponent 'e' is neg.	        */
-#define FL_FHEX     0x4000      /* hex significand              */
+#define FL_MINUS    0x40	/* minus flag (field or value)	*/
+#define FL_ANY	    0x80	/* any digit was read	        */
+#define FL_OVFL	    0x100	/* significand overflowed       */
+#define FL_DOT	    0x200	/* decimal '.' was	        */
+#define FL_MEXP	    0x400 	/* exponent 'e' is neg.	        */
+#define FL_FHEX     0x800       /* hex significand              */
 
 #ifndef	__AVR_HAVE_LPMX__
 # if  defined(__AVR_ENHANCED__) && __AVR_ENHANCED__


### PR DESCRIPTION
Instead of embedding the base in the flags parameter, pass the
value explicitly and then use that in simple computation instead of
using the 'mulacc' helper function.

This saves space on every ARM target.

Signed-off-by: Keith Packard <keithp@keithp.com>