### PR TITLE
fix -Werror=double-promotion issues

### DIFF
--- a/newlib/libm/common/sf_expm1.c
+++ b/newlib/libm/common/sf_expm1.c
@@ -59,7 +59,7 @@ Q5  =  -2.0109921195e-07; /* 0xb457edbb */
 	    if(FLT_UWORD_IS_NAN(hx))
 	        return x+x;
 	    if(FLT_UWORD_IS_INFINITE(hx))
-		return (xsb==0)? x:-1.0;/* exp(+-inf)={inf,-1} */
+		return (xsb==0)? x:(float)-1.0;/* exp(+-inf)={inf,-1} */
 	    if(xsb == 0 && hx > FLT_UWORD_LOG_MAX) /* if x>=o_threshold */
 		return __math_oflowf (0); /* overflow */
 	    if(xsb!=0) { /* x < -27*ln2, return -1.0 with inexact */

--- a/newlib/libm/common/sf_fdim.c
+++ b/newlib/libm/common/sf_fdim.c
@@ -16,7 +16,7 @@
 {
   if (isnanf(x) || isnanf(y)) return(x+y);
 
-  float z = x > y ? x - y : 0.0;
+  float z = x > y ? x - y : (float)0.0;
   if (!isinf(x) && !isinf(y))
     z = check_oflowf(z);
   return z;

--- a/newlib/libm/math/sf_exp.c
+++ b/newlib/libm/math/sf_exp.c
@@ -52,7 +52,7 @@ expf(float x) /* default IEEE double exp */
     if (FLT_UWORD_IS_NAN(hx))
         return x + x; /* NaN */
     if (FLT_UWORD_IS_INFINITE(hx))
-        return (xsb == 0) ? x : 0.0; /* exp(+-inf)={inf,0} */
+        return (xsb == 0) ? x : (float)0.0; /* exp(+-inf)={inf,0} */
     if (sx > FLT_UWORD_LOG_MAX)
         return __math_oflowf(0); /* overflow */
     if (sx < 0 && hx > FLT_UWORD_LOG_MIN)


### PR DESCRIPTION
When compiling with the gcc flag -Werror=double-promotion. Three errors are given which are implicit conversion from float to double to match other result of the conditional