### PR TITLE
Run tests PowerPC tests under QEMU

### DIFF
--- a/.github/do-linux
+++ b/.github/do-linux
@@ -21,6 +21,8 @@ HERE=`dirname "$0"`
 "$HERE"/do-avr-build avr "$@"
 "$HERE"/do-build powerpc64 "$@"
 "$HERE"/do-build powerpc64le "$@"
+"$HERE"/do-test power9 "$@"
+"$HERE"/do-test power9-fp128 "$@"
 "$HERE"/do-test riscv "$@"
 "$HERE"/do-test rv32imac "$@"
 "$HERE"/do-test clang-riscv "$@"

--- a/.github/do-test
+++ b/.github/do-test
@@ -29,4 +29,4 @@ trap 'rm -rf "$DIR"' 0 1 15
 	 ;;
  esac
  cat meson-logs/*
- ninja && meson test -v) || exit 1
+ ninja && meson test -t 4 -v) || exit 1

--- a/.github/packages.txt
+++ b/.github/packages.txt
@@ -20,5 +20,6 @@ gcc-sparc64-linux-gnu
 qemu-system-x86
 qemu-system-arm
 qemu-system-misc
+qemu-system-ppc64
 clang
 lld

--- a/meson.build
+++ b/meson.build
@@ -261,15 +261,33 @@ posix_console = posix_io and get_option('posix-console')
 io_float_exact = not tinystdio or get_option('io-float-exact')
 atomic_ungetc = tinystdio and get_option('atomic-ungetc')
 format_default = get_option('format-default')
+printf_aliases = get_option('printf-aliases')
 io_percent_b = tinystdio and get_option('io-percent-b')
 
-double_printf_compile_args=['-DPICOLIBC_DOUBLE_PRINTF_SCANF']
+if printf_aliases
+  double_printf_compile_args=['-DPICOLIBC_DOUBLE_PRINTF_SCANF']
+  float_printf_compile_args=['-DPICOLIBC_FLOAT_PRINTF_SCANF']
+  int_printf_compile_args=['-DPICOLIBC_INTEGER_PRINTF_SCANF']
+else
+  double_printf_compile_args=[]
+  float_printf_compile_args=[]
+  int_printf_compile_args=[]
+endif
 double_printf_link_args=double_printf_compile_args
-float_printf_compile_args=['-DPICOLIBC_FLOAT_PRINTF_SCANF']
 float_printf_link_args=float_printf_compile_args
-int_printf_compile_args=['-DPICOLIBC_INTEGER_PRINTF_SCANF']
 int_printf_link_args=int_printf_compile_args
+
 if tinystdio
+  if format_default == 'double'
+    c_args += '-DFORMAT_DEFAULT_DOUBLE'
+  elif format_default == 'float'
+    c_args += '-DFORMAT_DEFAULT_FLOAT'
+  elif format_default == 'integer'
+    c_args += '-DFORMAT_DEFAULT_INTEGER'
+  endif
+endif
+
+if tinystdio and printf_aliases
   vfprintf_symbol = global_prefix + 'vfprintf'
   __d_vfprintf_symbol = global_prefix + '__d_vfprintf'
   __f_vfprintf_symbol = global_prefix + '__f_vfprintf'
@@ -278,14 +296,6 @@ if tinystdio
   __d_vfscanf_symbol = global_prefix + '__d_vfscanf'
   __f_vfscanf_symbol = global_prefix + '__f_vfscanf'
   __i_vfscanf_symbol = global_prefix + '__i_vfscanf'
-
-  if format_default == 'double'
-    c_args += '-DFORMAT_DEFAULT_DOUBLE'
-  elif format_default == 'float'
-    c_args += '-DFORMAT_DEFAULT_FLOAT'
-  elif format_default == 'integer'
-    c_args += '-DFORMAT_DEFAULT_INTEGER'
-  endif
 
   if has_link_defsym
     if format_default != 'double'
@@ -500,7 +510,7 @@ if specs_extra_list != []
 endif
 
 specs_printf = ''
-if tinystdio
+if tinystdio and printf_aliases
   specs_printf=('%{DPICOLIBC_FLOAT_PRINTF_SCANF:--defsym=vfprintf=__f_vfprintf}' +
 		' %{DPICOLIBC_FLOAT_PRINTF_SCANF:--defsym=vfscanf=__f_vfscanf}' +
 		' %{DPICOLIBC_DOUBLE_PRINTF_SCANF:--defsym=vfprintf=__d_vfprintf}' +

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -134,6 +134,8 @@ option('posix-console', type: 'boolean', value: false,
        description: 'Use POSIX I/O for stdin/stdout/stderr')
 option('format-default', type: 'combo', choices: ['double', 'float', 'integer'], value: 'double',
        description: 'which printf/scanf versions should be the default')
+option('printf-aliases', type: 'boolean', value: true,
+       description: 'Allow link-time printf aliases')
 
 #
 # Options applying to only legacy stdio

--- a/newlib/libm/ld/common/e_atan2l.c
+++ b/newlib/libm/ld/common/e_atan2l.c
@@ -114,3 +114,12 @@ atan2l(long double y, long double x)
 	    	    return  (z-pi_lo)-pi;/* atan(-,-) */
 	}
 }
+
+#if __LDBL_MANT_DIG__ == 113
+#if defined(_HAVE_ALIAS_ATTRIBUTE)
+#ifndef __clang__
+#pragma GCC diagnostic ignored "-Wmissing-attributes"
+#endif
+__strong_reference(atan2l, __atan2ieee128);
+#endif
+#endif

