### PR TITLE
cmake: Automatically detect compiler characteristics

### DIFF
--- a/.github/do-cmake-linux
+++ b/.github/do-cmake-linux
@@ -1,8 +1,9 @@
 #!/bin/sh
 set -e
 HERE=`dirname "$0"`
-"$HERE"/do-cmake-test cmake-thumbv7m "$@"
-"$HERE"/do-cmake-test cmake-thumbv7m -DCMAKE_BUILD_TYPE=Debug "$@"
-"$HERE"/do-cmake-test cmake-thumbv7m -DCMAKE_BUILD_TYPE=Release "$@"
-"$HERE"/do-cmake-test cmake-thumbv7m -DCMAKE_BUILD_TYPE=RelWithDebInfo "$@"
-"$HERE"/do-cmake-test cmake-thumbv7m -DCMAKE_BUILD_TYPE=MinSizeRel "$@"
+for target in cmake-thumbv7m cmake-clang-thumbv7m; do
+    "$HERE"/do-cmake-test "$target" "$@" "$@"
+    for buildtype in Debug Release RelWithDebInfo MinSizeRel; do
+	"$HERE"/do-cmake-test "$target" "$@" -DCMAKE_BUILD_TYPE="$buildtype" "$@"
+    done
+done

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,83 +119,85 @@ set(_FSEEK_OPTIMIZATION 0)
 
 set(_FVWRITE_IN_STREAMIO 0)
 
