### PR TITLE
stdlib: Support old GCC version without deprecated message

### DIFF
--- a/newlib/libc/include/stdlib.h
+++ b/newlib/libc/include/stdlib.h
@@ -155,7 +155,7 @@ int	mkstemp (char *);
 int	mkstemps (char *, int);
 #endif
 #if __BSD_VISIBLE || (__XSI_VISIBLE >= 4 && __POSIX_VISIBLE < 200112)
-char *	mktemp (char *) _ATTRIBUTE ((__deprecated__("the use of `mktemp' is dangerous; use `mkstemp' instead")));
+char *	mktemp (char *) __deprecated("the use of `mktemp' is dangerous; use `mkstemp' instead");
 #endif
 void	qsort (void *__base, size_t __nmemb, size_t __size, __compar_fn_t _compar);
 int	rand (void);

--- a/newlib/libc/include/sys/cdefs.h
+++ b/newlib/libc/include/sys/cdefs.h
@@ -262,6 +262,12 @@
 #define	__alignof(x)	__offsetof(struct { char __a; x __b; }, __b)
 #endif
 
+#if __GNUC_PREREQ__(4,5) || defined(__clang__)
+#define __deprecated(m) __attribute__((__deprecated__(m)))
+#else
+#define __deprecated(m) _ATTRIBUTE(__deprecated__)
+#endif
+
 /*
  * Keywords added in C11.
  */


### PR DESCRIPTION
Starting with GCC version 4.5.0, the deprecated attribute allowed an optional string parameter which was displayed when the warning was emitted at compile time. Before that version, this parameter was not permitted and including it would cause a compile error.

Signed-off-by: Keith Packard <keithp@keithp.com>