--- a/newlib/libm/ld/common/s_sincosl.c
+++ b/newlib/libm/ld/common/s_sincosl.c
@@ -15,3 +15,12 @@ sincosl( long double x, long double * s, long double * c )
     *s = _sinl( x );
     *c = _cosl( x );
 }
+
+#if __LDBL_MANT_DIG__ == 113
+#if defined(_HAVE_ALIAS_ATTRIBUTE)
+#ifndef __clang__
+#pragma GCC diagnostic ignored "-Wmissing-attributes"
+#endif
+__strong_reference(sincosl, __sincosieee128);
+#endif
+#endif

--- a/newlib/libm/ld/powerpc_fpmath.h
+++ b/newlib/libm/ld/powerpc_fpmath.h
@@ -26,6 +26,52 @@
  * $FreeBSD$
  */
 
+#if __LDBL_MANT_DIG__ == 113
+
+union IEEEl2bits {
+	long double	e;
+	struct {
+#if __FLOAT_WORD_ORDER__ == __ORDER_BIG_ENDIAN__
+		uint64_t	sign	:1;
+		uint64_t	exp	:15;
+		uint64_t	manh	:48;
+		uint64_t	manl	:64;
+#else
+		uint64_t	manl	:64;
+		uint64_t	manh	:48;
+		uint64_t	exp	:15;
+		uint64_t	sign	:1;
+#endif
+	} bits;
+	struct {
+#if __FLOAT_WORD_ORDER__ == __ORDER_BIG_ENDIAN__
+		uint64_t	expsign	:16;
+		uint64_t	manh	:48;
+		uint64_t	manl	:64;
+#else
+		uint64_t	manl	:64;
+		uint64_t	manh	:48;
+		uint64_t	expsign	:16;
+#endif
+	} xbits;
+};
+
+#define	LDBL_NBIT	0
+#define	LDBL_IMPLICIT_NBIT
+#define	mask_nbit_l(u)	((void)0)
+
+#define	LDBL_MANH_SIZE	48
+#define	LDBL_MANL_SIZE	64
+
+#define	LDBL_TO_ARRAY32(u, a) do {			\
+	(a)[0] = (uint32_t)(u).bits.manl;		\
+	(a)[1] = (uint32_t)((u).bits.manl >> 32);	\
+	(a)[2] = (uint32_t)(u).bits.manh;		\
+	(a)[3] = (uint32_t)((u).bits.manh >> 32);	\
+} while(0)
+
+#else
+
 union IEEEl2bits {
 	long double	e;
 	struct {
@@ -47,3 +93,5 @@ union IEEEl2bits {
 	(a)[0] = (uint32_t)(u).bits.manl;		\
 	(a)[1] = (uint32_t)(u).bits.manh;		\
 } while(0)
+
+#endif

--- a/newlib/libm/machine/powerpc/complex128.c
+++ b/newlib/libm/machine/powerpc/complex128.c
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2022 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifdef __LONG_DOUBLE_IEEE128__
+
+#define TCtype long double __complex
+#define TFtype long double
+
+TCtype
+__mulkc3_hw (TFtype a, TFtype b, TFtype c, TFtype d);
+
+TCtype
+__mulkc3 (TFtype a, TFtype b, TFtype c, TFtype d)
+{
+    return __mulkc3_hw(a, b, c, d);
+}
+
+TCtype
+__divkc3_hw (TFtype a, TFtype b, TFtype c, TFtype d);
+
+TCtype
+__divkc3 (TFtype a, TFtype b, TFtype c, TFtype d)
+{
+    return __divkc3_hw(a, b, c, d);
+}
+
+#endif

--- a/newlib/libm/machine/powerpc/meson.build
+++ b/newlib/libm/machine/powerpc/meson.build
@@ -32,9 +32,19 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+
 srcs_libm_machine_real = [
   'fenv.c',
 ]
+
+srcs_libm_machine_complex128 = [
+  'complex128.c'
+]
+
+if cc.has_function('__mulkc3_hw', args: core_c_args + ['-lgcc'])
+  srcs_libm_machine_real += srcs_libm_machine_complex128
+endif
+
 srcs_libm_machine = srcs_libm_machine_real + [
   'feclearexcept.c',
   'fedisableexcept.c',

--- a/newlib/libm/test/math.c
+++ b/newlib/libm/test/math.c
@@ -432,6 +432,7 @@ run_vector_1 (int vector,
   double result;
   float fresult;
 
+#if 0
   if (vector)
   {
 
@@ -483,6 +484,7 @@ run_vector_1 (int vector,
       return;
     }
   }
+#endif
 
   newfunc(name);
   while (p->line)

--- a/newlib/libm/test/math2.c
+++ b/newlib/libm/test/math2.c
@@ -27,6 +27,10 @@ randi (void)
   return ((next >> 16) & 0xffff);
 }
 
+#ifndef __FLOAT_WORD_ORDER__
+#define __FLOAT_WORD_ORDER__ __BYTE_ORDER__
+#endif
+
 double randx (void)
 {
   double res;
@@ -38,10 +42,17 @@ double randx (void)
 	double res;
       } u;
 
+#if __FLOAT_WORD_ORDER__ == __ORDER_LITTLE_ENDIAN__
     u.parts[0] = randi();
     u.parts[1] = randi();
     u.parts[2] = randi();
     u.parts[3] = randi();
+#else
+    u.parts[3] = randi();
+    u.parts[2] = randi();
+    u.parts[1] = randi();
+    u.parts[0] = randi();
+#endif
     res = u.res;
 
   } while (!finite(res));

--- a/picocrt/machine/powerpc/crt0.S
+++ b/picocrt/machine/powerpc/crt0.S
@@ -1,0 +1,84 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2022 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#define PPC_BIT(bit)            (0x8000000000000000ULL >> (bit))
+	.text
+	.section	.text.init.enter
+	.global _start
+	.type	_start, @function
+_start:
+
+	/* Where are we? */
+	bl	here
+here:	mflr	%r2
+
+	/* Get stack pointer */
+	addi	%r1,%r2,stackaddr - here
+	ld	%r1,0(%r1)
+
+#ifdef __PPC64__
+	/* Figure out the initial TOC value */
+	addi	%r2,%r2,toc-here
+	ld	%r2,0(%r2)
+#endif
+	
+	mfmsr	%r0
+	/* Enable FPU */
+	ori	%r0,%r0,PPC_BIT(50)
+	/* Enable VSX */
+	oris	%r0,%r0,PPC_BIT(40)>>16
+	/* Enable Altivec */
+	oris	%r0,%r0,PPC_BIT(38)>>16
+	mtmsr	%r0
+
+	/*
+	 *   r8 is the OPAL base
+	 *   r9 is the OPAL entry point point
+	 */
+	mr	%r3, %r8
+	mr	%r4, %r9
+	bl	_cstart
+	.align	3
+#ifdef __PPC64__
+toc:	
+	.quad 	.TOC.@tocbase
+
+stackaddr:
+	.quad	__stack
+
+#else
+stackaddr:
+	.long	__stack
+#endif
+	

--- a/picocrt/machine/powerpc/cstart.c
+++ b/picocrt/machine/powerpc/cstart.c
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2020 Sebastian Meyer
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../../crt0.h"
+#include "powerpc_crt.h"
+
+
+void *__opal_base __attribute__((section(".preserve")));
+void *__opal_entry __attribute__((section(".preserve")));
+
+void __attribute__((used)) __section(".init")
+_cstart(void *opal_base, void *opal_entry)
+{
+        __opal_base = opal_base;
+        __opal_entry = opal_entry;
+	__start();
+}

--- a/picocrt/machine/powerpc/meson.build
+++ b/picocrt/machine/powerpc/meson.build
@@ -1,0 +1,35 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2021 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+src_picocrt += files('crt0.S', 'cstart.c')

--- a/picocrt/machine/powerpc/powerpc_crt.h
+++ b/picocrt/machine/powerpc/powerpc_crt.h
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2022 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+extern void *__opal_base, *__opal_entry;

--- a/picolibc.ld.in
+++ b/picolibc.ld.in
@@ -69,7 +69,7 @@ SECTIONS
                 /* code */
 		*(.text.unlikely .text.unlikely.*)
 		*(.text.startup .text.startup.*)
-		*(.text .text.*)
+		*(.text .text.* .opd .opd.*)
 		*(.gnu.linkonce.t.*)
 		KEEP (*(.fini .fini.*))
 		__text_end = .;
@@ -108,6 +108,11 @@ SECTIONS
 		KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
 		KEEP (*(.fini_array .dtors))
 		PROVIDE_HIDDEN ( __fini_array_end = . );
+
+	} >flash AT>flash :text
+
+	.toc : {
+		*(.toc .toc.*)
 	} >flash AT>flash :text
 
         /* additional sections when compiling with C++ exception support */

--- a/scripts/cross-power9-fp128.txt
+++ b/scripts/cross-power9-fp128.txt
@@ -1,0 +1,18 @@
+[binaries]
+c = ['powerpc64-linux-gnu-gcc', '-fno-pic', '-fno-pie', '-static', '-mabi=ieeelongdouble', '-mlong-double-128', '-mfloat128-hardware', '-mvsx', '-mfloat128', '-mpower9-vector', '-mcpu=power9', '-Wno-psabi']
+ar = 'powerpc64-linux-gnu-ar'
+nm = 'powerpc64-linux-gnu-nm'
+strip = 'powerpc64-linux-gnu-strip'
+objcopy = 'powerpc64-linux-gnu-objcopy'
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-power9 "$@"', 'run-power9']
+
+[host_machine]
+system = 'linux'
+cpu_family = 'powerpc'
+cpu = 'power9'
+endian = 'big'
+
+[properties]
+skip_sanity_check = true
+needs_exe_wrapper = true
+link_spec = '--build-id=none'

--- a/scripts/cross-power9.txt
+++ b/scripts/cross-power9.txt
@@ -1,0 +1,18 @@
+[binaries]
+c = ['powerpc64-linux-gnu-gcc', '-fno-pic', '-fno-pie', '-static', '-mfloat128-hardware', '-mvsx', '-mpower9-vector', '-mcpu=power9', '-Wno-psabi']
+ar = 'powerpc64-linux-gnu-ar'
+nm = 'powerpc64-linux-gnu-nm'
+strip = 'powerpc64-linux-gnu-strip'
+objcopy = 'powerpc64-linux-gnu-objcopy'
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-power9 "$@"', 'run-power9']
+
+[host_machine]
+system = 'linux'
+cpu_family = 'powerpc'
+cpu = 'power9'
+endian = 'big'
+
+[properties]
+skip_sanity_check = true
+needs_exe_wrapper = true
+link_spec = '--build-id=none'

--- a/scripts/do-configure
+++ b/scripts/do-configure
@@ -67,10 +67,10 @@ case "$ARCH" in
 esac
 
 case "$ARCH" in
-    *rv[36][24]*|*riscv*|*aarch64*|*powerpc*|*sparc*)
+    *rv[36][24]*|*riscv*|*aarch64*|*power*|*sparc*)
 	case "$*" in
 	    *-Dnewlib-io-long-double=true*)
