### PR TITLE
Add -Werror=double=promotion to default warning set

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -706,8 +706,19 @@ picolibcpp_ld = configure_file(input: 'picolibc.ld.in',
 			     install_dir: lib_dir)
 
 # Not all compilers necessarily support all warnings; only use these which are:
-c_warnings = ['-Werror=implicit-function-declaration', '-Werror=vla', '-Warray-bounds', '-Wold-style-definition']
-disabled_warnings = ['-Wno-missing-braces', '-Wno-implicit-int', '-Wno-return-type', '-Wno-unused-command-line-argument']
+c_warnings = [
+  '-Werror=implicit-function-declaration',
+  '-Werror=vla',
+  '-Warray-bounds',
+  '-Wold-style-definition',
+  '-Werror=double-promotion',
+]
+disabled_warnings = [
+  '-Wno-missing-braces',
+  '-Wno-implicit-int',
+  '-Wno-return-type',
+  '-Wno-unused-command-line-argument',
+]
 c_flags = cc.get_supported_arguments(c_warnings, disabled_warnings)
 c_args += c_flags
 native_c_args += c_flags

--- a/newlib/libm/common/sf_expm1.c
+++ b/newlib/libm/common/sf_expm1.c
@@ -59,11 +59,11 @@ Q5  =  -2.0109921195e-07; /* 0xb457edbb */
 	    if(FLT_UWORD_IS_NAN(hx))
 	        return x+x;
 	    if(FLT_UWORD_IS_INFINITE(hx))
-		return (xsb==0)? x:(float)-1.0;/* exp(+-inf)={inf,-1} */
+		return (xsb==0)? x:-1.0f;/* exp(+-inf)={inf,-1} */
 	    if(xsb == 0 && hx > FLT_UWORD_LOG_MAX) /* if x>=o_threshold */
 		return __math_oflowf (0); /* overflow */
 	    if(xsb!=0) { /* x < -27*ln2, return -1.0 with inexact */
-		if(x+tiny<(float)0.0)	/* raise inexact */
+		if(x+tiny<0.0f)	/* raise inexact */
 		return tiny-one;	/* return -1 */
 	    }
 	}
@@ -76,7 +76,7 @@ Q5  =  -2.0109921195e-07; /* 0xb457edbb */
 		else
 		    {hi = x + ln2_hi; lo = -ln2_lo;  k = -1;}
 	    } else {
-		k  = invln2*x+((xsb==0)?(float)0.5:(float)-0.5);
+		k  = invln2*x+((xsb==0)?0.5f:-0.5f);
 		t  = k;
 		hi = x - t*ln2_hi;	/* t*ln2_hi is exact here */
 		lo = t*ln2_lo;
@@ -91,19 +91,19 @@ Q5  =  -2.0109921195e-07; /* 0xb457edbb */
 	else k = 0;
 
     /* x is now in primary range */
-	hfx = (float)0.5*x;
+	hfx = 0.5f*x;
 	hxs = x*hfx;
 	r1 = one+hxs*(Q1+hxs*(Q2+hxs*(Q3+hxs*(Q4+hxs*Q5))));
-	t  = (float)3.0-r1*hfx;
-	e  = hxs*((r1-t)/((float)6.0 - x*t));
+	t  = 3.0f-r1*hfx;
+	e  = hxs*((r1-t)/(6.0f - x*t));
 	if(k==0) return x - (x*e-hxs);		/* c is 0 */
 	else {
 	    e  = (x*(e-c)-c);
 	    e -= hxs;
-	    if(k== -1) return (float)0.5*(x-e)-(float)0.5;
+	    if(k== -1) return 0.5f*(x-e)-0.5f;
            if(k==1) {
-	       	if(x < (float)-0.25) return -(float)2.0*(e-(x+(float)0.5));
-	       	else 	      return  one+(float)2.0*(x-e);
+	       	if(x < -0.25f) return -2.0f*(e-(x+0.5f));
+	       	else 	      return  one+2.0f*(x-e);
            }
 	    if (k <= -2 || k>56) {   /* suffice to return exp(x)-1 */
 	        __int32_t i;

--- a/newlib/libm/common/sf_fdim.c
+++ b/newlib/libm/common/sf_fdim.c
@@ -16,7 +16,7 @@
 {
   if (isnanf(x) || isnanf(y)) return(x+y);
 
-  float z = x > y ? x - y : (float)0.0;
+  float z = x > y ? x - y : 0.0f;
   if (!isinf(x) && !isinf(y))
     z = check_oflowf(z);
   return z;

--- a/newlib/libm/machine/x86/f_powf.c
+++ b/newlib/libm/machine/x86/f_powf.c
@@ -29,7 +29,7 @@ set errno as normal.
 float _f_powf (float x, float y)
 {
   /* following sequence handles the majority of cases for pow() */
-  if (x > 0.0 && check_finitef(y))
+  if (x > 0.0f && check_finitef(y))
     {
       float result;
       /* calculate x ** y as 2 ** (y log2(x)).  On Intel, can only

--- a/newlib/libm/math/sf_exp.c
+++ b/newlib/libm/math/sf_exp.c
@@ -52,7 +52,7 @@ expf(float x) /* default IEEE double exp */
     if (FLT_UWORD_IS_NAN(hx))
         return x + x; /* NaN */
     if (FLT_UWORD_IS_INFINITE(hx))
-        return (xsb == 0) ? x : (float)0.0; /* exp(+-inf)={inf,0} */
+        return (xsb == 0) ? x : 0.0f; /* exp(+-inf)={inf,0} */
     if (sx > FLT_UWORD_LOG_MAX)
         return __math_oflowf(0); /* overflow */
     if (sx < 0 && hx > FLT_UWORD_LOG_MIN)
@@ -80,9 +80,9 @@ expf(float x) /* default IEEE double exp */
     t = x * x;
     c = x - t * (P1 + t * (P2 + t * (P3 + t * (P4 + t * P5))));
     if (k == 0)
-        return one - ((x * c) / (c - (float)2.0) - x);
+        return one - ((x * c) / (c - 2.0f) - x);
     else
-        y = one - ((lo - (x * c) / ((float)2.0 - c)) - hi);
+        y = one - ((lo - (x * c) / (2.0f - c)) - hi);
     if (k >= -125) {
         __uint32_t hy;
         GET_FLOAT_WORD(hy, y);

--- a/test/printf_scanf.c
+++ b/test/printf_scanf.c
@@ -49,7 +49,7 @@
 # define _WANT_IO_C99_FORMATS
 # define _WANT_IO_LONG_LONG
 # define _WANT_IO_POS_ARGS
-# define printf_float(x) (x)
+# define printf_float(x) ((double) (x))
 #elif defined(TINY_STDIO)
 # ifdef PICOLIBC_INTEGER_PRINTF_SCANF
 #  ifndef _WANT_IO_POS_ARGS


### PR DESCRIPTION
This will catch places where computations are forced to double instead of being done in float, often due to a constant lacking a trailing 'f'.

Signed-off-by: Keith Packard <keithp@keithp.com>