### PR TITLE
picocrt: Risc-V binutils at 2.38 requires _zicsr to get CSR ISA

### DIFF
--- a/picocrt/machine/riscv/meson.build
+++ b/picocrt/machine/riscv/meson.build
@@ -33,3 +33,7 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 src_picocrt += files('crt0.c')
+
+if cc.compiles('int i;', args: core_c_args + ['-march=rv32imac_zicsr', '-mabi=ilp32'])
+  picocrt_march_add='_zicsr'
+endif

--- a/picocrt/meson.build
+++ b/picocrt/meson.build
@@ -36,6 +36,7 @@
 src_picocrt = []
 
 machine_dir = 'machine' / host_cpu_family
+picocrt_march_add=''
 if fs.is_dir(machine_dir)
   subdir(machine_dir)
 else
@@ -46,6 +47,17 @@ foreach target : targets
   value = get_variable('target_' + target)
 
   instdir = join_paths(lib_dir, value[0])
+
+  if picocrt_march_add != ''
+    new_cflags=[]
+    foreach cflag : value[1]
+      if cflag.startswith('-march')
+	cflag = cflag + picocrt_march_add
+      endif
+      new_cflags += cflag
+    endforeach
+    value = [value[0], new_cflags]
+  endif
 
   if target == ''
     crt_name = 'crt0.o'


### PR DESCRIPTION
For some reason, current binutils bits now require appending _zicsr to
the -march flag to enable CSR access instructions. Fix this by hacking
up the -march flag provided by the build system to append _zicsr while
building picocrt but not other parts of the library.

Signed-off-by: Keith Packard <keithp@keithp.com>