-		echo "newlib-io-long-double not supported on riscv, aarch64 or sparc"
+		echo "newlib-io-long-double not supported on riscv, aarch64, power or sparc"
 		exit 77
 		;;
 	esac

--- a/scripts/do-power9-configure
+++ b/scripts/do-power9-configure
@@ -1,0 +1,43 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2021 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+case "$*" in
+    *-Dformat-default=integer*|*-Dformat-default=float*)
+	echo 'format-default must be double on PowerPC'
+	exit 77
+	;;
+esac
+
+exec "$(dirname "$0")"/do-configure power9 -Dtests=true -Dtests-enable-posix-io=false -Dmultilib=false -Dprintf-aliases=false "$@"

--- a/scripts/do-power9-fp128-configure
+++ b/scripts/do-power9-fp128-configure
@@ -1,0 +1,43 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2021 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+case "$*" in
+    *-Dformat-default=integer*|*-Dformat-default=float*)
+	echo 'format-default must be double on PowerPC'
+	exit 77
+	;;
+esac
+
+exec "$(dirname "$0")"/do-configure power9-fp128 -Dtests=true -Dtests-enable-posix-io=false -Dmultilib=false -Dprintf-aliases=false "$@"

--- a/scripts/do-powerpc64-configure
+++ b/scripts/do-powerpc64-configure
@@ -33,4 +33,11 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+case "$*" in
+    *-Dformat-default=integer*|*-Dformat-default=float*)
+	echo 'format-default must be double on PowerPC'
+	exit 77
+	;;
+esac
+
 exec "$(dirname "$0")"/do-configure powerpc64-linux-gnu -Dtests=false "$@"

