### PR TITLE
tinystdio: strtoi/vfscanf bug parsing numbers

### DIFF
--- a/newlib/libc/tinystdio/strtoi.h
+++ b/newlib/libc/tinystdio/strtoi.h
@@ -116,15 +116,11 @@ strtoi(const char *__restrict nptr, char **__restrict endptr, int ibase)
 #endif
 #endif
 
-/* This fact is used below to parse hexidecimal digit.	*/
-#if	('A' - '0') != (('a' - '0') & ~('A' ^ 'a'))
-# error
-#endif
-
     for(;;) {
-        if (TOLOW(i) > '9')
-            i = TOLOW(i) + (('0' - 'a') + 10);
-	i -= '0';
+        /* Map digits to 0..35, non-digits above 35. */
+        if (i > '9')
+            i = TOLOW(i-1) + ('0' - 'a' + 11);
+        i -= '0';
 
         /* detect invalid char */
         if (i >= base)

--- a/newlib/libc/tinystdio/vfscanf.c
+++ b/newlib/libc/tinystdio/vfscanf.c
@@ -135,15 +135,14 @@ conv_int (FILE *stream, int *lenp, width_t width, void *addr, uint16_t flags, un
     } else if (base == 0)
         base = 10;
 
-/* This fact is used below to parse hexidecimal digit.	*/
-#if	('A' - '0') != (('a' - '0') & ~('A' ^ 'a'))
-# error
-#endif
     do {
 	unsigned char c = i;
-        if (TOLOW(c) > '9')
-            c = TOLOW(c) + ('0' - 'a') + 10;
+
+        /* Map digits to 0..35, non-digits above 35. */
+        if (c > '9')
+            c = TOLOW(c-1) + ('0' - 'a' + 11);
 	c -= '0';
+
         if (c >= base) {
             scanf_ungetc (i, stream, lenp);
             break;

--- a/test/libc-testsuite/strtol.c
+++ b/test/libc-testsuite/strtol.c
@@ -132,8 +132,30 @@ int test_strtol(void)
 	TEST(l, strtol(s="0x1234", &c, 16), 0x1234, "%ld != %ld");
 	TEST2(i, c-s, 6, "wrong final position %ld != %ld");
 
-	TEST(l, strtol(s="1234:", &c, 16), 0x1234, "%ld != %ld");
-	TEST2(i, c-s, 4, "wrong final position %ld != %ld");
+        char delim_buf[6] = "09af:";
+
+        for (int j = 0; j < 256; j++) {
+            delim_buf[4] = j;
+            if (('0' <= j && j <= '9') ||
+                ('A' <= j && j <= 'F') ||
+                ('a' <= j && j <= 'f'))
+            {
+                int k;
+                if ('0' <= j && j <= '9')
+                    k = j - '0';
+                else if ('A' <= j && j <= 'Z')
+                    k = j - 'A' + 10;
+                else if ('a' <= j && j <= 'z')
+                    k = j - 'a' + 10;
+                else
+                    k = 0xffffffff;
+                TEST(l, strtol(s=delim_buf, &c, 16), 0x09af0 | k, "%ld != %ld");
+                TEST2(i, c-s, 5, "wrong final position %ld != %ld");
+            } else {
+                TEST(l, strtol(s=delim_buf, &c, 16), 0x09af, "%ld != %ld");
+                TEST2(i, c-s, 4, "wrong final position %ld != %ld");
+            }
+        }
 
 	errno = 0;
 	c = NULL;


### PR DESCRIPTION
The code would accept @ and ` as legitimate digits, assigning them the value 9. Fix that by subtracting 1 from the character before oring in 0x20 to convert to lower case:
    
    '0' is 0x30
    'a' is 0x61
    
    @ (0x40):
    	((0x40 - 1) | 0x20) + 0x30 - 0x61 + 11 - 0x30 = -0x17 (0xe9 unsigned)
    ` (0x60):
    	((0x60 - 1) | 0x20) + 0x30 - 0x61 + 11 - 0x30 = 0x29
    
Signed-off-by: Keith Packard <keithp@keithp.com>