### PR TITLE
System libc option

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -156,7 +156,7 @@ jobs:
           "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dtinystdio=false",
         ]
         test: [
-          "./.github/do-many do-test do-native-configure build-native do-test do-aarch64-configure build-aarch64 do-build do-lx106-configure build-lx106 do-test do-i386-configure build-i386 do-build do-m68k-configure build-m68k end",
+          "./.github/do-many do-test do-native-configure build-native do-test do-aarch64-configure build-aarch64 do-build do-lx106-configure build-lx106 do-test do-i386-configure build-i386 do-build do-m68k-configure build-m68k do-build do-sparc64-configure build-sparc64 end",
         ]
     steps:
       - name: Clone picolibc
@@ -331,56 +331,6 @@ jobs:
         run: |
           docker run -v $(readlink -f picolibc):/picolibc -w /picolibc $IMAGE ${{ matrix.test }} ${{ matrix.meson_flags }} -Dfortify-source=2
 
-  fortify-source-sparc64:
-    needs: cache-maker
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        meson_flags: [
-          "",
-
-          # Math configurations
-          "-Dnewlib-obsolete-math=false -Dwant-math-errno=true",
-          "-Dnewlib-obsolete-math=true -Dwant-math-errno=true",
-
-          # Tinystdio configurations
-          "-Dio-float-exact=false -Dio-long-long=true",
-          "-Dformat-default=integer",
-
-          # Original stdio
-          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dnewlib-io-long-double=true",
-
-          # Locale, iconv and original malloc configurations
-          "-Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false",
-
-          # Multithread disabled
-          "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false",
-          "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dtinystdio=false",
-        ]
-        test: [
-          "./.github/do-build do-sparc64-configure build-sparc64",
-        ]
-    steps:
-      - name: Clone picolibc
-        uses: actions/checkout@v2
-        with:
-          path: picolibc
-
-      - name: Restore the Docker Image
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.HASH_FILE ) }}
-
-      - name: Load and Check the Docker Image
-        run: |
-          docker load -i $IMAGE_FILE
-          docker images -a $IMAGE
-
-      - name: Fortity source test
-        run: |
-          docker run -v $(readlink -f picolibc):/picolibc -w /picolibc $IMAGE ${{ matrix.test }} ${{ matrix.meson_flags }} -Dfortify-source=2
-
   minsize-arm:
     needs: cache-maker
     runs-on: ubuntu-latest
@@ -459,7 +409,7 @@ jobs:
           "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dtinystdio=false",
         ]
         test: [
-          "./.github/do-many do-test do-native-configure build-native do-test do-aarch64-configure build-aarch64 do-build do-lx106-configure build-lx106 do-test do-i386-configure build-i386 do-build do-m68k-configure build-m68k end",
+          "./.github/do-many do-test do-native-configure build-native do-test do-aarch64-configure build-aarch64 do-build do-lx106-configure build-lx106 do-test do-i386-configure build-i386 do-build do-m68k-configure build-m68k do-build do-sparc64-configure build-sparc64 end",
         ]
     steps:
       - name: Clone picolibc
@@ -634,56 +584,6 @@ jobs:
         run: |
           docker run -v $(readlink -f picolibc):/picolibc -w /picolibc $IMAGE ${{ matrix.test }} ${{ matrix.meson_flags }} --buildtype minsize
 
-  minsize-sparc64:
-    needs: cache-maker
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        meson_flags: [
-          "",
-
-          # Math configurations
-          "-Dnewlib-obsolete-math=false -Dwant-math-errno=true",
-          "-Dnewlib-obsolete-math=true -Dwant-math-errno=true",
-
-          # Tinystdio configurations
-          "-Dio-float-exact=false -Dio-long-long=true",
-          "-Dformat-default=integer",
-
-          # Original stdio
-          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dnewlib-io-long-double=true",
-
-          # Locale, iconv and original malloc configurations
-          "-Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false",
-
-          # Multithread disabled
-          "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false",
-          "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dtinystdio=false",
-        ]
-        test: [
-          "./.github/do-build do-sparc64-configure build-sparc64",
-        ]
-    steps:
-      - name: Clone picolibc
-        uses: actions/checkout@v2
-        with:
-          path: picolibc
-
-      - name: Restore the Docker Image
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.HASH_FILE ) }}
-
-      - name: Load and Check the Docker Image
-        run: |
-          docker load -i $IMAGE_FILE
-          docker images -a $IMAGE
-
-      - name: Minsize test
-        run: |
-          docker run -v $(readlink -f picolibc):/picolibc -w /picolibc $IMAGE ${{ matrix.test }} ${{ matrix.meson_flags }} --buildtype minsize
-
   release-arm:
     needs: cache-maker
     runs-on: ubuntu-latest
@@ -762,7 +662,7 @@ jobs:
           "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dtinystdio=false",
         ]
         test: [
-          "./.github/do-many do-test do-native-configure build-native do-test do-aarch64-configure build-aarch64 do-build do-lx106-configure build-lx106 do-test do-i386-configure build-i386 do-build do-m68k-configure build-m68k end",
+          "./.github/do-many do-test do-native-configure build-native do-test do-aarch64-configure build-aarch64 do-build do-lx106-configure build-lx106 do-test do-i386-configure build-i386 do-build do-m68k-configure build-m68k do-build do-sparc64-configure build-sparc64 end",
         ]
     steps:
       - name: Clone picolibc
