### PR TITLE
Fix bug in ieee 128-bit trig code

### DIFF
--- a/COPYING.picolibc
+++ b/COPYING.picolibc
@@ -108,6 +108,7 @@ Files: newlib/libc/machine/aarch64/machine/fenv-fp.h
  newlib/libc/machine/powerpc/machine/fenv-fp.h
  newlib/libc/machine/powerpc/sys/fenv.h
  newlib/libc/machine/sparc/sys/fenv.h
+ newlib/libm/ld/common/s_frexpl.c
 Copyright: 2004-2005 David Schultz <das@FreeBSD.ORG>
 License: BSD2-1
 
@@ -224,6 +225,51 @@ Files: newlib/libm/complex/csqrtl.c
 Copyright: 2007-2008 David Schultz <das@FreeBSD.ORG>
 License: BSD2-1
 
+Files: newlib/libm/ld/common/e_remainderl.c
+ newlib/libm/ld/common/s_rintl.c
+ newlib/libm/ld/ld128/invtrig.c
+ newlib/libm/ld/ld128/invtrig.h
+ newlib/libm/ld/ld80/invtrig.c
+ newlib/libm/ld/ld80/invtrig.h
+Copyright: 2008 David Schultz <das@FreeBSD.ORG>
+License: BSD2-1
+
+Files: newlib/libm/ld/common/s_fdiml.c
+ newlib/libm/ld/common/s_finitel.c
+ newlib/libm/ld/common/s_fmaxl.c
+ newlib/libm/ld/common/s_fminl.c
+ newlib/libm/ld/common/s_isinfl.c
+ newlib/libm/ld/common/s_isnanl.c
+ newlib/libm/ld/common/s_scalbl.c
+ newlib/libm/ld/common/s_scalbln.c
+ newlib/libm/machine/mips/fenv.c
+ newlib/libm/machine/powerpc/fenv.c
+Copyright: 2004 David Schultz <das@FreeBSD.ORG>
+License: BSD2-1
+
+Files: newlib/libm/ld/common/s_fmal.c
+Copyright: 2005-2011 David Schultz <das@FreeBSD.ORG>
+License: BSD2-1
+
+Files: newlib/libm/ld/common/s_lrintl.c
+ newlib/libm/ld/common/s_lround.c
+Copyright: 2005 David Schultz <das@FreeBSD.ORG>
+License: BSD2-1
+
+Files: newlib/libm/ld/fpmath.h
+Copyright: 2003 Mike Barcroft <mike@FreeBSD.org>
+ 2002 David Schultz <das@FreeBSD.ORG>
+License: BSD2-1
+
+Files: newlib/libm/ld/ld128/s_exp2l.c
+ newlib/libm/ld/ld80/s_exp2l.c
+Copyright: 2005-2008 David Schultz <das@FreeBSD.ORG>
+License: BSD2-1
+
+Files: newlib/libm/ld/ld80/i386_fpmath.h
+Copyright: 2002, 2003 David Schultz <das@FreeBSD.ORG>
+License: BSD2-1
+
 Files: newlib/libm/machine/aarch64/fenv.c
 Copyright: 2004 David Schultz <das@FreeBSD.ORG>
  2013 Andrew Turner <andrew@FreeBSD.ORG>
@@ -246,11 +292,6 @@ Files: newlib/libm/machine/arm/_fenv.h
  newlib/libm/machine/arm/feupdateenv.c
 Copyright: 2004-2005 David Schultz <das@FreeBSD.ORG>
  2013 Andrew Turner <andrew@FreeBSD.ORG>
-License: BSD2-1
-
-Files: newlib/libm/machine/mips/fenv.c
- newlib/libm/machine/powerpc/fenv.c
-Copyright: 2004 David Schultz <das@FreeBSD.ORG>
 License: BSD2-1
 
 Files: newlib/testsuite/newlib.iconv/iconv.exp
@@ -456,9 +497,25 @@ Files: newlib/libc/signal/sig2str.c
 Copyright: 2021 Matthew Joyce
 License: BSD2-11
 
+Files: newlib/libm/ld/common/e_sqrtl.c
+ newlib/libm/ld/common/s_cosl.c
+ newlib/libm/ld/common/s_sinl.c
+ newlib/libm/ld/common/s_tanl.c
+Copyright: 2007 Steven G. Kargl
+License: BSD2-12
+
+Files: newlib/libm/ld/common/s_roundl.c
+Copyright: 2003, Steven G. Kargl
+License: BSD2-12
+
+Files: newlib/libm/ld/ld128/s_nanl.c
+ newlib/libm/ld/ld80/s_nanl.c
+Copyright: 2007 David Schultz
+License: BSD2-13
+
 Files: newlib/libm/machine/sparc/fenv.c
 Copyright: 2004-2005 David Schultz <das@FreeBSD.ORG>
-License: BSD2-12
+License: BSD2-14
 
 Files: CMakeLists.txt
  cmake/picolibc.cmake
@@ -492,6 +549,7 @@ Files: CMakeLists.txt
  newlib/libc/machine/arm/CMakeLists.txt
  newlib/libc/machine/arm/machine/CMakeLists.txt
  newlib/libc/machine/arm/sys/CMakeLists.txt
+ newlib/libc/machine/avr/meson.build
  newlib/libc/machine/mips/CMakeLists.txt
  newlib/libc/machine/mips/machine/CMakeLists.txt
  newlib/libc/machine/mips/machine/meson.build
@@ -540,7 +598,14 @@ Files: CMakeLists.txt
  newlib/libc/tinystdio/fcvt_r.c
  newlib/libc/tinystdio/fcvtf_r.c
  newlib/libc/tinystdio/fmemopen.c
+ newlib/libc/tinystdio/remove.c
  newlib/libc/tinystdio/stdio-bufio.h
+ newlib/libc/tinystdio/strtol_l.c
+ newlib/libc/tinystdio/strtoll_l.c
+ newlib/libc/tinystdio/strtoul_l.c
+ newlib/libc/tinystdio/strtoull_l.c
+ newlib/libc/tinystdio/tmpfile.c
+ newlib/libc/tinystdio/tmpnam.c
  newlib/libc/xdr/CMakeLists.txt
  newlib/libm/CMakeLists.txt
  newlib/libm/common/CMakeLists.txt
@@ -551,6 +616,83 @@ Files: CMakeLists.txt
  newlib/libm/fenv/fegetmode.c
  newlib/libm/fenv/fesetexcept.c
  newlib/libm/fenv/fesetmode.c