--- a/scripts/do-powerpc64le-configure
+++ b/scripts/do-powerpc64le-configure
@@ -33,4 +33,11 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+case "$*" in
+    *-Dformat-default=integer*|*-Dformat-default=float*)
+	echo 'format-default must be double on PowerPC'
+	exit 77
+	;;
+esac
+
 exec "$(dirname "$0")"/do-configure powerpc64le-linux-gnu -Dtests=false "$@"

--- a/scripts/run-power9
+++ b/scripts/run-power9
@@ -1,0 +1,70 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2019 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+dir="$(dirname "$0")"
+
+qemu="qemu-system-ppc64"
+
+# select the program
+elf="$1"
+shift
+
+base=`basename "$elf" .elf`
+one_elf=`mktemp --suffix=.elf "$base".XXX`
+one_bin=`mktemp --suffix=.bin "$base".XXX`
+
+trap 'rm -f "$one_elf"' 0 1 15
+trap 'rm -f "$one_bin"' 0 1 15
+
+objcopy=powerpc64-linux-gnu-objcopy
+
+$objcopy "$elf" -Obinary $one_bin 2>/dev/null
+
+$objcopy --update-section .init="$one_bin" --remove-section=.text --remove-section=.sfpr --remove-section=.toc --remove-section=.data "$elf" "$one_elf" 2>/dev/null
+
+mon=none
+
+"$dir"/monitor-e9 $qemu \
+	-nodefaults \
+	-device ipmi-bmc-sim,id=bmc0 \
+	-cpu power9 \
+	-monitor none \
+	-serial none \
+	-device isa-serial,chardev=s1 \
+	-chardev stdio,id=s1 \
+	-machine powernv,accel=tcg \
+	-kernel "$one_elf" \
+	-nographic "$@" < /dev/null

--- a/scripts/test-powerpc.ld
+++ b/scripts/test-powerpc.ld
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2020 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+__flash =      0x20010000;
+__flash_size = 0x00400000;
+__ram =        0x20410000;
+__ram_size   = 0x00200000;
+__stack_size = 4k;

--- a/semihost/machine/powerpc/meson.build
+++ b/semihost/machine/powerpc/meson.build
@@ -1,0 +1,86 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2021 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+lib_semihost_srcs = [
+  'opal_call.S',
+  'opal_console_write.c',
+  'opal_cec_power_down.c',
+  'powerpc_exit.c',
+  'powerpc_kill.c',
+  'powerpc_stub.c',
+  ]
+
+if tinystdio
+  lib_semihost_srcs += 'powerpc_io.c'
+endif
+
+has_semihost = true
+
+foreach target : targets
+  value = get_variable('target_' + target)
+
+  instdir = join_paths(lib_dir, value[0])
+
+  test_flags = []
+  skipping = false
+  foreach tf : value[1]
+    if skipping
+      skipping = false
+    elif tf == '-include'
+      skipping = true
+    else
+      test_flags += tf
+    endif
+  endforeach
+
+  if cc.get_define('__PPC64__', args : test_flags) != ''
+    if target == ''
+      libsemihost_name = 'semihost'
+    else
+      libsemihost_name = join_paths(target, 'libsemihost')
+    endif
+
+    local_lib_semihost_target = static_library(libsemihost_name,
+					       lib_semihost_srcs,
+					       install : true,
+					       install_dir : instdir,
+					       include_directories : inc,
+					       c_args : value[1],
+					       pic: false)
+
+    set_variable('lib_semihost' + target, local_lib_semihost_target)
+  endif
+
+endforeach

