### PR TITLE
test/tls: Add overaligned_bss_var test

### DIFF
--- a/doc/tls.md
+++ b/doc/tls.md
@@ -61,12 +61,13 @@ the normal data/bss initialization process for the application.
 | bss | |
 |     | __bss_end 
 
-The crt0 code copies __data_end - __data_start bytes from _data_source
-to _data_start. This initializes the regular data segment *and* the
-initial TLS data segment. Then, it clears memory from __bss_start to
-__bss_end, initializing the TLS bss segment *and* the regular bss
-segment. Finally, it sets the architecture-specific TLS data pointer
-to __tls_base. Once that is set, access to TLS variables will
+The crt0 code copies __data_end - __data_start bytes from __data_source to
+__data_start. This initializes the regular data segment. Then, it clears memory
+from __bss_start to __bss_end, initializing the regular bss segment. Then
+__tdata_end - __tdata_start bytes are copied from __tdata_start to __tls_base,
+and memory is cleared from __tls_base + __tdata_size to __tls_end, this
+initializes TLS data variables. Finally, it sets the architecture-specific TLS
+data pointer to __tls_base. Once that is set, access to TLS variables will
 reference this initial TLS block.
 
 ## Creating more TLS blocks

--- a/newlib/libc/include/picotls.h
+++ b/newlib/libc/include/picotls.h
@@ -41,8 +41,10 @@
 #include <sys/types.h>
 
 extern char __tls_size[];
+extern char __tls_align[];
 
 static inline size_t _tls_size(void) { return (size_t) (uintptr_t) __tls_size; }
+static inline size_t _tls_align(void) { return (size_t) (uintptr_t) __tls_align; }
 
 /*
  * Initialize a TLS block, copying the data segment from flash and

--- a/newlib/libc/picolib/inittls.c
+++ b/newlib/libc/picolib/inittls.c
@@ -44,13 +44,12 @@
  * These addresses must be defined by the loader configuration file
  */
 
-extern char __tdata_source[];	/* Source of TLS initialization data (in ROM) */
+extern char __tdata_start[];	/* Source of TLS initialization data (in ROM) */
+extern char __tdata_end[];      /* End of static tdata area */
 extern char __tdata_size[];	/* Size of TLS initized data */
 extern char __tbss_start[];     /* Start of static zero-initialized TLS data */
 extern char __tbss_end[];       /* End of static zero-initialized TLS data */
 extern char __tbss_size[];	/* Size of TLS zero-filled data */
-extern char __tdata_start[];    /* Start of static tdata area */
-extern char __tdata_end[];      /* End of static tdata area */
 
 #ifdef __PICOLIBC_CRT_RUNTIME_SIZE
 #define __tdata_size (__tdata_end - __tdata_start)
@@ -63,7 +62,7 @@ _init_tls(void *__tls)
 	char *tls = __tls;
 
 	/* Copy tls initialized data */
-	memcpy(tls, __tdata_source, (uintptr_t) __tdata_size);
+	memcpy(tls, __tdata_start, (uintptr_t) __tdata_size);
 
 	/* Clear tls zero data */
 	memset(tls + (uintptr_t) __tdata_size, '\0', (uintptr_t) __tbss_size);

--- a/picocrt/machine/x86/crt0-32.S
+++ b/picocrt/machine/x86/crt0-32.S
@@ -88,7 +88,12 @@ _start32:
 	addl	$12, %esp
 
 #ifdef PICOLIBC_TLS
-	// call to _set_tls(__tls_base)
+	/* Initialize thread local variables for the initial thread */
+	pushl	$__tls_base
+	call	_init_tls
+	addl	$4, %esp
+
+	/* Set the TLS pointer for the initial thread */
 	pushl	$__tls_base
 	call	_set_tls
 	addl	$4, %esp

--- a/picocrt/machine/x86/crt0-64.S
+++ b/picocrt/machine/x86/crt0-64.S
@@ -92,7 +92,11 @@ _start64:
 	call	memset
 
 #ifdef PICOLIBC_TLS
-	// call to _set_tls(__tls_base)
+	/* Initialize thread local variables for the initial thread */
+	mov	$__tls_base, %rdi
+	call	_init_tls
+
+	/* Set the TLS pointer for the initial thread */
 	mov	$__tls_base, %rdi
 	call	_set_tls
 #endif

--- a/picolibc.ld.in
+++ b/picolibc.ld.in
@@ -51,6 +51,7 @@ PHDRS
 	text PT_LOAD;
 	ram PT_LOAD;
 	ram_init PT_LOAD;
+	tls_load PT_LOAD;
 	tls PT_TLS;
 }
 
