### PR TITLE
Fix nios2 configuration and build during CI

### DIFF
--- a/.github/do-zephyr-build
+++ b/.github/do-zephyr-build
@@ -1,0 +1,3 @@
+#!/bin/bash
+here=`dirname "$0"`
+"$here"/do-zephyr "$here"/do-build "$@"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -157,7 +157,7 @@ jobs:
           "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dtinystdio=false",
         ]
         test: [
-          "./.github/do-many do-test do-native-configure build-native do-test do-aarch64-configure build-aarch64 do-build do-lx106-configure build-lx106 do-test do-i386-configure build-i386 do-build do-m68k-configure build-m68k do-build do-clang-msp430-configure build-clang-msp430 do-build do-msp430-configure build-msp430 do-build do-sparc64-configure build-sparc64 do-test do-x86_64-configure build-x86_64 do-test do-x86-configure build-x86 end",
+          "./.github/do-many do-test do-native-configure build-native do-test do-aarch64-configure build-aarch64 do-build do-lx106-configure build-lx106 do-test do-i386-configure build-i386 do-build do-m68k-configure build-m68k do-build do-clang-msp430-configure build-clang-msp430 do-build do-msp430-configure build-msp430 do-zephyr-build do-nios2-configure build-nios2 do-build do-sparc64-configure build-sparc64 do-test do-x86_64-configure build-x86_64 do-test do-x86-configure build-x86 end",
         ]
     steps:
       - name: Clone picolibc
@@ -460,7 +460,7 @@ jobs:
           "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dtinystdio=false",
         ]
         test: [
-          "./.github/do-many do-test do-native-configure build-native do-test do-aarch64-configure build-aarch64 do-build do-lx106-configure build-lx106 do-test do-i386-configure build-i386 do-build do-m68k-configure build-m68k do-build do-clang-msp430-configure build-clang-msp430 do-build do-msp430-configure build-msp430 do-build do-sparc64-configure build-sparc64 do-test do-x86_64-configure build-x86_64 do-test do-x86-configure build-x86 end",
+          "./.github/do-many do-test do-native-configure build-native do-test do-aarch64-configure build-aarch64 do-build do-lx106-configure build-lx106 do-test do-i386-configure build-i386 do-build do-m68k-configure build-m68k do-build do-clang-msp430-configure build-clang-msp430 do-build do-msp430-configure build-msp430 do-zephyr-build do-nios2-configure build-nios2 do-build do-sparc64-configure build-sparc64 do-test do-x86_64-configure build-x86_64 do-test do-x86-configure build-x86 end",
         ]
     steps:
       - name: Clone picolibc
@@ -763,7 +763,7 @@ jobs:
           "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dtinystdio=false",
         ]
         test: [
-          "./.github/do-many do-test do-native-configure build-native do-test do-aarch64-configure build-aarch64 do-build do-lx106-configure build-lx106 do-test do-i386-configure build-i386 do-build do-m68k-configure build-m68k do-build do-clang-msp430-configure build-clang-msp430 do-build do-msp430-configure build-msp430 do-build do-sparc64-configure build-sparc64 do-test do-x86_64-configure build-x86_64 do-test do-x86-configure build-x86 end",
+          "./.github/do-many do-test do-native-configure build-native do-test do-aarch64-configure build-aarch64 do-build do-lx106-configure build-lx106 do-test do-i386-configure build-i386 do-build do-m68k-configure build-m68k do-build do-clang-msp430-configure build-clang-msp430 do-build do-msp430-configure build-msp430 do-zephyr-build do-nios2-configure build-nios2 do-build do-sparc64-configure build-sparc64 do-test do-x86_64-configure build-x86_64 do-test do-x86-configure build-x86 end",
         ]
     steps:
       - name: Clone picolibc

