### PR TITLE
Fix references to _r function

### DIFF
--- a/newlib/libc/stdio/fputws.c
+++ b/newlib/libc/stdio/fputws.c
@@ -113,7 +113,7 @@ _fputws_r (struct _reent *ptr,
   iov.iov_base = buf;
   do
     {
-      nbytes = _wcsrtombs_r(ptr, buf, &ws, sizeof (buf), &fp->_mbstate);
+      nbytes = wcsrtombs(buf, &ws, sizeof (buf), &fp->_mbstate);
       if (nbytes == (size_t) -1)
 	goto error;
       iov.iov_len = uio.uio_resid = nbytes;


### PR DESCRIPTION
Encounter this when use `newlib-fvwrite-in-streamio` option.