### PR TITLE
Allow linking with ld.lld

### DIFF
--- a/cmake/TC-arm-none-eabi.ld
+++ b/cmake/TC-arm-none-eabi.ld
@@ -156,12 +156,14 @@ SECTIONS
 	PROVIDE( __tdata_start = ADDR(.tdata));
 	PROVIDE( __tdata_source = LOADADDR(.tdata) );
 	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+	PROVIDE( __data_source_end = __tdata_source_end );
 	PROVIDE( __tdata_size = SIZEOF(.tdata) );
 
 	PROVIDE( __edata = __data_end );
 	PROVIDE( _edata = __data_end );
 	PROVIDE( edata = __data_end );
 	PROVIDE( __data_size = __data_end - __data_start );
+	PROVIDE( __data_source_size = __data_source_end - __data_source );
 
 	.tbss (NOLOAD) : {
 		*(.tbss .tbss.* .gnu.linkonce.tb.*)
@@ -225,3 +227,9 @@ SECTIONS
 		*(.ARM.exidx*)
 	}
 }
+/*
+ * Check that sections that are copied from flash to RAM have matching
+ * padding, so that a single memcpy() of __data_size copies the correct bytes.
+ */
+ASSERT( __data_size == __data_source_size,
+	"ERROR: .data/.tdata flash size does not match RAM size");

--- a/doc/linking.md
+++ b/doc/linking.md
@@ -46,6 +46,11 @@ this with gcc, the command line would look like this:
 
 	gcc -specs=picolibc.specs -Tsample.ld
 
+Alternatively, you can specify those values using `--defsym` and use
+picolibc.ld as the linker script:
+
+	cc -Wl,--defsym=__flash=__0x08000000 -Wl,--defsym=__flash_size=128K ... -Tpicolibc.ld
+
 ### Defining Memory Regions
 
 Picolibc.ld defines only two memory regions: `flash` and `ram`. Flash

--- a/meson.build
+++ b/meson.build
@@ -689,8 +689,12 @@ if cc.get_linker_id() == 'ld.lld'
     # An added ASSERT() statement in the linker script ensures that we don't
     # get silent failures in case this changes in the future.
     picolibc_linker_type_data.set('LDSCRIPT_ALIGN_WITH_INPUT', '')
+    # The i MEMORY attribute is also not implemented, but it would does not
+    # make any difference on the output even if it was.
+    picolibc_linker_type_data.set('LDSCRIPT_MEMORY_ATTR_I', '')
 else
     picolibc_linker_type_data.set('LDSCRIPT_ALIGN_WITH_INPUT', 'ALIGN_WITH_INPUT')
+    picolibc_linker_type_data.set('LDSCRIPT_MEMORY_ATTR_I', 'i')
 endif
 
 picolibc_ld_data = configuration_data()

--- a/meson.build
+++ b/meson.build
@@ -692,6 +692,16 @@ if cc.get_linker_id() == 'ld.lld'
     # The i MEMORY attribute is also not implemented, but it would does not
     # make any difference on the output even if it was.
     picolibc_linker_type_data.set('LDSCRIPT_MEMORY_ATTR_I', '')
+    if host_cpu_family == 'riscv'
+        # ld.lld before version 15 did not support linker relaxations, disable
+        # them if we are using an older version.
+        # There is no `cc.get_linker_version()` function, so we detect ld.lld
+        # version 15 by checking for a newly added linker flag.
+        if not cc.has_link_argument('--package-metadata=1')
+            message('Linking for RISCV with ld.lld < 15, forcing -mno-relax')
+            c_args += ['-mno-relax']
+        endif
+    endif
 else
     picolibc_linker_type_data.set('LDSCRIPT_ALIGN_WITH_INPUT', 'ALIGN_WITH_INPUT')
     picolibc_linker_type_data.set('LDSCRIPT_MEMORY_ATTR_I', 'i')

--- a/meson.build
+++ b/meson.build
@@ -682,7 +682,19 @@ test_specs = configure_file(input: 'test.specs.in',
 			    configuration: specs_data,
 			    install: false)
 