+ newlib/libm/ld/CMakeLists.txt
+ newlib/libm/ld/common/meson.build
+ newlib/libm/ld/e_acoshl.c
+ newlib/libm/ld/e_acosl.c
+ newlib/libm/ld/e_asinl.c
+ newlib/libm/ld/e_atan2l.c
+ newlib/libm/ld/e_atanhl.c
+ newlib/libm/ld/e_coshl.c
+ newlib/libm/ld/e_expl.c
+ newlib/libm/ld/e_fmodl.c
+ newlib/libm/ld/e_hypotl.c
+ newlib/libm/ld/e_lgammal.c
+ newlib/libm/ld/e_lgammal_r.c
+ newlib/libm/ld/e_log10l.c
+ newlib/libm/ld/e_log2l.c
+ newlib/libm/ld/e_logl.c
+ newlib/libm/ld/e_powl.c
+ newlib/libm/ld/e_remainderl.c
+ newlib/libm/ld/e_sinhl.c
+ newlib/libm/ld/e_sqrtl.c
+ newlib/libm/ld/e_tgammal.c
+ newlib/libm/ld/invtrig.c
+ newlib/libm/ld/k_cosl.c
+ newlib/libm/ld/k_rem_pio2.c
+ newlib/libm/ld/k_sinl.c
+ newlib/libm/ld/k_tanl.c
+ newlib/libm/ld/ldd/s_ceill.c
+ newlib/libm/ld/ldd/s_floorl.c
+ newlib/libm/ld/ldd/s_fpclassifyl.c
+ newlib/libm/ld/ldd/s_nanl.c
+ newlib/libm/ld/ldd/s_nearbyintl.c
+ newlib/libm/ld/ldd/s_truncl.c
+ newlib/libm/ld/math_ld.h
+ newlib/libm/ld/meson.build
+ newlib/libm/ld/polevll.c
+ newlib/libm/ld/s_asinhl.c
+ newlib/libm/ld/s_atanl.c
+ newlib/libm/ld/s_cbrtl.c
+ newlib/libm/ld/s_ceill.c
+ newlib/libm/ld/s_copysignl.c
+ newlib/libm/ld/s_cosl.c
+ newlib/libm/ld/s_erfl.c
+ newlib/libm/ld/s_exp2l.c
+ newlib/libm/ld/s_expm1l.c
+ newlib/libm/ld/s_fabsl.c
+ newlib/libm/ld/s_fdiml.c
+ newlib/libm/ld/s_finitel.c
+ newlib/libm/ld/s_floorl.c
+ newlib/libm/ld/s_fmal.c
+ newlib/libm/ld/s_fmaxl.c
+ newlib/libm/ld/s_fminl.c
+ newlib/libm/ld/s_fpclassifyl.c
+ newlib/libm/ld/s_frexpl.c
+ newlib/libm/ld/s_ilogbl.c
+ newlib/libm/ld/s_isnanl.c
+ newlib/libm/ld/s_llrintl.c
+ newlib/libm/ld/s_llroundl.c
+ newlib/libm/ld/s_log1pl.c
+ newlib/libm/ld/s_logbl.c
+ newlib/libm/ld/s_lrintl.c
+ newlib/libm/ld/s_lroundl.c
+ newlib/libm/ld/s_modfl.c
+ newlib/libm/ld/s_nanl.c
+ newlib/libm/ld/s_nextafterl.c
+ newlib/libm/ld/s_nexttoward.c
+ newlib/libm/ld/s_nexttowardf.c
+ newlib/libm/ld/s_remquol.c
+ newlib/libm/ld/s_rintl.c
+ newlib/libm/ld/s_roundl.c
+ newlib/libm/ld/s_scalbl.c
+ newlib/libm/ld/s_scalbln.c
+ newlib/libm/ld/s_scalbnl.c
+ newlib/libm/ld/s_sincosl.c
+ newlib/libm/ld/s_sinl.c
+ newlib/libm/ld/s_tanhl.c
+ newlib/libm/ld/s_tanl.c
+ newlib/libm/ld/s_truncl.c
  newlib/libm/machine/CMakeLists.txt
  newlib/libm/machine/aarch64/CMakeLists.txt
  newlib/libm/machine/arm/CMakeLists.txt
@@ -558,6 +700,7 @@ Files: CMakeLists.txt
  newlib/libm/machine/arm/sf_fabs.c
  newlib/libm/machine/mips/CMakeLists.txt
  newlib/libm/machine/mips/meson.build
+ newlib/libm/machine/powerpc/complex128.c
  newlib/libm/machine/riscv/CMakeLists.txt
  newlib/libm/machine/sparc/CMakeLists.txt
  newlib/libm/machine/sparc/meson.build
@@ -567,6 +710,8 @@ Files: CMakeLists.txt
  newlib/testsuite/newlib.time/meson.build
  picocrt/CMakeLists.txt
  picocrt/machine/arm/CMakeLists.txt
+ picocrt/machine/powerpc/crt0.S
+ picocrt/machine/powerpc/powerpc_crt.h
  semihost/CMakeLists.txt
  semihost/fake/fake_exit.c
  semihost/fake/fake_io.c
@@ -575,7 +720,13 @@ Files: CMakeLists.txt
  semihost/fake/meson.build
  semihost/getentropy.c
  semihost/machine/arm/CMakeLists.txt
+ semihost/machine/powerpc/opal.h
+ semihost/machine/powerpc/opal_call.S
+ semihost/machine/powerpc/opal_cec_power_down.c
+ semihost/machine/powerpc/opal_console_write.c
  test/CMakeLists.txt
+ test/lock-valid.c
+ test/long_double.c
  test/test-efcvt.c
  test/test-except.c
  test/test-fopen.c
@@ -638,14 +789,13 @@ Files: cmake/TC-arm-none-eabi.ld
  newlib/libm/math/s_lgamma.c
  scripts/run-aarch64
  scripts/run-i386
- scripts/run-rv32imac
- scripts/run-rv32imafdc
  scripts/run-x86
  scripts/run-x86_64
  scripts/test-arm.ld
  scripts/test-cortex-a9.ld
  scripts/test-i386.ld
  scripts/test-m68k.ld
+ scripts/test-powerpc.ld
  scripts/test-riscv.ld
  scripts/test-riscv32.ld
  scripts/test-riscv64.ld
@@ -845,6 +995,7 @@ Files: dummyhost/iob.c
  scripts/do-arc-configure
  scripts/do-arc64-configure
  scripts/do-arm-configure
+ scripts/do-avr-configure
  scripts/do-clang-arm-configure
  scripts/do-clang-msp430-configure
  scripts/do-clang-riscv-configure
@@ -880,6 +1031,7 @@ Files: dummyhost/iob.c
  scripts/do-zephyr-riscv-configure
  scripts/run-arm
  scripts/run-cortex-a9
+ scripts/run-power9
  scripts/run-riscv
  scripts/run-thumbv6m
  scripts/run-thumbv7e
@@ -954,26 +1106,32 @@ Files: newlib/empty.c
  newlib/libc/tinystdio/rewind.c
  newlib/libc/tinystdio/strfromd.c
  newlib/libc/tinystdio/strfromf.c
- newlib/libm/common/dreml.c
  newlib/libm/common/exp10l.c
  newlib/libm/common/math_inexact.c
  newlib/libm/common/math_inexactf.c
- newlib/libm/common/pow10l.c
+ newlib/libm/common/math_inexactl.c
  newlib/libm/common/s_getpayload.c
  newlib/libm/common/sf_getpayload.c
- newlib/libm/common/sincosl.c
  newlib/libm/machine/powerpc/meson.build
  newlib/libm/test/scalb_vec.c
  newlib/libm/test/scalbn_vec.c
  picocrt/machine/aarch64/meson.build
  picocrt/machine/arm/meson.build
+ picocrt/machine/powerpc/meson.build
  picocrt/machine/riscv/meson.build
  picocrt/machine/x86/meson.build
+ scripts/do-power9-configure
+ scripts/do-power9-fp128-configure
  scripts/do-powerpc64-configure
  scripts/do-powerpc64le-configure
  semihost/gettimeofday.c
  semihost/machine/aarch64/meson.build
  semihost/machine/arm/meson.build
+ semihost/machine/powerpc/meson.build
+ semihost/machine/powerpc/powerpc_exit.c
+ semihost/machine/powerpc/powerpc_io.c
+ semihost/machine/powerpc/powerpc_kill.c
+ semihost/machine/powerpc/powerpc_stub.c
  semihost/machine/riscv/meson.build
  semihost/machine/x86/bios.S
  semihost/machine/x86/e9_exit.c
@@ -1051,7 +1209,8 @@ Files: newlib/libm/machine/riscv/s_copysign.c
 Copyright: 2020 Kito Cheng
 License: BSD3-1
 
-Files: picocrt/machine/riscv/crt0.c
+Files: picocrt/machine/powerpc/cstart.c
+ picocrt/machine/riscv/crt0.c
 Copyright: 2020 Sebastian Meyer
 License: BSD3-1
 
@@ -1579,39 +1738,158 @@ Files: newlib/libc/machine/arm/strlen-armv7.S
 Copyright: 2010-2011,2013 Linaro Limited
 License: BSD3-12
 
