### PR TITLE
tinystdio: Add remove, tmpnam, tmpfile APIs

### DIFF
--- a/newlib/libc/tinystdio/CMakeLists.txt
+++ b/newlib/libc/tinystdio/CMakeLists.txt
@@ -77,6 +77,7 @@ picolibc_sources(
   printf.c
   putchar.c
   puts.c
+  remove.c
   rewind.c
   scanf.c
   setbuf.c

--- a/newlib/libc/tinystdio/CMakeLists.txt
+++ b/newlib/libc/tinystdio/CMakeLists.txt
@@ -103,6 +103,8 @@ picolibc_sources(
   strtoul.c
   strtoull.c
   strtoumax.c
+  tmpnam.c
+  tmpfile.c
   ungetc.c
   vasprintf.c
   vfiprintf.c

--- a/newlib/libc/tinystdio/meson.build
+++ b/newlib/libc/tinystdio/meson.build
@@ -77,6 +77,7 @@ srcs_tinystdio = [
     'printf.c',
     'putchar.c',
     'puts.c',
+    'remove.c',
     'rewind.c',
     'scanf.c',
     'setbuf.c',

--- a/newlib/libc/tinystdio/meson.build
+++ b/newlib/libc/tinystdio/meson.build
@@ -107,6 +107,8 @@ srcs_tinystdio = [
     'strtoll_l.c',
     'strtoul_l.c',
     'strtoull_l.c',
+    'tmpnam.c',
+    'tmpfile.c',
     'ungetc.c',
     'vasprintf.c',
     'vfiprintf.c',

--- a/newlib/libc/tinystdio/remove.c
+++ b/newlib/libc/tinystdio/remove.c
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2022 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <unistd.h>
+#include <stdio.h>
+
+int remove(const char *pathname)
+{
+    return unlink(pathname);
+}

--- a/newlib/libc/tinystdio/stdio.h
+++ b/newlib/libc/tinystdio/stdio.h
@@ -939,6 +939,23 @@ extern void setlinebuf(FILE *stream);
 extern int setvbuf(FILE *stream, char *buf, int mode, size_t size);
 extern FILE *tmpfile(void);
 extern char *tmpnam (char *s);
+
+/*
+ * The format of tmpnam names is TXXXXXX, which works with mktemp
+ */
+#define L_tmpnam        8
+
+/*
+ * tmpnam files are created in the current directory
+ */
+#define P_tmpdir        ""
+
+/*
+ * We don't have any way of knowing any underlying POSIX limits,
+ * so just use a reasonably small value here
+ */
+#define TMP_MAX         32
+
 #endif	/* !__DOXYGEN__ */
 
 #ifdef __cplusplus

--- a/newlib/libc/tinystdio/tmpfile.c
+++ b/newlib/libc/tinystdio/tmpfile.c
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2022 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _DEFAULT_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+FILE *tmpfile(void)
+{
+    char        tmpnam[L_tmpnam];
+    int         fd;
+    FILE        *f;
+
+    strcpy(tmpnam, "TXXXXXX");
+    fd = mkstemp(tmpnam);
+    if (fd < 0)
+        return NULL;
+    /* Assume POSIX semantics for unlinking in-use files */
+    unlink(tmpnam);
+    f = fdopen(fd, "w+");
+    if (f == NULL)
+        close(fd);
+    return f;
+}

--- a/newlib/libc/tinystdio/tmpnam.c
+++ b/newlib/libc/tinystdio/tmpnam.c
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2022 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+#define _DEFAULT_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* No requirement for re-entrancy for this variable */
+static char _tmpnam[L_tmpnam];
+
+char *tmpnam(char *s)
+{
+    if (!s)
+        s = _tmpnam;
+
+    strcpy(s, "TXXXXXX");
+    return mktemp(s);
+}

--- a/test/posix-io.c
+++ b/test/posix-io.c
@@ -36,7 +36,6 @@
 #define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <string.h>
 
 static const char file_name[] = "posix-io-test-file";
@@ -44,7 +43,7 @@ static const char test_string[] = "hello, world\n";
 
 static void test_cleanup(void)
 {
-	unlink(file_name);
+	remove(file_name);
 }
 
 static int

--- a/test/test-fopen.c
+++ b/test/test-fopen.c
@@ -35,7 +35,6 @@
 #define _DEFAULT_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 
 #define TEST_FILE_NAME "FOPEN.TXT"
 
@@ -44,7 +43,7 @@
             printf("%s: %s\n", message, #condition);    \
             if (f)                                      \
                 fclose(f);                              \
-            (void) unlink(TEST_FILE_NAME);              \
+            (void) remove(TEST_FILE_NAME);              \
             exit(1);                                    \
         }                                               \
     } while(0)
@@ -99,7 +98,7 @@ main(void)
     fclose(f);
     check_contents(0);
 
-    (void) unlink(TEST_FILE_NAME);
+    (void) remove(TEST_FILE_NAME);
 
     exit(0);
 }

--- a/test/test-mktemp.c
+++ b/test/test-mktemp.c
@@ -36,14 +36,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #define check(condition, message) do {                  \
         if (!(condition)) {                             \
             printf("%s: %s\n", message, #condition);    \
             if (f)                                      \
                 fclose(f);                              \
-            (void) unlink(template);                    \
+            (void) remove(template);                    \
             exit(1);                                    \
         }                                               \
     } while(0)
@@ -103,7 +102,7 @@ main(void)
     fputs(MESSAGE, f);
     fclose(f);
     check_contents(template, 1);
-    (void) unlink(template);
+    (void) remove(template);
 
     /* Create temp file */
     strcpy(template, NAME_TEMPLATE);
@@ -116,7 +115,7 @@ main(void)
     fputs(MESSAGE, f);
     fclose(f);
     check_contents(template, 1);
-    (void) unlink(template);
+    (void) remove(template);
 
     /* Create temp file with extension */
     strcpy(template, NAME_TEMPLATE_EXT);
@@ -131,7 +130,7 @@ main(void)
     fputs(MESSAGE, f);
     fclose(f);
     check_contents(template, 1);
-    (void) unlink(template);
+    (void) remove(template);
 
     exit(0);
 }


### PR DESCRIPTION
These are part of the ISO C stdio interface, and should be included in tinystdio.

 * tmpnam relies on mktemp
 * tmpfile relies on mkstemp, unlink, fdopen and close
 * remove relies on unlink (note that it doesn't rely on rmdir, as ISO C doesn't appear to require that)