### PR TITLE
Fix handling of ARM/AArch64 overaligned TLS 

### DIFF
--- a/cmake/TC-arm-none-eabi.ld
+++ b/cmake/TC-arm-none-eabi.ld
@@ -173,6 +173,9 @@ SECTIONS
 	PROVIDE( __tbss_start = ADDR(.tbss));
 	PROVIDE( __tbss_size = SIZEOF(.tbss) );
 	PROVIDE( __tls_size = __tls_end - __tls_base );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+	PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
 
 	/*
 	 * The linker special cases .tbss segments which are

--- a/newlib/libc/picolib/machine/aarch64/tls.c
+++ b/newlib/libc/picolib/machine/aarch64/tls.c
@@ -42,15 +42,20 @@
  * TLS relocations are generated relative to
  * a location this far *before* the first thread
  * variable (!)
+ * NB: The actual size before tp also includes padding
+ * to align up to the alignment of .tdata/.tbss.
  */
 #if __SIZE_WIDTH__ == 32
-#define TCB_SIZE	8
+extern char __arm32_tls_tcb_offset;
+#define TP_OFFSET ((size_t)&__arm32_tls_tcb_offset)
 #else
-#define TCB_SIZE	16
+extern char __arm64_tls_tcb_offset;
+#define TP_OFFSET ((size_t)&__arm64_tls_tcb_offset)
 #endif
+
 
 void
 _set_tls(void *tls)
 {
-	__asm__ volatile("msr tpidr_el0, %0" : : "r" (tls - TCB_SIZE));
+	__asm__ volatile("msr tpidr_el0, %0" : : "r" (tls - TP_OFFSET));
 }

--- a/newlib/libc/picolib/machine/arm/tls.c
+++ b/newlib/libc/picolib/machine/arm/tls.c
@@ -49,15 +49,19 @@ void *__tls;
  * TLS relocations are generated relative to
  * a location this far *before* the first thread
  * variable (!)
+ * NB: The actual size before tp also includes padding
+ * to align up to the alignment of .tdata/.tbss.
  */
 #define TCB_SIZE	8
+extern char __arm32_tls_tcb_offset;
+#define TP_OFFSET ((size_t)&__arm32_tls_tcb_offset)
 
 void
 _set_tls(void *tls)
 {
 #ifdef ARM_TLS_CP15
-	__asm__("mcr 15, 0, %0, cr13, cr0, 3" : : "r" (tls - TCB_SIZE));
+	__asm__("mcr 15, 0, %0, cr13, cr0, 3" : : "r" (tls - TP_OFFSET));
 #else
-	__tls = (uint8_t *) tls - TCB_SIZE;
+	__tls = (uint8_t *) tls - TP_OFFSET;
 #endif
 }

--- a/picocrt/machine/aarch64/crt0.c
+++ b/picocrt/machine/aarch64/crt0.c
@@ -32,16 +32,21 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include <sys/cdefs.h>
 
 /* The size of the thread control block.
  * TLS relocations are generated relative to
  * a location this far *before* the first thread
  * variable (!)
+ * NB: The actual size before tp also includes padding
+ * to align up to the alignment of .tdata/.tbss.
  */
 #if __SIZE_WIDTH__ == 32
-#define TCB_SIZE	8
+extern char __arm32_tls_tcb_offset;
+#define TP_OFFSET ((size_t)&__arm32_tls_tcb_offset)
 #else
-#define TCB_SIZE	16
+extern char __arm64_tls_tcb_offset;
+#define TP_OFFSET ((size_t)&__arm64_tls_tcb_offset)
 #endif
 
 #pragma GCC diagnostic ignored "-Warray-bounds"
@@ -49,7 +54,7 @@
 static inline void
 _set_tls(void *tls)
 {
-	__asm__ volatile("msr tpidr_el0, %0" : : "r" (tls - TCB_SIZE));
+	__asm__ volatile("msr tpidr_el0, %0" : : "r" (tls - TP_OFFSET));
 }
 
 #include "../../crt0.h"