+Files: newlib/libc/machine/avr/macros.inc
+Copyright: 2002, 2005, 2006, 2007 Marek Michalkiewicz
+ 2006 Dmitry Xmelkov
+License: BSD3-13
+
+Files: newlib/libc/machine/avr/sectionname.h
+Copyright: 2009 Atmel Corporation
+License: BSD3-13
+
+Files: newlib/libc/machine/avr/setjmp.S
+Copyright: 2002, Marek Michalkiewicz
+License: BSD3-13
+
+Files: newlib/libc/tinystdio/atod_engine.c
+ newlib/libc/tinystdio/atof_engine.c
+ newlib/libc/tinystdio/conv_flt.c
+ newlib/libc/tinystdio/scanf_private.h
+ newlib/libc/tinystdio/strtoi.h
+ newlib/libc/tinystdio/strtoimax.c
+ newlib/libc/tinystdio/strtol.c
+ newlib/libc/tinystdio/strtoll.c
+ newlib/libc/tinystdio/strtoul.c
+ newlib/libc/tinystdio/strtoull.c
+ newlib/libc/tinystdio/strtoumax.c
+ newlib/libc/tinystdio/vfscanf.c
+Copyright: 2002,2004,2005 Joerg Wunsch
+ 2008  Dmitry Xmelkov
+License: BSD3-13
+
+Files: newlib/libc/tinystdio/clearerr.c
+ newlib/libc/tinystdio/fclose.c
+ newlib/libc/tinystdio/feof.c
+ newlib/libc/tinystdio/ferror.c
+ newlib/libc/tinystdio/fgetc.c
+ newlib/libc/tinystdio/stdio_private.h
+Copyright: 2002,2005 Joerg Wunsch
+License: BSD3-13
+
+Files: newlib/libc/tinystdio/dtoa_data.c
+ newlib/libc/tinystdio/dtoa_engine.c
+ newlib/libc/tinystdio/dtoa_engine.h
+ newlib/libc/tinystdio/make-dtoa-data
+ newlib/libc/tinystdio/sprintfd.c
+ newlib/libc/tinystdio/sprintff.c
+ newlib/libc/tinystdio/vfiprintf.c
+ newlib/libc/tinystdio/vfiscanf.c
+ newlib/libc/tinystdio/vfprintff.c
+ newlib/libc/tinystdio/vfscanff.c
+Copyright: 2018, Keith Packard
+License: BSD3-13
+
+Files: newlib/libc/tinystdio/fdevopen.c
+Copyright: 2002,2005, 2007 Joerg Wunsch
+License: BSD3-13
+
+Files: newlib/libc/tinystdio/fgets.c
+ newlib/libc/tinystdio/fprintf.c
+ newlib/libc/tinystdio/fputc.c
+ newlib/libc/tinystdio/fputs.c
+ newlib/libc/tinystdio/fread.c
+ newlib/libc/tinystdio/fscanf.c
+ newlib/libc/tinystdio/fwrite.c
+ newlib/libc/tinystdio/getchar.c
+ newlib/libc/tinystdio/gets.c
+ newlib/libc/tinystdio/printf.c
+ newlib/libc/tinystdio/putchar.c
+ newlib/libc/tinystdio/puts.c
+ newlib/libc/tinystdio/scanf.c
+ newlib/libc/tinystdio/snprintf.c
+ newlib/libc/tinystdio/sprintf.c
+ newlib/libc/tinystdio/sscanf.c
+ newlib/libc/tinystdio/ungetc.c
+Copyright: 2002, Joerg Wunsch
+License: BSD3-13
+
+Files: newlib/libc/tinystdio/ftoa_engine.h
+ newlib/libc/tinystdio/xtoa_fast.h
+Copyright: 2005, Dmitry Xmelkov
+License: BSD3-13
+
+Files: newlib/libc/tinystdio/snprintfd.c
+ newlib/libc/tinystdio/snprintff.c
+Copyright: 2021 Keith Packard
+License: BSD3-13
+
+Files: newlib/libc/tinystdio/stdio.h
+Copyright: 2002, 2005, 2007 Joerg Wunsch  
+ 1990, 1991, 1993 The Regents of the University of California. 
+License: BSD3-13
+
+Files: newlib/libc/tinystdio/strtod.c
+ newlib/libc/tinystdio/strtof.c
+ newlib/libc/tinystdio/strtold.c
+Copyright: 2002-2005  Michael Stumpf  <mistumpf@de.pepperl-fuchs.com>
+ 2006,2008  Dmitry Xmelkov 
+License: BSD3-13
+
+Files: newlib/libc/tinystdio/ultoa_invert.c
+Copyright: 2017 Keith Packard
+License: BSD3-13
+
+Files: newlib/libc/tinystdio/vfprintf.c
+Copyright: 2002, Alexander Popov (sasho@vip.bg)
+ 2002,2004,2005 Joerg Wunsch
+ 2005, Helmut Wallner
+ 2007, Dmitry Xmelkov
+License: BSD3-13
+
+Files: newlib/libc/tinystdio/vprintf.c
+ newlib/libc/tinystdio/vscanf.c
+ newlib/libc/tinystdio/vsscanf.c
+Copyright: 2005, Joerg Wunsch
+License: BSD3-13
+
+Files: newlib/libc/tinystdio/vsnprintf.c
+ newlib/libc/tinystdio/vsprintf.c
+Copyright: 2003, Joerg Wunsch
+License: BSD3-13
+
 Files: newlib/libc/machine/epiphany/setjmp.S
 Copyright: 2011, Adapteva, Inc.
-License: BSD3-13
+License: BSD3-14
 
 Files: newlib/libc/machine/microblaze/abort.c
  newlib/libc/machine/microblaze/longjmp.S
  newlib/libc/machine/microblaze/setjmp.S
 Copyright: 2001, 2009 Xilinx, Inc.
-License: BSD3-14
+License: BSD3-15
 
 Files: newlib/libc/machine/microblaze/strcmp.c
  newlib/libc/machine/microblaze/strcpy.c
  newlib/libc/machine/microblaze/strlen.c
 Copyright: 2009 Xilinx, Inc.
-License: BSD3-14
+License: BSD3-15
 
 Files: newlib/libc/machine/mips/machine/asm.h
  newlib/libc/machine/mips/machine/regdef.h
 Copyright: 1996-2007 MIPS Technologies, Inc.
  2009 CodeSourcery, LLC. 
-License: BSD3-15
+License: BSD3-16
 
 Files: newlib/libc/machine/mips/memcpy.S
 Copyright: 2012-2015 MIPS Technologies, Inc., California.
-License: BSD3-16
+License: BSD3-17
 
 Files: newlib/libc/machine/mips/memset.S
 Copyright: 2013 MIPS Technologies, Inc., California.
-License: BSD3-16
+License: BSD3-17
 
 Files: newlib/libc/machine/mips/strcmp.S
 Copyright: 2014 Imagination Technologies Limited.
-License: BSD3-17
+License: BSD3-18
 
 Files: newlib/libc/machine/nds32/abort.c
  newlib/libc/machine/nds32/memcpy.S
@@ -1620,20 +1898,20 @@ Files: newlib/libc/machine/nds32/abort.c
  newlib/libc/machine/nds32/strcmp.S
  newlib/libc/machine/nds32/strcpy.S
 Copyright: 2013 Andes Technology Corporation.
-License: BSD3-18
+License: BSD3-19
 
 Files: newlib/libm/machine/nds32/w_sqrt.S
  newlib/libm/machine/nds32/wf_sqrt.S
 Copyright: 2013-2014 Andes Technology Corporation.
-License: BSD3-18
+License: BSD3-19
 
 Files: newlib/libc/machine/nios2/setjmp.s
 Copyright: 2003 Altera Corporation
-License: BSD3-19
+License: BSD3-20
 
 Files: newlib/libc/machine/sparc/setjmp.S
 Copyright: 1992, 1993 The Regents of the University of California.
