### PR TITLE
cmake: Use -fno-builtin-malloc -fno-builtin-free for malloc sources

### DIFF
--- a/cmake/picolibc.cmake
+++ b/cmake/picolibc.cmake
@@ -58,9 +58,13 @@ function(picolibc_sources_flags flags)
 
   # Set flags if specified
   if(flags)
-    set_source_files_properties(${sources}
-      TARGET_DIRECTORY c
-      PROPERTIES COMPILE_OPTIONS "${flags}")
+    foreach(flag ${flags})
+      foreach(source ${sources})
+	set_property(SOURCE ${source}
+	  TARGET_DIRECTORY c
+	  APPEND PROPERTY COMPILE_OPTIONS ${flag})
+      endforeach()
+    endforeach()
   endif()
 endfunction()
 

--- a/newlib/libc/stdlib/CMakeLists.txt
+++ b/newlib/libc/stdlib/CMakeLists.txt
@@ -115,6 +115,13 @@ picolibc_sources(
   wctob.c
   wctomb.c
   wctomb_r.c
+  pico-atexit.c
+  pico-exit.c
+  pico-onexit.c
+  pico-cxa-atexit.c
+  )
+
+picolibc_sources_flags("-fno-builtin-malloc;-fno-builtin-free"
   nano-malloc-calloc.c
   nano-malloc-cfree.c
   nano-malloc-free.c
@@ -129,8 +136,4 @@ picolibc_sources(
   nano-malloc-pvalloc.c
   nano-malloc-realloc.c
   nano-malloc-valloc.c
-  pico-atexit.c
-  pico-exit.c
-  pico-onexit.c
-  pico-cxa-atexit.c
   )


### PR DESCRIPTION
These files need to be compiled without the compiler "knowing" how
malloc and free work as that messes up the malloc/free
implementation. Copy the parameters used for meson into the cmake
build system.

Signed-off-by: Keith Packard <keithp@keithp.com>