### PR TITLE
Add -fno-builtin-copysignl to default compiler args

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -180,7 +180,9 @@ endif
 
 # Disable ssp and fortify source while building picolibc (it's enabled
 # by default by the ubuntu native compiler)
-c_flags = cc.get_supported_arguments(['-fno-common', '-frounding-math', '-fsignaling-nans', '-Wno-unsupported-floating-point-opt', '-fno-stack-protector'])
+c_flags = cc.get_supported_arguments(['-fno-common', '-frounding-math', '-fsignaling-nans',
+				      '-Wno-unsupported-floating-point-opt', '-fno-stack-protector',
+				      '-fno-builtin-copysignl'])
 c_args += c_flags
 native_c_args += c_flags
 

--- a/picocrt/machine/riscv/meson.build
+++ b/picocrt/machine/riscv/meson.build
@@ -33,3 +33,7 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 src_picocrt += files('crt0.c')
+
+if cc.compiles('int i;', args: core_c_args + ['-march=rv32imac_zicsr', '-mabi=ilp32'])
+  picocrt_march_add='_zicsr'
+endif

--- a/picocrt/meson.build
+++ b/picocrt/meson.build
@@ -36,6 +36,7 @@
 src_picocrt = []
 
 machine_dir = 'machine' / host_cpu_family
+picocrt_march_add=''
 if fs.is_dir(machine_dir)
   subdir(machine_dir)
 else
@@ -46,6 +47,17 @@ foreach target : targets
   value = get_variable('target_' + target)
 
   instdir = join_paths(lib_dir, value[0])
+
+  if picocrt_march_add != ''
+    new_cflags=[]
+    foreach cflag : value[1]
+      if cflag.startswith('-march')
+	cflag = cflag + picocrt_march_add
+      endif
+      new_cflags += cflag
+    endforeach
+    value = [value[0], new_cflags]
+  endif
 
   if target == ''
     crt_name = 'crt0.o'


### PR DESCRIPTION
It seems that GCC 12 gets confused by newlib/libm/common/copysignl.c
and thinks it's a recursive function. Disabling the builtin
'copysignl' avoids this; as copysignl isn't actually used anywhere
else, this doesn't affect other code.
    
Ideally, perhaps every wrapper around a builtin function should be
compiled with just that builtin disabled?
    
Signed-off-by: Keith Packard <keithp@keithp.com>