-License: BSD3-20
+License: BSD3-21
 
 Files: newlib/libc/machine/spu/c99ppe.h
  newlib/libc/machine/spu/clearerr.c
@@ -1678,7 +1956,7 @@ Files: newlib/libc/machine/spu/c99ppe.h
  newlib/libc/machine/spu/vsprintf.c
  newlib/libc/machine/spu/vsscanf.c
 Copyright: IBM Corp. 2006 
-License: BSD3-21
+License: BSD3-22
 
 Files: newlib/libc/machine/spu/calloc_ea.c
  newlib/libc/machine/spu/ea_internal.h
@@ -1710,69 +1988,21 @@ Files: newlib/libc/machine/spu/calloc_ea.c
  newlib/libc/machine/spu/strspn_ea.c
  newlib/libc/machine/spu/strstr_ea.c
 Copyright: IBM Corp. 2007, 2008 
-License: BSD3-21
+License: BSD3-22
 
 Files: newlib/libc/machine/spu/fdopen.c
  newlib/libc/stdlib/strtold.c
  newlib/libc/stdlib/wcstold.c
- newlib/libm/common/acoshl.c
- newlib/libm/common/acosl.c
- newlib/libm/common/asinhl.c
- newlib/libm/common/asinl.c
- newlib/libm/common/atan2l.c
- newlib/libm/common/atanhl.c
- newlib/libm/common/atanl.c
- newlib/libm/common/cbrtl.c
- newlib/libm/common/ceill.c
  newlib/libm/common/copysignl.c
- newlib/libm/common/coshl.c
- newlib/libm/common/cosl.c
- newlib/libm/common/erfcl.c
- newlib/libm/common/erfl.c
- newlib/libm/common/exp2l.c
- newlib/libm/common/expl.c
- newlib/libm/common/expm1l.c
  newlib/libm/common/fabsl.c
- newlib/libm/common/fdiml.c
- newlib/libm/common/finitel.c
- newlib/libm/common/floorl.c
- newlib/libm/common/fmal.c
- newlib/libm/common/fmaxl.c
- newlib/libm/common/fminl.c
- newlib/libm/common/fmodl.c
  newlib/libm/common/frexpl.c
- newlib/libm/common/ilogbl.c
  newlib/libm/common/isinfl.c
  newlib/libm/common/isnanl.c
- newlib/libm/common/ldexpl.c
- newlib/libm/common/lgammal.c
- newlib/libm/common/llrintl.c
- newlib/libm/common/llroundl.c
- newlib/libm/common/log10l.c
- newlib/libm/common/log1pl.c
- newlib/libm/common/logl.c
- newlib/libm/common/lrintl.c
- newlib/libm/common/lroundl.c
- newlib/libm/common/modfl.c
  newlib/libm/common/nanl.c
- newlib/libm/common/nearbyintl.c
- newlib/libm/common/nextafterl.c
- newlib/libm/common/powl.c
- newlib/libm/common/remainderl.c
- newlib/libm/common/remquol.c
- newlib/libm/common/rintl.c
- newlib/libm/common/roundl.c
- newlib/libm/common/scalblnl.c
  newlib/libm/common/scalbnl.c
- newlib/libm/common/sinhl.c
- newlib/libm/common/sinl.c
- newlib/libm/common/sqrtl.c
- newlib/libm/common/tanhl.c
- newlib/libm/common/tanl.c
- newlib/libm/common/tgammal.c
- newlib/libm/common/truncl.c
+ newlib/libm/ld/s_isinfl.c
 Copyright: IBM Corp. 2009 
-License: BSD3-21
+License: BSD3-22
 
 Files: newlib/libc/machine/spu/include/spu_timer.h
  newlib/libc/machine/spu/pread_ea.c
@@ -1795,15 +2025,15 @@ Files: newlib/libc/machine/spu/include/spu_timer.h
  newlib/libc/machine/spu/write_ea.c
  newlib/libc/machine/spu/writev_ea.c
 Copyright: IBM Corp. 2008 
-License: BSD3-21
+License: BSD3-22
 
 Files: newlib/libc/machine/spu/setjmp.S
 Copyright: IBM Corp. 2005, 2006 
-License: BSD3-21
+License: BSD3-22
 
 Files: newlib/libc/machine/spu/sys/mman.h
 Copyright: IBM Corp. 2007 
-License: BSD3-21
+License: BSD3-22
 
 Files: newlib/libc/machine/spu/fiprintf.S
  newlib/libc/machine/spu/fiscanf.S
@@ -1821,17 +2051,17 @@ Files: newlib/libc/machine/spu/fiprintf.S
  newlib/libc/machine/spu/sscanf.S
  newlib/libc/machine/spu/stack_reg_va.S
 Copyright: 2007, Toshiba Corporation 
-License: BSD3-22
+License: BSD3-23
 
 Files: newlib/libc/machine/spu/mk_syscalls
  newlib/libc/machine/spu/syscall.def
 Copyright: 2007 TOSHIBA CORPORATION
-License: BSD3-22
+License: BSD3-23
 
 Files: newlib/libc/machine/spu/include/fenv.h
  newlib/libc/machine/spu/sys/fenv.h
 Copyright: 2006, 2007 International Business Machines Corporation, Sony Computer Entertainment, Incorporated, Toshiba Corporation, 
-License: BSD3-23
+License: BSD3-24
 
 Files: newlib/libc/machine/spu/machine/_types.h
  newlib/libc/machine/spu/sys/dirent.h
@@ -1846,7 +2076,7 @@ Files: newlib/libc/machine/spu/machine/_types.h
  newlib/libm/machine/spu/sf_isnanf.c
  newlib/libm/machine/spu/sf_nan.c
 Copyright: 2007 International Business Machines Corporation, Sony Computer Entertainment, Incorporated, Toshiba Corporation, 
-License: BSD3-23
+License: BSD3-24
 
 Files: newlib/libc/machine/spu/memcmp.c
  newlib/libc/machine/spu/straddr.h
@@ -1856,7 +2086,7 @@ Files: newlib/libc/machine/spu/memcmp.c
  newlib/libc/machine/spu/strncat.c
  newlib/libc/machine/spu/strncpy.c
 Copyright: 2008 International Business Machines Corporation
-License: BSD3-23
+License: BSD3-24
 
 Files: newlib/libc/machine/spu/memcpy.c
  newlib/libc/machine/spu/memmove.c
@@ -1991,20 +2221,20 @@ Files: newlib/libc/machine/spu/memcpy.c
  newlib/libm/machine/spu/wf_log10.c
  newlib/libm/machine/spu/wf_remainder.c
 Copyright: 2001,2006, International Business Machines Corporation, Sony Computer Entertainment, Incorporated, Toshiba Corporation, 
-License: BSD3-23
+License: BSD3-24
 
 Files: newlib/libc/machine/spu/stdio.c
 Copyright: 2007 Sony Computer Entertainment Inc.
  2007 Sony Corp. 
-License: BSD3-23
+License: BSD3-24
 
 Files: newlib/libc/machine/spu/strncmp.h
 Copyright: 2001,2006,2008 International Business Machines Corporation, Sony Computer Entertainment, Incorporated, Toshiba Corporation, 
-License: BSD3-23
+License: BSD3-24
 
 Files: newlib/libc/machine/tic6x/setjmp.S
 Copyright: 1996-2010 Texas Instruments Incorporated http://www.ti.com
-License: BSD3-24
+License: BSD3-25
 
 Files: newlib/libc/machine/visium/memcpy.c
  newlib/libc/machine/visium/memcpy.h
@@ -2013,21 +2243,21 @@ Files: newlib/libc/machine/visium/memcpy.c
  newlib/libc/machine/visium/memset.h
  newlib/libc/machine/visium/setjmp.S
 Copyright: 2015 Rolls-Royce Controls and Data Services Limited.
-License: BSD3-25
+License: BSD3-26
 
 Files: newlib/libc/search/hcreate.c
  newlib/libc/search/hcreate_r.c
  newlib/testsuite/newlib.search/hsearchtest.c
 Copyright: 2001 Christopher G. Demetriou
