### PR TITLE
Emit a meson error if the linker doesn't support symbol aliases

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -331,6 +331,12 @@ if tinystdio
       int_printf_link_args += '-Wl,-alias,' + __i_vfprintf_symbol +  ',' + vfprintf_symbol
       int_printf_link_args += '-Wl,-alias,' + __i_vfscanf_symbol + ',' + vfscanf_symbol
     endif
+  else
+    if enable_tests
+      # If the alias flag is not supported and we are building tests, emit an
+      # error here to avoid surprising test failures.
+      error('Symbol alias linker flag not supported - printf tests will fail!')
+    endif
   endif
 endif
 


### PR DESCRIPTION
I spent many hours trying to debug why printff-tests and printff_scanff were failing for me. It turns out I had removed "-nostdlib" from my meson cross file and this in turn meant that cc.has_link_argument() returned false for any argument (since it errored out due to missing "-lc"). To avoid anyone else running into this problem in the future, emit an error at configure time if neither "--defsym" not "-alias" are accepted.