### PR TITLE
scripts: Update clang ARM scripts to use libgcc from gcc 12.2.1

### DIFF
--- a/picocrt/machine/x86/crt0-32.S
+++ b/picocrt/machine/x86/crt0-32.S
@@ -101,6 +101,10 @@ _start32:
 	call	main
 
 #ifdef CRT0_EXIT
+	/* keep stack aligned to 16-byte boundary so SSE works */
+	push	$0
+	push	$0
+	push	$0
 	push	%eax
 	call	exit
 #else

--- a/scripts/cross-clang-thumbv6m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv6m-none-eabi.txt
@@ -20,5 +20,5 @@ endian = 'little'
 
 [properties]
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt', '-fshort-enums']
-c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v6-m/nofp/', '-Wl,-z,noexecstack']
+c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v6-m/nofp/', '-Wl,-z,noexecstack']
 skip_sanity_check = true

--- a/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
@@ -20,5 +20,5 @@ endian = 'little'
 
 [properties]
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt', '-fshort-enums']
-c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m+dp/hard/']
+c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7e-m+dp/hard/']
 skip_sanity_check = true

--- a/scripts/cross-clang-thumbv7m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7m-none-eabi.txt
@@ -20,5 +20,5 @@ endian = 'little'
 
 [properties]
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt', '-fshort-enums']
-c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7-m/nofp/']
+c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7-m/nofp/']
 skip_sanity_check = true

--- a/scripts/do-lx106-configure
+++ b/scripts/do-lx106-configure
@@ -33,4 +33,4 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-exec "$(dirname "$0")"/do-configure xtensa-lx106-elf "$@"
+exec "$(dirname "$0")"/do-configure xtensa-lx106-elf "$@" -Ddebug=false


### PR DESCRIPTION
Debian testing now provides gcc 12.2.1. Look for libgcc there.

Signed-off-by: Keith Packard <keithp@keithp.com>