### PR TITLE
Fixes found with Zephyr testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -418,6 +418,10 @@ set(PICOLIBC_INCLUDE ${PROJECT_BINARY_DIR}/picolibc/include)
 
 set(PICOLIBC_SCRIPTS "${CMAKE_CURRENT_SOURCE_DIR}/scripts")
 
+include(CheckIncludeFile)
+
+CHECK_INCLUDE_FILE(xtensa/config/core-isa.h _XTENSA_HAVE_CONFIG_CORE_ISA_H)
+
 configure_file(picolibc.h.in "${PICOLIBC_INCLUDE}/picolibc.h")
 
 set(INCLUDEDIR include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,6 +455,7 @@ set(PICOLIBC_COMPILE_OPTIONS
   "-Werror=vla"
   "-Warray-bounds"
   "-Wold-style-definition"
+  "-D_LIBC"
   ${TLSMODEL}
   ${TARGET_COMPILE_OPTIONS}
   ${PICOLIBC_EXTRA_COMPILE_OPTIONS}

--- a/newlib/libc/machine/aarch64/CMakeLists.txt
+++ b/newlib/libc/machine/aarch64/CMakeLists.txt
@@ -32,41 +32,39 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-
 picolibc_sources_flags("-fno-builtin"
+  memchr-stub.c
+  memchr.S
+  memcmp-stub.c
+  memcmp.S
+  memcpy-stub.c
+  memcpy.S
+  memmove-stub.c
+  memmove.S
+  memset-stub.c
+  memset.S
+  rawmemchr-stub.c
+  rawmemchr.S
   setjmp.S
+  stpcpy-stub.c
+  stpcpy.S
+  strchr-stub.c
+  strchr.S
+  strchrnul-stub.c
+  strchrnul.S
+  strcmp-stub.c
+  strcmp.S
+  strcpy-stub.c
+  strcpy.S
+  strlen-stub.c
+  strlen.S
+  strncmp-stub.c
+  strncmp.S
+  strnlen-stub.c
+  strnlen.S
+  strchr-stub.c
+  strchr.S
   )
 
-if(NOT DEFINED CONFIG_64BIT)
-  picolibc_sources_flags("-fno-builtin"
-    memcmp-bs-norm.S
-    memcmp.S
-    memcmp-stub.c
-    memcpy-archs.S
-    memcpy-bs.S
-    memcpy.S
-    memcpy-stub.c
-    memset-archs.S
-    memset-bs.S
-    memset.S
-    memset-stub.c
-    strchr-bs-norm.S
-    strchr-bs.S
-    strchr.S
-    strchr-stub.c
-    strcmp-archs.S
-    strcmp.S
-    strcmp-stub.c
-    strcpy-bs-arc600.S
-    strcpy-bs.S
-    strcpy.S
-    strcpy-stub.c
-    strlen-bs-norm.S
-    strlen-bs.S
-    strlen.S
-    strlen-stub.c
-    strncpy-bs.S
-    strncpy.S
-    strncpy-stub.c
-    )
-endif()
+add_subdirectory(sys)
+add_subdirectory(machine)

--- a/newlib/libc/machine/aarch64/machine/CMakeLists.txt
+++ b/newlib/libc/machine/aarch64/machine/CMakeLists.txt
@@ -32,41 +32,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-
-picolibc_sources_flags("-fno-builtin"
-  setjmp.S
+picolibc_headers(machine
+  _types.h
+  fenv-fp.h
+  math.h
   )
-
-if(NOT DEFINED CONFIG_64BIT)
-  picolibc_sources_flags("-fno-builtin"
-    memcmp-bs-norm.S
-    memcmp.S
-    memcmp-stub.c
-    memcpy-archs.S
-    memcpy-bs.S
-    memcpy.S
-    memcpy-stub.c
-    memset-archs.S
-    memset-bs.S
-    memset.S
-    memset-stub.c
-    strchr-bs-norm.S
-    strchr-bs.S
-    strchr.S
-    strchr-stub.c
-    strcmp-archs.S
-    strcmp.S
-    strcmp-stub.c
-    strcpy-bs-arc600.S
-    strcpy-bs.S
-    strcpy.S
-    strcpy-stub.c
-    strlen-bs-norm.S
-    strlen-bs.S
-    strlen.S
-    strlen-stub.c
-    strncpy-bs.S
-    strncpy.S
-    strncpy-stub.c
-    )
-endif()

--- a/newlib/libc/machine/aarch64/sys/CMakeLists.txt
+++ b/newlib/libc/machine/aarch64/sys/CMakeLists.txt
@@ -32,41 +32,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-
-picolibc_sources_flags("-fno-builtin"
-  setjmp.S
+picolibc_headers(sys
+  fenv.h
   )
-
-if(NOT DEFINED CONFIG_64BIT)
-  picolibc_sources_flags("-fno-builtin"
-    memcmp-bs-norm.S
-    memcmp.S
-    memcmp-stub.c
-    memcpy-archs.S
-    memcpy-bs.S
-    memcpy.S
-    memcpy-stub.c
-    memset-archs.S
-    memset-bs.S
-    memset.S
-    memset-stub.c
-    strchr-bs-norm.S
-    strchr-bs.S
-    strchr.S
-    strchr-stub.c
-    strcmp-archs.S
-    strcmp.S
-    strcmp-stub.c
-    strcpy-bs-arc600.S
-    strcpy-bs.S
-    strcpy.S
-    strcpy-stub.c
-    strlen-bs-norm.S
-    strlen-bs.S
-    strlen.S
-    strlen-stub.c
-    strncpy-bs.S
-    strncpy.S
-    strncpy-stub.c
-    )
-endif()

--- a/newlib/libc/machine/arc/CMakeLists.txt
+++ b/newlib/libc/machine/arc/CMakeLists.txt
@@ -37,7 +37,7 @@ picolibc_sources_flags("-fno-builtin"
   setjmp.S
   )
 
-if(NOT DEFINED CONFIG_64BIT)
+if(NOT DEFINED CONFIG_ISA_ARCV3)
   picolibc_sources_flags("-fno-builtin"
     memcmp-bs-norm.S
     memcmp.S

--- a/newlib/libc/machine/mips/CMakeLists.txt
+++ b/newlib/libc/machine/mips/CMakeLists.txt
@@ -33,40 +33,15 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+add_subdirectory(sys)
+add_subdirectory(machine)
+
 picolibc_sources_flags("-fno-builtin"
+  memcpy.S
+  memset.S
+  setjmp.S
+  strcmp.S
+  strlen.c
+  strncpy.c
   setjmp.S
   )
-
-if(NOT DEFINED CONFIG_64BIT)
-  picolibc_sources_flags("-fno-builtin"
-    memcmp-bs-norm.S
-    memcmp.S
-    memcmp-stub.c
-    memcpy-archs.S
-    memcpy-bs.S
-    memcpy.S
-    memcpy-stub.c
-    memset-archs.S
-    memset-bs.S
-    memset.S
-    memset-stub.c
-    strchr-bs-norm.S
-    strchr-bs.S
-    strchr.S
-    strchr-stub.c
-    strcmp-archs.S
-    strcmp.S
-    strcmp-stub.c
-    strcpy-bs-arc600.S
-    strcpy-bs.S
-    strcpy.S
-    strcpy-stub.c
-    strlen-bs-norm.S
-    strlen-bs.S
-    strlen.S
-    strlen-stub.c
-    strncpy-bs.S
-    strncpy.S
-    strncpy-stub.c
-    )
-endif()

--- a/newlib/libc/machine/mips/machine/CMakeLists.txt
+++ b/newlib/libc/machine/mips/machine/CMakeLists.txt
@@ -32,41 +32,9 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-
-picolibc_sources_flags("-fno-builtin"
-  setjmp.S
+picolibc_headers(machine
+  asm.h
+  fenv-fp.h
+  fenv-softfloat.h
+  regdef.h
   )
-
-if(NOT DEFINED CONFIG_64BIT)
-  picolibc_sources_flags("-fno-builtin"
-    memcmp-bs-norm.S
-    memcmp.S
-    memcmp-stub.c
-    memcpy-archs.S
-    memcpy-bs.S
-    memcpy.S
-    memcpy-stub.c
-    memset-archs.S
-    memset-bs.S
-    memset.S
-    memset-stub.c
-    strchr-bs-norm.S
-    strchr-bs.S
-    strchr.S
-    strchr-stub.c
-    strcmp-archs.S
-    strcmp.S
-    strcmp-stub.c
-    strcpy-bs-arc600.S
-    strcpy-bs.S
-    strcpy.S
-    strcpy-stub.c
-    strlen-bs-norm.S
-    strlen-bs.S
-    strlen.S
-    strlen-stub.c
-    strncpy-bs.S
-    strncpy.S
-    strncpy-stub.c
-    )
-endif()

--- a/newlib/libc/machine/mips/sys/CMakeLists.txt
+++ b/newlib/libc/machine/mips/sys/CMakeLists.txt
@@ -32,41 +32,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-
-picolibc_sources_flags("-fno-builtin"
-  setjmp.S
+picolibc_headers(sys
+  fenv.h
   )
-
-if(NOT DEFINED CONFIG_64BIT)
-  picolibc_sources_flags("-fno-builtin"
-    memcmp-bs-norm.S
-    memcmp.S
-    memcmp-stub.c
-    memcpy-archs.S
-    memcpy-bs.S
-    memcpy.S
-    memcpy-stub.c
-    memset-archs.S
-    memset-bs.S
-    memset.S
-    memset-stub.c
-    strchr-bs-norm.S
-    strchr-bs.S
-    strchr.S
-    strchr-stub.c
-    strcmp-archs.S
-    strcmp.S
-    strcmp-stub.c
-    strcpy-bs-arc600.S
-    strcpy-bs.S
-    strcpy.S
-    strcpy-stub.c
-    strlen-bs-norm.S
-    strlen-bs.S
-    strlen.S
-    strlen-stub.c
-    strncpy-bs.S
-    strncpy.S
-    strncpy-stub.c
-    )
-endif()

--- a/newlib/libc/machine/nios2/CMakeLists.txt
+++ b/newlib/libc/machine/nios2/CMakeLists.txt
@@ -32,41 +32,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-
-picolibc_sources_flags("-fno-builtin"
-  setjmp.S
+picolibc_sources(
+  setjmp.s
   )
-
-if(NOT DEFINED CONFIG_64BIT)
-  picolibc_sources_flags("-fno-builtin"
-    memcmp-bs-norm.S
-    memcmp.S
-    memcmp-stub.c
-    memcpy-archs.S
-    memcpy-bs.S
-    memcpy.S
-    memcpy-stub.c
-    memset-archs.S
-    memset-bs.S
-    memset.S
-    memset-stub.c
-    strchr-bs-norm.S
-    strchr-bs.S
-    strchr.S
-    strchr-stub.c
-    strcmp-archs.S
-    strcmp.S
-    strcmp-stub.c
-    strcpy-bs-arc600.S
-    strcpy-bs.S
-    strcpy.S
-    strcpy-stub.c
-    strlen-bs-norm.S
-    strlen-bs.S
-    strlen.S
-    strlen-stub.c
-    strncpy-bs.S
-    strncpy.S
-    strncpy-stub.c
-    )
-endif()

--- a/newlib/libc/machine/sparc/CMakeLists.txt
+++ b/newlib/libc/machine/sparc/CMakeLists.txt
@@ -35,38 +35,9 @@
 
 picolibc_sources_flags("-fno-builtin"
   setjmp.S
+  scan.c
+  shuffle.c
   )
 
-if(NOT DEFINED CONFIG_64BIT)
-  picolibc_sources_flags("-fno-builtin"
-    memcmp-bs-norm.S
-    memcmp.S
-    memcmp-stub.c
-    memcpy-archs.S
-    memcpy-bs.S
-    memcpy.S
-    memcpy-stub.c
-    memset-archs.S
-    memset-bs.S
-    memset.S
-    memset-stub.c
-    strchr-bs-norm.S
-    strchr-bs.S
-    strchr.S
-    strchr-stub.c
-    strcmp-archs.S
-    strcmp.S
-    strcmp-stub.c
-    strcpy-bs-arc600.S
-    strcpy-bs.S
-    strcpy.S
-    strcpy-stub.c
-    strlen-bs-norm.S
-    strlen-bs.S
-    strlen.S
-    strlen-stub.c
-    strncpy-bs.S
-    strncpy.S
-    strncpy-stub.c
-    )
-endif()
+add_subdirectory(sys)
+add_subdirectory(machine)

--- a/newlib/libc/machine/sparc/machine/CMakeLists.txt
+++ b/newlib/libc/machine/sparc/machine/CMakeLists.txt
@@ -32,41 +32,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-
-picolibc_sources_flags("-fno-builtin"
-  setjmp.S
+picolibc_headers(machine
+  sparclet.h
   )
-
-if(NOT DEFINED CONFIG_64BIT)
-  picolibc_sources_flags("-fno-builtin"
-    memcmp-bs-norm.S
-    memcmp.S
-    memcmp-stub.c
-    memcpy-archs.S
-    memcpy-bs.S
-    memcpy.S
-    memcpy-stub.c
-    memset-archs.S
-    memset-bs.S
-    memset.S
-    memset-stub.c
-    strchr-bs-norm.S
-    strchr-bs.S
-    strchr.S
-    strchr-stub.c
-    strcmp-archs.S
-    strcmp.S
-    strcmp-stub.c
-    strcpy-bs-arc600.S
-    strcpy-bs.S
-    strcpy.S
-    strcpy-stub.c
-    strlen-bs-norm.S
-    strlen-bs.S
-    strlen.S
-    strlen-stub.c
-    strncpy-bs.S
-    strncpy.S
-    strncpy-stub.c
-    )
-endif()

--- a/newlib/libc/machine/sparc/sys/CMakeLists.txt
+++ b/newlib/libc/machine/sparc/sys/CMakeLists.txt
@@ -32,41 +32,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-
-picolibc_sources_flags("-fno-builtin"
-  setjmp.S
+picolibc_headers(sys
+  fenv.h
   )
-
-if(NOT DEFINED CONFIG_64BIT)
-  picolibc_sources_flags("-fno-builtin"
-    memcmp-bs-norm.S
-    memcmp.S
-    memcmp-stub.c
-    memcpy-archs.S
-    memcpy-bs.S
-    memcpy.S
-    memcpy-stub.c
-    memset-archs.S
-    memset-bs.S
-    memset.S
-    memset-stub.c
-    strchr-bs-norm.S
-    strchr-bs.S
-    strchr.S
-    strchr-stub.c
-    strcmp-archs.S
-    strcmp.S
-    strcmp-stub.c
-    strcpy-bs-arc600.S
-    strcpy-bs.S
-    strcpy.S
-    strcpy-stub.c
-    strlen-bs-norm.S
-    strlen-bs.S
-    strlen.S
-    strlen-stub.c
-    strncpy-bs.S
-    strncpy.S
-    strncpy-stub.c
-    )
-endif()

--- a/newlib/libc/machine/x86/machine/CMakeLists.txt
+++ b/newlib/libc/machine/x86/machine/CMakeLists.txt
@@ -32,41 +32,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-
-picolibc_sources_flags("-fno-builtin"
-  setjmp.S
+picolibc_headers(machine
+  fastmath.h
   )
-
-if(NOT DEFINED CONFIG_64BIT)
-  picolibc_sources_flags("-fno-builtin"
-    memcmp-bs-norm.S
-    memcmp.S
-    memcmp-stub.c
-    memcpy-archs.S
-    memcpy-bs.S
-    memcpy.S
-    memcpy-stub.c
-    memset-archs.S
-    memset-bs.S
-    memset.S
-    memset-stub.c
-    strchr-bs-norm.S
-    strchr-bs.S
-    strchr.S
-    strchr-stub.c
-    strcmp-archs.S
-    strcmp.S
-    strcmp-stub.c
-    strcpy-bs-arc600.S
-    strcpy-bs.S
-    strcpy.S
-    strcpy-stub.c
-    strlen-bs-norm.S
-    strlen-bs.S
-    strlen.S
-    strlen-stub.c
-    strncpy-bs.S
-    strncpy.S
-    strncpy-stub.c
-    )
-endif()

--- a/newlib/libc/machine/xtensa/CMakeLists.txt
+++ b/newlib/libc/machine/xtensa/CMakeLists.txt
@@ -34,39 +34,14 @@
 #
 
 picolibc_sources_flags("-fno-builtin"
+  memcpy.S
+  memset.S
   setjmp.S
+  strcmp.S
+  strcpy.S
+  strlen.S
+  strncpy.S
   )
 
-if(NOT DEFINED CONFIG_64BIT)
-  picolibc_sources_flags("-fno-builtin"
-    memcmp-bs-norm.S
-    memcmp.S
-    memcmp-stub.c
-    memcpy-archs.S
-    memcpy-bs.S
-    memcpy.S
-    memcpy-stub.c
-    memset-archs.S
-    memset-bs.S
-    memset.S
-    memset-stub.c
-    strchr-bs-norm.S
-    strchr-bs.S
-    strchr.S
-    strchr-stub.c
-    strcmp-archs.S
-    strcmp.S
-    strcmp-stub.c
-    strcpy-bs-arc600.S
-    strcpy-bs.S
-    strcpy.S
-    strcpy-stub.c
-    strlen-bs-norm.S
-    strlen-bs.S
-    strlen.S
-    strlen-stub.c
-    strncpy-bs.S
-    strncpy.S
-    strncpy-stub.c
-    )
-endif()
+add_subdirectory(sys)
+add_subdirectory(machine)

--- a/newlib/libc/machine/xtensa/machine/CMakeLists.txt
+++ b/newlib/libc/machine/xtensa/machine/CMakeLists.txt
@@ -32,41 +32,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-
-picolibc_sources_flags("-fno-builtin"
-  setjmp.S
+picolibc_headers(machine
+  core-isa.h
   )
-
-if(NOT DEFINED CONFIG_64BIT)
-  picolibc_sources_flags("-fno-builtin"
-    memcmp-bs-norm.S
-    memcmp.S
-    memcmp-stub.c
-    memcpy-archs.S
-    memcpy-bs.S
-    memcpy.S
-    memcpy-stub.c
-    memset-archs.S
-    memset-bs.S
-    memset.S
-    memset-stub.c
-    strchr-bs-norm.S
-    strchr-bs.S
-    strchr.S
-    strchr-stub.c
-    strcmp-archs.S
-    strcmp.S
-    strcmp-stub.c
-    strcpy-bs-arc600.S
-    strcpy-bs.S
-    strcpy.S
-    strcpy-stub.c
-    strlen-bs-norm.S
-    strlen-bs.S
-    strlen.S
-    strlen-stub.c
-    strncpy-bs.S
-    strncpy.S
-    strncpy-stub.c
-    )
-endif()

--- a/newlib/libc/machine/xtensa/machine/core-isa.h
+++ b/newlib/libc/machine/xtensa/machine/core-isa.h
@@ -1,3 +1,7 @@
+#ifdef _XTENSA_HAVE_CONFIG_CORE_ISA_H
+#include <xtensa/config/core-isa.h>
+#else
+
 /* 
  * xtensa/config/core-isa.h -- HAL definitions that are dependent on Xtensa
  *				processor CORE configuration
@@ -457,3 +461,4 @@
 
 #endif /* _XTENSA_CORE_CONFIGURATION_H */
 
+#endif

--- a/newlib/libc/machine/xtensa/meson.build
+++ b/newlib/libc/machine/xtensa/meson.build
@@ -43,6 +43,10 @@ srcs_machine = [
   'strncpy.S',
 ]
 
+conf_data.set('_XTENSA_HAVE_CONFIG_CORE_ISA_H',
+	      cc.check_header('xtensa/config/core-isa.h'),
+	      description: 'Xtensa toolchain includes core-isa.h')
+
 subdir('sys')
 subdir('machine')
 

--- a/newlib/libc/machine/xtensa/sys/CMakeLists.txt
+++ b/newlib/libc/machine/xtensa/sys/CMakeLists.txt
@@ -32,41 +32,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-
-picolibc_sources_flags("-fno-builtin"
-  setjmp.S
+picolibc_headers(sys
+  fenv.h
   )
-
-if(NOT DEFINED CONFIG_64BIT)
-  picolibc_sources_flags("-fno-builtin"
-    memcmp-bs-norm.S
-    memcmp.S
-    memcmp-stub.c
-    memcpy-archs.S
-    memcpy-bs.S
-    memcpy.S
-    memcpy-stub.c
-    memset-archs.S
-    memset-bs.S
-    memset.S
-    memset-stub.c
-    strchr-bs-norm.S
-    strchr-bs.S
-    strchr.S
-    strchr-stub.c
-    strcmp-archs.S
-    strcmp.S
-    strcmp-stub.c
-    strcpy-bs-arc600.S
-    strcpy-bs.S
-    strcpy.S
-    strcpy-stub.c
-    strlen-bs-norm.S
-    strlen-bs.S
-    strlen.S
-    strlen-stub.c
-    strncpy-bs.S
-    strncpy.S
-    strncpy-stub.c
-    )
-endif()

--- a/newlib/libm/machine/aarch64/CMakeLists.txt
+++ b/newlib/libm/machine/aarch64/CMakeLists.txt
@@ -33,40 +33,50 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-picolibc_sources_flags("-fno-builtin"
-  setjmp.S
+picolibc_sources(
+  fenv.c
+  s_ceil.c
+  s_fabs.c
+  s_floor.c
+  s_fma.c
+  s_fmax.c
+  s_fmin.c
+  s_llrint.c
+  s_llround.c
+  s_lrint.c
+  s_lround.c
+  s_sqrt.c
+  s_trunc.c
+  sf_ceil.c
+  sf_fabs.c
+  sf_floor.c
+  sf_fma.c
+  sf_fmax.c
+  sf_fmin.c
+  sf_llrint.c
+  sf_llround.c
+  sf_lrint.c
+  sf_lround.c
+  sf_nearbyint.c
+  sf_rint.c
+  sf_round.c
+  sf_sqrt.c
+  sf_trunc.c
   )
 
-if(NOT DEFINED CONFIG_64BIT)
-  picolibc_sources_flags("-fno-builtin"
-    memcmp-bs-norm.S
-    memcmp.S
-    memcmp-stub.c
-    memcpy-archs.S
-    memcpy-bs.S
-    memcpy.S
-    memcpy-stub.c
-    memset-archs.S
-    memset-bs.S
-    memset.S
-    memset-stub.c
-    strchr-bs-norm.S
-    strchr-bs.S
-    strchr.S
-    strchr-stub.c
-    strcmp-archs.S
-    strcmp.S
-    strcmp-stub.c
-    strcpy-bs-arc600.S
-    strcpy-bs.S
-    strcpy.S
-    strcpy-stub.c
-    strlen-bs-norm.S
-    strlen-bs.S
-    strlen.S
-    strlen-stub.c
-    strncpy-bs.S
-    strncpy.S
-    strncpy-stub.c
-    )
-endif()
+picolibc_sources_fake(
+  feclearexcept.c
+  fedisableexcept.c
+  feenableexcept.c
+  fegetenv.c
+  fegetexcept.c
+  fegetexceptflag.c
+  fegetround.c
+  feholdexcept.c
+  feraiseexcept.c
+  fesetenv.c
+  fesetexceptflag.c
+  fesetround.c
+  fetestexcept.c
+  feupdateenv.c
+  )

--- a/newlib/libm/machine/mips/CMakeLists.txt
+++ b/newlib/libm/machine/mips/CMakeLists.txt
@@ -33,40 +33,23 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-picolibc_sources_flags("-fno-builtin"
-  setjmp.S
+picolibc_sources(
+  fenv.c
   )
 
-if(NOT DEFINED CONFIG_64BIT)
-  picolibc_sources_flags("-fno-builtin"
-    memcmp-bs-norm.S
-    memcmp.S
-    memcmp-stub.c
-    memcpy-archs.S
-    memcpy-bs.S
-    memcpy.S
-    memcpy-stub.c
-    memset-archs.S
-    memset-bs.S
-    memset.S
-    memset-stub.c
-    strchr-bs-norm.S
-    strchr-bs.S
-    strchr.S
-    strchr-stub.c
-    strcmp-archs.S
-    strcmp.S
-    strcmp-stub.c
-    strcpy-bs-arc600.S
-    strcpy-bs.S
-    strcpy.S
-    strcpy-stub.c
-    strlen-bs-norm.S
-    strlen-bs.S
-    strlen.S
-    strlen-stub.c
-    strncpy-bs.S
-    strncpy.S
-    strncpy-stub.c
-    )
-endif()
+picolibc_sources_fake(
+  feclearexcept.c
+  fedisableexcept.c
+  feenableexcept.c
+  fegetenv.c
+  fegetexcept.c
+  fegetexceptflag.c
+  fegetround.c
+  feholdexcept.c
+  feraiseexcept.c
+  fesetenv.c
+  fesetexceptflag.c
+  fesetround.c
+  fetestexcept.c
+  feupdateenv.c
+  )

--- a/newlib/libm/machine/sparc/CMakeLists.txt
+++ b/newlib/libm/machine/sparc/CMakeLists.txt
@@ -33,40 +33,23 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-picolibc_sources_flags("-fno-builtin"
-  setjmp.S
+picolibc_sources(
+  fenv.c
   )
 
-if(NOT DEFINED CONFIG_64BIT)
-  picolibc_sources_flags("-fno-builtin"
-    memcmp-bs-norm.S
-    memcmp.S
-    memcmp-stub.c
-    memcpy-archs.S
-    memcpy-bs.S
-    memcpy.S
-    memcpy-stub.c
-    memset-archs.S
-    memset-bs.S
-    memset.S
-    memset-stub.c
-    strchr-bs-norm.S
-    strchr-bs.S
-    strchr.S
-    strchr-stub.c
-    strcmp-archs.S
-    strcmp.S
-    strcmp-stub.c
-    strcpy-bs-arc600.S
-    strcpy-bs.S
-    strcpy.S
-    strcpy-stub.c
-    strlen-bs-norm.S
-    strlen-bs.S
-    strlen.S
-    strlen-stub.c
-    strncpy-bs.S
-    strncpy.S
-    strncpy-stub.c
-    )
-endif()
+picolibc_sources_fake(
+  feclearexcept.c
+  fedisableexcept.c
+  feenableexcept.c
+  fegetenv.c
+  fegetexcept.c
+  fegetexceptflag.c
+  fegetround.c
+  feholdexcept.c
+  feraiseexcept.c
+  fesetenv.c
+  fesetexceptflag.c
+  fesetround.c
+  fetestexcept.c
+  feupdateenv.c
+  )

--- a/newlib/libm/machine/xtensa/CMakeLists.txt
+++ b/newlib/libm/machine/xtensa/CMakeLists.txt
@@ -32,41 +32,19 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-
-picolibc_sources_flags("-fno-builtin"
-  setjmp.S
+picolibc_sources(
+  feclearexcept.c
+  fedisableexcept.c
+  feenableexcept.c
+  fegetenv.c
+  fegetexcept.c
+  fegetexceptflag.c
+  fegetround.c
+  feholdexcept.c
+  feraiseexcept.c
+  fesetenv.c
+  fesetexceptflag.c
+  fesetround.c
+  fetestexcept.c
+  feupdateenv.c
   )
-
-if(NOT DEFINED CONFIG_64BIT)
-  picolibc_sources_flags("-fno-builtin"
-    memcmp-bs-norm.S
-    memcmp.S
-    memcmp-stub.c
-    memcpy-archs.S
-    memcpy-bs.S
-    memcpy.S
-    memcpy-stub.c
-    memset-archs.S
-    memset-bs.S
-    memset.S
-    memset-stub.c
-    strchr-bs-norm.S
-    strchr-bs.S
-    strchr.S
-    strchr-stub.c
-    strcmp-archs.S
-    strcmp.S
-    strcmp-stub.c
-    strcpy-bs-arc600.S
-    strcpy-bs.S
-    strcpy.S
-    strcpy-stub.c
-    strlen-bs-norm.S
-    strlen-bs.S
-    strlen.S
-    strlen-stub.c
-    strncpy-bs.S
-    strncpy.S
-    strncpy-stub.c
-    )
-endif()

--- a/picolibc.h.in
+++ b/picolibc.h.in
@@ -448,3 +448,5 @@
 
 #cmakedefine __SINGLE_THREAD__
 
+/* Compiler has Xtensa-specific core-isa.h header file */
+#cmakedefine _XTENSA_HAVE_CONFIG_CORE_ISA_H


### PR DESCRIPTION
Three cmake fixes to bring it up to parity with meson and an xtensa which uses the toolchain core-isa.h file if available.