### PR TITLE
tinystdio: fix compiling freopen on AVR

### DIFF
--- a/newlib/libc/tinystdio/freopen.c
+++ b/newlib/libc/tinystdio/freopen.c
@@ -67,8 +67,8 @@ freopen(const char *pathname, const char *mode, FILE *stream)
         pf->fd = fd;
 
         /* Switch to POSIX backend */
-        pf->read = (void *) read;
-        pf->write = (void *) write;
+        pf->read = (ssize_t (*)(int, void *, size_t))read;
+        pf->write = (ssize_t (*)(int, const void *, size_t))write;
         pf->lseek = lseek;
         pf->close = close;
 


### PR DESCRIPTION
AVR puts functions in a non-default address space. Unfortunately, Clang doesn't fully support this and crashes with the following code:

```c
    pf->read = (void *) read;
    pf->write = (void *) write;
```

However, this cast seems a bit odd to me: it casts from a function pointer to a `void*` pointer and then back to a function pointer (to store in the pf struct). Instead, this patch casts to the desired function signature instad. This gets the code to compile for Clang/AVR.