-try_compile(_HAVE_ALIAS_ATTRIBUTE ${PROJECT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/have-alias-attribute.c)
+# Compiler supports alias symbol attribute
+picolibc_flag(_HAVE_ALIAS_ATTRIBUTE)
 
 # The compiler REALLY has the attribute __alloc_size__
-try_compile(_HAVE_ALLOC_SIZE ${PROJECT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/have-alloc-size.c)
+picolibc_flag(_HAVE_ALLOC_SIZE)
 
 # The compiler supports the always_inline function attribute
-try_compile(_HAVE_ATTRIBUTE_ALWAYS_INLINE ${PROJECT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/have-attribute-always-inline.c)
+picolibc_flag(_HAVE_ATTRIBUTE_ALWAYS_INLINE)
 
 # The compiler supports the gnu_inline function attribute
-try_compile(_HAVE_ATTRIBUTE_GNU_INLINE  ${PROJECT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/have-attribute-gnu-inline.c)
+picolibc_flag(_HAVE_ATTRIBUTE_GNU_INLINE)
 
 # Use bitfields in packed structs
-set(_HAVE_BITFIELDS_IN_PACKED_STRUCTS 1)
+picolibc_flag(_HAVE_BITFIELDS_IN_PACKED_STRUCTS)
 
 # The compiler supports __builtin_alloca
-set(_HAVE_BUILTIN_ALLOCA 1)
+picolibc_flag(_HAVE_BUILTIN_ALLOCA)
 
 # The compiler supports __builtin_copysign
-set(_HAVE_BUILTIN_COPYSIGN 1)
+picolibc_flag(_HAVE_BUILTIN_COPYSIGN)
 
 # The compiler supports __builtin_copysignl
-set(_HAVE_BUILTIN_COPYSIGNL 1)
+picolibc_flag(_HAVE_BUILTIN_COPYSIGNL)
 
 # The compiler supports __builtin_ctz
-set(_HAVE_BUILTIN_CTZ 1)
+picolibc_flag(_HAVE_BUILTIN_CTZ)
 
 # The compiler supports __builtin_ctzl
-set(_HAVE_BUILTIN_CTZL 1)
+picolibc_flag(_HAVE_BUILTIN_CTZL)
 
 # The compiler supports __builtin_ctzll
-set(_HAVE_BUILTIN_CTZLL 1)
+picolibc_flag(_HAVE_BUILTIN_CTZLL)
 
 # Compiler has __builtin_expect
-set(_HAVE_BUILTIN_EXPECT 1)
+picolibc_flag(_HAVE_BUILTIN_EXPECT)
 
 # The compiler supports __builtin_ffs
-set(_HAVE_BUILTIN_FFS 1)
+picolibc_flag(_HAVE_BUILTIN_FFS)
 
 # The compiler supports __builtin_ffsl
-set(_HAVE_BUILTIN_FFSL 1)
+picolibc_flag(_HAVE_BUILTIN_FFSL)
 
 # The compiler supports __builtin_ffsll
-set(_HAVE_BUILTIN_FFSLL 1)
+picolibc_flag(_HAVE_BUILTIN_FFSLL)
 
 # The compiler supports __builtin_finitel
-set(_HAVE_BUILTIN_FINITEL 1)
+picolibc_flag(_HAVE_BUILTIN_FINITEL)
 
 # The compiler supports __builtin_isfinite
-set(_HAVE_BUILTIN_ISFINITE 1)
+picolibc_flag(_HAVE_BUILTIN_ISFINITE)
 
 # The compiler supports __builtin_isinf
-set(_HAVE_BUILTIN_ISINF 1)
+picolibc_flag(_HAVE_BUILTIN_ISINF)
 
 # The compiler supports __builtin_isinfl
-set(_HAVE_BUILTIN_ISINFL 1)
+picolibc_flag(_HAVE_BUILTIN_ISINFL)
 
 # The compiler supports __builtin_isnan
-set(_HAVE_BUILTIN_ISNAN 1)
+picolibc_flag(_HAVE_BUILTIN_ISNAN)
 
 # The compiler supports __builtin_isnanl
-set(_HAVE_BUILTIN_ISNANL 1)
+picolibc_flag(_HAVE_BUILTIN_ISNANL)
 
 # Compiler has __builtin_mul_overflow
-set(_HAVE_BUILTIN_MUL_OVERFLOW 1)
+picolibc_flag(_HAVE_BUILTIN_MUL_OVERFLOW)
 
 # Compiler has __builtin_add_overflow
-set(_HAVE_BUILTIN_ADD_OVERFLOW 1)
+picolibc_flag(_HAVE_BUILTIN_ADD_OVERFLOW)
 
-# Compiler flag to prevent detecting memcpy/memset patterns
-set(_HAVE_CC_INHIBIT_LOOP_TO_LIBCALL 1)
+# Compiler has support for flag to prevent mis-optimizing memcpy/memset patterns
+picolibc_flag(_HAVE_CC_INHIBIT_LOOP_TO_LIBCALL)
 
 # Compiler supports _Complex
-try_compile(_HAVE_COMPLEX ${PROJECT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/have-complex.c)
+picolibc_flag(_HAVE_COMPLEX)
+
+# Compiler supports format function attribute
+picolibc_flag(_HAVE_FORMAT_ATTRIBUTE 1)
 
 set(_HAVE_FCNTL 0)
-
-set(_HAVE_FORMAT_ATTRIBUTE 1)
 
 # IEEE fp funcs available
 set(_HAVE_IEEEFP_FUNCS 0)
@@ -207,10 +209,10 @@ set(_HAVE_INITFINI_ARRAY 1)
 set(_HAVE_INIT_FINI 1)
 
 # Compiler has long double type
-try_compile(_HAVE_LONG_DOUBLE ${PROJECT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/have-long-double.c)
+picolibc_flag(_HAVE_LONG_DOUBLE)
 
 # Compiler attribute to prevent the optimizer from adding new builtin calls
-set(_HAVE_NO_BUILTIN_ATTRIBUTE 0)
+picolibc_flag(_HAVE_NO_BUILTIN_ATTRIBUTE)
 
 # _set_tls and _init_tls functions available
 if(NOT DEFINED _HAVE_PICOLIBC_TLS_API)
@@ -457,9 +459,24 @@ configure_file(picolibc.specs.in "${PROJECT_BINARY_DIR}/picolibc.specs" @ONLY)
 set(PICOLIBC_COMPILE_OPTIONS
   "--include" "${PICOLIBC_INCLUDE}/picolibc.h"
   "-nostdlib"
+  "-D_LIBC"
+  ${TLSMODEL}
+  ${TARGET_COMPILE_OPTIONS}
+  ${PICOLIBC_EXTRA_COMPILE_OPTIONS}
+  ${PICOLIBC_MATH_FLAGS}
+  )
+
+# Strip out any generator expressions as those cannot be used with
+# try_compile
+
+foreach(c_option "${PICOLIBC_COMPILE_OPTIONS}")
+  if(NOT "${c_option}" MATCHES "\\$")
+    list(APPEND PICOLIBC_TEST_COMPILE_OPTIONS "${c_option}")
+  endif()
+endforeach()
+
+picolibc_supported_compile_options(
   "-fno-common"
-  "-frounding-math"
-  "-fsignaling-nans"
   "-fno-stack-protector"
   "-ffunction-sections"
   "-fdata-sections"
@@ -469,10 +486,8 @@ set(PICOLIBC_COMPILE_OPTIONS
   "-Werror=vla"
   "-Warray-bounds"
   "-Wold-style-definition"
-  "-D_LIBC"
-  ${TLSMODEL}
-  ${TARGET_COMPILE_OPTIONS}
-  ${PICOLIBC_EXTRA_COMPILE_OPTIONS}
+  "-frounding-math"
+  "-fsignaling-nans"
   )
 
 add_library(c STATIC)
@@ -510,7 +525,6 @@ if(TESTS)
   # linker group
 
   set(PICOLIBC_TEST_LINK_LIBRARIES
-    ${PICOLIBC_COMPILE_OPTIONS}
     ${PICOCRT_SEMIHOST_OBJ}
     -Wl,--start-group c semihost -Wl,--end-group
     ${PICOLIBC_LINK_FLAGS}

--- a/cmake/TC-clang-arm-none-eabi.cmake
+++ b/cmake/TC-clang-arm-none-eabi.cmake
@@ -1,0 +1,33 @@
+# the name of the target operating system
+set(CMAKE_SYSTEM_NAME Generic)
+
+set(CMAKE_SYSTEM_PROCESSOR arm)
+
+# which compilers to use for C
+set(TARGET_COMPILE_OPTIONS -m32 -target thumbv7m-none-eabi -mfloat-abi=soft -nostdlib)
+set(CMAKE_C_COMPILER clang)
+
+# where is the target environment located
+set(CMAKE_FIND_ROOT_PATH /usr/bin)
+
+# adjust the default behavior of the FIND_XXX() commands:
+# search programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+
+# search headers and libraries in the target environment
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+set(_HAVE_PICOLIBC_TLS_API TRUE)
+
+set(FORMAT_DEFAULT_DOUBLE 1)
+set(FORMAT_DEFAULT_FLOAT 0)
+set(FORMAT_DEFAULT_INTEGER 0)
+
+set(PICOLIBC_LINK_FLAGS
+  --ld-path=/usr/bin/arm-none-eabi-ld
+  -L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7-m/nofp/
+  -Wl,-z,noexecstack
+  -Wl,-no-enum-size-warning
+  -T ${CMAKE_CURRENT_SOURCE_DIR}/cmake/TC-arm-none-eabi.ld
+  -lgcc)

--- a/cmake/have-bitfields-in-packed-structs.c
+++ b/cmake/have-bitfields-in-packed-structs.c
@@ -1,0 +1,3 @@
+struct test { int part: 24; } __attribute__((packed));
+static unsigned int foo (const struct test *p) { return p->part; }
+int main() { struct test x = { 12 }; return foo(&x); }

--- a/cmake/have-builtin-add-overflow.c
+++ b/cmake/have-builtin-add-overflow.c
@@ -1,0 +1,4 @@
+#include <stddef.h>
+static int overflows (size_t a, size_t b) { size_t x; return __builtin_add_overflow(a, b, &x); }
+volatile size_t aa = 42;
+int main (void) { return overflows(aa, aa); }

--- a/cmake/have-builtin-alloca.c
+++ b/cmake/have-builtin-alloca.c
@@ -1,0 +1,2 @@
+static int foo(void * i __attribute__((unused))) { return 0; }
+int main(void) { return foo(__builtin_alloca(1)); }

--- a/cmake/have-builtin-copysign.c
+++ b/cmake/have-builtin-copysign.c
@@ -1,0 +1,2 @@
+static int foo(double i __attribute__((unused))) { return 0; }
+int main(void) { return foo(__builtin_copysign(42, 42)); }

--- a/cmake/have-builtin-copysignl.c
+++ b/cmake/have-builtin-copysignl.c
@@ -1,0 +1,2 @@
+static int foo(long double i __attribute__((unused))) { return 0; }
+int main(void) { return foo(__builtin_copysignl((long double)42, (long double) 42)); }

--- a/cmake/have-builtin-ctz.c
+++ b/cmake/have-builtin-ctz.c
@@ -1,0 +1,2 @@
+static int foo(int i __attribute__((unused))) { return 0; }
+int main(void) { return foo(__builtin_ctz((unsigned int)42)); }

--- a/cmake/have-builtin-ctzl.c
+++ b/cmake/have-builtin-ctzl.c
@@ -1,0 +1,2 @@
+static int foo(int i __attribute__((unused))) { return 0; }
+int main(void) { return foo(__builtin_ctzl((unsigned long)42)); }

--- a/cmake/have-builtin-ctzll.c
+++ b/cmake/have-builtin-ctzll.c
@@ -1,0 +1,2 @@
+static int foo(int i __attribute__((unused))) { return 0; }
+int main(void) { return foo(__builtin_ctzll((unsigned long long)42)); }

--- a/cmake/have-builtin-expect.c
+++ b/cmake/have-builtin-expect.c
@@ -1,0 +1,4 @@
+volatile int a = 42;
+int main (void) {
+  return __builtin_expect(a, 1);
+}

--- a/cmake/have-builtin-ffs.c
+++ b/cmake/have-builtin-ffs.c
@@ -1,0 +1,2 @@
+static int foo(int i __attribute__((unused))) { return 0; }
+int main(void) { return foo(__builtin_ffs(42)); }

--- a/cmake/have-builtin-ffsl.c
+++ b/cmake/have-builtin-ffsl.c
@@ -1,0 +1,2 @@
+static int foo(long i __attribute__((unused))) { return 0; }
+int main(void) { return foo(__builtin_ffsl((long)42)); }

--- a/cmake/have-builtin-ffsll.c
+++ b/cmake/have-builtin-ffsll.c
@@ -1,0 +1,2 @@
+static int foo(long long i __attribute__((unused))) { return 0; }
+int main(void) { return foo(__builtin_ffsll((long long)42)); }

--- a/cmake/have-builtin-finitel.c
+++ b/cmake/have-builtin-finitel.c
@@ -1,0 +1,2 @@
+static int foo(int i __attribute__((unused))) { return 0; }
+int main(void) { return foo(__builtin_finitel((long double)42)); }

--- a/cmake/have-builtin-isfinite.c
+++ b/cmake/have-builtin-isfinite.c
@@ -1,0 +1,2 @@
+static int foo(int i __attribute__((unused))) { return 0; }
+int main(void) { return foo(__builtin_isfinite((long double)42)); }

--- a/cmake/have-builtin-isinf.c
+++ b/cmake/have-builtin-isinf.c
@@ -1,0 +1,2 @@
+static int foo(int i __attribute__((unused))) { return 0; }
+int main(void) { return foo(__builtin_isinf((double)42)); }

--- a/cmake/have-builtin-isinfl.c
+++ b/cmake/have-builtin-isinfl.c
@@ -1,0 +1,2 @@
+static int foo(int i __attribute__((unused))) { return 0; }
+int main(void) { return foo(__builtin_isinfl((long double)42)); }

--- a/cmake/have-builtin-isnan.c
+++ b/cmake/have-builtin-isnan.c
@@ -1,0 +1,2 @@
+static int foo(int i __attribute__((unused))) { return 0; }
+int main(void) { return foo(__builtin_isnan((double)42)); }

--- a/cmake/have-builtin-isnanl.c
+++ b/cmake/have-builtin-isnanl.c
@@ -1,0 +1,2 @@
+static int foo(int i __attribute__((unused))) { return 0; }
+int main(void) { return foo(__builtin_isnanl((long double)42)); }

--- a/cmake/have-builtin-mul-overflow.c
+++ b/cmake/have-builtin-mul-overflow.c
@@ -1,0 +1,4 @@
+#include <stddef.h>
+static int overflows (size_t a, size_t b) { size_t x; return __builtin_mul_overflow(a, b, &x); }
+volatile size_t aa = 42;
+int main (void) { return overflows(aa, aa); }

--- a/cmake/have-builtin_isinf.c
+++ b/cmake/have-builtin_isinf.c
@@ -1,0 +1,2 @@
+static int foo(int i __attribute__((unused))) { return 0; }
+int main(void) { return foo(__builtin_isinf((double)42)); }

--- a/cmake/have-cc-inhibit-loop-to-libcall.c
+++ b/cmake/have-cc-inhibit-loop-to-libcall.c
@@ -1,0 +1,4 @@
+__attribute__ ((__optimize__ ("-fno-tree-loop-distribute-patterns")))
+static int foo(int x) { return x + 1; }
+volatile int aa = 42;
+int main(void) { return foo(aa); }

--- a/cmake/have-format-attribute.c
+++ b/cmake/have-format-attribute.c
@@ -1,0 +1,1 @@
+int foo(const char * p, ...) __attribute__((format(printf, 1, 2)));

--- a/cmake/have-no-builtin-attribute.c
+++ b/cmake/have-no-builtin-attribute.c
@@ -1,0 +1,3 @@
+static int __attribute__((no_builtin)) foo(int x) { return x + 1; }
+volatile int aa = 42;
+int main(void) { return foo(aa); }

--- a/cmake/simple-main.c
+++ b/cmake/simple-main.c
@@ -1,0 +1,1 @@
+int main(void) { return 0; }

--- a/newlib/libc/include/math.h
+++ b/newlib/libc/include/math.h
@@ -340,7 +340,11 @@ int __issignalingf(float f);
 int __issignaling(double d);
 
 #if defined(_HAVE_LONG_DOUBLE)
+#if __SIZEOF_LONG_DOUBLE__ == __SIZEOF_DOUBLE__ && __SIZEOF_DOUBLE__ > 0
+static inline int __issignalingl(long double d) { return __issignaling((double) d); }
+#else
 int __issignalingl(long double d);
+#endif
 #define issignaling(__x)						\
 	((sizeof(__x) == sizeof(float))  ? __issignalingf(__x) :	\
 	 (sizeof(__x) == sizeof(double)) ? __issignaling ((double) (__x)) :	\

--- a/newlib/libc/machine/arm/strcpy.S
+++ b/newlib/libc/machine/arm/strcpy.S
@@ -174,3 +174,7 @@ strcpy:
         bx	lr
 	.size	strcpy, . - strcpy
 #endif
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/newlib/libc/machine/arm/strlen-armv7.S
+++ b/newlib/libc/machine/arm/strlen-armv7.S
@@ -178,3 +178,7 @@ def_fn	strlen p2align=6
 	mov	const_0, #0
 	b	.Lstart_realigned
 	.size	strlen, . - strlen
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/newlib/libc/machine/arm/strlen-thumb1-Os.S
+++ b/newlib/libc/machine/arm/strlen-thumb1-Os.S
@@ -48,3 +48,8 @@ def_fn	strlen p2align=1
 	subs	r0, r3, #1
 	bx	lr
 	.size	strlen, . - strlen
+
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/newlib/libc/machine/arm/strlen-thumb2-Os.S
+++ b/newlib/libc/machine/arm/strlen-thumb2-Os.S
@@ -52,3 +52,7 @@ def_fn	strlen p2align=1
 	subs    r0, #1
 	bx      lr
 	.size	strlen, . - strlen
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/newlib/libc/machine/arm/strlen.S
+++ b/newlib/libc/machine/arm/strlen.S
@@ -49,3 +49,7 @@
   /* Implemented in strlen-stub.c.  */
 #endif
 #endif
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/newlib/libm/common/math_config.h
+++ b/newlib/libm/common/math_config.h
@@ -594,7 +594,7 @@ force_eval_long_double (long double x)
 #   define _MATH_ALIAS_l_llI_to_d(name) long double _LD_NAME(name)(long double x, long double y, int *z) { return (long double) _D_NAME(name)((double) x, (double) y, z); }
 #   define _MATH_ALIAS_l_il_to_d(name) long double _LD_NAME(name)(int n, long double x) { return (long double) _D_NAME(name)(n, (double) x); }
 #   define _MATH_ALIAS_l_li_to_d(name) long double _LD_NAME(name)(long double x, int n) { return (long double) _D_NAME(name)((double) x, n); }
-#   define _MATH_ALIAS_l_lj_to_d(name) long double _LD_NAME(name)(long double x, long j) { return (long double) _D_NAME(name)((double) x, n); }
+#   define _MATH_ALIAS_l_lj_to_d(name) long double _LD_NAME(name)(long double x, long j) { return (long double) _D_NAME(name)((double) x, j); }
 #   define _MATH_ALIAS_i_l_to_d(name) int _LD_NAME(name)(long double x) { return _D_NAME(name)((double) x); }
 #   define _MATH_ALIAS_j_l_to_d(name) long _LD_NAME(name)(long double x) { return _D_NAME(name)((double) x); }
 #   define _MATH_ALIAS_k_l_to_d(name) long long _LD_NAME(name)(long double x) { return _D_NAME(name)((double) x); }

--- a/newlib/libm/math/sl_hypot.c
+++ b/newlib/libm/math/sl_hypot.c
@@ -11,8 +11,8 @@
 long double
 hypotl(long double x, long double y)
 {
-    if ((isinf(x) && isnanl(y) && !__issignalingl(y)) ||
-        (isinf(y) && isnanl(x) && !__issignaling(x)))
+    if ((isinf(x) && isnan(y) && !issignaling(y)) ||
+        (isinf(y) && isnan(x) && !issignaling(x)))
         return (long double)INFINITY;
 
     /* Keep it simple for now...  */

--- a/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
@@ -20,5 +20,5 @@ endian = 'little'
 
 [properties]
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt', '-fshort-enums']
-c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7e-m+dp/hard/']
+c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7e-m+dp/hard/', '-Wl,-z,noexecstack']
 skip_sanity_check = true

--- a/scripts/cross-clang-thumbv7m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7m-none-eabi.txt
@@ -20,5 +20,5 @@ endian = 'little'
 
 [properties]
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt', '-fshort-enums']
-c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7-m/nofp/']
+c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7-m/nofp/', '-Wl,-z,noexecstack']
 skip_sanity_check = true

--- a/scripts/do-cmake-clang-thumbv7m-configure
+++ b/scripts/do-cmake-clang-thumbv7m-configure
@@ -1,0 +1,2 @@
+#!/bin/sh
+cmake -G Ninja -DTESTS=ON -DCMAKE_TOOLCHAIN_FILE="$(dirname $0)/../cmake/TC-clang-arm-none-eabi.cmake" "$(dirname $0)/.." "$@"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -71,6 +71,8 @@ function(picolibc_test test)
 
   target_compile_options(${test} PRIVATE "-fno-builtin" ${PICOLIBC_COMPILE_OPTIONS})
 
+  target_link_options(${test} PRIVATE ${TARGET_COMPILE_OPTIONS})
+
   add_test(
     NAME ${test}
     COMMAND "${PICOLIBC_SCRIPTS}/run-thumbv7m" $<TARGET_FILE:${test}>


### PR DESCRIPTION
The cmake stuff in picolibc was built to work with Zephyr using GCC. As such, all of the compiler-specific definitions were hard-coded, which makes them fail when building with clang (or anything but gcc).

This series makes all of those auto-detected, just like with the meson build. It's a bit kludgy, because cmake really doesn't want to run the compiler at configure time. It's a bit slow, but better than failing entirely.

This series adds tests using cmake + clang to make sure it all works.

Closes: #417 