### PR TITLE
Clean up PowerPC ABI bits

### DIFF
--- a/picocrt/machine/powerpc/crt0.S
+++ b/picocrt/machine/powerpc/crt0.S
@@ -32,13 +32,16 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#ifdef _CALL_ELF
+	.abiversion _CALL_ELF
+#endif
 #define PPC_BIT(bit)            (0x8000000000000000ULL >> (bit))
 	.text
 	.section	.text.init.enter
 	.global _start
 	.type	_start, @function
 _start:
-
+	.cfi_startproc
 	/* Where are we? */
 	bl	here
 here:	mflr	%r2
@@ -69,6 +72,9 @@ here:	mflr	%r2
 	mr	%r3, %r8
 	mr	%r4, %r9
 	bl	_cstart
+	.cfi_endproc
+	.size _start,.-_start
+
 	.align	3
 #ifdef __PPC64__
 toc:	
@@ -82,3 +88,6 @@ stackaddr:
 	.long	__stack
 #endif
 	
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/picolibc.ld.in
+++ b/picolibc.ld.in
@@ -111,10 +111,6 @@ SECTIONS
 
 	} >flash AT>flash :text
 
-	.toc : {
-		*(.toc .toc.*)
-	} >flash AT>flash :text
-
         /* additional sections when compiling with C++ exception support */
 	@CPP_START@
         .except_ordered : {
@@ -208,6 +204,11 @@ SECTIONS
 	.tbss_space (NOLOAD) : {
 		. = . + SIZEOF(.tbss);
 	} >ram AT>ram :ram
+
+	/* PowerPC ABI */
+	.toc (NOLOAD) : {
+		*(.toc .toc.*)
+	} >ram AT>ram : ram
 
 	.bss (NOLOAD) : {
 		*(.sbss*)

--- a/semihost/machine/powerpc/opal_call.S
+++ b/semihost/machine/powerpc/opal_call.S
@@ -32,7 +32,9 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
+#ifdef _CALL_ELF
+	.abiversion _CALL_ELF
+#endif
 	.text
 	.section	.text.opal_call
 	.align		2
@@ -41,8 +43,8 @@
  * void
  * opal_call(void *r3, void *r4, void *r5, int call_r6, void *base_r7, void *entry_r8);
  */
-#ifdef __PPC64__
 	.global		opal_call
+#if defined(__PPC64__) && _CALL_ELF == 1
 	.section	".opd","aw"
 	.align		3
 opal_call:
@@ -91,3 +93,7 @@ opal_call:
 
 	.cfi_endproc
 	.size		opal_call,.-.opal_call
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif


### PR DESCRIPTION
Use .abiversion and %progbits in .S files. Move .toc to uninitialized RAM in linker script.

Signed-off-by: Keith Packard <keithp@keithp.com>