### PR TITLE
x86: More 64/32 multilib build fixes

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && \
      xargs -a packages.txt apt-get install -y || \
      xargs -a packages.txt apt-get install -y || \
      xargs -a packages.txt apt-get install -y) && \
+    dpkg -l && \
     mkdir -p /opt && \
     (cd /opt && while read file; do wget $file && tar xf `basename $file`; done) < extra-files.txt
 

--- a/.github/packages.txt
+++ b/.github/packages.txt
@@ -3,7 +3,7 @@ meson
 cmake
 file
 ninja-build
-gcc
+gcc-12
 libx32gcc-12-dev
 lib32gcc-12-dev
 gcc-i686-linux-gnu

--- a/newlib/libc/machine/x86/meson.build
+++ b/newlib/libc/machine/x86/meson.build
@@ -69,7 +69,7 @@ is_x86_64 = cc.compiles(x86_64_code, name : 'x86_64 check')
 
 foreach target : targets
   value = get_variable('target_' + target)
-  if target == '32' or (target == '' and not is_x86_64)
+  if target.startswith('32') or (target == '' and not is_x86_64)
     srcs_machine_target = srcs_machine_common + srcs_machine_32
   else
     srcs_machine_target = srcs_machine_common + srcs_machine_64

--- a/newlib/libm/machine/x86/meson.build
+++ b/newlib/libm/machine/x86/meson.build
@@ -85,7 +85,7 @@ srcs_libm_machine = srcs_libm_machine_common + [
 src_libm_machine = []
 
 foreach target : targets
-  if target == '32' or (target == '' and not is_x86_64)
+  if target.startswith('32') or (target == '' and not is_x86_64)
     src_libm_machine_target = srcs_libm_machine_common + srcs_libm_machine_32
   else
     src_libm_machine_target = srcs_libm_machine_common

--- a/semihost/machine/x86/meson.build
+++ b/semihost/machine/x86/meson.build
@@ -68,23 +68,24 @@ foreach target : targets
 
   set_variable('lib_semihost' + target, local_lib_semihost_target)
 
-  if objcopy.found()
-    # Stub BIOS which provides a jump instruction at the CPU start
-    # address (0xfffffff0) to get us to our default start address at 1MB
-    # (0x100000)
-
-    bios_ld = '@0@/@1@'.format(meson.current_source_dir(), 'bios.ld')
-    bios = executable('bios' + target, 'bios.S',
-		      c_args: ['-m32'],
-		      link_args: ['-nostartfiles', '-m32', '-Wl,--build-id=none', '-T', bios_ld])
-
-    bios_bin = custom_target('bios' + target + '.bin',
-		             build_by_default: true,
-		             input: bios,
-		             install: true,
-		             install_dir: instdir,
-		             output: 'bios' + target + '.bin',
-		             command: [objcopy, '-O', 'binary', '@INPUT@', '@OUTPUT@'])
-  endif
-
 endforeach
+
+if objcopy.found()
+  # Stub BIOS which provides a jump instruction at the CPU start
+  # address (0xfffffff0) to get us to our default start address at 1MB
+  # (0x100000)
+
+  bios_ld = '@0@/@1@'.format(meson.current_source_dir(), 'bios.ld')
+  bios = executable('bios', 'bios.S',
+		    c_args: ['-m32'],
+		    link_args: ['-nostdlib', '-m32', '-Wl,--build-id=none', '-T', bios_ld])
+
+  bios_bin = custom_target('bios.bin',
+		           build_by_default: true,
+		           input: bios,
+		           install: true,
+		           install_dir: instdir,
+		           output: 'bios.bin',
+		           command: [objcopy, '-O', 'binary', '@INPUT@', '@OUTPUT@'])
+endif
+


### PR DESCRIPTION
Only build one copy of bios.bin, using -nostdlib to avoid looking for libc.
Make sure all 32-bit targets,even 32/soft-float get the i386 specific bits.