--- a/semihost/machine/powerpc/opal.h
+++ b/semihost/machine/powerpc/opal.h
@@ -1,0 +1,278 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2022 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/cdefs.h>
+#include <stdio.h>
+
+extern void *__opal_base, *__opal_entry;
+
+int
+opal_call(void *r3, void *r4, void *r5, int call_r6, void *base_r7, void *entry_r8);
+
+int
+opal_console_write(int terminal, size_t len, const char *base);
+
+void _ATTRIBUTE((__noreturn__))
+opal_cec_power_down(uint64_t request);
+
+#define OPAL_TERMINAL_DEFAULT   0
+
+/* status codes */
+#define OPAL_SUCCESS		0
+#define OPAL_PARAMETER		-1
+#define OPAL_BUSY		-2
+#define OPAL_PARTIAL		-3
+#define OPAL_CONSTRAINED	-4
+#define OPAL_CLOSED		-5
+#define OPAL_HARDWARE		-6
+#define OPAL_UNSUPPORTED	-7
+#define OPAL_PERMISSION		-8
+#define OPAL_NO_MEM		-9
+#define OPAL_RESOURCE		-10
+#define OPAL_INTERNAL_ERROR	-11
+#define OPAL_BUSY_EVENT		-12
+#define OPAL_HARDWARE_FROZEN	-13
+#define OPAL_WRONG_STATE	-14
+#define OPAL_ASYNC_COMPLETION	-15
+#define OPAL_EMPTY		-16
+#define OPAL_I2C_TIMEOUT	-17
+#define OPAL_I2C_INVALID_CMD	-18
+#define OPAL_I2C_LBUS_PARITY	-19
+#define OPAL_I2C_BKEND_OVERRUN	-20
+#define OPAL_I2C_BKEND_ACCESS	-21
+#define OPAL_I2C_ARBT_LOST	-22
+#define OPAL_I2C_NACK_RCVD	-23
+#define OPAL_I2C_STOP_ERR	-24
+#define OPAL_XSCOM_BUSY		OPAL_BUSY
+#define OPAL_XSCOM_CHIPLET_OFF	OPAL_WRONG_STATE
+#define OPAL_XSCOM_PARTIAL_GOOD	-25
+#define OPAL_XSCOM_ADDR_ERROR	-26
+#define OPAL_XSCOM_CLOCK_ERROR	-27
+#define OPAL_XSCOM_PARITY_ERROR	-28
+#define OPAL_XSCOM_TIMEOUT	-29
+#define OPAL_XSCOM_CTR_OFFLINED	-30
+#define OPAL_XIVE_PROVISIONING	-31
+#define OPAL_XIVE_FREE_ACTIVE	-32
+#define OPAL_TIMEOUT		-33
+
+/* API Tokens (in r0) */
+#define OPAL_INVALID_CALL		       -1
+#define OPAL_TEST				0
+#define OPAL_CONSOLE_WRITE			1
+#define OPAL_CONSOLE_READ			2
+#define OPAL_RTC_READ				3
+#define OPAL_RTC_WRITE				4
+#define OPAL_CEC_POWER_DOWN			5
+#define OPAL_CEC_REBOOT				6
+#define OPAL_READ_NVRAM				7
+#define OPAL_WRITE_NVRAM			8
+#define OPAL_HANDLE_INTERRUPT			9
+#define OPAL_POLL_EVENTS			10
+#define OPAL_PCI_SET_HUB_TCE_MEMORY		11 /* Removed, p5ioc only */
+#define OPAL_PCI_SET_PHB_TCE_MEMORY		12 /* Removed, p5ioc only */
+#define OPAL_PCI_CONFIG_READ_BYTE		13
+#define OPAL_PCI_CONFIG_READ_HALF_WORD  	14
+#define OPAL_PCI_CONFIG_READ_WORD		15
+#define OPAL_PCI_CONFIG_WRITE_BYTE		16
+#define OPAL_PCI_CONFIG_WRITE_HALF_WORD		17
+#define OPAL_PCI_CONFIG_WRITE_WORD		18
+#define OPAL_SET_XIVE				19
+#define OPAL_GET_XIVE				20
+#define OPAL_GET_COMPLETION_TOKEN_STATUS	21 /* obsolete */
+#define OPAL_REGISTER_OPAL_EXCEPTION_HANDLER	22
+#define OPAL_PCI_EEH_FREEZE_STATUS		23
+#define OPAL_PCI_SHPC				24
+#define OPAL_CONSOLE_WRITE_BUFFER_SPACE		25
+#define OPAL_PCI_EEH_FREEZE_CLEAR		26
+#define OPAL_PCI_PHB_MMIO_ENABLE		27
+#define OPAL_PCI_SET_PHB_MEM_WINDOW		28
+#define OPAL_PCI_MAP_PE_MMIO_WINDOW		29
+#define OPAL_PCI_SET_PHB_TABLE_MEMORY		30 /* never implemented */
+#define OPAL_PCI_SET_PE				31
+#define OPAL_PCI_SET_PELTV			32
+#define OPAL_PCI_SET_MVE			33
+#define OPAL_PCI_SET_MVE_ENABLE			34
+#define OPAL_PCI_GET_XIVE_REISSUE		35 /* never implemented */
+#define OPAL_PCI_SET_XIVE_REISSUE		36 /* never implemented */
+#define OPAL_PCI_SET_XIVE_PE			37
+#define OPAL_GET_XIVE_SOURCE			38
+#define OPAL_GET_MSI_32				39
+#define OPAL_GET_MSI_64				40
+#define OPAL_START_CPU				41
+#define OPAL_QUERY_CPU_STATUS			42
+#define OPAL_WRITE_OPPANEL			43 /* unimplemented */
+#define OPAL_PCI_MAP_PE_DMA_WINDOW		44
+#define OPAL_PCI_MAP_PE_DMA_WINDOW_REAL		45
+/* 46 is unused */
+/* 47 is unused */
+/* 48 is unused */
+#define OPAL_PCI_RESET				49
+#define OPAL_PCI_GET_HUB_DIAG_DATA		50
+#define OPAL_PCI_GET_PHB_DIAG_DATA		51
+#define OPAL_PCI_FENCE_PHB			52
+#define OPAL_PCI_REINIT				53
+#define OPAL_PCI_MASK_PE_ERROR			54
+#define OPAL_SET_SLOT_LED_STATUS		55
+#define OPAL_GET_EPOW_STATUS			56
+#define OPAL_SET_SYSTEM_ATTENTION_LED		57
+#define OPAL_RESERVED1				58
+#define OPAL_RESERVED2				59
+#define OPAL_PCI_NEXT_ERROR			60
+#define OPAL_PCI_EEH_FREEZE_STATUS2		61
+#define OPAL_PCI_POLL				62
+#define OPAL_PCI_MSI_EOI			63
+#define OPAL_PCI_GET_PHB_DIAG_DATA2		64
+#define OPAL_XSCOM_READ				65
+#define OPAL_XSCOM_WRITE			66
+#define OPAL_LPC_READ				67
+#define OPAL_LPC_WRITE				68
+#define OPAL_RETURN_CPU				69
+#define OPAL_REINIT_CPUS			70
+#define OPAL_ELOG_READ				71
+#define OPAL_ELOG_WRITE				72
+#define OPAL_ELOG_ACK				73
+#define OPAL_ELOG_RESEND			74
+#define OPAL_ELOG_SIZE				75
+#define OPAL_FLASH_VALIDATE			76
+#define OPAL_FLASH_MANAGE			77
+#define OPAL_FLASH_UPDATE			78
+#define OPAL_RESYNC_TIMEBASE			79
+#define OPAL_CHECK_TOKEN			80
+#define OPAL_DUMP_INIT				81
+#define OPAL_DUMP_INFO				82
+#define OPAL_DUMP_READ				83
+#define OPAL_DUMP_ACK				84
+#define OPAL_GET_MSG				85
+#define OPAL_CHECK_ASYNC_COMPLETION		86
+#define OPAL_SYNC_HOST_REBOOT			87
+#define OPAL_SENSOR_READ			88
+#define OPAL_GET_PARAM				89
+#define OPAL_SET_PARAM				90
+#define OPAL_DUMP_RESEND			91
+#define OPAL_ELOG_SEND				92	/* Deprecated */
+#define OPAL_PCI_SET_PHB_CAPI_MODE		93
+#define OPAL_DUMP_INFO2				94
+#define OPAL_WRITE_OPPANEL_ASYNC		95
+#define OPAL_PCI_ERR_INJECT			96
+#define OPAL_PCI_EEH_FREEZE_SET			97
+#define OPAL_HANDLE_HMI				98
+#define OPAL_CONFIG_CPU_IDLE_STATE		99
+#define OPAL_SLW_SET_REG			100
+#define OPAL_REGISTER_DUMP_REGION		101
+#define OPAL_UNREGISTER_DUMP_REGION		102
+#define OPAL_WRITE_TPO				103
+#define OPAL_READ_TPO				104
+#define OPAL_GET_DPO_STATUS			105
+#define OPAL_OLD_I2C_REQUEST			106	/* Deprecated */
+#define OPAL_IPMI_SEND				107
+#define OPAL_IPMI_RECV				108
+#define OPAL_I2C_REQUEST			109
+#define OPAL_FLASH_READ				110
+#define OPAL_FLASH_WRITE			111
+#define OPAL_FLASH_ERASE			112
+#define OPAL_PRD_MSG				113
+#define OPAL_LEDS_GET_INDICATOR			114
+#define OPAL_LEDS_SET_INDICATOR			115
+#define OPAL_CEC_REBOOT2			116
+#define OPAL_CONSOLE_FLUSH			117
+#define OPAL_GET_DEVICE_TREE			118
+#define OPAL_PCI_GET_PRESENCE_STATE		119
+#define OPAL_PCI_GET_POWER_STATE		120
+#define OPAL_PCI_SET_POWER_STATE		121
+#define OPAL_INT_GET_XIRR			122
+#define	OPAL_INT_SET_CPPR			123
+#define OPAL_INT_EOI				124
+#define OPAL_INT_SET_MFRR			125
+#define OPAL_PCI_TCE_KILL			126
+#define OPAL_NMMU_SET_PTCR			127
+#define OPAL_XIVE_RESET				128
+#define OPAL_XIVE_GET_IRQ_INFO			129
+#define OPAL_XIVE_GET_IRQ_CONFIG		130
+#define OPAL_XIVE_SET_IRQ_CONFIG		131
+#define OPAL_XIVE_GET_QUEUE_INFO		132
+#define OPAL_XIVE_SET_QUEUE_INFO		133
+#define OPAL_XIVE_DONATE_PAGE			134
+#define OPAL_XIVE_ALLOCATE_VP_BLOCK		135
+#define OPAL_XIVE_FREE_VP_BLOCK			136
+#define OPAL_XIVE_GET_VP_INFO			137
+#define OPAL_XIVE_SET_VP_INFO			138
+#define OPAL_XIVE_ALLOCATE_IRQ			139
+#define OPAL_XIVE_FREE_IRQ			140
+#define OPAL_XIVE_SYNC				141
+#define OPAL_XIVE_DUMP				142
+#define OPAL_XIVE_GET_QUEUE_STATE		143 /* Get END state */
+#define OPAL_XIVE_SET_QUEUE_STATE		144 /* Set END state */
+#define OPAL_SIGNAL_SYSTEM_RESET		145
+#define OPAL_NPU_INIT_CONTEXT			146
+#define OPAL_NPU_DESTROY_CONTEXT		147
+#define OPAL_NPU_MAP_LPAR			148
+#define OPAL_IMC_COUNTERS_INIT			149
+#define OPAL_IMC_COUNTERS_START			150
+#define OPAL_IMC_COUNTERS_STOP			151
+#define OPAL_GET_POWERCAP			152
+#define OPAL_SET_POWERCAP			153
+#define OPAL_GET_POWER_SHIFT_RATIO		154
+#define OPAL_SET_POWER_SHIFT_RATIO		155
+#define OPAL_SENSOR_GROUP_CLEAR			156
+#define OPAL_PCI_SET_P2P			157
+#define OPAL_QUIESCE				158
+#define OPAL_NPU_SPA_SETUP			159
+#define OPAL_NPU_SPA_CLEAR_CACHE		160
+#define OPAL_NPU_TL_SET				161
+#define OPAL_SENSOR_READ_U64			162
+#define OPAL_SENSOR_GROUP_ENABLE		163
+#define OPAL_PCI_GET_PBCQ_TUNNEL_BAR		164
+#define OPAL_PCI_SET_PBCQ_TUNNEL_BAR		165
+#define OPAL_HANDLE_HMI2			166
+#define OPAL_NX_COPROC_INIT			167
+#define OPAL_NPU_SET_RELAXED_ORDER		168
+#define OPAL_NPU_GET_RELAXED_ORDER		169
+#define OPAL_XIVE_GET_VP_STATE			170 /* Get NVT state */
+#define OPAL_NPU_MEM_ALLOC			171
+#define OPAL_NPU_MEM_RELEASE			172
+#define OPAL_MPIPL_UPDATE			173
+#define OPAL_MPIPL_REGISTER_TAG			174
+#define OPAL_MPIPL_QUERY_TAG			175
+#define OPAL_SECVAR_GET				176
+#define OPAL_SECVAR_GET_NEXT			177
+#define OPAL_SECVAR_ENQUEUE_UPDATE		178
+#define OPAL_PHB_SET_OPTION			179
+#define OPAL_PHB_GET_OPTION			180
+#define OPAL_LAST				180
+

