### PR TITLE
avr: support `-mdouble=64`

### DIFF
--- a/newlib/libc/include/machine/ieeefp.h
+++ b/newlib/libc/include/machine/ieeefp.h
@@ -408,7 +408,9 @@ warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 #ifdef __AVR__
 #define __IEEE_LITTLE_ENDIAN
+#if !defined(__SIZEOF_DOUBLE__) || __SIZEOF_DOUBLE__ == 4
 #define _DOUBLE_IS_32BITS
+#endif
 #endif
 
 #if defined(__or1k__) || defined(__OR1K__) || defined(__OR1KND__)


### PR DESCRIPTION
Modern avr-gcc versions support 64-bit doubles using `-mdouble=64` (but still default to 32-bit doubles), while older versions only support 32-bit double. This can be checked using the `__SIZEOF_DOUBLE__` macro.

Clang also support this `-mdouble=64` flag on AVR.

More information:
https://gcc.gnu.org/wiki/avr-gcc#Deviations_from_the_Standard

The check here is updated to use the `__SIZEOF_DOUBLE__` macro if it is defined, and assume 32-bit doubles if it isn't defined.

---

I wonder if it makes sense to always use `__SIZEOF_DOUBLE__` if it is defined, instead of all these platform specific macros? It would work on at least GCC and Clang, I'm not so sure about other compilers.

Also, you probably already guessed it but I'm making this PR so that I can use 64-bit doubles on the AVR targets of TinyGo. Without it, functions like `sqrt` are not defined.