--- a/picolibc.ld.in
+++ b/picolibc.ld.in
@@ -185,6 +185,9 @@ SECTIONS
 	PROVIDE( __tbss_start = ADDR(.tbss));
 	PROVIDE( __tbss_size = SIZEOF(.tbss) );
 	PROVIDE( __tls_size = __tls_end - __tls_base );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+	PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
 
 	/*
 	 * The linker special cases .tbss segments which are

--- a/test/tls.c
+++ b/test/tls.c
@@ -37,24 +37,64 @@
 #include <picotls.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
 
-#define DATA_VAL	0x600df00d
+#define DATA_VAL 0x600df00d
+#define DATA_VAL2 0x0a0a0a0a
 
 NEWLIB_THREAD_LOCAL volatile int data_var = DATA_VAL;
 NEWLIB_THREAD_LOCAL volatile int bss_var;
+_Alignas(128) NEWLIB_THREAD_LOCAL volatile int overaligned_data_var = DATA_VAL2;
 
 volatile int *volatile data_addr;
+volatile int *volatile overaligned_data_addr;
 volatile int *volatile bss_addr;
 
+#ifdef PICOLIBC_TLS
+extern char __tdata_start, __tdata_end;
+extern char __tdata_source, __tdata_source_end;
+extern char __data_start, __data_source;
+
+static bool
+inside_tls_region(void *ptr, const void *tls)
+{
+	return (uintptr_t)ptr >= (uintptr_t)tls &&
+	       (uintptr_t)ptr < (uintptr_t)tls + _tls_size();
+}
+
+#define check_inside_tls_region(ptr, tls_start)                                \
+	if (!inside_tls_region(__DEVOLATILE(void *, ptr), tls_start)) {        \
+		printf("%s (%p) is not inside TLS region [%p-%p)\n", #ptr,     \
+		       ptr, tls_start, (char *)tls_start + _tls_size());       \
+		result++;                                                      \
+	}
+#endif
+
 int
-check_tls(char *where, bool check_addr)
+check_tls(char *where, bool check_addr, void *tls_region)
 {
 	int result = 0;
 
-	printf("tls check %s %p %p\n", where, &data_var, &bss_var);
+	printf("tls check %s %p %p %p\n", where, &data_var,
+	       &overaligned_data_var, &bss_var);
+	if (!__is_aligned(tls_region, 128)) {
+		printf("TLS data region (%p) is not aligned\n", tls_region);
+		result++;
+	}
+	if (!__is_aligned((uintptr_t)&overaligned_data_var, 128)) {
+		printf("overaligned_data_var (%p) is not aligned\n",
+		       &overaligned_data_var);
+		result++;
+	}
 	if (data_var != DATA_VAL) {
 		printf("%s: initialized thread var has wrong value (0x%x instead of 0x%x)\n",
 		       where, data_var, DATA_VAL);
+		result++;
+	}
+	if (overaligned_data_var != DATA_VAL2) {
+		printf("%s: initialized overaligned thread var has wrong value (0x%x instead of 0x%x)\n",
+		       where, overaligned_data_var, DATA_VAL2);
 		result++;
 	}
 
@@ -72,6 +112,14 @@ check_tls(char *where, bool check_addr)
 		result++;
 	}
 
+	overaligned_data_var = ~overaligned_data_var;
+
+	if (overaligned_data_var != ~DATA_VAL2) {
+		printf("%s: initialized thread var set to wrong value (0x%x instead of 0x%x)\n",
+		       where, overaligned_data_var, ~DATA_VAL2);
+		result++;
+	}
+
 	bss_var = ~bss_var;
 
 	if (bss_var != ~0) {
@@ -86,33 +134,93 @@ check_tls(char *where, bool check_addr)
 			result++;
 		}
 
+                if (overaligned_data_addr == &overaligned_data_var) {
+			printf("_set_tls didn't affect initialized addr %p\n", overaligned_data_addr);
+			result++;
+		}
+
 		if (bss_addr == &bss_var) {
 			printf("_set_tls didn't affect uninitialized addr %p\n", bss_addr);
 			result++;
 		}
 	}
-
+#ifdef PICOLIBC_TLS
+	check_inside_tls_region(&data_var, tls_region);
+	check_inside_tls_region(&overaligned_data_var, tls_region);
+	check_inside_tls_region(&bss_var, tls_region);
+#endif
 	return result;
+}
+
+void
+hexdump(const void *ptr, int length, const char *hdr)
+{
+	const unsigned char *cp = ptr;
+
+	for (int i = 0; i < length; i += 16) {
+		printf("%s%08zx  ", hdr, i + (size_t)ptr);
+		for (int j = 0; j < 16; j++) {
+			int offset = i + j;
+			if (offset < length)
+				printf(" %02x", cp[offset]);
+			else
+				printf("   ");
+		}
+		printf("\n");
+	}
 }
 
 int
 main(void)
 {
-	int result;
+	int result = 0;
 
 	data_addr = &data_var;
+	overaligned_data_addr = &overaligned_data_var;
 	bss_addr = &bss_var;
 
-	result = check_tls("pre-defined", false);
+#ifdef PICOLIBC_TLS
+        printf("TLS region: %p-%p (%zd bytes)\n", &__tdata_start,
+	       &__tdata_start + _tls_size(), _tls_size());
+	size_t tdata_source_size = &__tdata_source_end - &__tdata_source;
+	size_t tdata_size = &__tdata_end - &__tdata_start;
+
+	if (&__tdata_start - &__data_start != &__tdata_source - &__data_source) {
+		printf("ROM/RAM .tdata offset from .data mismatch. "
+		       "VMA offset=%zd, LMA offset =%zd."
+		       "Linker behaviour changed?\n",
+		       &__tdata_start - &__data_start,
+		       &__tdata_source - &__data_source);
+	}
+
+	if (tdata_source_size != tdata_size ||
+	    memcmp(&__tdata_source, &__tdata_start, tdata_size) != 0) {
+		printf("TLS data in RAM does not match ROM\n");
+		hexdump(&__tdata_source, tdata_source_size, "ROM:");
+		hexdump(&__tdata_start, tdata_size, "RAM:");
+		result++;
+	}
+        result += check_tls("pre-defined", false, &__tdata_start);
+#else
+        result += check_tls("pre-defined", false, NULL);
+#endif
+
 
 #ifdef _HAVE_PICOLIBC_TLS_API
 
-	void *tls = malloc(_tls_size());
+	void *tls = aligned_alloc(128, _tls_size());
 
 	_init_tls(tls);
 	_set_tls(tls);
 
-	result += check_tls("allocated", true);
+	if (memcmp(tls, &__tdata_source, tdata_size) != 0) {
+		printf("New TLS data in RAM does not match ROM\n");
+		hexdump(&__tdata_source, tdata_source_size, "ROM:");
+		hexdump(tls, tdata_size, "RAM:");
+		result++;
+	}
+
+	result += check_tls("allocated", true, tls);
 #endif
 
 	printf("tls test result %d\n", result);


### PR DESCRIPTION
This was originally intended as a PR that only adds tests, but CI pointed out that the new tests break ARM builds, so I spent some time debugging and fixing ARM overaligned TLS (we need additional padding when setting the thread pointer).