+picolibc_linker_type_data = configuration_data()
+if cc.get_linker_id() == 'ld.lld'
+    # ld.lld does not implement ALIGN_WITH_INPUT, but this flag is not needed
+    # with ld.lld's output section LMA/VMA algorithm.
+    # An added ASSERT() statement in the linker script ensures that we don't
+    # get silent failures in case this changes in the future.
+    picolibc_linker_type_data.set('LDSCRIPT_ALIGN_WITH_INPUT', '')
+else
+    picolibc_linker_type_data.set('LDSCRIPT_ALIGN_WITH_INPUT', 'ALIGN_WITH_INPUT')
+endif
+
 picolibc_ld_data = configuration_data()
+picolibc_ld_data.merge_from(picolibc_linker_type_data)
 picolibc_ld_data.set('CPP_START', '/*')
 picolibc_ld_data.set('CPP_END', '*/')
 picolibc_ld_data.set('C_START', '')
@@ -694,6 +706,7 @@ picolibc_ld = configure_file(input: 'picolibc.ld.in',
 			     install_dir: lib_dir)
 
 picolibcpp_ld_data = configuration_data()
+picolibcpp_ld_data.merge_from(picolibc_linker_type_data)
 picolibcpp_ld_data.set('CPP_START', '')
 picolibcpp_ld_data.set('CPP_END', '')
 picolibcpp_ld_data.set('C_START', '/*')

--- a/picolibc.ld.in
+++ b/picolibc.ld.in
@@ -137,7 +137,7 @@ SECTIONS
 		PROVIDE(__preserve_end__ = .);
 	} >ram AT>ram :ram
 
