### PR TITLE
Use compiler weak attributes instead of inline asm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,9 @@ picolibc_flag(_HAVE_COMPLEX)
 # Compiler supports format function attribute
 picolibc_flag(_HAVE_FORMAT_ATTRIBUTE 1)
 
+# Compiler supports weak attribute
+picolibc_flag(_HAVE_WEAK_ATTRIBUTE)
+
 set(_HAVE_FCNTL 0)
 
 # IEEE fp funcs available
@@ -220,7 +223,6 @@ if(NOT DEFINED _HAVE_PICOLIBC_TLS_API OR NOT PICOLIBC_TLS)
 endif()
 
 set(_HAVE_SEMIHOST 1)
-set(_HAVE_WEAK_ATTRIBUTE 1)
 set(_ICONV_ENABLE_EXTERNAL_CCS 0)
 set(_ICONV_FROM_ENCODING_ 1)
 set(_ICONV_FROM_ENCODING_BIG5 1)

--- a/cmake/have-weak-attribute.c
+++ b/cmake/have-weak-attribute.c
@@ -1,0 +1,1 @@
+int x __attribute__((__weak__));

--- a/newlib/libc/include/sys/cdefs.h
+++ b/newlib/libc/include/sys/cdefs.h
@@ -542,6 +542,11 @@
     extern __typeof (sym) aliassym __attribute__ ((__alias__ (__STRING(sym))))
 #endif
 
+#if defined(_HAVE_WEAK_ATTRIBUTE) && defined(_HAVE_ALIAS_ATTRIBUTE)
+#define	__weak_reference(sym,aliassym)	\
+    extern __typeof (sym) aliassym __attribute__ ((__weak__, __alias__ (__STRING(sym))))
+#endif
+
 /*
    Taken from glibc:
    Add the compiler optimization to inhibit loop transformation to library
@@ -569,6 +574,7 @@
 #define __inhibit_new_builtin_calls
 #endif
 
+#ifndef __weak_reference
 #ifdef __ELF__
 #ifdef __STDC__
 #define	__weak_reference(sym,alias)	\
@@ -610,6 +616,7 @@
 #define	__weak_reference(sym,alias)	\
 	__asm__(".stabs \"_/**/alias\",11,0,0,0");	\
 	__asm__(".stabs \"_/**/sym\",1,0,0,0")
+#endif
 #endif
 #endif
 

--- a/newlib/libc/include/sys/cdefs.h
+++ b/newlib/libc/include/sys/cdefs.h
@@ -536,7 +536,6 @@
 #define	__printf0like(fmtarg, firstvararg)
 #endif
 
-#if defined(__GNUC__)
 #if defined(_HAVE_ALIAS_ATTRIBUTE)
 #define	__strong_reference(sym,aliassym)	\
     extern __typeof (sym) aliassym __attribute__ ((__alias__ (__STRING(sym))))
@@ -574,6 +573,7 @@
 #define __inhibit_new_builtin_calls
 #endif
 
+#if defined(__GNUC__)
 #ifndef __weak_reference
 #ifdef __ELF__
 #ifdef __STDC__

--- a/newlib/libc/include/sys/cdefs.h
+++ b/newlib/libc/include/sys/cdefs.h
@@ -620,37 +620,6 @@
 #endif
 #endif
 
-#if defined(__ELF__)
-#ifdef __STDC__
-#define	__warn_references(sym,msg)	\
-	__asm__(".section .gnu.warning." #sym);	\
-	__asm__(".asciz \"" msg "\"");	\
-	__asm__(".previous")
-#define	__sym_compat(sym,impl,verid)	\
-	__asm__(".symver " #impl ", " #sym "@" #verid)
-#define	__sym_default(sym,impl,verid)	\
-	__asm__(".symver " #impl ", " #sym "@@" #verid)
-#else
-#define	__warn_references(sym,msg)	\
-	__asm__(".section .gnu.warning.sym"); \
-	__asm__(".asciz \"msg\"");	\
-	__asm__(".previous")
-#define	__sym_compat(sym,impl,verid)	\
-	__asm__(".symver impl, sym@verid")
-#define	__sym_default(impl,sym,verid)	\
-	__asm__(".symver impl, sym@@verid")
-#endif	/* __STDC__ */
-#else	/* !__ELF__ */
-#ifdef __STDC__
-#define	__warn_references(sym,msg)	\
-	__asm__(".stabs \"" msg "\",30,0,0,0");		\
-	__asm__(".stabs \"_" #sym "\",1,0,0,0")
-#else
-#define	__warn_references(sym,msg)	\
-	__asm__(".stabs msg,30,0,0,0");			\
-	__asm__(".stabs \"_/**/sym\",1,0,0,0")
-#endif	/* __STDC__ */
-#endif	/* __ELF__ */
 #endif	/* __GNUC__ */
 
 #ifndef	__FBSDID

--- a/newlib/libc/include/sys/cdefs.h
+++ b/newlib/libc/include/sys/cdefs.h
@@ -538,9 +538,8 @@
 
 #if defined(__GNUC__)
 #if defined(_HAVE_ALIAS_ATTRIBUTE)
-#define __strong_reference_alias(n) #n
 #define	__strong_reference(sym,aliassym)	\
-    extern __typeof (sym) aliassym __attribute__ ((__alias__ (__strong_reference_alias(sym))))
+    extern __typeof (sym) aliassym __attribute__ ((__alias__ (__STRING(sym))))
 #endif
 
 /*

--- a/newlib/libm/common/math_config.h
+++ b/newlib/libm/common/math_config.h
@@ -1144,7 +1144,7 @@ __math_lgamma_r (__float64 y, int *signgamp, int *divzero);
 HIDDEN float
 __math_lgammaf_r (float y, int *signgamp, int *divzero);
 
-#if defined(_HAVE_ALIAS_ATTRIBUTE) && defined(_HAVE_WEAK_ATTRIBUTE)
+#ifdef __weak_reference
 extern int __signgam;
 #else
 #define __signgam signgam

--- a/newlib/libm/common/signgam.c
+++ b/newlib/libm/common/signgam.c
@@ -35,10 +35,9 @@
 
 #include <math.h>
 
-#if defined(_HAVE_ALIAS_ATTRIBUTE) && defined(_HAVE_WEAK_ATTRIBUTE)
+#ifdef __weak_reference
 int __signgam;
-
-extern __typeof(__signgam) signgam __attribute__ ((__weak__, __alias__ ("__signgam")));
+__weak_reference(__signgam, signgam);
 #else
 int signgam;
 #endif


### PR DESCRIPTION
There was already autodetection support in meson for the `weak` attribute. Add that for cmake then use that in include/sys/cdefs.h instead of only using it for signgam in libm. This series also cleans up cdefs.h, removing unused macros and exposing autodetected features to non-__GNUC__ compilers.