### PR TITLE
tinystdio: strtol et al improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,9 @@ set(_HAVE_BUILTIN_ISNANL 1)
 # Compiler has __builtin_mul_overflow
 set(_HAVE_BUILTIN_MUL_OVERFLOW 1)
 
+# Compiler has __builtin_add_overflow
+set(_HAVE_BUILTIN_ADD_OVERFLOW 1)
+
 # Compiler flag to prevent detecting memcpy/memset patterns
 set(_HAVE_CC_INHIBIT_LOOP_TO_LIBCALL 1)
 

--- a/meson.build
+++ b/meson.build
@@ -728,6 +728,15 @@ int main (void) { return overflows(aa, aa); }
 '''
 have_builtin_mul_overflow = cc.links(builtin_mul_overflow_code, name : 'has __builtin_mul_overflow', args: core_c_args)
 
+# CompCert does not have __builtin_add_overflow
+builtin_add_overflow_code = '''
+#include <stddef.h>
+int overflows (size_t a, size_t b) { size_t x; return __builtin_add_overflow(a, b, &x); }
+volatile size_t aa = 42;
+int main (void) { return overflows(aa, aa); }
+'''
+have_builtin_add_overflow = cc.links(builtin_add_overflow_code, name : 'has __builtin_add_overflow', args: core_c_args)
+
 # CompCert does not support _Complex
 complex_code = '''
 float _Complex test(float _Complex z) { return z; }
@@ -964,6 +973,7 @@ conf_data.set('POSIX_IO', posix_io, description: 'Use open/close/read/write in t
 conf_data.set('ATOMIC_UNGETC', atomic_ungetc, description: 'Use atomics for fgetc/ungetc for re-entrancy')
 conf_data.set('_HAVE_BITFIELDS_IN_PACKED_STRUCTS', have_bitfields_in_packed_structs, description: 'Use bitfields in packed structs')
 conf_data.set('_HAVE_BUILTIN_MUL_OVERFLOW', have_builtin_mul_overflow, description: 'Compiler has __builtin_mul_overflow')
+conf_data.set('_HAVE_BUILTIN_ADD_OVERFLOW', have_builtin_add_overflow, description: 'Compiler has __builtin_add_overflow')
 conf_data.set('_HAVE_COMPLEX', have_complex, description: 'Compiler supports _Complex')
 conf_data.set('_HAVE_BUILTIN_EXPECT', have_builtin_expect, description: 'Compiler has __builtin_expect')
 conf_data.set('_HAVE_ALLOC_SIZE', have_alloc_size, description: 'The compiler REALLY has the attribute __alloc_size__')

--- a/newlib/libc/stdlib/CMakeLists.txt
+++ b/newlib/libc/stdlib/CMakeLists.txt
@@ -93,12 +93,6 @@ picolibc_sources(
   srand.c
   srand48.c
   srandom.c
-  strtoimax.c
-  strtol.c
-  strtoll.c
-  strtoul.c
-  strtoull.c
-  strtoumax.c
   system.c
   utoa.c
   wcrtomb.c

--- a/newlib/libc/tinystdio/CMakeLists.txt
+++ b/newlib/libc/tinystdio/CMakeLists.txt
@@ -96,6 +96,12 @@ picolibc_sources(
   strtof_l.c
   strtod.c
   strtod_l.c
+  strtoimax.c
+  strtol.c
+  strtoll.c
+  strtoul.c
+  strtoull.c
+  strtoumax.c
   ungetc.c
   vasprintf.c
   vfiprintf.c

--- a/picolibc.h.in
+++ b/picolibc.h.in
@@ -112,6 +112,9 @@
 /* Compiler has __builtin_mul_overflow */
 #cmakedefine _HAVE_BUILTIN_MUL_OVERFLOW
 
+/* Compiler has __builtin_add_overflow */
+#cmakedefine _HAVE_BUILTIN_ADD_OVERFLOW
+
 /* Compiler flag to prevent detecting memcpy/memset patterns */
 #cmakedefine _HAVE_CC_INHIBIT_LOOP_TO_LIBCALL
 

--- a/scripts/run-rv32imac
+++ b/scripts/run-rv32imac
@@ -52,6 +52,10 @@ fi
 
 all_options="i e g m a f d c s u"
 
+if $qemu --version | grep -q 'version [789]'; then
+    all_options="h $all_options"
+fi
+
 for o in $all_options; do
     if echo "$options" | grep -q "$o"; then
 	value=true

--- a/scripts/run-rv32imafdc
+++ b/scripts/run-rv32imafdc
@@ -52,6 +52,10 @@ fi
 
 all_options="i e g m a f d c s u"
 
+if $qemu --version | grep -q 'version [789]'; then
+    all_options="h $all_options"
+fi
+
 for o in $all_options; do
     if echo "$options" | grep -q "$o"; then
 	value=true


### PR DESCRIPTION
Shrink code a bit, including use of __builtin_{mul,add}_overflow for unsigned variants. Add cmake bits.

Signed-off-by: Keith Packard <keithp@keithp.com>