@@ -133,6 +134,48 @@ SECTIONS
 	@CPP_END@
 
 	/*
+	 * Thread local initialized data. This is used as a template for TLS data
+	 * blocks allocated at runtime.
+	 */
+	.tdata : {
+		*(.tdata .tdata.* .gnu.linkonce.td.*)
+		PROVIDE( __tdata_end = . );
+	} >flash AT>flash :tls_load :tls
+	PROVIDE( __tdata_start = ADDR(.tdata) );
+	PROVIDE( __tdata_size = __tdata_end - __tdata_start );
+	PROVIDE( __tdata_align = ALIGNOF(.tdata) );
+
+	/*
+	 * Thread local zero-initialized data. Although we place this in flash, it
+	 * will not take up any space because . (dot) is not incremented by NOLOAD
+	 * TLS output sections. We need to place this right after the .tdata
+	 * section without any padding in order to compute the correct size of the
+	 * complete TLS segment in RAM with alignment included for the
+	 * initialization code to be able to set up the area in RAM at runtime.
+	 */
+	.tbss : {
+		*(.tbss .tbss.* .gnu.linkonce.tb.*)
+		*(.tcommon)
+	} >flash AT>flash :tls
+	PROVIDE( __tbss_align = ALIGNOF(.tbss) );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+	/*
+	 * Align the size of .tdata when calculating the total TLS size to also
+	 * include the size of the padding between .tdata and .tbss
+	 */
+	PROVIDE( __tls_size = ALIGN(SIZEOF(.tdata), ALIGNOF(.tbss)) + SIZEOF(.tbss) );
+	/*
+	 * We use the difference between total TLS size and initialized TLS
+	 * variables to account for any alignment padding bytes required between
+	 * the end of .tdata and the beginning of .tbss. This means that we can
+	 * simply memset(x + __tdata_size, 0, __tbss_size) to initialize the tbss
+	 * area in _init_tls()
+	 */
+	PROVIDE( __tbss_size = __tls_size - __tdata_size );
+	PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
+
+	/*
 	 * Data values which are preserved across reset
 	 */
 	.preserve (NOLOAD) : {
@@ -142,7 +185,7 @@ SECTIONS
 		PROVIDE(__preserve_end__ = .);
 	} >ram AT>ram :ram
 
-	.data : @LDSCRIPT_ALIGN_WITH_INPUT@ {
+	.data : {
 		*(.data .data.*)
 		*(.gnu.linkonce.d.*)
 
@@ -152,61 +195,37 @@ SECTIONS
 		PROVIDE( __global_pointer$ = . + 0x800 );
 		*(.sdata .sdata.* .sdata2.*)
 		*(.gnu.linkonce.s.*)
-	} >ram AT>flash :ram_init
-	PROVIDE(__data_start = ADDR(.data));
-	PROVIDE(__data_source = LOADADDR(.data));
-
-	/* Thread local initialized data. This gets
-	 * space allocated as it is expected to be placed
-	 * in ram to be used as a template for TLS data blocks
-	 * allocated at runtime. We're slightly abusing that
-	 * by placing the data in flash where it will be copied
-	 * into the allocate ram addresses by the existing
-	 * data initialization code in crt0
-	 */
-	.tdata : @LDSCRIPT_ALIGN_WITH_INPUT@ {
-		*(.tdata .tdata.* .gnu.linkonce.td.*)
 		PROVIDE(__data_end = .);
-		PROVIDE(__tdata_end = .);
-	} >ram AT>flash :tls :ram_init
-	PROVIDE( __tls_base = ADDR(.tdata));
-	PROVIDE( __tdata_start = ADDR(.tdata));
-	PROVIDE( __tdata_source = LOADADDR(.tdata) );
-	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
-	PROVIDE( __data_source_end = __tdata_source_end );
-	PROVIDE( __tdata_size = SIZEOF(.tdata) );
-
+	} >ram AT>flash :ram_init
+	PROVIDE( __data_start = ADDR(.data) );
+	PROVIDE( __data_source = LOADADDR(.data) );
+	PROVIDE( __data_source_end = LOADADDR(.data) + SIZEOF(.data) );
 	PROVIDE( __edata = __data_end );
 	PROVIDE( _edata = __data_end );
 	PROVIDE( edata = __data_end );
 	PROVIDE( __data_size = __data_end - __data_start );
 	PROVIDE( __data_source_size = __data_source_end - __data_source );
 
-	.tbss (NOLOAD) : {
-		*(.tbss .tbss.* .gnu.linkonce.tb.*)
-		*(.tcommon)
-		PROVIDE( __tls_end = . );
-		PROVIDE( __tbss_end = . );
-	} >ram AT>ram :tls :ram
-	PROVIDE( __bss_start = ADDR(.tbss));
-	PROVIDE( __tbss_start = ADDR(.tbss));
-	PROVIDE( __tbss_size = SIZEOF(.tbss) );
-	PROVIDE( __tls_size = __tls_end - __tls_base );
-	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
-	PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
-	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
 
 	/*
 	 * The linker special cases .tbss segments which are
 	 * identified as segments which are not loaded and are
 	 * thread_local.
 	 *
-	 * For these segments, the linker does not advance 'dot'
-	 * across them.  We actually need memory allocated for tbss,
-	 * so we create a special segment here just to make room
+	 * For these segments, the linker does not advance 'dot' across them.  We
+	 * need to allocate a piece of RAM to hold TLS variables for the initial
+	 * thread so that we can point the TLS pointer register at something before
+	 * we run constructors and jump to main().
+	 *
+	 * A threading library or operating system will also need to do this for
+	 * any subsequent threads and ensure that the thread pointer register is
+	 * updated when thread switches occur.
 	 */
