### PR TITLE
tinystdio: Allow building without c99 float scanf support

### DIFF
--- a/newlib/libc/tinystdio/conv_flt.c
+++ b/newlib/libc/tinystdio/conv_flt.c
@@ -521,3 +521,5 @@ conv_flt (FLT_STREAM *stream, int *lenp, width_t width, void *addr, uint16_t fla
     }
     return 1;
 }
+
+#undef base


### PR DESCRIPTION
Disabling C99 support replaces variable 'base' with a #define base, which then conflicts where conv_flt.c gets included.

Signed-off-by: Keith Packard <keithp@keithp.com>