--- a/semihost/machine/powerpc/opal_call.S
+++ b/semihost/machine/powerpc/opal_call.S
@@ -1,0 +1,93 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2022 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+	.text
+	.section	.text.opal_call
+	.align		2
+	.p2align	4,,15
+/*
+ * void
+ * opal_call(void *r3, void *r4, void *r5, int call_r6, void *base_r7, void *entry_r8);
+ */
+#ifdef __PPC64__
+	.global		opal_call
+	.section	".opd","aw"
+	.align		3
+opal_call:
+	.quad		.opal_call,.TOC.@tocbase,0
+	.previous
+#else
+opal_call:
+#endif
+	.type		opal_call, @function
+.opal_call:
+	.cfi_startproc
+
+	/* Save LR */
+	mflr		%r0
+	std		%r0, 16(%r1)
+	/* Save TOC */
+	std		%r2, 40(%r1)
+
+	/* Create a new stack frame */
+	stdu		%r1,-112(%r1)
+
+	/* Put 'call' in %r0 */
+	mr		%r0, %r6
+
+	/* Set OPAL TOC */
+	mr		%r2, %r7
+
+	/* Call OPAL */
+	mtctr		%r8
+	bctrl
+
+	nop
+
+	/* Pop stack frame */
+	addi		%r1, %r1, 112
+
+	/* Restore TOC */
+	ld		%r2, 40(%r1)
+
+	/* Restore LR */
+	ld		%r0, 16(%r1)
+	mtlr		%r0
+
+	/* All done */
+	blr
+
+	.cfi_endproc
+	.size		opal_call,.-.opal_call

