### PR TITLE
cdefs: Avoid __deprecated name as Zephyr already uses that

### DIFF
--- a/newlib/libc/include/stdlib.h
+++ b/newlib/libc/include/stdlib.h
@@ -155,7 +155,7 @@ int	mkstemp (char *);
 int	mkstemps (char *, int);
 #endif
 #if __BSD_VISIBLE || (__XSI_VISIBLE >= 4 && __POSIX_VISIBLE < 200112)
-char *	mktemp (char *) __deprecated("the use of `mktemp' is dangerous; use `mkstemp' instead");
+char *	mktemp (char *) __picolibc_deprecated("the use of `mktemp' is dangerous; use `mkstemp' instead");
 #endif
 void	qsort (void *__base, size_t __nmemb, size_t __size, __compar_fn_t _compar);
 int	rand (void);

--- a/newlib/libc/include/sys/cdefs.h
+++ b/newlib/libc/include/sys/cdefs.h
@@ -263,9 +263,9 @@
 #endif
 
 #if __GNUC_PREREQ__(4,5) || defined(__clang__)
-#define __deprecated(m) __attribute__((__deprecated__(m)))
+#define __picolibc_deprecated(m) __attribute__((__deprecated__(m)))
 #else
-#define __deprecated(m) _ATTRIBUTE(__deprecated__)
+#define __picolibc_deprecated(m) _ATTRIBUTE(__deprecated__)
 #endif
 
 /*


### PR DESCRIPTION
Zephyr uses __deprecated as a macro without argument, which conflicted with picolibc usage that included an argument. Avoid that by using __picolibc_deprecated instead.

Signed-off-by: Keith Packard <keithp@keithp.com>