### PR TITLE
Add mbstate_t.h for compatibility with libc++

### DIFF
--- a/newlib/libc/include/bits/types/mbstate_t.h
+++ b/newlib/libc/include/bits/types/mbstate_t.h
@@ -1,0 +1,8 @@
+#ifndef _PICOLIBC_BITS_TYPES_MBSTATE_T_H
+#define _PICOLIBC_BITS_TYPES_MBSTATE_T_H
+
+#include <sys/_types.h>
+
+typedef _mbstate_t mbstate_t;
+
+#endif /* _PICOLIBC_BITS_TYPES_MBSTATE_T_H */

--- a/newlib/libc/include/meson.build
+++ b/newlib/libc/include/meson.build
@@ -107,3 +107,7 @@ inc_headers += ['picotls.h']
 
 install_headers(inc_headers,
 		install_dir: include_dir)
+
+# For compatibility with libc++'s __mbstate_t.h:
+install_headers(['bits/types/mbstate_t.h'],
+		install_dir: include_dir / 'bits/types')


### PR DESCRIPTION
tinystdio doesn't provide wide character functions like wcstold. Therefore libc++ must be built with wide character support disabled. When libc++ wide character support is disabled, it can't include wchar.h. However wchar.h is where mbstate_t is defined. Several types like std::fpos are defined in terms of mbstate_t so it's needed even if wide character support isn't. To get around this, libc++ attempts to include the non-standard header mbstate_t.h. This change adds mbstate_t.h in the location that libc++ expects to find it.