### PR TITLE
Provide a 'zephyr' mode for errno-function

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -992,7 +992,14 @@ int main(void) {
       break
     endif
   endforeach
+elif errno_function == 'zephyr'
+  if thread_local_storage
+    errno_function = 'false'
+  else
+    errno_function = 'z_errno_wrap'
+  endif
 endif
+
 if errno_function != 'false'
   conf_data.set('__PICOLIBC_ERRNO_FUNCTION', errno_function)
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -232,7 +232,7 @@ option('newlib-global-errno', type: 'boolean', value: false,
        description: 'use global errno variable')
 option('errno-function', type: 'string',
        value: 'false',
-       description: 'Use this function to compute errno address (default false, auto means autodetect)')
+       description: 'Use this function to compute errno address (default false, auto means autodetect, zephyr means use z_errno_wrap if !tls)')
 
 #
 # Math options


### PR DESCRIPTION
Select z_errno_wrap when picolibc is configured without thread local storage support. Otherwise, place errno in a TLS variable.

Signed-off-by: Keith Packard <keithp@keithp.com>