--- a/semihost/machine/powerpc/opal_cec_power_down.c
+++ b/semihost/machine/powerpc/opal_cec_power_down.c
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2022 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "opal.h"
+
+void _ATTRIBUTE((__noreturn__))
+opal_cec_power_down(uint64_t request)
+{
+    opal_call((void *) (intptr_t) request, NULL, NULL, OPAL_CEC_POWER_DOWN, __opal_base, __opal_entry);
+    __unreachable();
+}

--- a/semihost/machine/powerpc/opal_console_write.c
+++ b/semihost/machine/powerpc/opal_console_write.c
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2022 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "opal.h"
+
+int
+opal_console_write(int terminal, size_t len, const char *base)
+{
+    return opal_call((void *) (intptr_t) terminal, (void *) &len, (void *) base, OPAL_CONSOLE_WRITE, __opal_base, __opal_entry);
+}

--- a/semihost/machine/powerpc/powerpc_exit.c
+++ b/semihost/machine/powerpc/powerpc_exit.c
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2021 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "opal.h"
+
+void  _ATTRIBUTE((__noreturn__))
+_exit(int code)
+{
+        char buf[15];
+        int n;
+        /* Can't use printf because stdout has already been cleaned up */
+        n = snprintf(buf, sizeof(buf), "%cexit %d\n", 0xe9, code);
+        opal_console_write(OPAL_TERMINAL_DEFAULT, n, buf);
+        opal_cec_power_down(0);
+}

