### PR TITLE
meson: Remove unused variable lib_m{target}

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1321,5 +1321,5 @@ configure_file(output : 'picolibc.h',
 # provide a dependency to be used by the main project:
 #   dependency('libc', fallback: ['picolibc', 'libc_dep'])
 if not enable_multilib and meson.is_subproject()
-  picolibc_dep = declare_dependency(include_directories: inc, link_with: [lib_c, lib_m])
+  picolibc_dep = declare_dependency(include_directories: inc, link_with: [lib_c])
 endif

--- a/newlib/meson.build
+++ b/newlib/meson.build
@@ -75,15 +75,12 @@ foreach target : targets
 				      c_args: value[1])
 
   set_variable('lib_c' + target, local_lib_c_target)
-
-  local_lib_m_target = static_library(libm_name,
-                                      ['empty.c'],
-                                      install : true,
-                                      install_dir : instdir,
-                                      pic: false,
-                                      objects : [])
-
-  set_variable('lib_m' + target, local_lib_m_target)
+  static_library(libm_name,
+		 ['empty.c'],
+		 install : true,
+		 install_dir : instdir,
+		 pic: false,
+		 objects : [])
 
   if check_duplicate_names
     custom_target('libc_duplicates' + target,


### PR DESCRIPTION
Leftovers after 55bc0abd6c2b89d697ca160b88f46d5951e9fba3 "Merge core C library with math library"