### PR TITLE
Switch read/write to posix types

### DIFF
--- a/newlib/libc/include/ssp/unistd.h
+++ b/newlib/libc/include/ssp/unistd.h
@@ -70,7 +70,7 @@ __ssp_redirect0(ssize_t, pread, (int __fd, void *__buf, size_t __len, off_t __of
     (__fd, __buf, __len, __off));
 #endif
 
-__ssp_redirect0(_READ_WRITE_RETURN_TYPE, read, \
+__ssp_redirect0(ssize_t, read, \
     (int __fd, void *__buf, size_t __len), (__fd, __buf, __len));
 
 #if __BSD_VISIBLE || __POSIX_VISIBLE >= 200112 || __XSI_VISIBLE >= 4

--- a/newlib/libc/include/sys/config.h
+++ b/newlib/libc/include/sys/config.h
@@ -109,10 +109,6 @@ SUCH DAMAGE.
 #define _POINTER_INT short
 #endif
 
-#if defined(__m68k__) || defined(__mc68000__) || defined(__riscv)
-#define _READ_WRITE_RETURN_TYPE _ssize_t
-#endif
-
 #ifdef ___AM29K__
 #define _FLOAT_RET double
 #endif
@@ -126,7 +122,6 @@ SUCH DAMAGE.
 /* we want the reentrancy structure to be returned by a function */
 #define __DYNAMIC_REENT__
 #define HAVE_GETDATE
-#define _READ_WRITE_RETURN_TYPE _ssize_t
 #ifndef __LARGE64_FILES
 #define __LARGE64_FILES 1
 #endif
@@ -272,7 +267,6 @@ SUCH DAMAGE.
 
 #if defined(__rtems__)
 #define __FILENAME_MAX__ 255
-#define _READ_WRITE_RETURN_TYPE _ssize_t
 #define __DYNAMIC_REENT__
 #endif
 
@@ -282,19 +276,6 @@ SUCH DAMAGE.
 
 #ifndef __IMPORT
 #define __IMPORT
-#endif
-
-/* Define return type of read/write routines.  In POSIX, the return type
-   for read()/write() is "ssize_t" but legacy newlib code has been using
-   "int" for some time.  If not specified, "int" is defaulted.  */
-#ifndef _READ_WRITE_RETURN_TYPE
-#define _READ_WRITE_RETURN_TYPE int
-#endif
-/* Define `count' parameter of read/write routines.  In POSIX, the `count'
-   parameter is "size_t" but legacy newlib code has been using "int" for some
-   time.  If not specified, "int" is defaulted.  */
-#ifndef _READ_WRITE_BUFSIZE_TYPE
-#define _READ_WRITE_BUFSIZE_TYPE int
 #endif
 
 #ifndef __WCHAR_MAX__

--- a/newlib/libc/include/sys/unistd.h
+++ b/newlib/libc/include/sys/unistd.h
@@ -204,7 +204,7 @@ int     pipe2 (int __fildes[2], int flags);
 ssize_t pread (int __fd, void *__buf, size_t __nbytes, off_t __offset);
 ssize_t pwrite (int __fd, const void *__buf, size_t __nbytes, off_t __offset);
 #endif
-_READ_WRITE_RETURN_TYPE read (int __fd, void *__buf, size_t __nbyte);
+ssize_t read (int __fd, void *__buf, size_t __nbyte);
 #if __BSD_VISIBLE
 int	rresvport (int *__alport);
 int	revoke (char *__path);
@@ -256,7 +256,7 @@ int 	usleep (useconds_t __useconds);
 #if __BSD_VISIBLE
 int     vhangup (void);
 #endif
-_READ_WRITE_RETURN_TYPE write (int __fd, const void *__buf, size_t __nbyte);
+ssize_t write (int __fd, const void *__buf, size_t __nbyte);
 
 #ifdef __CYGWIN__
 # define __UNISTD_GETOPT__
@@ -285,11 +285,8 @@ _off_t  lseek (int __fildes, _off_t __offset, int __whence);
 #ifdef __LARGE64_FILES
 _off64_t lseek64 (int __filedes, _off64_t __offset, int __whence);
 #endif
-_READ_WRITE_RETURN_TYPE _read (int __fd, void *__buf, size_t __nbyte);
 void *  sbrk (ptrdiff_t __incr);
 int     unlink (const char *__path);
-_READ_WRITE_RETURN_TYPE _write (int __fd, const void *__buf, size_t __nbyte);
-int     execve (const char *__path, char * const __argv[], char * const __envp[]);
 #endif
 
 #if !defined(__INSIDE_CYGWIN__)

--- a/newlib/libc/machine/nvptx/write.c
+++ b/newlib/libc/machine/nvptx/write.c
@@ -18,7 +18,7 @@
 #include <unistd.h>
 #include <errno.h>
 
-_READ_WRITE_RETURN_TYPE write (int fd, const void *buf, size_t count)
+ssize_t write (int fd, const void *buf, size_t count)
 {
   size_t i;
   char *b = (char *)buf;
@@ -29,5 +29,5 @@ _READ_WRITE_RETURN_TYPE write (int fd, const void *buf, size_t count)
     }
   for (i = 0; i < count; i++)
     printf ("%c", b[i]);
-  return count;
+  return (ssize_t) count;
 }

--- a/newlib/libc/stdio/fflush.c
+++ b/newlib/libc/stdio/fflush.c
@@ -105,8 +105,8 @@ _sflush (
        register FILE * fp)
 {
   register unsigned char *p;
-  register _READ_WRITE_BUFSIZE_TYPE n;
-  register _READ_WRITE_RETURN_TYPE t;
+  register size_t n;
+  register ssize_t t;
   short flags;
 
   flags = fp->_flags;

--- a/newlib/libc/stdio/fmemopen.c
+++ b/newlib/libc/stdio/fmemopen.c
@@ -83,17 +83,17 @@ typedef struct fmemcookie {
 
 /* Read up to non-zero N bytes into BUF from stream described by
    COOKIE; return number of bytes read (0 on EOF).  */
-static _READ_WRITE_RETURN_TYPE
+static ssize_t
 fmemreader (
        void *cookie,
        char *buf,
-       _READ_WRITE_BUFSIZE_TYPE n)
+       size_t n)
 {
   fmemcookie *c = (fmemcookie *) cookie;
   /* Can't read beyond current size, but EOF condition is not an error.  */
   if (c->pos > c->eof)
     return 0;
-  if (n >= 0 && (size_t) n >= c->eof - c->pos)
+  if (n >= c->eof - c->pos)
     n = c->eof - c->pos;
   memcpy (buf, c->buf + c->pos, n);
   c->pos += n;
@@ -102,11 +102,11 @@ fmemreader (
 
 /* Write up to non-zero N bytes of BUF into the stream described by COOKIE,
    returning the number of bytes written or EOF on failure.  */
-static _READ_WRITE_RETURN_TYPE
+static ssize_t
 fmemwriter (
        void *cookie,
        const char *buf,
-       _READ_WRITE_BUFSIZE_TYPE n)
+       size_t n)
 {
   fmemcookie *c = (fmemcookie *) cookie;
   int adjust = 0; /* true if at EOF, but still need to write NUL.  */

--- a/newlib/libc/stdio/fopencookie.c
+++ b/newlib/libc/stdio/fopencookie.c
@@ -97,11 +97,11 @@ typedef struct fccookie {
   cookie_close_function_t *closefn;
 } fccookie;
 
-static _READ_WRITE_RETURN_TYPE
+static ssize_t
 fcreader (
        void *cookie,
        char *buf,
-       _READ_WRITE_BUFSIZE_TYPE n)
+       size_t n)
 {
   int result;
   fccookie *c = (fccookie *) cookie;
@@ -111,11 +111,11 @@ fcreader (
   return result;
 }
 
-static _READ_WRITE_RETURN_TYPE
+static ssize_t
 fcwriter (
        void *cookie,
        const char *buf,
-       _READ_WRITE_BUFSIZE_TYPE n)
+       size_t n)
 {
   int result;
   fccookie *c = (fccookie *) cookie;

--- a/newlib/libc/stdio/funopen.c
+++ b/newlib/libc/stdio/funopen.c
@@ -86,9 +86,9 @@ Supporting OS subroutines required: <<sbrk>>.
 #include <sys/lock.h>
 #include "local.h"
 
-typedef int (*funread)(void *_cookie, char *_buf, _READ_WRITE_BUFSIZE_TYPE _n);
+typedef int (*funread)(void *_cookie, char *_buf, size_t _n);
 typedef int (*funwrite)(void *_cookie, const char *_buf,
-			_READ_WRITE_BUFSIZE_TYPE _n);
+			size_t _n);
 #ifdef __LARGE64_FILES
 typedef _fpos64_t (*funseek)(void *_cookie, _fpos64_t _off, int _whence);
 #else
@@ -104,11 +104,11 @@ typedef struct funcookie {
   funclose closefn;
 } funcookie;
 
-static _READ_WRITE_RETURN_TYPE
+static ssize_t
 funreader (
        void *cookie,
        char *buf,
-       _READ_WRITE_BUFSIZE_TYPE n)
+       size_t n)
 {
   int result;
   funcookie *c = (funcookie *) cookie;
@@ -118,11 +118,11 @@ funreader (
   return result;
 }
 
-static _READ_WRITE_RETURN_TYPE
+static ssize_t
 funwriter (
        void *cookie,
        const char *buf,
-       _READ_WRITE_BUFSIZE_TYPE n)
+       size_t n)
 {
   int result;
   funcookie *c = (funcookie *) cookie;

--- a/newlib/libc/stdio/fvwrite.c
+++ b/newlib/libc/stdio/fvwrite.c
@@ -53,7 +53,7 @@ _sfvwrite (
   register size_t len;
   register const char *p = NULL;
   register struct __siov *iov;
-  register _READ_WRITE_RETURN_TYPE w, s;
+  register ssize_t w, s;
   char *nl;
   int nlknown, nldist;
 

--- a/newlib/libc/stdio/local.h
+++ b/newlib/libc/stdio/local.h
@@ -167,14 +167,14 @@ extern int    _sflush (FILE *);
 extern int    _sflushw (FILE *);
 #endif
 extern int    _srefill (FILE *);
-extern _READ_WRITE_RETURN_TYPE __sread (void *, char *,
-					       _READ_WRITE_BUFSIZE_TYPE);
-extern _READ_WRITE_RETURN_TYPE __seofread (void *,
+extern ssize_t __sread (void *, char *,
+					       size_t);
+extern ssize_t __seofread (void *,
 						  char *,
-						  _READ_WRITE_BUFSIZE_TYPE);
-extern _READ_WRITE_RETURN_TYPE __swrite (void *,
+						  size_t);
+extern ssize_t __swrite (void *,
 						const char *,
-						_READ_WRITE_BUFSIZE_TYPE);
+						size_t);
 extern _fpos_t __sseek (void *, _fpos_t, int);
 extern int    __sclose (void *);
 extern int    __stextmode (int);
@@ -185,9 +185,9 @@ extern int __submore (FILE *);
 
 #ifdef __LARGE64_FILES
 extern _fpos64_t __sseek64 (void *, _fpos64_t, int);
-extern _READ_WRITE_RETURN_TYPE __swrite64 (void *,
+extern ssize_t __swrite64 (void *,
 						  const char *,
-						  _READ_WRITE_BUFSIZE_TYPE);
+						  size_t);
 #endif
 
 extern NEWLIB_THREAD_LOCAL void (*_tls_cleanup)(void);

--- a/newlib/libc/stdio/open_memstream.c
+++ b/newlib/libc/stdio/open_memstream.c
@@ -93,11 +93,11 @@ typedef struct memstream {
 
 /* Write up to non-zero N bytes of BUF into the stream described by COOKIE,
    returning the number of bytes written or EOF on failure.  */
-static _READ_WRITE_RETURN_TYPE
+static ssize_t
 memwriter (
        void *cookie,
        const char *buf,
-       _READ_WRITE_BUFSIZE_TYPE n)
+       size_t n)
 {
   memstream *c = (memstream *) cookie;
   char *cbuf = *c->pbuf;

--- a/newlib/libc/stdio/stdio.c
+++ b/newlib/libc/stdio/stdio.c
@@ -29,11 +29,11 @@
  * These maintain the `known seek offset' for seek optimisation.
  */
 
-_READ_WRITE_RETURN_TYPE
+ssize_t
 __sread (
        void *cookie,
        char *buf,
-       _READ_WRITE_BUFSIZE_TYPE n)
+       size_t n)
 {
   register FILE *fp = (FILE *) cookie;
   register ssize_t ret;
@@ -61,11 +61,11 @@ __sread (
 }
 
 /* Dummy function used in sscanf/swscanf. */
-_READ_WRITE_RETURN_TYPE
+ssize_t
 __seofread (
        void *cookie,
        char *buf,
-       _READ_WRITE_BUFSIZE_TYPE len)
+       size_t len)
 {
   (void) cookie;
   (void) buf;
@@ -73,11 +73,11 @@ __seofread (
   return 0;
 }
 
-_READ_WRITE_RETURN_TYPE
+ssize_t
 __swrite (
        void *cookie,
        char const *buf,
-       _READ_WRITE_BUFSIZE_TYPE n)
+       size_t n)
 {
   register FILE *fp = (FILE *) cookie;
   ssize_t w;

--- a/newlib/libc/stdio/stdio.h
+++ b/newlib/libc/stdio/stdio.h
@@ -31,6 +31,7 @@
 #define	_FSTDIO			/* ``function stdio'' */
 
 #define __need_size_t
+#define __need_ssize_t
 #define __need_NULL
 #include <sys/cdefs.h>
 #include <stddef.h>
@@ -92,11 +93,11 @@ struct __sFILE {
   /* operations */
   void *	_cookie;	/* cookie passed to io functions */
 
-  _READ_WRITE_RETURN_TYPE (*_read) (void *,
-					   char *, _READ_WRITE_BUFSIZE_TYPE);
-  _READ_WRITE_RETURN_TYPE (*_write) (void *,
+  _ssize_t (*_read) (void *,
+					   char *, size_t);
+  _ssize_t (*_write) (void *,
 					    const char *,
-					    _READ_WRITE_BUFSIZE_TYPE);
+					    size_t);
   _fpos_t (*_seek) (void *, _fpos_t, int);
   int (*_close) (void *);
 
@@ -142,11 +143,11 @@ struct __sFILE64 {
   /* operations */
   void *	_cookie;	/* cookie passed to io functions */
 
-  _READ_WRITE_RETURN_TYPE (*_read) (void *,
-					   char *, _READ_WRITE_BUFSIZE_TYPE);
-  _READ_WRITE_RETURN_TYPE (*_write) (void *,
+  _ssize_t (*_read) (void *,
+					   char *, size_t);
+  _ssize_t (*_write) (void *,
 					    const char *,
-					    _READ_WRITE_BUFSIZE_TYPE);
+					    size_t);
   _fpos_t (*_seek) (void *, _fpos_t, int);
   int (*_close) (void *);
 
@@ -594,31 +595,31 @@ int	_swbuf ( int, FILE *);
 # ifdef __LARGE64_FILES
 FILE	*funopen (const void *__cookie,
 		int (*__readfn)(void *__c, char *__buf,
-				_READ_WRITE_BUFSIZE_TYPE __n),
+				size_t __n),
 		int (*__writefn)(void *__c, const char *__buf,
-				 _READ_WRITE_BUFSIZE_TYPE __n),
+				 size_t __n),
 		_fpos64_t (*__seekfn)(void *__c, _fpos64_t __off, int __whence),
 		int (*__closefn)(void *__c));
 FILE	*funopen ( const void *__cookie,
 		int (*__readfn)(void *__c, char *__buf,
-				_READ_WRITE_BUFSIZE_TYPE __n),
+				size_t __n),
 		int (*__writefn)(void *__c, const char *__buf,
-				 _READ_WRITE_BUFSIZE_TYPE __n),
+				 size_t __n),
 		_fpos64_t (*__seekfn)(void *__c, _fpos64_t __off, int __whence),
 		int (*__closefn)(void *__c));
 # else
 FILE	*funopen (const void *__cookie,
 		int (*__readfn)(void *__cookie, char *__buf,
-				_READ_WRITE_BUFSIZE_TYPE __n),
+				size_t __n),
 		int (*__writefn)(void *__cookie, const char *__buf,
-				 _READ_WRITE_BUFSIZE_TYPE __n),
+				 size_t __n),
 		fpos_t (*__seekfn)(void *__cookie, fpos_t __off, int __whence),
 		int (*__closefn)(void *__cookie));
 FILE	*funopen ( const void *__cookie,
 		int (*__readfn)(void *__cookie, char *__buf,
-				_READ_WRITE_BUFSIZE_TYPE __n),
+				size_t __n),
 		int (*__writefn)(void *__cookie, const char *__buf,
-				 _READ_WRITE_BUFSIZE_TYPE __n),
+				 size_t __n),
 		fpos_t (*__seekfn)(void *__cookie, fpos_t __off, int __whence),
 		int (*__closefn)(void *__cookie));
 # endif /* !__LARGE64_FILES */

--- a/newlib/libc/stdio64/stdio64.c
+++ b/newlib/libc/stdio64/stdio64.c
@@ -49,14 +49,14 @@ __sseek64 (
   return ret;
 }
 
-_READ_WRITE_RETURN_TYPE
+ssize_t
 __swrite64 (
        void *cookie,
        char const *buf,
-       _READ_WRITE_BUFSIZE_TYPE n)
+       size_t n)
 {
   register FILE *fp = (FILE *) cookie;
-  _READ_WRITE_RETURN_TYPE w;
+  ssize_t w;
 #ifdef __SCLE
   int oldmode=0;
 #endif

--- a/newlib/libc/tinystdio/freopen.c
+++ b/newlib/libc/tinystdio/freopen.c
@@ -67,8 +67,8 @@ freopen(const char *pathname, const char *mode, FILE *stream)
         pf->fd = fd;
 
         /* Switch to POSIX backend */
-        pf->read = (void *) read;
-        pf->write = (void *) write;
+        pf->read = read;
+        pf->write = write;
         pf->lseek = lseek;
         pf->close = close;
 

--- a/newlib/libc/tinystdio/stdio_private.h
+++ b/newlib/libc/tinystdio/stdio_private.h
@@ -113,7 +113,7 @@ bool __matchcaseprefix(const char *input, const char *pattern);
 
 #define FDEV_SETUP_POSIX(fd, buf, size, rwflags, bflags)        \
         FDEV_SETUP_BUFIO(fd, buf, size,                         \
-                         (void *)read, (void *)write,           \
+                         read, write,                           \
                          lseek, close, rwflags, bflags)
 
 int

--- a/semihost/fake/fake_stub.c
+++ b/semihost/fake/fake_stub.c
@@ -40,7 +40,7 @@
 #include <string.h>
 #include <errno.h>
 
-_READ_WRITE_RETURN_TYPE
+ssize_t
 read(int fd, void *buf, size_t count)
 {
         (void) fd;
@@ -49,17 +49,12 @@ read(int fd, void *buf, size_t count)
 	return 0;
 }
 
-_READ_WRITE_RETURN_TYPE
+ssize_t
 write(int fd, const void *buf, size_t count)
 {
-	const uint8_t *b = buf;
-	size_t c = count;
-
         (void) fd;
-        (void) b;
-	while (c--) {
-	}
-	return count;
+        (void) buf;
+	return (ssize_t) count;
 }
 
 int

--- a/semihost/machine/x86/e9_stub.c
+++ b/semihost/machine/x86/e9_stub.c
@@ -40,7 +40,7 @@
 #include <string.h>
 #include <errno.h>
 
-_READ_WRITE_RETURN_TYPE
+ssize_t
 read(int fd, void *buf, size_t count)
 {
         (void) fd;
@@ -49,7 +49,7 @@ read(int fd, void *buf, size_t count)
 	return 0;
 }
 
-_READ_WRITE_RETURN_TYPE
+ssize_t
 write(int fd, const void *buf, size_t count)
 {
 	const uint8_t *b = buf;

--- a/semihost/read.c
+++ b/semihost/read.c
@@ -41,7 +41,7 @@
 #include <string.h>
 #include <errno.h>
 
-_READ_WRITE_RETURN_TYPE
+ssize_t
 read(int fd, void *buf, size_t count)
 {
 #ifndef TINY_STDIO

--- a/semihost/write.c
+++ b/semihost/write.c
@@ -44,7 +44,7 @@
 extern struct timeval __semihost_write_time _ATTRIBUTE((__weak__));
 int gettimeofday(struct timeval *restrict tv, void *restrict tz) _ATTRIBUTE((__weak__));
 
-_READ_WRITE_RETURN_TYPE
+ssize_t
 write(int fd, const void *buf, size_t count)
 {
 #ifndef TINY_STDIO
@@ -55,6 +55,6 @@ write(int fd, const void *buf, size_t count)
         if (&__semihost_write_time && gettimeofday)
             gettimeofday(&__semihost_write_time, NULL);
 
-	_READ_WRITE_RETURN_TYPE put = (_READ_WRITE_RETURN_TYPE) count - (_READ_WRITE_RETURN_TYPE) ret;
+	ssize_t put = (ssize_t) (count - ret);
 	return put;
 }


### PR DESCRIPTION
Remove legacy cygwin hacks which set the buffer size and return value for read and write to int, switch them to the correct POSIX types, size_t for buffer size and ssize_t for the return value.

Signed-off-by: Keith Packard <keithp@keithp.com>