### PR TITLE
Tinystdio cleanups

### DIFF
--- a/newlib/libc/tinystdio/stdio_private.h
+++ b/newlib/libc/tinystdio/stdio_private.h
@@ -505,4 +505,85 @@ __atomic_exchange_ungetc(__ungetc_t *p, __ungetc_t v);
 
 #endif /* ATOMIC_UNGETC */
 
+#define CASE_CONVERT    ('a' - 'A')
+#define TOLOW(c)        ((c) | CASE_CONVERT)
+
+/*
+ * Convert a single character to the value of the digit for any
+ * character 0 .. 9, A .. Z or a .. z
+ *
+ * Characters out of these ranges will return a value above 36
+ *
+ * Work in unsigned int type to avoid extra instructions required for
+ * unsigned char folding. The only time this matters is when
+ * subtracting '0' from values below '0', which results in very large
+ * unsigned values.
+ */
+
+static inline unsigned int
+digit_to_val(unsigned int c)
+{
+    /*
+     * Convert letters with some tricky code.
+     *
+     * TOLOW(c-1) maps characters as follows (Skipping values not
+     * greater than '9' (0x39), as those are skipped by the 'if'):
+     *
+     * Minus 1, bitwise-OR ('a' - 'A') (0x20):
+     *
+     *             0x3a..0x40 -> 0x39..0x3f
+     * 0x41..0x60, 0x61..0x80 -> 0x60..0x7f
+     * 0x81..0xa0, 0xa1..0xc0 -> 0xa0..0xbf
+     * 0xc1..0xe0, 0xe1..0x00 -> 0xe0..0xff
+     *
+     * Plus '0' (0x30), minus 'a') (0x61), plus 11 (0xb), for
+     * a total of minus 0x26:
+     *
+     *             0x3a..0x40 -> 0x39..0x3f -> 0x13..0x19
+     * 0x41..0x60, 0x61..0x80 -> 0x60..0x7f -> 0x3a..0x59
+     * 0x81..0xa0, 0xa1..0xc0 -> 0xa0..0xbf -> 0x7a..0x99
+     * 0xc1..0xe0, 0xe1..0x00 -> 0xe0..0xff -> 0xba..0xd9
+     */
+
+    if (c > '9') {
+
+        /*
+         * For the letters, we want TOLOW(c) - 'a' + 10, but that
+         * would map both '@' and '`' to 9.
+         *
+         * To work around this, subtract 1 before the bitwise-or so
+         * that '@' (0x40) gets mapped down to 0x3f (0x3f | 0x20)
+         * while '`' (0x60) gets mapped up to 0x7f (0x5f | 0x20),
+         * moving them away from the letters (which end up in the
+         * range 0x60..0x79). Then add the 1 back in when subtracting
+         * 'a' and adding 10.
+         *
+         * Add in '0' so that it can get subtracted out in the common
+         * code (c -= '0') below, avoiding an else clause.
+         */
+
+        c = TOLOW(c-1) + ('0' - 'a' + 11);
+    }
+
+    /*
+     * Now, include the range from NUL (0x00) through '9' (0x39)
+     *
+     * Minus '0' (0x30):
+     *
+     * 0x00..0x2f                                         ->-0x30..-0x01
+     * 0x30..0x39                                         -> 0x00..0x09 *
+     *             0x3a..0x40 -> 0x39..0x3f -> 0x13..0x19 ->-0x1d..-0x17
+     * 0x41..0x60, 0x61..0x80 -> 0x60..0x7f -> 0x3a..0x59 -> 0x0a..0x29 *
+     * 0x81..0xa0, 0xa1..0xc0 -> 0xa0..0xbf -> 0x7a..0x99 -> 0x4a..0x69
+     * 0xc1..0xe0, 0xe1..0x00 -> 0xe0..0xff -> 0xba..0xd9 -> 0x8a..0xa9
+     *
+     * The first starred row has the digits '0'..'9', while the second
+     * starts with the letters 'A'..'Z' and 'a'..'z'. All of the other
+     * rows end up with values above any allowed conversion base
+     */
+
+    c -= '0';
+    return c;
+}
+
 #endif /* _STDIO_PRIVATE_H_ */

