### PR TITLE
math: Ignore maybe uninitialized warning in both rem_pio2 funcs

### DIFF
--- a/newlib/libm/math/k_rem_pio2.c
+++ b/newlib/libm/math/k_rem_pio2.c
@@ -148,6 +148,10 @@ static const double zero = 0.0, one = 1.0,
                         1.67772160000000000000e+07, /* 0x41700000, 0x00000000 */
     twon24 = 5.96046447753906250000e-08; /* 0x3E700000, 0x00000000 */
 
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+
 int
 __kernel_rem_pio2(double *x, double *y, int e0, int nx, int prec,
                   const __int32_t *ipio2)

--- a/newlib/libm/math/kf_rem_pio2.c
+++ b/newlib/libm/math/kf_rem_pio2.c
@@ -38,6 +38,10 @@ static const float zero = 0.0, one = 1.0,
                    two8 = 2.5600000000e+02, /* 0x43800000 */
     twon8 = 3.9062500000e-03; /* 0x3b800000 */
 
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+
 int
 __kernel_rem_pio2f(float *x, float *y, int e0, int nx, int prec,
                    const __int32_t *ipio2)


### PR DESCRIPTION
These functions set the 'fq' values in a loop which GCC can't figure
out are actually set, so it emits a warning. Instead of adding code to
initialize these variables (which are arrays of 20 elements), silence
the warning.

Signed-off-by: Keith Packard <keithp@keithp.com>