### PR TITLE
cmake: Fix single-thread build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -413,7 +413,11 @@ if(NOT DEFINED __SINGLE_THREAD__)
   option(__SINGLE_THREAD__ "Disable multithreading support" 0)
 endif()
 
-set(_RETARGETABLE_LOCKING NOT ${__SINGLE_THREAD__})
+if(__SINGLE_THREAD__)
+  set(_RETARGETABLE_LOCKING 0)
+else()
+  set(_RETARGETABLE_LOCKING 1)
+endif()
 
 set(NEWLIB_VERSION 4.3.0)
 set(NEWLIB_MAJOR 4)


### PR DESCRIPTION
_RETARGETABLE_LOCKING must be set to the inverse of __SINGLE_THREAD__, but cmake has no way to compute this value directly -- the set() command does not evaluate expressions. Instead, use an if() command to test __SINGLE_THREAD__ and select the correct value for _RETARGETABLE_LOCKING.

Signed-off-by: Keith Packard <keithp@keithp.com>