### PR TITLE
picocrt/aarch64: Ignore array bounds while building crt0

### DIFF
--- a/picocrt/machine/aarch64/crt0.c
+++ b/picocrt/machine/aarch64/crt0.c
@@ -44,6 +44,8 @@
 #define TCB_SIZE	16
 #endif
 
+#pragma GCC diagnostic ignored "-Warray-bounds"
+
 static inline void
 _set_tls(void *tls)
 {


### PR DESCRIPTION
crt0 sets the TLS registers 8 bytes before the TLS block. This makes
GCC 12 emit a warning about array bounds. Disable this check.

Signed-off-by: Keith Packard <keithp@keithp.com>