### PR TITLE
Fix picocrt build with clang for thumbv6m

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -107,7 +107,7 @@ jobs:
         ]
         test: [
           "./.github/do-test do-arm-configure build-arm",
-          "./.github/do-many do-test do-clang-thumbv7e+fp-configure build-clang-thumbv7e+fp do-test do-clang-thumbv7m-configure build-clang-thumbv7m do-test do-cortex-a9-configure build-cortex-a9 end",
+          "./.github/do-many do-test do-clang-thumbv7e+fp-configure build-clang-thumbv7e+fp do-test do-clang-thumbv7m-configure build-clang-thumbv7m do-test do-cortex-a9-configure build-cortex-a9 do-test do-clang-thumbv6m-configure build-clang-thumbv6m end",
         ]
     steps:
       - name: Clone picolibc
@@ -360,7 +360,7 @@ jobs:
         ]
         test: [
           "./.github/do-test do-arm-configure build-arm",
-          "./.github/do-many do-test do-clang-thumbv7e+fp-configure build-clang-thumbv7e+fp do-test do-clang-thumbv7m-configure build-clang-thumbv7m do-test do-cortex-a9-configure build-cortex-a9 end",
+          "./.github/do-many do-test do-clang-thumbv7e+fp-configure build-clang-thumbv7e+fp do-test do-clang-thumbv7m-configure build-clang-thumbv7m do-test do-cortex-a9-configure build-cortex-a9 do-test do-clang-thumbv6m-configure build-clang-thumbv6m end",
         ]
     steps:
       - name: Clone picolibc
@@ -613,7 +613,7 @@ jobs:
         ]
         test: [
           "./.github/do-test do-arm-configure build-arm",
-          "./.github/do-many do-test do-clang-thumbv7e+fp-configure build-clang-thumbv7e+fp do-test do-clang-thumbv7m-configure build-clang-thumbv7m do-test do-cortex-a9-configure build-cortex-a9 end",
+          "./.github/do-many do-test do-clang-thumbv7e+fp-configure build-clang-thumbv7e+fp do-test do-clang-thumbv7m-configure build-clang-thumbv7m do-test do-cortex-a9-configure build-cortex-a9 do-test do-clang-thumbv6m-configure build-clang-thumbv6m end",
         ]
     steps:
       - name: Clone picolibc

--- a/.github/workflows/targets-arm
+++ b/.github/workflows/targets-arm
@@ -1,4 +1,4 @@
         test: [
           "./.github/do-test do-arm-configure build-arm",
-          "./.github/do-many do-test do-clang-thumbv7e+fp-configure build-clang-thumbv7e+fp do-test do-clang-thumbv7m-configure build-clang-thumbv7m do-test do-cortex-a9-configure build-cortex-a9 end",
+          "./.github/do-many do-test do-clang-thumbv7e+fp-configure build-clang-thumbv7e+fp do-test do-clang-thumbv7m-configure build-clang-thumbv7m do-test do-cortex-a9-configure build-cortex-a9 do-test do-clang-thumbv6m-configure build-clang-thumbv6m end",
         ]

--- a/picocrt/machine/arm/crt0.c
+++ b/picocrt/machine/arm/crt0.c
@@ -176,7 +176,7 @@ void __attribute__((naked))
 arm_hardfault_isr(void)
 {
     __asm__("mov r0, sp");
-    __asm__("mov r1, #" REASON(REASON_HARDFAULT));
+    __asm__("movs r1, #" REASON(REASON_HARDFAULT));
     __asm__("bl  arm_fault");
 }
 
@@ -184,7 +184,7 @@ void __attribute__((naked))
 arm_memmange_isr(void)
 {
     __asm__("mov r0, sp");
-    __asm__("mov r1, #" REASON(REASON_MEMMANAGE));
+    __asm__("movs r1, #" REASON(REASON_MEMMANAGE));
     __asm__("bl  arm_fault");
 }
 