@@ -915,56 +815,6 @@ jobs:
         ]
         test: [
           "./.github/do-many do-build do-mips-configure build-mips do-build do-mipsel-configure build-mipsel end",
-        ]
-    steps:
-      - name: Clone picolibc
-        uses: actions/checkout@v2
-        with:
-          path: picolibc
-
-      - name: Restore the Docker Image
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.HASH_FILE ) }}
-
-      - name: Load and Check the Docker Image
-        run: |
-          docker load -i $IMAGE_FILE
-          docker images -a $IMAGE
-
-      - name: Release test
-        run: |
-          docker run -v $(readlink -f picolibc):/picolibc -w /picolibc $IMAGE ${{ matrix.test }} ${{ matrix.meson_flags }} --buildtype release
-
-  release-sparc64:
-    needs: cache-maker
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        meson_flags: [
-          "",
-
-          # Math configurations
-          "-Dnewlib-obsolete-math=false -Dwant-math-errno=true",
-          "-Dnewlib-obsolete-math=true -Dwant-math-errno=true",
-
-          # Tinystdio configurations
-          "-Dio-float-exact=false -Dio-long-long=true",
-          "-Dformat-default=integer",
-
-          # Original stdio
-          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dnewlib-io-long-double=true",
-
-          # Locale, iconv and original malloc configurations
-          "-Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false",
-
-          # Multithread disabled
-          "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false",
-          "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dtinystdio=false",
-        ]
-        test: [
-          "./.github/do-build do-sparc64-configure build-sparc64",
         ]
     steps:
       - name: Clone picolibc

--- a/.github/workflows/make-workflow
+++ b/.github/workflows/make-workflow
@@ -14,7 +14,7 @@ for build in cmake; do
 done
 
 for build in fortify-source minsize release; do
-    for arch in arm misc ppc riscv mips sparc64; do
+    for arch in arm misc ppc riscv mips; do
 	echo "  $build-$arch:"
 	cat variants
 	cat targets-$arch

--- a/.github/workflows/targets-misc
+++ b/.github/workflows/targets-misc
@@ -1,3 +1,3 @@
         test: [
-          "./.github/do-many do-test do-native-configure build-native do-test do-aarch64-configure build-aarch64 do-build do-lx106-configure build-lx106 do-test do-i386-configure build-i386 do-build do-m68k-configure build-m68k end",
+          "./.github/do-many do-test do-native-configure build-native do-test do-aarch64-configure build-aarch64 do-build do-lx106-configure build-lx106 do-test do-i386-configure build-i386 do-build do-m68k-configure build-m68k do-build do-sparc64-configure build-sparc64 end",
         ]

--- a/.github/workflows/targets-sparc64
+++ b/.github/workflows/targets-sparc64
@@ -1,3 +1,0 @@
-        test: [
-          "./.github/do-build do-sparc64-configure build-sparc64",
-        ]

--- a/meson.build
+++ b/meson.build
@@ -215,6 +215,7 @@ newlib_obsolete_math_float = get_option('newlib-obsolete-math-float')
 newlib_obsolete_math_double = get_option('newlib-obsolete-math-double')
 
 sysroot_install = get_option('sysroot-install')
+system_libc = get_option('system-libc')
 prefix = get_option('prefix')
 
 nm = find_program('nm', required : false)
@@ -495,6 +496,12 @@ if tinystdio
 		' %{DPICOLIBC_INTEGER_PRINTF_SCANF:--defsym=vfscanf=__i_vfscanf}')
 endif
 
+if system_libc
+  specs_isystem = ''
+  specs_libpath = ''
+  specs_startfile = 'crt0%O%s'
+else
+
 #
 # Construct path values for specs file
 #
@@ -614,6 +621,7 @@ endif
 # multilib path or the non-multilib path
 #
 specs_startfile = specs_option_format.format(crt0_prefix, crt0_buildtype, crt0_gen)
+endif
 
 specs_data = configuration_data()
 specs_data.set('SPECS_ISYSTEM', specs_isystem)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -68,6 +68,9 @@ option('specsdir', type: 'string',
 option('sysroot-install', type: 'boolean', value: false,
        description: 'Install in gcc sysroot')
 
+option('system-libc', type: 'boolean', value: false,
+       description: 'Install as system C library')
+					      
 option('picoexit', type: 'boolean', value: true,
        description: 'Smaller exit/atexit/onexit code')
 

--- a/semihost/getentropy.c
+++ b/semihost/getentropy.c
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2022 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sys/unistd.h>
+#include <string.h>
+#include "semihost.h"
+
+int
+getentropy(void *buffer, size_t length)
+{
+    uint8_t     *b = buffer;
+
+    while (length) {
+        uintptr_t bits = sys_semihost_time();
+        size_t this_time = sizeof (uintptr_t);
+        if (this_time > length)
+            this_time = length;
+        memcpy(b, &bits, this_time);
+        length -= this_time;
+        b += this_time;
+    }
+    return 0;
+}

--- a/semihost/meson.build
+++ b/semihost/meson.build
@@ -57,6 +57,7 @@ if src_semihost != []
     'close.c',
     'exit.c',
     'fstat.c',
+    'getentropy.c',
     'gettimeofday.c',
     'isatty.c',
     'kill.c',


### PR DESCRIPTION
Add an option to remove include and library path definitions from picolibc.specs for use when
picolibc is the system C library.