### PR TITLE
picotls: Respect alignment requirements for .tbss

### DIFF
--- a/cmake/TC-arm-none-eabi.ld
+++ b/cmake/TC-arm-none-eabi.ld
@@ -173,6 +173,7 @@ SECTIONS
 	} >ram AT>ram :tls :ram
 	PROVIDE( __bss_start = ADDR(.tbss));
 	PROVIDE( __tbss_start = ADDR(.tbss));
+	PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
 	PROVIDE( __tbss_size = SIZEOF(.tbss) );
 	PROVIDE( __tls_size = __tls_end - __tls_base );
 	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
@@ -189,6 +190,7 @@ SECTIONS
 	 * so we create a special segment here just to make room
 	 */
 	.tbss_space (NOLOAD) : {
+		. = ADDR(.tbss);
 		. = . + SIZEOF(.tbss);
 	} >ram AT>ram :ram
 
@@ -203,6 +205,7 @@ SECTIONS
 		. = ALIGN(8);
 		__bss_end = .;
 	} >ram AT>ram :ram
+	PROVIDE( __non_tls_bss_start = ADDR(.bss) );
 	PROVIDE( __end = __bss_end );
 	PROVIDE( _end = __bss_end );
 	PROVIDE( end = __bss_end );

--- a/newlib/libc/include/picotls.h
+++ b/newlib/libc/include/picotls.h
@@ -44,6 +44,10 @@ extern char __tls_size[];
 
 static inline size_t _tls_size(void) { return (size_t) (uintptr_t) __tls_size; }
 
+extern char __tls_align[];
+
+static inline size_t _tls_align(void) { return (size_t) (uintptr_t) __tls_align; }
+
 /*
  * Initialize a TLS block, copying the data segment from flash and
  * zeroing the BSS segment.

--- a/newlib/libc/picolib/inittls.c
+++ b/newlib/libc/picolib/inittls.c
@@ -45,16 +45,20 @@
  */
 
 extern char __tdata_source[];	/* Source of TLS initialization data (in ROM) */
-extern char __tdata_size[];	/* Size of TLS initized data */
-extern char __tbss_start[];     /* Start of static zero-initialized TLS data */
-extern char __tbss_end[];       /* End of static zero-initialized TLS data */
-extern char __tbss_size[];	/* Size of TLS zero-filled data */
+
 extern char __tdata_start[];    /* Start of static tdata area */
 extern char __tdata_end[];      /* End of static tdata area */
+extern char __tbss_start[];     /* Start of static zero-initialized TLS data */
+extern char __tbss_end[];       /* End of static zero-initialized TLS data */
 
 #ifdef __PICOLIBC_CRT_RUNTIME_SIZE
 #define __tdata_size (__tdata_end - __tdata_start)
 #define __tbss_size (__tbss_end - __tbss_start)
+#define __tbss_offset (__tbss_start - __tdata_start)
+#else
+extern char __tdata_size[];	/* Size of TLS initized data */
+extern char __tbss_size[];	/* Size of TLS zero-filled data */
+extern char __tbss_offset[];    /* Offset from tdata to tbss */
 #endif
 
 void
@@ -66,5 +70,5 @@ _init_tls(void *__tls)
 	memcpy(tls, __tdata_source, (uintptr_t) __tdata_size);
 
 	/* Clear tls zero data */
-	memset(tls + (uintptr_t) __tdata_size, '\0', (uintptr_t) __tbss_size);
+	memset(tls + (uintptr_t) __tbss_offset, '\0', (uintptr_t) __tbss_size);
 }

--- a/picolibc.ld.in
+++ b/picolibc.ld.in
@@ -223,6 +223,7 @@ SECTIONS
 		. = ALIGN(8);
 		__bss_end = .;
 	} >ram AT>ram :ram
+	PROVIDE( __non_tls_bss_start = ADDR(.bss) );
 	PROVIDE( __end = __bss_end );
 	PROVIDE( _end = __bss_end );
 	PROVIDE( end = __bss_end );

--- a/picolibc.ld.in
+++ b/picolibc.ld.in
@@ -175,6 +175,7 @@ SECTIONS
 	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
 	PROVIDE( __data_source_end = __tdata_source_end );
 	PROVIDE( __tdata_size = SIZEOF(.tdata) );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata),ALIGNOF(.tbss)) );
 
 	PROVIDE( __edata = __data_end );
 	PROVIDE( _edata = __data_end );