--- a/newlib/libc/tinystdio/strtoi.h
+++ b/newlib/libc/tinystdio/strtoi.h
@@ -55,8 +55,10 @@ ISSPACE(unsigned char c)
 strtoi_type
 strtoi(const char *__restrict nptr, char **__restrict endptr, int ibase)
 {
+    unsigned int base = ibase;
+
     /* Check for invalid base value */
-    if ((unsigned int) ibase > 36 || ibase == 1) {
+    if (base > 36 || base == 1) {
         errno = EINVAL;
         if (endptr)
             *endptr = (char *) nptr;
@@ -69,8 +71,7 @@ strtoi(const char *__restrict nptr, char **__restrict endptr, int ibase)
     const unsigned char *s = (const unsigned char *) nptr;
     strtoi_type val = 0;
     unsigned char flags = 0;
-    unsigned char base = (unsigned char) ibase;
-    unsigned char i;
+    unsigned int i;
 
     /* Skip leading spaces */
     do {
@@ -88,7 +89,7 @@ strtoi(const char *__restrict nptr, char **__restrict endptr, int ibase)
 
     /* Leading '0' digit -- check for base indication */
     if (i == '0') {
-        if (TOLOW(*s) == 'x' && (base == 0 || base == 16)) {
+        if (TOLOW(*s) == 'x' && ((base | 16) == 16)) {
             base = 16;
             /* Parsed the '0' */
             nptr = (const char *) s;
@@ -136,7 +137,7 @@ strtoi(const char *__restrict nptr, char **__restrict endptr, int ibase)
 #else
         if (val > cutoff || (val == cutoff && i > cutlim))
             flags |= FLAG_OFLOW;
-        val = val * (strtoi_type) base + i;
+        val = val * (strtoi_type) base + (strtoi_type) i;
 #endif
         /* Parsed another digit */
         nptr = (const char *) s;

--- a/newlib/libc/tinystdio/strtoi.h
+++ b/newlib/libc/tinystdio/strtoi.h
@@ -40,9 +40,7 @@
 #include <string.h>
 #include <errno.h>
 #include <stdbool.h>
-
-#define CASE_CONVERT    ('a' - 'A')
-#define TOLOW(c)        ((c) | CASE_CONVERT)
+#include "stdio_private.h"
 
 #if defined(_HAVE_BUILTIN_MUL_OVERFLOW) && defined(_HAVE_BUILTIN_ADD_OVERFLOW) && !defined(strtoi_signed)
 #define USE_OVERFLOW
@@ -117,11 +115,7 @@ strtoi(const char *__restrict nptr, char **__restrict endptr, int ibase)
 #endif
 
     for(;;) {
-        /* Map digits to 0..35, non-digits above 35. */
-        if (i > '9')
-            i = TOLOW(i-1) + ('0' - 'a' + 11);
-        i -= '0';
-
+        i = digit_to_val(i);
         /* detect invalid char */
         if (i >= base)
             break;

--- a/newlib/libc/tinystdio/vfprintf.c
+++ b/newlib/libc/tinystdio/vfprintf.c
@@ -1094,7 +1094,7 @@ int vfprintf (FILE * stream, const char *fmt, va_list ap_orig)
                 pnt = va_arg (ap, char *);
                 if (!pnt)
                     pnt = "(null)";
-                size = strnlen (pnt, (flags & FL_PREC) ? prec : ~0);
+                size = strnlen (pnt, (flags & FL_PREC) ? (size_t) prec : SIZE_MAX);
 
             str_lpad:
                 if (!(flags & FL_LPAD)) {

--- a/newlib/libc/tinystdio/vfprintf.c
+++ b/newlib/libc/tinystdio/vfprintf.c
@@ -188,9 +188,6 @@ typedef long ultoa_signed_t;
 #define FL_FLTEXP	0x1000
 #define	FL_FLTFIX	0x2000
 
-#define CASE_CONVERT    ('a' - 'A')
-#define TOLOW(c)        ((c) | CASE_CONVERT)
-
 #ifdef PRINTF_POSITIONAL
 
 typedef struct {

--- a/newlib/libc/tinystdio/vfscanf.c
+++ b/newlib/libc/tinystdio/vfscanf.c
@@ -116,7 +116,7 @@ conv_int (FILE *stream, int *lenp, width_t width, void *addr, uint16_t flags, un
     val = 0;
 
     /* Leading '0' digit -- check for base indication */
-    if ((unsigned char)i == '0') {
+    if (i == '0') {
 	if (!--width || (i = scanf_getc (stream, lenp)) < 0)
 	    goto putval;
 
@@ -139,7 +139,7 @@ conv_int (FILE *stream, int *lenp, width_t width, void *addr, uint16_t flags, un
         base = 10;
 
     do {
-	unsigned char c = digit_to_val((unsigned char) i);
+	unsigned int c = digit_to_val(i);
         if (c >= base) {
             scanf_ungetc (i, stream, lenp);
             break;

--- a/newlib/libc/tinystdio/vfscanf.c
+++ b/newlib/libc/tinystdio/vfscanf.c
@@ -96,9 +96,6 @@ putval (void *addr, int_scanf_t val, uint16_t flags)
     }
 }
 
-#define CASE_CONVERT    ('a' - 'A')
-#define TOLOW(c)        ((c) | CASE_CONVERT)
-
 static unsigned char
 conv_int (FILE *stream, int *lenp, width_t width, void *addr, uint16_t flags, unsigned int base)
 {
@@ -142,13 +139,7 @@ conv_int (FILE *stream, int *lenp, width_t width, void *addr, uint16_t flags, un
         base = 10;
 
     do {
-	unsigned char c = i;
-
-        /* Map digits to 0..35, non-digits above 35. */
-        if (c > '9')
-            c = TOLOW(c-1) + ('0' - 'a' + 11);
-	c -= '0';
-
+	unsigned char c = digit_to_val((unsigned char) i);
         if (c >= base) {
             scanf_ungetc (i, stream, lenp);
             break;

--- a/picocrt/machine/x86/crt0-32.S
+++ b/picocrt/machine/x86/crt0-32.S
@@ -101,6 +101,10 @@ _start32:
 	call	main
 
 #ifdef CRT0_EXIT
+	/* keep stack aligned to 16-byte boundary so SSE works */
+	push	$0
+	push	$0
+	push	$0
 	push	%eax
 	call	exit
 #else

--- a/scripts/cross-clang-thumbv6m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv6m-none-eabi.txt
@@ -20,5 +20,5 @@ endian = 'little'
 
 [properties]
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt', '-fshort-enums']
-c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v6-m/nofp/', '-Wl,-z,noexecstack']
+c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v6-m/nofp/', '-Wl,-z,noexecstack']
 skip_sanity_check = true

--- a/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
@@ -20,5 +20,5 @@ endian = 'little'
 
 [properties]
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt', '-fshort-enums']
-c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m+dp/hard/']
+c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7e-m+dp/hard/']
 skip_sanity_check = true

--- a/scripts/cross-clang-thumbv7m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7m-none-eabi.txt
@@ -20,5 +20,5 @@ endian = 'little'
 
 [properties]
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt', '-fshort-enums']
-c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7-m/nofp/']
+c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7-m/nofp/']
 skip_sanity_check = true

--- a/scripts/do-lx106-configure
+++ b/scripts/do-lx106-configure
@@ -33,4 +33,4 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-exec "$(dirname "$0")"/do-configure xtensa-lx106-elf "$@"
+exec "$(dirname "$0")"/do-configure xtensa-lx106-elf "$@" -Ddebug=false


### PR DESCRIPTION
This is mostly about documenting the tricky digit-to-value conversion in strto*l and vfscanf, but along the way I found
a couple more cleanups, improving code for targets with native signed chars and reducing code duplication.