### PR TITLE
picocrt: Only add _zicsr for risc-v if it isn't present

### DIFF
--- a/picocrt/meson.build
+++ b/picocrt/meson.build
@@ -51,7 +51,7 @@ foreach target : targets
   if picocrt_march_add != ''
     new_cflags=[]
     foreach cflag : value[1]
-      if cflag.startswith('-march')
+      if cflag.startswith('-march') and not cflag.contains(picocrt_march_add)
 	cflag = cflag + picocrt_march_add
       endif
       new_cflags += cflag


### PR DESCRIPTION
Check to see if the -march flag already contains _zicsr before
appending it -- the compiler complains if it is added twice.

Signed-off-by: Keith Packard <keithp@keithp.com>