-License: BSD3-26
+License: BSD3-27
 
 Files: newlib/libc/search/tsearch.3
 Copyright: 1997 Todd C. Miller <Todd.Miller@courtesan.com>
-License: BSD3-27
+License: BSD3-28
 
 Files: newlib/libc/stdlib/aligned_alloc.c
 Copyright: 2020 Arm Ltd.
-License: BSD3-28
+License: BSD3-29
 
 Files: newlib/libc/string/memmem.c
  newlib/libc/string/strstr.c
@@ -2049,7 +2279,12 @@ Files: newlib/libc/string/memmem.c
  newlib/libm/common/math_err_with_errno.c
  newlib/libm/common/math_errf_check_oflowf.c
  newlib/libm/common/math_errf_check_uflowf.c
+ newlib/libm/common/math_errl_check_oflowl.c
+ newlib/libm/common/math_errl_check_uflowl.c
+ newlib/libm/common/math_errl_divzerol.c
  newlib/libm/common/math_errl_invalidl.c
+ newlib/libm/common/math_errl_oflowl.c
+ newlib/libm/common/math_errl_uflowl.c
  newlib/libm/common/math_errl_with_errnol.c
  newlib/libm/common/pow.c
  newlib/libm/common/pow_log_data.c
@@ -2058,7 +2293,7 @@ Files: newlib/libc/string/memmem.c
  newlib/libm/common/sincosf_data.c
  newlib/libm/common/sinf.c
 Copyright: 2018 Arm Ltd.
-License: BSD3-28
+License: BSD3-29
 
 Files: newlib/libm/common/math_config.h
  newlib/libm/common/math_errf_divzerof.c
@@ -2069,7 +2304,7 @@ Files: newlib/libm/common/math_config.h
  newlib/libm/common/math_errf_with_errnof.c
  newlib/libm/common/sf_pow.c
 Copyright: 2017-2018 Arm Ltd.
-License: BSD3-28
+License: BSD3-29
 
 Files: newlib/libm/common/sf_exp.c
  newlib/libm/common/sf_exp2.c
@@ -2080,7 +2315,7 @@ Files: newlib/libm/common/sf_exp.c
  newlib/libm/common/sf_log_data.c
  newlib/libm/common/sf_pow_log2_data.c
 Copyright: 2017 Arm Ltd.
-License: BSD3-28
+License: BSD3-29
 
 Files: newlib/libc/stdlib/strtoimax.c
  newlib/libc/stdlib/strtoumax.c
@@ -2088,132 +2323,28 @@ Files: newlib/libc/stdlib/strtoimax.c
  newlib/libc/stdlib/wcstoumax.c
 Copyright: 1992, 1993 The Regents of the University of California. 
  2011 The FreeBSD Foundation
-License: BSD3-29
+License: BSD3-30
 
 Files: newlib/libc/sys/rtems/include/sys/poll.h
 Copyright: 1997 Peter Wemm <peter@freebsd.org>
-License: BSD3-30
+License: BSD3-31
 
 Files: newlib/libc/time/strptime.c
 Copyright: 1999 Kungliga Tekniska Hgskolan Royal Institute of Technology, Stockholm, Sweden).
-License: BSD3-31
-
-Files: newlib/libc/tinystdio/atod_engine.c
- newlib/libc/tinystdio/atof_engine.c
- newlib/libc/tinystdio/conv_flt.c
- newlib/libc/tinystdio/scanf_private.h
- newlib/libc/tinystdio/strtoi.h
- newlib/libc/tinystdio/strtoimax.c
- newlib/libc/tinystdio/strtol.c
- newlib/libc/tinystdio/strtoll.c
- newlib/libc/tinystdio/strtoul.c
- newlib/libc/tinystdio/strtoull.c
- newlib/libc/tinystdio/strtoumax.c
- newlib/libc/tinystdio/vfscanf.c
-Copyright: 2002,2004,2005 Joerg Wunsch
- 2008  Dmitry Xmelkov
-License: BSD3-32
-
-Files: newlib/libc/tinystdio/clearerr.c
- newlib/libc/tinystdio/fclose.c
- newlib/libc/tinystdio/feof.c
- newlib/libc/tinystdio/ferror.c
- newlib/libc/tinystdio/fgetc.c
- newlib/libc/tinystdio/stdio_private.h
-Copyright: 2002,2005 Joerg Wunsch
-License: BSD3-32
-
-Files: newlib/libc/tinystdio/dtoa_data.c
- newlib/libc/tinystdio/dtoa_engine.c
- newlib/libc/tinystdio/dtoa_engine.h
- newlib/libc/tinystdio/make-dtoa-data
- newlib/libc/tinystdio/sprintfd.c
- newlib/libc/tinystdio/sprintff.c
- newlib/libc/tinystdio/vfiprintf.c
- newlib/libc/tinystdio/vfiscanf.c
- newlib/libc/tinystdio/vfprintff.c
- newlib/libc/tinystdio/vfscanff.c
-Copyright: 2018, Keith Packard
-License: BSD3-32
-
-Files: newlib/libc/tinystdio/fdevopen.c
-Copyright: 2002,2005, 2007 Joerg Wunsch
-License: BSD3-32
-
-Files: newlib/libc/tinystdio/fgets.c
- newlib/libc/tinystdio/fprintf.c
- newlib/libc/tinystdio/fputc.c
- newlib/libc/tinystdio/fputs.c
- newlib/libc/tinystdio/fread.c
- newlib/libc/tinystdio/fscanf.c
- newlib/libc/tinystdio/fwrite.c
- newlib/libc/tinystdio/getchar.c
- newlib/libc/tinystdio/gets.c
- newlib/libc/tinystdio/printf.c
- newlib/libc/tinystdio/putchar.c
- newlib/libc/tinystdio/puts.c
- newlib/libc/tinystdio/scanf.c
- newlib/libc/tinystdio/snprintf.c
- newlib/libc/tinystdio/sprintf.c
- newlib/libc/tinystdio/sscanf.c
- newlib/libc/tinystdio/ungetc.c
-Copyright: 2002, Joerg Wunsch
-License: BSD3-32
-
-Files: newlib/libc/tinystdio/ftoa_engine.h
- newlib/libc/tinystdio/xtoa_fast.h
-Copyright: 2005, Dmitry Xmelkov
-License: BSD3-32
-
-Files: newlib/libc/tinystdio/snprintfd.c
- newlib/libc/tinystdio/snprintff.c
-Copyright: 2021 Keith Packard
-License: BSD3-32
-
-Files: newlib/libc/tinystdio/stdio.h
-Copyright: 2002, 2005, 2007 Joerg Wunsch  
- 1990, 1991, 1993 The Regents of the University of California. 
-License: BSD3-32
-
-Files: newlib/libc/tinystdio/strtod.c
- newlib/libc/tinystdio/strtof.c
- newlib/libc/tinystdio/strtold.c
-Copyright: 2002-2005  Michael Stumpf  <mistumpf@de.pepperl-fuchs.com>
- 2006,2008  Dmitry Xmelkov 
-License: BSD3-32
-
-Files: newlib/libc/tinystdio/ultoa_invert.c
-Copyright: 2017 Keith Packard
-License: BSD3-32
-
-Files: newlib/libc/tinystdio/vfprintf.c
-Copyright: 2002, Alexander Popov (sasho@vip.bg)
- 2002,2004,2005 Joerg Wunsch
- 2005, Helmut Wallner
- 2007, Dmitry Xmelkov
-License: BSD3-32
-
-Files: newlib/libc/tinystdio/vprintf.c
- newlib/libc/tinystdio/vscanf.c
- newlib/libc/tinystdio/vsscanf.c
-Copyright: 2005, Joerg Wunsch
-License: BSD3-32
-
-Files: newlib/libc/tinystdio/vsnprintf.c
- newlib/libc/tinystdio/vsprintf.c
-Copyright: 2003, Joerg Wunsch
 License: BSD3-32
 
 Files: newlib/libc/tinystdio/ftoa_engine.c
 Copyright: 2005, Dmitry Xmelkov
 License: BSD3-33
 