--- a/semihost/machine/powerpc/powerpc_io.c
+++ b/semihost/machine/powerpc/powerpc_io.c
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2021 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "opal.h"
+
+static int
+powerpc_putc(char c, FILE *file)
+{
+        opal_console_write(OPAL_TERMINAL_DEFAULT, 1, &c);
+	(void) file;
+	return (unsigned char) c;
+}
+
+static int
+powerpc_getc(FILE *file)
+{
+	(void) file;
+	return EOF;
+}
+
+static FILE __stdio = FDEV_SETUP_STREAM(powerpc_putc, powerpc_getc, NULL, _FDEV_SETUP_RW);
+
+#ifdef __strong_reference
+#define STDIO_ALIAS(x) __strong_reference(stdin, x);
+#else
+#define STDIO_ALIAS(x) FILE *const x = &__stdio;
+#endif
+
+FILE *const stdin = &__stdio;
+STDIO_ALIAS(stdout);
+STDIO_ALIAS(stderr);

--- a/semihost/machine/powerpc/powerpc_kill.c
+++ b/semihost/machine/powerpc/powerpc_kill.c
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2021 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sys/types.h>
+#include <signal.h>
+#include <unistd.h>
+#include <errno.h>
+
+pid_t getpid(void) { return 1; }
+
+int kill(pid_t pid, int sig) { if (pid == 1) _exit(128 + sig); errno = ESRCH; return -1; }

--- a/semihost/machine/powerpc/powerpc_stub.c
+++ b/semihost/machine/powerpc/powerpc_stub.c
@@ -1,0 +1,109 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2021 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include "opal.h"
+
+ssize_t
+read(int fd, void *buf, size_t count)
+{
+        (void) fd;
+        (void) buf;
+        (void) count;
+	return 0;
+}
+
+ssize_t
+write(int fd, const void *buf, size_t count)
+{
+        (void) fd;
+        opal_console_write(0, count, buf);
+	return count;
+}
+
+int
+open(const char *pathname, int flags, ...)
+{
+        (void) pathname;
+        (void) flags;
+	return -1;
+}
+
+int
+close(int fd)
+{
+        (void) fd;
+	return 0;
+}
+
+off_t lseek(int fd, off_t offset, int whence)
+{
+        (void) fd;
+        (void) offset;
+        (void) whence;
+	return (off_t) -1;
+}
+
+_off64_t lseek64(int fd, _off64_t offset, int whence)
+{
+	return (_off64_t) lseek(fd, (off_t) offset, whence);
+}
+
+int
+unlink(const char *pathname)
+{
+        (void) pathname;
+	return 0;
+}
+
+int
+fstat (int fd, struct stat *sbuf)
+{
+        (void) fd;
+        (void) sbuf;
+	return -1;
+}
+
+int
+isatty (int fd)
+{
+        (void) fd;
+	return 1;
+}

--- a/test/math_errhandling_tests.c
+++ b/test/math_errhandling_tests.c
@@ -624,6 +624,8 @@ FLOAT_T makemathname(test_scalbn_tiny)(void) { return makemathname(scalbn)(makem
 #define FE_UNDERFLOW 0
 #endif
 
+#define MY_EXCEPT (FE_DIVBYZERO|FE_INEXACT|FE_INVALID|FE_OVERFLOW|FE_UNDERFLOW)
+
 #ifdef __i386__
 /*
  * i386 ABI returns floats in the 8087 registers, which convert sNAN
@@ -1237,7 +1239,7 @@ makemathname(run_tests)(void) {
 		feclearexcept(FE_ALL_EXCEPT);
 		v = makemathname(tests)[t].func();
 		err = errno;
-		except = fetestexcept(FE_ALL_EXCEPT);
+		except = fetestexcept(MY_EXCEPT);
 		if (!makemathname(is_equal)(v, makemathname(tests)[t].value))
 		{
                         PRINT;
@@ -1250,7 +1252,7 @@ makemathname(run_tests)(void) {
 		}
 		if (math_errhandling & EXCEPTION_TEST) {
                     int expect_except = makemathname(tests)[t].except;
-                    int mask = FE_ALL_EXCEPT;
+                    int mask = MY_EXCEPT;
 
                     /* underflow can be set for inexact operations */
                     if (expect_except & FE_INEXACT)
@@ -1292,7 +1294,7 @@ makemathname(run_tests)(void) {
 		feclearexcept(FE_ALL_EXCEPT);
 		iv = makemathname(itests)[t].func();
 		err = errno;
-		except = fetestexcept(FE_ALL_EXCEPT);
+		except = fetestexcept(MY_EXCEPT);
 		if (iv != makemathname(itests)[t].value)
 		{
                         IPRINT;
@@ -1301,7 +1303,7 @@ makemathname(run_tests)(void) {
 		}
 		if (math_errhandling & EXCEPTION_TEST) {
                         int expect_except = makemathname(itests)[t].except;
-                        int mask = FE_ALL_EXCEPT;
+                        int mask = MY_EXCEPT;
 
                         /* underflow can be set for inexact operations */
                         if (expect_except & FE_INEXACT)

--- a/test/meson.build
+++ b/test/meson.build
@@ -303,7 +303,7 @@ foreach target : targets
 		 'math-funcs', 'timegm', 'time-tests',
                  'test-strtod', 'test-strchr',
 		 'test-memset', 'test-put',
-		 'test-efcvt'
+		 'test-efcvt',
 		]
 
   if have_attr_ctor_dtor
@@ -347,6 +347,7 @@ foreach target : targets
 		    link_depends:  test_link_depends,
 		    include_directories: inc),
          depends: bios_bin,
+	 timeout: 60,
 	 env: test_env)
   endforeach
 


### PR DESCRIPTION
Use the QEMU OPAL support provided by skiboot to run tests using both double-double and 128-bit versions of 'long double'.