-	.data : ALIGN_WITH_INPUT {
+	.data : @LDSCRIPT_ALIGN_WITH_INPUT@ {
 		*(.data .data.*)
 		*(.gnu.linkonce.d.*)
 
@@ -159,7 +159,7 @@ SECTIONS
 	 * into the allocate ram addresses by the existing
 	 * data initialization code in crt0
 	 */
-	.tdata : ALIGN_WITH_INPUT {
+	.tdata : @LDSCRIPT_ALIGN_WITH_INPUT@ {
 		*(.tdata .tdata.* .gnu.linkonce.td.*)
 		PROVIDE(__data_end = .);
 		PROVIDE(__tdata_end = .);
@@ -168,12 +168,14 @@ SECTIONS
 	PROVIDE( __tdata_start = ADDR(.tdata));
 	PROVIDE( __tdata_source = LOADADDR(.tdata) );
 	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+	PROVIDE( __data_source_end = __tdata_source_end );
 	PROVIDE( __tdata_size = SIZEOF(.tdata) );
 
 	PROVIDE( __edata = __data_end );
 	PROVIDE( _edata = __data_end );
 	PROVIDE( edata = __data_end );
 	PROVIDE( __data_size = __data_end - __data_start );
+	PROVIDE( __data_source_size = __data_source_end - __data_source );
 
 	.tbss (NOLOAD) : {
 		*(.tbss .tbss.* .gnu.linkonce.tb.*)
@@ -241,3 +243,9 @@ SECTIONS
 
 	@C_END@
 }
+/*
+ * Check that sections that are copied from flash to RAM have matching
+ * padding, so that a single memcpy() of __data_size copies the correct bytes.
+ */
+ASSERT( __data_size == __data_source_size,
+	"ERROR: .data/.tdata flash size does not match RAM size");

--- a/picolibc.ld.in
+++ b/picolibc.ld.in
@@ -42,8 +42,8 @@ ENTRY(_start)
 
 MEMORY
 {
-	flash (rxai!w) : ORIGIN = DEFINED(__flash) ? __flash : 0x10000000, LENGTH = DEFINED(__flash_size) ? __flash_size : 0x10000
-	ram (wxa!ri)   : ORIGIN = DEFINED(__ram  ) ? __ram   : 0x20000000, LENGTH = DEFINED(__ram_size  ) ? __ram_size   : 0x08000
+	flash (rxa@LDSCRIPT_MEMORY_ATTR_I@!w) : ORIGIN = DEFINED(__flash) ? __flash : 0x10000000, LENGTH = DEFINED(__flash_size) ? __flash_size : 0x10000
+	ram (wxa!r@LDSCRIPT_MEMORY_ATTR_I@)   : ORIGIN = DEFINED(__ram  ) ? __ram   : 0x20000000, LENGTH = DEFINED(__ram_size  ) ? __ram_size   : 0x08000
 }
 
 PHDRS

--- a/scripts/cross-clang-old-riscv64-unknown-elf.txt
+++ b/scripts/cross-clang-old-riscv64-unknown-elf.txt
@@ -4,6 +4,8 @@
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
 c = ['clang', '-target', 'riscv64-unknown-elf', '-mcmodel=medany', '-nostdlib']
+# TODO: it would be nice to use ld.lld here, but that depends on
+# https://reviews.llvm.org/D107280 being merged or building with -fpie.
 c_ld = '/usr/bin/riscv64-unknown-elf-ld'
 ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'

--- a/scripts/cross-clang-old-rv32imafdc-unknown-elf.txt
+++ b/scripts/cross-clang-old-rv32imafdc-unknown-elf.txt
@@ -4,7 +4,7 @@
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
 c = ['clang', '-m32', '-target', 'riscv32-unknown-elf', '-march=rv32imafdc', '-mabi=ilp32d', '-nostdlib']
-c_ld = '/usr/bin/riscv64-unknown-elf-ld'
+c_ld = 'lld'
 ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'
 nm = 'riscv64-unknown-elf-nm'

--- a/scripts/cross-clang-riscv64-unknown-elf.txt
+++ b/scripts/cross-clang-riscv64-unknown-elf.txt
@@ -4,6 +4,8 @@
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
 c = ['clang', '-target', 'riscv64-unknown-elf', '-mcmodel=medany', '-nostdlib']
+# TODO: it would be nice to use ld.lld here, but that depends on
+# https://reviews.llvm.org/D107280 being merged or building with -fpie.
 c_ld = '/usr/bin/riscv64-unknown-elf-ld'
 ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'

--- a/scripts/cross-clang-rv32imafdc-unknown-elf.txt
+++ b/scripts/cross-clang-rv32imafdc-unknown-elf.txt
@@ -4,7 +4,7 @@
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
 c = ['clang', '-m32', '-target', 'riscv32-unknown-elf', '-march=rv32imafdc', '-mabi=ilp32d', '-nostdlib']
-c_ld = '/usr/bin/riscv64-unknown-elf-ld'
+c_ld = 'lld'
 ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'
 nm = 'riscv64-unknown-elf-nm'

--- a/scripts/cross-clang-thumbv6m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv6m-none-eabi.txt
@@ -4,7 +4,7 @@
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
 c = ['clang', '-m32', '--target=thumbv6m-none-eabi', '-nostdlib']
-c_ld = '/usr/bin/arm-none-eabi-ld'
+c_ld = 'lld'
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eab-as'
 nm = 'arm-none-eab-nm'

--- a/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
@@ -4,7 +4,7 @@
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
 c = ['clang', '-m32', '-target', 'thumbv7e-none-eabi', '-mcpu=cortex-m7', '-mfloat-abi=hard', '-nostdlib']
-c_ld = '/usr/bin/arm-none-eabi-ld'
+c_ld = 'lld'
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eab-as'
 nm = 'arm-none-eab-nm'

--- a/scripts/cross-clang-thumbv7m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7m-none-eabi.txt
@@ -4,7 +4,7 @@
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
 c = ['clang', '-m32', '-target', 'thumbv7m-none-eabi', '-mfloat-abi=soft', '-nostdlib']
-c_ld = '/usr/bin/arm-none-eabi-ld'
+c_ld = 'lld'
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eab-as'
 nm = 'arm-none-eab-nm'


### PR DESCRIPTION
ld.lld rejects ALIGN_WITH_INPUT and the "i" memory region attribute.
However, the former is only needed due to a behaviour change in ld.bfd 2.32.2 - ld.lld uses an algorithm for LMA/VMA padding that ensures .data&.tdata have matching padding in RAM/flags.
Dropping latter attribute does not make any difference (unless maybe in cases where there are orphan sections), so we can also omit this for ld.lld.

See individual commit messages for more details.

Fixes #164 