-Files: newlib/libm/common/log2l.c
- newlib/libm/common/logbl.c
- newlib/libm/common/nexttoward.c
+Files: newlib/libm/common/nexttoward.c
  newlib/libm/common/nexttowardl.c
 Copyright: 2014 Mentor Graphics, Inc.
 License: BSD3-34
+
+Files: newlib/libm/ld/common/s_fabsl.c
+Copyright: 2003 Dag-Erling Coïdan Smørgrav
+License: BSD3-35
 
 Files: newlib/libm/machine/riscv/feclearexcept.c
  newlib/libm/machine/riscv/fegetenv.c
@@ -2227,7 +2358,7 @@ Files: newlib/libm/machine/riscv/feclearexcept.c
  newlib/libm/machine/riscv/fetestexcept.c
  newlib/libm/machine/riscv/feupdateenv.c
 Copyright: 2017 Michael R. Neilly
-License: BSD3-35
+License: BSD3-36
 
 Files: newlib/libm/machine/spu/headers/acos.h
  newlib/libm/machine/spu/headers/acosd2.h
@@ -2352,7 +2483,7 @@ Files: newlib/libm/machine/spu/headers/acos.h
  newlib/libm/machine/spu/wf_sqrt.c
  newlib/libm/machine/spu/wf_tgamma.c
 Copyright: 2006,2008, International Business Machines Corporation
-License: BSD3-36
+License: BSD3-37
 
 Files: newlib/libm/machine/spu/headers/acosf4.h
  newlib/libm/machine/spu/headers/asinf4.h
@@ -2388,7 +2519,7 @@ Files: newlib/libm/machine/spu/headers/acosf4.h
  newlib/libm/machine/spu/headers/truncd2.h
  newlib/libm/machine/spu/headers/truncf4.h
 Copyright: 2001,2008, International Business Machines Corporation, Sony Computer Entertainment, Incorporated, Toshiba Corporation, 
-License: BSD3-36
+License: BSD3-37
 
 Files: newlib/libm/machine/spu/headers/acoshd2.h
  newlib/libm/machine/spu/headers/acoshf4.h
@@ -2420,19 +2551,20 @@ Files: newlib/libm/machine/spu/headers/acoshd2.h
  newlib/libm/machine/spu/headers/tgammad2.h
  newlib/libm/machine/spu/headers/tgammaf4.h
 Copyright: 2007,2008, International Business Machines Corporation
-License: BSD3-36
+License: BSD3-37
 
 Files: newlib/libm/machine/spu/headers/nearbyintf4.h
  newlib/libm/machine/spu/headers/rintf4.h
  newlib/libm/machine/spu/headers/scalbnf4.h
 Copyright: 2006,2008, International Business Machines Corporation, Sony Computer Entertainment, Incorporated, Toshiba Corporation, 
-License: BSD3-36
+License: BSD3-37
 
 Files: .clang-format
  .gitattributes
  .github/Dockerfile
  .github/do-build
  .github/do-cmake-test
+ .github/do-linux
  .github/do-many
  .github/do-test
  .github/do-zephyr
@@ -2443,7 +2575,6 @@ Files: .clang-format
  .github/workflows/make-workflow
  .github/workflows/steps-head
  .github/workflows/variants
- .github/workflows/variants-cmake
  .gitignore
  README.md
  cmake/TC-arm-none-eabi.cmake
@@ -2480,8 +2611,12 @@ Files: .clang-format
  newlib/libc/time/strftime.c
  newlib/libc/time/tzset.c
  newlib/libc/xdr/README
+ newlib/libm/complex/CMakeLists.txt
  newlib/libm/complex/complex.tex
  newlib/libm/fenv/fenv.tex
+ newlib/libm/ld/files
+ newlib/libm/ld/ld128/Make.files
+ newlib/libm/ld/ld80/Make.files
  newlib/libm/libm.in.xml
  newlib/man.xsl
  newlib/newlib.hin
@@ -2496,6 +2631,7 @@ Files: .clang-format
  scripts/cross-arc64-zephyr-elf.txt
  scripts/cross-arm-none-eabi.txt
  scripts/cross-arm-zephyr-eabi.txt
+ scripts/cross-avr.txt
  scripts/cross-clang-msp430.txt
  scripts/cross-clang-old-riscv64-unknown-elf.txt
  scripts/cross-clang-old-rv32imafdc-unknown-elf.txt
@@ -2512,6 +2648,8 @@ Files: .clang-format
  scripts/cross-msp430.txt
  scripts/cross-nios2-zephyr-elf.txt
  scripts/cross-old-clang-riscv64-unknown-elf.txt
+ scripts/cross-power9-fp128.txt
+ scripts/cross-power9.txt
  scripts/cross-powerpc64-linux-gnu.txt
  scripts/cross-powerpc64le-linux-gnu.txt
  scripts/cross-riscv64-unknown-elf.txt
@@ -2534,8 +2672,10 @@ Files: .clang-format
  scripts/monitor-e9
  semihost/machine/x86/bios.ld
  test/complex-funcs.c
+ test/long_double_gen.5c
+ test/long_double_vec.h
  test/time-sprintf.c
-Copyright: 2020 The Newlib Project
+Copyright:
 License: Default-1
 
 Files: newlib/doc/chapter-texi2docbook.py
@@ -3163,15 +3303,20 @@ License: Other-1
 
 Files: newlib/libm/common/s_fpclassify.c
  newlib/libm/common/sf_fpclassify.c
+ newlib/libm/ld/ld128/s_fpclassifyl.c
+ newlib/libm/ld/ld80/s_fpclassifyl.c
 Copyright: 2002, 2007 Red Hat, Incorporated.
 License: Other-1
 
-Files: newlib/libm/common/sl_finite.c
- newlib/libm/complex/cabsl.c
+Files: newlib/libm/complex/cabsl.c
  newlib/libm/complex/cimagl.c
  newlib/libm/complex/creall.c
  newlib/libm/math/sl_hypot.c
 Copyright: 2015 Red Hat, Incorporated.
+License: Other-1
+
+Files: newlib/libm/ld/common/s_sincosl.c
+Copyright: 2013 Elliot Saba Developed at the University of Washington
 License: Other-1
 
 Files: newlib/testsuite/lib/flags.exp
@@ -3289,6 +3434,29 @@ License: Other-5
 
 Files: newlib/libc/string/timingsafe_memcmp.c
 Copyright: 2014 Google Inc.
+License: Other-5
+
+Files: newlib/libm/ld/common/polevll.c
+ newlib/libm/ld/ld128/e_expl.c
+ newlib/libm/ld/ld128/e_lgammal_r.c
+ newlib/libm/ld/ld128/e_log10l.c
+ newlib/libm/ld/ld128/e_log2l.c
+ newlib/libm/ld/ld128/e_logl.c
+ newlib/libm/ld/ld128/s_expm1l.c
+ newlib/libm/ld/ld128/s_log1pl.c
+ newlib/libm/ld/ld80/e_expl.c
+ newlib/libm/ld/ld80/e_log10l.c
+ newlib/libm/ld/ld80/e_log2l.c
+ newlib/libm/ld/ld80/e_logl.c
+ newlib/libm/ld/ld80/e_powl.c
+ newlib/libm/ld/ld80/e_tgammal.c
+ newlib/libm/ld/ld80/s_expm1l.c
+ newlib/libm/ld/ld80/s_log1pl.c
+Copyright: 2008 Stephen L. Moshier <steve@moshier.net>
+License: Other-5
+
+Files: newlib/libm/ld/ld128/e_tgammal.c
+Copyright: 2011 Martynas Venckus <martynas@openbsd.org>
 License: Other-5
 
 Files: newlib/libc/include/machine/fastmath.h
