### PR TITLE
Add -no-warn-rwx-segments to link specs

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -479,6 +479,13 @@ if tinystdio
 		' %{DPICOLIBC_INTEGER_PRINTF_SCANF:--defsym=vfscanf=__i_vfscanf}')
 endif
 
+specs_flags=''
+if cc.links('int main(void) { return 0; }',
+	    name: 'check for no-warn-rwx-segments',
+	    args: core_c_args + ['-Wl,--no-warn-rwx-segments'])
+  specs_flags='--no-warn-rwx-segments'
+endif
+
 specs_data = configuration_data()
 specs_data.set('PREFIX', sysroot_install? '%R' : prefix)
 specs_data.set('INCLUDEDIR', get_option('includedir'))
@@ -490,6 +497,7 @@ specs_data.set('CC1PLUS_SPEC', meson.get_cross_property('cc1plus_spec', ''))
 specs_data.set('ADDITIONAL_LIBS', additional_libs)
 specs_data.set('SPECS_EXTRA', specs_extra)
 specs_data.set('SPECS_PRINTF', specs_printf)
+specs_data.set('SPECS_FLAGS', specs_flags)
 
 # Create C and C++ specific specs data,
 # that includes setting the correct linker script

--- a/picolibc.specs.in-multilib
+++ b/picolibc.specs.in-multilib
@@ -13,7 +13,7 @@
 -isystem %{-picolibc-prefix=*:%*/@INCLUDEDIR@; -picolibc-buildtype=*:@PREFIX@/@INCLUDEDIR@/%*; :@PREFIX@/@INCLUDEDIR@} -idirafter %{-picolibc-prefix=*:%*/@INCLUDEDIR@; -picolibc-buildtype=*:@PREFIX@/@INCLUDEDIR@/%*; :@PREFIX@/@INCLUDEDIR@} @TLSMODEL@ %(picolibc_cc1plus) @CC1_SPEC@ @CC1PLUS_SPEC@
 
 *link:
-@SPECS_PRINTF@ -L%{-picolibc-prefix=*:%*/@LIBDIR@/%M; -picolibc-buildtype=*:@PREFIX@/@LIBDIR@/%*/%M; :@PREFIX@/@LIBDIR@/%M} -L%{-picolibc-prefix=*:%*/@LIBDIR@; -picolibc-buildtype=*:@PREFIX@/@LIBDIR@/%*; :@PREFIX@/@LIBDIR@} %{!T:-T@PICOLIBC_LD@} %(picolibc_link) --gc-sections @LINK_SPEC@
+@SPECS_PRINTF@ -L%{-picolibc-prefix=*:%*/@LIBDIR@/%M; -picolibc-buildtype=*:@PREFIX@/@LIBDIR@/%*/%M; :@PREFIX@/@LIBDIR@/%M} -L%{-picolibc-prefix=*:%*/@LIBDIR@; -picolibc-buildtype=*:@PREFIX@/@LIBDIR@/%*; :@PREFIX@/@LIBDIR@} %{!T:-T@PICOLIBC_LD@} %(picolibc_link) --gc-sections @LINK_SPEC@ @SPECS_FLAGS@
 
 *lib:
 --start-group %(libgcc) @ADDITIONAL_LIBS@ -lc %{-oslib=*:-l%*} --end-group

--- a/picolibc.specs.in-singlelib
+++ b/picolibc.specs.in-singlelib
@@ -13,7 +13,7 @@
 -isystem %{-picolibc-prefix=*:%*/@INCLUDEDIR@; -picolibc-buildtype=*:@PREFIX@/@INCLUDEDIR@/%*; :@PREFIX@/@INCLUDEDIR@} -idirafter %{-picolibc-prefix=*:%*/@INCLUDEDIR@; -picolibc-buildtype=*:@PREFIX@/@INCLUDEDIR@/%*; :@PREFIX@/@INCLUDEDIR@} @TLSMODEL@ %(picolibc_cc1plus) @CC1_SPEC@ @CC1PLUS_SPEC@
 
 *link:
-@SPECS_PRINTF@ -L%{-picolibc-prefix=*:%*/@LIBDIR@; -picolibc-buildtype=*:@PREFIX@/@LIBDIR@/%*; :@PREFIX@/@LIBDIR@} %{!T:-T@PICOLIBC_LD@} %(picolibc_link) --gc-sections @LINK_SPEC@
+@SPECS_PRINTF@ -L%{-picolibc-prefix=*:%*/@LIBDIR@; -picolibc-buildtype=*:@PREFIX@/@LIBDIR@/%*; :@PREFIX@/@LIBDIR@} %{!T:-T@PICOLIBC_LD@} %(picolibc_link) --gc-sections @LINK_SPEC@ @SPECS_FLAGS@
 
 *lib:
 --start-group %(libgcc) @ADDITIONAL_LIBS@ -lc %{-oslib=*:-l%*} --end-group

--- a/test.specs.in
+++ b/test.specs.in
@@ -1,4 +1,4 @@
 %rename link test_link
 
 *link:
-@SPECS_PRINTF@ --gc-sections %(test_link)
+--no-warn-rwx-segments @SPECS_PRINTF@ --gc-sections %(test_link)


### PR DESCRIPTION
The linker changed the default value of whether to warn about segments marked rwx in executables as that's a security concern for systems which can actually protect memory.
    
Signed-off-by: Keith Packard <keithp@keithp.com>