--- a/picolibc.ld.in
+++ b/picolibc.ld.in
@@ -190,6 +190,7 @@ SECTIONS
 	} >ram AT>ram :tls :ram
 	PROVIDE( __bss_start = ADDR(.tbss));
 	PROVIDE( __tbss_start = ADDR(.tbss));
+	PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
 	PROVIDE( __tbss_size = SIZEOF(.tbss) );
 	PROVIDE( __tls_size = __tls_end - __tls_base );
 	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
@@ -206,6 +207,7 @@ SECTIONS
 	 * so we create a special segment here just to make room
 	 */
 	.tbss_space (NOLOAD) : {
+		. = ADDR(.tbss);
 		. = . + SIZEOF(.tbss);
 	} >ram AT>ram :ram
 

--- a/scripts/cross-clang-old-riscv64-unknown-elf.txt
+++ b/scripts/cross-clang-old-riscv64-unknown-elf.txt
@@ -4,8 +4,6 @@
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
 c = ['clang', '-target', 'riscv64-unknown-elf', '-mcmodel=medany', '-nostdlib']
-# TODO: it would be nice to use ld.lld here, but that depends on
-# https://reviews.llvm.org/D107280 being merged or building with -fpie.
 c_ld = '/usr/bin/riscv64-unknown-elf-ld'
 ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'

--- a/scripts/cross-clang-old-rv32imafdc-unknown-elf.txt
+++ b/scripts/cross-clang-old-rv32imafdc-unknown-elf.txt
@@ -4,7 +4,7 @@
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
 c = ['clang', '-m32', '-target', 'riscv32-unknown-elf', '-march=rv32imafdc', '-mabi=ilp32d', '-nostdlib']
-c_ld = 'lld'
+c_ld = '/usr/bin/riscv64-unknown-elf-ld'
 ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'
 nm = 'riscv64-unknown-elf-nm'

--- a/scripts/cross-clang-riscv64-unknown-elf.txt
+++ b/scripts/cross-clang-riscv64-unknown-elf.txt
@@ -4,8 +4,6 @@
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
 c = ['clang', '-target', 'riscv64-unknown-elf', '-mcmodel=medany', '-nostdlib']
-# TODO: it would be nice to use ld.lld here, but that depends on
-# https://reviews.llvm.org/D107280 being merged or building with -fpie.
 c_ld = '/usr/bin/riscv64-unknown-elf-ld'
 ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'

--- a/scripts/cross-clang-rv32imafdc-unknown-elf.txt
+++ b/scripts/cross-clang-rv32imafdc-unknown-elf.txt
@@ -4,7 +4,7 @@
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
 c = ['clang', '-m32', '-target', 'riscv32-unknown-elf', '-march=rv32imafdc', '-mabi=ilp32d', '-nostdlib']
-c_ld = 'lld'
+c_ld = '/usr/bin/riscv64-unknown-elf-ld'
 ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'
 nm = 'riscv64-unknown-elf-nm'

--- a/scripts/cross-clang-thumbv6m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv6m-none-eabi.txt
@@ -4,7 +4,7 @@
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
 c = ['clang', '-m32', '--target=thumbv6m-none-eabi', '-nostdlib']
-c_ld = 'lld'
+c_ld = '/usr/bin/arm-none-eabi-ld'
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eab-as'
 nm = 'arm-none-eab-nm'

--- a/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
@@ -4,7 +4,7 @@
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
 c = ['clang', '-m32', '-target', 'thumbv7e-none-eabi', '-mcpu=cortex-m7', '-mfloat-abi=hard', '-nostdlib']
-c_ld = 'lld'
+c_ld = '/usr/bin/arm-none-eabi-ld'
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eab-as'
 nm = 'arm-none-eab-nm'

--- a/scripts/cross-clang-thumbv7m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7m-none-eabi.txt
@@ -4,7 +4,7 @@
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
 c = ['clang', '-m32', '-target', 'thumbv7m-none-eabi', '-mfloat-abi=soft', '-nostdlib']
-c_ld = 'lld'
+c_ld = '/usr/bin/arm-none-eabi-ld'
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eab-as'
 nm = 'arm-none-eab-nm'


### PR DESCRIPTION
.tbss might require padding after .tdata to ensure correct overall
alignment of data within that section. Add a new __tbss_offset value
in the linker script which sets the distance from the start of .tdata
to the start of .tbss.
    
Ensure that the space allocated for .tbss is positioned correctly by
explicitly setting the start address of .tbss_space to match .tbss.
    
Signed-off-by: Keith Packard <keithp@keithp.com>