@@ -3789,6 +3957,44 @@ Files: newlib/libm/common/fdlibm.h
  newlib/libm/common/sf_scalbln.c
  newlib/libm/common/sf_scalbn.c
  newlib/libm/common/sf_trunc.c
+ newlib/libm/ld/common/s_atanl.c
+ newlib/libm/ld/common/s_ilogbl.c
+ newlib/libm/ld/common/s_logbl.c
+ newlib/libm/ld/common/s_scalbnl.c
+ newlib/libm/ld/ld128/e_acoshl.c
+ newlib/libm/ld/ld128/e_atanhl.c
+ newlib/libm/ld/ld128/e_coshl.c
+ newlib/libm/ld/ld128/e_fmodl.c
+ newlib/libm/ld/ld128/e_hypotl.c
+ newlib/libm/ld/ld128/e_powl.c
+ newlib/libm/ld/ld128/e_sinhl.c
+ newlib/libm/ld/ld128/s_asinhl.c
+ newlib/libm/ld/ld128/s_ceill.c
+ newlib/libm/ld/ld128/s_copysignl.c
+ newlib/libm/ld/ld128/s_erfl.c
+ newlib/libm/ld/ld128/s_floorl.c
+ newlib/libm/ld/ld128/s_modfl.c
+ newlib/libm/ld/ld128/s_nextafterl.c
+ newlib/libm/ld/ld128/s_nexttoward.c
+ newlib/libm/ld/ld128/s_nexttowardf.c
+ newlib/libm/ld/ld128/s_tanhl.c
+ newlib/libm/ld/ld80/e_acoshl.c
+ newlib/libm/ld/ld80/e_atanhl.c
+ newlib/libm/ld/ld80/e_coshl.c
+ newlib/libm/ld/ld80/e_hypotl.c
+ newlib/libm/ld/ld80/e_lgammal_r.c
+ newlib/libm/ld/ld80/e_sinhl.c
+ newlib/libm/ld/ld80/s_asinhl.c
+ newlib/libm/ld/ld80/s_ceill.c
+ newlib/libm/ld/ld80/s_copysignl.c
+ newlib/libm/ld/ld80/s_erfl.c
+ newlib/libm/ld/ld80/s_floorl.c
+ newlib/libm/ld/ld80/s_modfl.c
+ newlib/libm/ld/ld80/s_nextafterl.c
+ newlib/libm/ld/ld80/s_nexttoward.c
+ newlib/libm/ld/ld80/s_nexttowardf.c
+ newlib/libm/ld/ld80/s_tanhl.c
+ newlib/libm/ld/math_private_openbsd.h
  newlib/libm/math/k_cos.c
  newlib/libm/math/k_rem_pio2.c
  newlib/libm/math/k_sin.c
@@ -3879,8 +4085,42 @@ License: Other-25
 
 Files: newlib/libm/common/s_remquo.c
  newlib/libm/common/sf_remquo.c
+ newlib/libm/ld/common/e_acosl.c
+ newlib/libm/ld/common/e_asinl.c
+ newlib/libm/ld/common/e_atan2l.c
+ newlib/libm/ld/common/e_lgammal.c
+ newlib/libm/ld/common/k_rem_pio2.c
+ newlib/libm/ld/ld128/s_remquol.c
+ newlib/libm/ld/ld80/e_fmodl.c
+ newlib/libm/ld/ld80/s_remquol.c
 Copyright: 1993 Sun Microsystems, Inc.
 License: Other-26
+
+Files: newlib/libm/ld/common/s_cbrtl.c
+Copyright: 1993 Sun Microsystems, Inc.
+License: Other-27
+
+Files: newlib/libm/ld/ld128/e_rem_pio2l.h
+ newlib/libm/ld/ld80/e_rem_pio2l.h
+Copyright: 1993 Sun Microsystems, Inc.
+License: Other-28
+
+Files: newlib/libm/ld/ld128/k_cosl.c
+ newlib/libm/ld/ld128/k_sinl.c
+ newlib/libm/ld/ld80/k_cosl.c
+ newlib/libm/ld/ld80/k_sinl.c
+Copyright: 1993 Sun Microsystems, Inc.
+License: Other-29
+
+Files: newlib/libm/ld/ld128/k_tanl.c
+ newlib/libm/ld/ld80/k_tanl.c
+Copyright: 2004 Sun Microsystems, Inc.
+License: Other-30
+
+Files: newlib/libm/ld/ld128/s_truncl.c
+ newlib/libm/ld/ld80/s_truncl.c
+Copyright: 1993 Sun Microsystems, Inc.
+License: Other-31
 
 Files: newlib/libm/machine/x86/f_llrint.c
  newlib/libm/machine/x86/f_llrintf.c
@@ -3892,7 +4132,7 @@ Files: newlib/libm/machine/x86/f_llrint.c
  newlib/libm/machine/x86/f_rintf.c
  newlib/libm/machine/x86/f_rintl.c
 Copyright: 2007 Dave Korn
-License: Other-27
+License: Other-32
 
 Files: newlib/libc/machine/d10v/setjmp.S
  newlib/libc/machine/d30v/setjmp.S
@@ -4355,6 +4595,50 @@ License: BSD2-12
  modification, are permitted provided that the following conditions
  are met:
  1. Redistributions of source code must retain the above copyright
+ notice unmodified, this list of conditions, and the following
+ disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+License: BSD2-13
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ .
+ THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ SUCH DAMAGE.
+
+License: BSD2-14
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
  notice, this list of conditions and the following disclaimer.
  2. Redistributions in binary form must reproduce the above copyright
  notice, this list of conditions and the following disclaimer in the
@@ -4692,6 +4976,34 @@ License: BSD3-12
 License: BSD3-13
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are met:
+ .
+ Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ .
+ Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in
+ the documentation and/or other materials provided with the
+ distribution.
+ .
+ Neither the name of the copyright holders nor the names of
+ contributors may be used to endorse or promote products derived
+ from this software without specific prior written permission.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+
+License: BSD3-14
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
  Redistributions of source code must retain the above copyright notice,
  this list of conditions and the following disclaimer.
  Redistributions in binary form must reproduce the above copyright
@@ -4713,7 +5025,7 @@ License: BSD3-13
  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  POSSIBILITY OF SUCH DAMAGE.
 
-License: BSD3-14
+License: BSD3-15
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are
  met:
@@ -4741,7 +5053,7 @@ License: BSD3-14
  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-License: BSD3-15
+License: BSD3-16
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
  are met:
@@ -4769,7 +5081,7 @@ License: BSD3-15
  INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-License: BSD3-16
+License: BSD3-17
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
  are met:
@@ -4794,7 +5106,7 @@ License: BSD3-16
  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  SUCH DAMAGE.
 
-License: BSD3-17
+License: BSD3-18
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
  are met:
@@ -4819,7 +5131,7 @@ License: BSD3-17
  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  SUCH DAMAGE.
 
-License: BSD3-18
+License: BSD3-19
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are met:
  .
@@ -4845,7 +5157,7 @@ License: BSD3-18
  INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-License: BSD3-19
+License: BSD3-20
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
  are met:
@@ -4871,7 +5183,7 @@ License: BSD3-19
  TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-License: BSD3-20
+License: BSD3-21
  This software was developed by the Computer Systems Engineering group
  at Lawrence Berkeley Laboratory under DARPA contract BG 91-66 and
  contributed to Berkeley.
@@ -4900,7 +5212,7 @@ License: BSD3-20
  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  SUCH DAMAGE.
 
-License: BSD3-21
+License: BSD3-22
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are met:
  .
@@ -4925,7 +5237,7 @@ License: BSD3-21
  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  POSSIBILITY OF SUCH DAMAGE.
 
-License: BSD3-22
+License: BSD3-23
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are met:
  .
@@ -4950,7 +5262,7 @@ License: BSD3-22
  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  POSSIBILITY OF SUCH DAMAGE.
 
