### PR TITLE
libc/include: Wrap <sys/fenv.h> inside the extern "C" block for C++

### DIFF
--- a/newlib/libc/include/fenv.h
+++ b/newlib/libc/include/fenv.h
@@ -12,6 +12,10 @@
 #ifndef _FENV_H
 #define _FENV_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <sys/fenv.h>
 
 #ifndef FE_TONEAREST
@@ -20,10 +24,6 @@
 
 #ifndef FE_ALL_EXCEPT
 #define FE_ALL_EXCEPT	0
-#endif
-
-#ifdef __cplusplus
-extern "C" {
 #endif
 
 /* Exception */


### PR DESCRIPTION
On aarch64 (and others), sys/fenv.h includes definitions of inline
versions of the various fenv functions. If those aren't enclosed in
the extern "C" block, then they appear as native C++ functions.

Make sure that doesn't happen by including sys/fenv.h inside the
extern "C" block instead of outside.

Signed-off-by: Keith Packard <keithp@keithp.com>