--- a/.github/workflows/targets-misc
+++ b/.github/workflows/targets-misc
@@ -1,3 +1,3 @@
         test: [
-          "./.github/do-many do-test do-native-configure build-native do-test do-aarch64-configure build-aarch64 do-build do-lx106-configure build-lx106 do-test do-i386-configure build-i386 do-build do-m68k-configure build-m68k do-build do-clang-msp430-configure build-clang-msp430 do-build do-msp430-configure build-msp430 do-build do-sparc64-configure build-sparc64 do-test do-x86_64-configure build-x86_64 do-test do-x86-configure build-x86 end",
+          "./.github/do-many do-test do-native-configure build-native do-test do-aarch64-configure build-aarch64 do-build do-lx106-configure build-lx106 do-test do-i386-configure build-i386 do-build do-m68k-configure build-m68k do-build do-clang-msp430-configure build-clang-msp430 do-build do-msp430-configure build-msp430 do-zephyr-build do-nios2-configure build-nios2 do-build do-sparc64-configure build-sparc64 do-test do-x86_64-configure build-x86_64 do-test do-x86-configure build-x86 end",
         ]

--- a/meson.build
+++ b/meson.build
@@ -786,7 +786,29 @@ if enable_multilib
       if tmp.length() > 1
 	foreach flag : tmp[1].strip('@').split('@')
 	  if flag != ''
-	    flags += '-' + flag
+	    if host_cpu_family == 'nios2'
+	      # Hacks for NIOS II to get rid of -fsingle-precision-constant
+	      # mode (which breaks libm). We don't need fph2 as that
+	      # doesn't set the single precision constant flag
+	      if flag == 'mcustom-fpu-cfg=60-1'
+		flags += ['-mcustom-fmuls=252', '-mcustom-fadds=253',
+			  '-mcustom-fsubs=254']
+	      elif flag == 'mcustom-fpu-cfg=60-2'
+		flags += ['-mcustom-fmuls=252', '-mcustom-fadds=253',
+			  '-mcustom-fsubs=254', '-mcustom-fdivs=255']
+	      elif flag == 'mcustom-fpu-cfg=72-3'
+		flags += ['-mcustom-floatus=243', '-mcustom-fixsi=244',
+			  '-mcustom-floatis=245','-mcustom-fcmpgts=246',
+			  '-mcustom-fcmples=249', '-mcustom-fcmpeqs=250',
+			  '-mcustom-fcmpnes=251', '-mcustom-fmuls=252',
+			  '-mcustom-fadds=253', '-mcustom-fsubs=254',
+			  '-mcustom-fdivs=255']
+	      else
+		flags += '-' + flag
+	      endif
+	    else
+	      flags += '-' + flag
+	    endif
 	  endif
 	endforeach
 	if tmp[0] == '.'

--- a/newlib/libc/machine/nios2/meson.build
+++ b/newlib/libc/machine/nios2/meson.build
@@ -1,0 +1,40 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2022 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+srcs_machine = [
+  'setjmp.s',
+]
+
+src_machine = files(srcs_machine)

--- a/scripts/cross-nios2-zephyr-elf.txt
+++ b/scripts/cross-nios2-zephyr-elf.txt
@@ -1,0 +1,19 @@
+[binaries]
+# Meson 0.53.2 doesn't use any cflags when doing basic compiler tests,
+# so we have to add -nostdlib to the compiler configuration itself or
+# early compiler tests will fail. This can be removed when picolibc
+# requires at least version 0.54.2 of meson.
+c = ['nios2-zephyr-elf-gcc', '-nostdlib']
+ar = 'nios2-zephyr-elf-ar'
+as = 'nios2-zephyr-elf-as'
+nm = 'nios2-zephyr-elf-nm'
+strip = 'nios2-zephyr-elf-strip'
+
+[host_machine]
+system = 'zephyr'
+cpu_family = 'nios2'
+cpu = 'nios2'
+endian = 'little'
+
+[properties]
+skip_sanity_check = true

--- a/scripts/do-nios2-configure
+++ b/scripts/do-nios2-configure
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2019 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+exec "$(dirname "$0")"/do-configure nios2-zephyr-elf "$@"


### PR DESCRIPTION
Nios2 requires some hacks to get rid of the -fsingle-precision-constant flag during multilib builds.

Use the Zephyr toolchain to build during CI.