-License: BSD3-23
+License: BSD3-24
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are met:
  .
@@ -4975,7 +5287,7 @@ License: BSD3-23
  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  POSSIBILITY OF SUCH DAMAGE.
 
-License: BSD3-24
+License: BSD3-25
  Redistribution and  use in source  and binary forms, with  or without
  modification,  are permitted provided  that the  following conditions
  are met:
@@ -5005,7 +5317,7 @@ License: BSD3-24
  INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-License: BSD3-25
+License: BSD3-26
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are met:
  .
@@ -5030,7 +5342,7 @@ License: BSD3-25
  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  THE POSSIBILITY OF SUCH DAMAGE.
 
-License: BSD3-26
+License: BSD3-27
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
  are met:
@@ -5053,7 +5365,7 @@ License: BSD3-26
  INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-License: BSD3-27
+License: BSD3-28
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
  are met:
@@ -5076,7 +5388,7 @@ License: BSD3-27
  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-License: BSD3-28
+License: BSD3-29
  SPDX-License-Identifier: BSD-3-Clause
  .
  Redistribution and use in source and binary forms, with or without
@@ -5102,7 +5414,7 @@ License: BSD3-28
  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-License: BSD3-29
+License: BSD3-30
  Portions of this software were developed by David Chisnall
  under sponsorship from the FreeBSD Foundation.
  .
@@ -5130,7 +5442,7 @@ License: BSD3-29
  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  SUCH DAMAGE.
 
-License: BSD3-30
+License: BSD3-31
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
  are met:
@@ -5154,7 +5466,7 @@ License: BSD3-30
  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  SUCH DAMAGE.
 
-License: BSD3-31
+License: BSD3-32
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
  are met:
@@ -5181,34 +5493,6 @@ License: BSD3-31
  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-License: BSD3-32
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
- .
- Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
- .
- Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in
- the documentation and/or other materials provided with the
- distribution.
- .
- Neither the name of the copyright holders nor the names of
- contributors may be used to endorse or promote products derived
- from this software without specific prior written permission.
- .
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- POSSIBILITY OF SUCH DAMAGE.
 
 License: BSD3-33
  Rewritten in C by Soren Kuula
@@ -5262,6 +5546,30 @@ License: BSD3-35
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
  are met:
+ 1. Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer
+ in this position and unchanged.
+ 2. Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+ derived from this software without specific prior written permission.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+License: BSD3-36
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
  .
  Redistributions of source code must retain the above copyright
  notice, this list of conditions and the following disclaimer.
@@ -5287,7 +5595,7 @@ License: BSD3-35
  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  POSSIBILITY OF SUCH DAMAGE.
 
-License: BSD3-36
+License: BSD3-37
  Redistribution and use in source and binary forms, with or
  without modification, are permitted provided that the
  following conditions are met:
@@ -5673,6 +5981,54 @@ License: Other-26
  is preserved.
 
 License: Other-27
+ Copyright (c) 2009-2011, Bruce D. Evans, Steven G. Kargl, David Schultz.
+ .
+ Developed at SunPro, a Sun Microsystems, Inc. business.
+ Permission to use, copy, modify, and distribute this
+ software is freely granted, provided that this notice
+ is preserved.
+ .
+ .
+ The argument reduction and testing for exceptional cases was
+ written by Steven G. Kargl with input from Bruce D. Evans
+ and David A. Schultz.
+
+License: Other-28
+ Copyright (c) 2008 Steven G. Kargl, David Schultz, Bruce D. Evans.
+ .
+ Developed at SunSoft, a Sun Microsystems, Inc. business.
+ Permission to use, copy, modify, and distribute this
+ software is freely granted, provided that this notice
+ is preserved.
+ .
+ .
+ Optimized by Bruce D. Evans.
+
+License: Other-29
+ Copyright (c) 2008 Steven G. Kargl, David Schultz, Bruce D. Evans.
+ .
+ Developed at SunSoft, a Sun Microsystems, Inc. business.
+ Permission to use, copy, modify, and distribute this
+ software is freely granted, provided that this notice
+ is preserved.
+
+License: Other-30
+ Copyright (c) 2008 Steven G. Kargl, David Schultz, Bruce D. Evans.
+ .
+ Permission to use, copy, modify, and distribute this
+ software is freely granted, provided that this notice
+ is preserved.
+
+License: Other-31
+ Developed at SunPro, a Sun Microsystems, Inc. business.
+ Permission to use, copy, modify, and distribute this
+ software is freely granted, provided that this notice
+ is preserved.
+ .
+ .
+ From: @(#)s_floor.c 5.1 93/09/24
+
+License: Other-32
  x87 FP implementation contributed to Newlib by
  Dave Korn, November 2007.  This file is placed in the
  public domain.  Permission to use, copy, modify, and

--- a/newlib/libm/ld/ld128/e_rem_pio2l.h
+++ b/newlib/libm/ld/ld128/e_rem_pio2l.h
@@ -70,8 +70,7 @@ __ieee754_rem_pio2l(long double x, long double *y)
 	u.e = x;
 	expsign = u.xbits.expsign;
 	ex = expsign & 0x7fff;
-	if ((ex < BIAS + 45 || ex == BIAS + 45) &&
-	    u.bits.manh < 0x921fb54442d1LL) {
+	if (ex < BIAS + 45 || (ex == BIAS + 45 && u.bits.manh < 0x921fb54442d1LL)) {
 	    /* |x| ~< 2^45*(pi/2), medium size */
 	    /* Use a specialized rint() to get fn.  Assume round-to-nearest. */
 	    fn = x*invpio2+0x1.8p112L;

--- a/test/long_double.c
+++ b/test/long_double.c
@@ -131,26 +131,36 @@ typedef struct {
  * (more accurate) odd value
  */
 #if LDBL_MANT_DIG == 64
-#define DEFAULT_PREC 1e-16L
-#define SQRTL_PREC 0x8.0p-63L
+#define DEFAULT_PREC 0x1p-55L
+#define SQRTL_PREC 0x1.0p-63L
 #define FULL_LONG_DOUBLE
 #elif LDBL_MANT_DIG == 113
 #define FULL_LONG_DOUBLE
-#define DEFAULT_PREC 1e-31L
-#define SQRTL_PREC 0x8.0p-112L
+#define DEFAULT_PREC 0x1p-105L
+#define SQRTL_PREC 0x1.0p-112L
 #elif LDBL_MANT_DIG == 106
-#define DEFAULT_PREC 1e-29L
-#define SQRTL_PREC 0x8.0p-105L
+#define DEFAULT_PREC 0x1p-97L
+#define SQRTL_PREC 0x1.0p-105L
+#define PART_LONG_DOUBLE
 #elif LDBL_MANT_DIG == 53
-#define DEFAULT_PREC 1e-13L
-#define SQRTL_PREC 0x8.0p-52L
+#define DEFAULT_PREC 0x1p-48L
+#define SQRTL_PREC 0x1.0p-52L
 #else
 #error unsupported long double
 #endif
 
+#define HYPOTL_PREC     SQRTL_PREC
+#define CBRTL_PREC      SQRTL_PREC
 #define CEILL_PREC      0
 #define FLOORL_PREC     0
 #define LOGBL_PREC      0
+#define RINTL_PREC      0
+#define FMINL_PREC      0
+#define FMAXL_PREC      0
+#define SCALBNL_PREC    0
+#define SCALBL_PREC     0
+#define LDEXPL_PREC     0
+#define COPYSIGNL_PREC  0
 #define NEARBYINTL_PREC 0
 #define ROUNDL_PREC     0
 #define TRUNCL_PREC     0


### PR DESCRIPTION
The 128-bit IEEE long double function to compute remainder mod pi/2 for trig functions got
mangled at some point and some parens were shifted around compared with the same code in the 80-bit Intel version. Fix that, then tighten up the long_double test tolerances to validate that.