@@ -192,7 +192,7 @@ void __attribute__((naked))
 arm_busfault_isr(void)
 {
     __asm__("mov r0, sp");
-    __asm__("mov r1, #" REASON(REASON_BUSFAULT));
+    __asm__("movs r1, #" REASON(REASON_BUSFAULT));
     __asm__("bl  arm_fault");
 }
 
@@ -200,7 +200,7 @@ void __attribute__((naked))
 arm_usagefault_isr(void)
 {
     __asm__("mov r0, sp");
-    __asm__("mov r1, #" REASON(REASON_USAGE));
+    __asm__("movs r1, #" REASON(REASON_USAGE));
     __asm__("bl  arm_fault");
 }
 

--- a/scripts/cross-clang-thumbv6m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv6m-none-eabi.txt
@@ -1,0 +1,24 @@
+[binaries]
+# Meson 0.53.2 doesn't use any cflags when doing basic compiler tests,
+# so we have to add -nostdlib to the compiler configuration itself or
+# early compiler tests will fail. This can be removed when picolibc
+# requires at least version 0.54.2 of meson.
+c = ['clang', '-m32', '--target=thumbv6m-none-eabi', '-nostdlib']
+c_ld = '/usr/bin/arm-none-eabi-ld'
+ar = 'arm-none-eabi-ar'
+as = 'arm-none-eab-as'
+nm = 'arm-none-eab-nm'
+strip = 'arm-none-eabi-strip'
+# only needed to run tests
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-thumbv6m "$@"', 'run-thumbv6m']
+
+[host_machine]
+system = 'none'
+cpu_family = 'arm'
+cpu = 'arm'
+endian = 'little'
+
+[properties]
+c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt', '-fshort-enums']
+c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v6-m/nofp/', '-Wl,-z,noexecstack']
+skip_sanity_check = true

--- a/scripts/do-clang-thumbv6m-configure
+++ b/scripts/do-clang-thumbv6m-configure
@@ -1,0 +1,40 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2019 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+exec "$(dirname "$0")"/do-configure clang-thumbv6m-none-eabi \
+     -Dtests=true \
+     -Dtests-enable-stack-protector=false \
+     -Dtests-enable-full-malloc-stress=false \
+     -Dmultilib=false "$@"

--- a/scripts/run-thumbv6m
+++ b/scripts/run-thumbv6m
@@ -1,0 +1,99 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2019 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+qemu="qemu-system-arm"
+
+# select the program
+elf="$1"
+shift
+
+cpu=cortex-m0
+machine=virtm
+
+#
+# Make sure the target machine is supported by qemu
+# 
+if "$qemu" -machine help | grep -q "^$machine "; then
+    :
+else
+    echo "Skipping $elf" unsupported machine
+    exit 77
+fi
+
+# Map stdio to a multiplexed character device so we can use it
+# for the monitor and semihosting output
+
+chardev=stdio,mux=on,id=stdio0
+
+# Point the semihosting driver at our new chardev
+
+semi=enable=on,chardev=stdio0
+
+input=""
+
+case "$1" in
+    --)
+	semi="$semi",arg="$2"
+	shift
+	shift
+	;;
+    -*|"")
+	;;
+    *)
+	semi="$semi",arg="$1"
+	input="$1"
+	shift
+	;;
+esac
+
+# Disable monitor
+
+mon=none
+
+# Disable serial
+
+serial=none
+
+echo "$input" | "$qemu" \
+      -chardev "$chardev" \
+      -semihosting-config "$semi" \
+      -monitor "$mon" \
+      -serial "$serial" \
+      -machine "$machine",accel=tcg \
+      -cpu "$cpu" \
+      -device loader,file="$elf",cpu-num=0 \
+      -nographic \
+      "$@"


### PR DESCRIPTION
PR #340 fixes a bug for thumbv6m targets in picocrt; this PR adds tests to validate the fix