### PR TITLE
Remove extra -D_LIBC compiler arg

### DIFF
--- a/newlib/libc/meson.build
+++ b/newlib/libc/meson.build
@@ -107,7 +107,7 @@ foreach target : targets
 				          pic: false,
 				          objects : libobjs,
 					  include_directories: inc,
-					  c_args: value[1] + ['-D_LIBC'])
+					  c_args: value[1])
 
   set_variable('lib_cpart' + target, local_lib_cpart_target)
 endforeach

--- a/newlib/libm/meson.build
+++ b/newlib/libm/meson.build
@@ -86,7 +86,7 @@ foreach target : targets
 					    pic: false,
 					    objects : libobjs,
 					    include_directories: inc,
-					    c_args: value[1] + ['-D_LIBC'])
+					    c_args: value[1])
     set_variable('lib_mpart' + target, local_lib_mpart_target)
   endif
 endforeach

--- a/newlib/meson.build
+++ b/newlib/meson.build
@@ -72,7 +72,7 @@ foreach target : targets
 				      pic: false,
 				      objects : libobjs,
 				      include_directories: inc,
-				      c_args: value[1] + ['-D_LIBC'])
+				      c_args: value[1])
 
   set_variable('lib_c' + target, local_lib_c_target)
 


### PR DESCRIPTION
With -D_LIBC part of the global compiler arguments, there's no need to add it in a couple of places. That's misleading (as it isn't everywhere) as well as being unnecessary.

Signed-off-by: Keith Packard <keithp@keithp.com>