### PR TITLE
picolibc.ld: Reduce number of memory region attributes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -699,9 +699,6 @@ if cc.get_linker_id() == 'ld.lld'
     # An added ASSERT() statement in the linker script ensures that we don't
     # get silent failures in case this changes in the future.
     picolibc_linker_type_data.set('LDSCRIPT_ALIGN_WITH_INPUT', '')
-    # The i MEMORY attribute is also not implemented, but it would does not
-    # make any difference on the output even if it was.
-    picolibc_linker_type_data.set('LDSCRIPT_MEMORY_ATTR_I', '')
     if host_cpu_family == 'riscv'
         # ld.lld before version 15 did not support linker relaxations, disable
         # them if we are using an older version.
@@ -714,7 +711,6 @@ if cc.get_linker_id() == 'ld.lld'
     endif
 else
     picolibc_linker_type_data.set('LDSCRIPT_ALIGN_WITH_INPUT', 'ALIGN_WITH_INPUT')
-    picolibc_linker_type_data.set('LDSCRIPT_MEMORY_ATTR_I', 'i')
 endif
 
 picolibc_ld_data = configuration_data()

--- a/picolibc.ld.in
+++ b/picolibc.ld.in
@@ -42,8 +42,8 @@ ENTRY(_start)
 
 MEMORY
 {
-	flash (rxa@LDSCRIPT_MEMORY_ATTR_I@!w) : ORIGIN = DEFINED(__flash) ? __flash : 0x10000000, LENGTH = DEFINED(__flash_size) ? __flash_size : 0x10000
-	ram (wxa!r@LDSCRIPT_MEMORY_ATTR_I@)   : ORIGIN = DEFINED(__ram  ) ? __ram   : 0x20000000, LENGTH = DEFINED(__ram_size  ) ? __ram_size   : 0x08000
+	flash (rx!w) : ORIGIN = DEFINED(__flash) ? __flash : 0x10000000, LENGTH = DEFINED(__flash_size) ? __flash_size : 0x10000
+	ram (w!rx)   : ORIGIN = DEFINED(__ram  ) ? __ram   : 0x20000000, LENGTH = DEFINED(__ram_size  ) ? __ram_size   : 0x08000
 }
 
 PHDRS


### PR DESCRIPTION
Place all read-only or executable regions in flash, place all read-write sections in RAM.

The memory region attributes in the ld script are used to select a suitable region for orphan sections, or output sections where the destination address or region has not been set explicitly.

If a section matches _ANY_ of the attributes listed before the '!' and matches NONE of the attrbutes after '!' then it will be placed in that region. Therefore it does not make sense to add too many attributes here when we only have two regions to choose from. In particular, having the 'a' attribute listed for both regions will defeat the purpose of all the other attributes because ld will pick the first one for all ALLOCATABLE sections.

References:
 - https://sourceware.org/binutils/docs/ld/MEMORY.html
 - https://sourceware.org/binutils/docs/ld/Output-Section-Address.html
 - https://sourceware.org/binutils/docs/ld/Output-Section-LMA.html