-	.tbss_space (NOLOAD) : {
-		. = . + SIZEOF(.tbss);
+	.tls_space (NOLOAD) : {
+		. = ALIGN(__tls_align);
+		PROVIDE( __tls_base = . );
+		. = . + __tls_size;
+		PROVIDE( __tls_end = . );
 	} >ram AT>ram :ram
 
 	.bss (NOLOAD) : {
@@ -220,6 +239,7 @@ SECTIONS
 		. = ALIGN(8);
 		__bss_end = .;
 	} >ram AT>ram :ram
+	PROVIDE( __bss_start = ADDR(.bss));
 	PROVIDE( __end = __bss_end );
 	PROVIDE( _end = __bss_end );
 	PROVIDE( end = __bss_end );
@@ -296,9 +316,3 @@ SECTIONS
 	.debug_sup      0 : { *(.debug_sup) }
 	.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
 }
-/*
- * Check that sections that are copied from flash to RAM have matching
- * padding, so that a single memcpy() of __data_size copies the correct bytes.
- */
-ASSERT( __data_size == __data_source_size,
-	"ERROR: .data/.tdata flash size does not match RAM size");

--- a/test/tls.c
+++ b/test/tls.c
@@ -55,8 +55,8 @@ volatile int *volatile overaligned_bss_addr;
 
 #ifdef PICOLIBC_TLS
 extern char __tdata_start, __tdata_end;
-extern char __tdata_source, __tdata_source_end;
 extern char __data_start, __data_source;
+extern char __tls_base;
 
 static bool
 inside_tls_region(void *ptr, const void *tls)
@@ -207,42 +207,26 @@ main(void)
 	overaligned_bss_addr = &overaligned_bss_var;
 
 #ifdef PICOLIBC_TLS
-        printf("TLS region: %p-%p (%zd bytes)\n", &__tdata_start,
-	       &__tdata_start + _tls_size(), _tls_size());
-	size_t tdata_source_size = &__tdata_source_end - &__tdata_source;
 	size_t tdata_size = &__tdata_end - &__tdata_start;
+	printf("TLS template region: %p-%p (%zd bytes)\n", &__tdata_start,
+	       &__tdata_start + tdata_size, tdata_size);
 
-	if (&__tdata_start - &__data_start != &__tdata_source - &__data_source) {
-		printf("ROM/RAM .tdata offset from .data mismatch. "
-		       "VMA offset=%zd, LMA offset =%zd."
-		       "Linker behaviour changed?\n",
-		       &__tdata_start - &__data_start,
-		       &__tdata_source - &__data_source);
-	}
-
-	if (tdata_source_size != tdata_size ||
-	    memcmp(&__tdata_source, &__tdata_start, tdata_size) != 0) {
-		printf("TLS data in RAM does not match ROM\n");
-		hexdump(&__tdata_source, tdata_source_size, "ROM:");
-		hexdump(&__tdata_start, tdata_size, "RAM:");
-		result++;
-	}
-        result += check_tls("pre-defined", false, &__tdata_start);
+	result += check_tls("pre-defined", false, &__tls_base);
 #else
-        result += check_tls("pre-defined", false, NULL);
+	result += check_tls("pre-defined", false, NULL);
 #endif
 
 
 #ifdef _HAVE_PICOLIBC_TLS_API
 
-	void *tls = aligned_alloc(128, _tls_size());
+	void *tls = aligned_alloc(_tls_align(), _tls_size());
 
 	_init_tls(tls);
 	_set_tls(tls);
 
-	if (memcmp(tls, &__tdata_source, tdata_size) != 0) {
+	if (memcmp(tls, &__tdata_start, tdata_size) != 0) {
 		printf("New TLS data in RAM does not match ROM\n");
-		hexdump(&__tdata_source, tdata_source_size, "ROM:");
+		hexdump(&__tdata_start, tdata_size, "ROM:");
 		hexdump(tls, tdata_size, "RAM:");
 		result++;
 	}


### PR DESCRIPTION
The initial TLS template image is placed in flash and a separate area is allocated for the TLS variables for the initial thread. crt0 calls `_init_tls` to set up the initial TLS area. The calculated size of the combined TLS area (`.tdata` + `.tbss`) needs to account for different alignment requirements for `.tbss` and `.tdata`, this is done by aligning the size of `.tdata` to the alignment of `.tbss`.
Add a function `_tls_align()` to get the alignment requirement for the TLS area.
This change also eliminates the need for `ALIGN_WITH_INPUT` on the `.tdata` section in the linker script because it is no longer meant to piggyback on the `.data` initialization code in crt0.

Untested on a real system. @keith-packard do you think you could try the test/tls program on some real boards and see if this is correct?