### PR TITLE
newlib/stdlib: Fix unbalanced preprocessor #if

### DIFF
--- a/newlib/libc/stdlib/__atexit.c
+++ b/newlib/libc/stdlib/__atexit.c
@@ -87,6 +87,7 @@ __register_exitproc (int type,
       p->_ind = 0;
       p->_next = _atexit;
       _atexit = p;
+#endif
     }
 
   if (type != __et_atexit)


### PR DESCRIPTION
I think something must have gone wrong with the merge in 3b8c9b74e6d1a6e9bc5a8fda5853a78a09a9d174, resulting in the loss of an `#endif` in stdlib/__atexit.c?