### PR TITLE
Add malloc attributes to memory management functions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1241,8 +1241,8 @@ conf_data.set('_HAVE_SEMIHOST', has_semihost, description: 'Semihost APIs suppor
 
 # By default, tests don't require any special arguments
 
-# disable compiler built-ins so we reach the library equivalents
-test_c_args = c_args + arg_fnobuiltin
+test_c_args = c_args
+# disable compiler built-ins so we don't use native equivalents
 native_c_args += arg_fnobuiltin
 if tests_enable_stack_protector
   if cc.has_argument('-fstack-protector-all') and cc.has_argument('-fstack-protector-strong')

--- a/newlib/libc/include/malloc.h
+++ b/newlib/libc/include/malloc.h
@@ -66,26 +66,29 @@ struct mallinfo {
 
 /* The routines.  */
 
-extern void *malloc (size_t);
-extern void free (void *);
-extern void *realloc (void *, size_t);
-extern void *calloc (size_t, size_t);
-extern void *memalign (size_t, size_t);
-extern struct mallinfo mallinfo (void);
-extern void malloc_stats (void);
-extern int mallopt (int, int);
-extern size_t malloc_usable_size (void *);
+void	free (void *) _NOTHROW;
+void	*malloc(size_t) __malloc_like __result_use_check __alloc_size(1) _NOTHROW;
+void	*calloc(size_t, size_t) __malloc_like __result_use_check
+    __alloc_size2(1, 2) _NOTHROW;
+void	*realloc(void *, size_t) __result_use_check __alloc_size(2) _NOTHROW;
+void    *memalign (size_t __alignment, size_t __size)  __malloc_like
+    __result_use_check __alloc_size(2) _NOTHROW;
+
+struct mallinfo mallinfo (void);
+void malloc_stats (void);
+int mallopt (int, int);
+size_t malloc_usable_size (void *);
 /* These aren't too useful on an embedded system, but we define them
    anyhow.  */
 
-extern void *pvalloc (size_t);
-extern int malloc_trim (size_t);
-extern void __malloc_lock(void);
-extern void __malloc_unlock(void);
+void *pvalloc (size_t);
+int malloc_trim (size_t);
+void __malloc_lock(void);
+void __malloc_unlock(void);
 
 /* A compatibility routine for an earlier version of the allocator.  */
 
-extern void mstats (char *);
+void mstats (char *);
 
 /* SVID2/XPG mallopt options */
 
@@ -103,7 +106,7 @@ extern void mstats (char *);
 
 #ifndef __CYGWIN__
 /* Some systems provide this, so do too for compatibility.  */
-extern void cfree (void *);
+void cfree (void *);
 #endif /* __CYGWIN__ */
 
 #ifdef __cplusplus

--- a/newlib/libc/include/stdlib.h
+++ b/newlib/libc/include/stdlib.h
@@ -118,11 +118,11 @@ void *	bsearch (const void *__key,
 		       size_t __nmemb,
 		       size_t __size,
 		       __compar_fn_t _compar);
+void	free (void *) _NOTHROW;
 void	*calloc(size_t, size_t) __malloc_like __result_use_check
 	     __alloc_size2(1, 2) _NOTHROW;
 div_t	div (int __numer, int __denom);
 void	exit (int __status) _ATTRIBUTE ((__noreturn__));
-void	free (void *) _NOTHROW;
 char *  getenv (const char *__string);
 #if __GNU_VISIBLE
 char *  secure_getenv (const char *__string);

--- a/newlib/libc/include/string.h
+++ b/newlib/libc/include/string.h
@@ -113,6 +113,7 @@ char	*strcasestr (const char *, const char *);
 char 	*strchrnul (const char *, int);
 #endif
 #if __MISC_VISIBLE || __POSIX_VISIBLE >= 200809 || __XSI_VISIBLE >= 4
+void	free (void *) _NOTHROW;
 char 	*strdup (const char *) __malloc_like __result_use_check;
 #endif
 #if __POSIX_VISIBLE >= 200809

--- a/newlib/libc/include/sys/cdefs.h
+++ b/newlib/libc/include/sys/cdefs.h
@@ -358,12 +358,18 @@
 #endif
 
 #if __GNUC_PREREQ__(2, 96)
-#define	__malloc_like	__attribute__((__malloc__))
-#define	__pure		__attribute__((__pure__))
+# if __GNUC_PREREQ__(11, 0)
+#  define       __malloc_like_with_free(_f,_a) __attribute__((__malloc__, __malloc__(_f,_a)))
+# else
+#  define       __malloc_like_with_free(_f,_a) __attribute__((__malloc__))
+# endif
+# define	__pure		__attribute__((__pure__))
 #else
-#define	__malloc_like
+#define __malloc_like_with_free(free,free_arg)
 #define	__pure
 #endif
+
+#define	__malloc_like __malloc_like_with_free(free, 1)
 
 #ifndef __always_inline
 #if __GNUC_PREREQ__(3, 1)

--- a/newlib/libc/include/wchar.h
+++ b/newlib/libc/include/wchar.h
@@ -126,6 +126,7 @@ wchar_t	*wcscpy (wchar_t *__restrict, const wchar_t *__restrict);
 #if __POSIX_VISIBLE >= 200809
 wchar_t	*wcpcpy (wchar_t *__restrict,
 				 const wchar_t *__restrict);
+void	free (void *) _NOTHROW;
 wchar_t	*wcsdup (const wchar_t *) __malloc_like __result_use_check;
 #endif
 size_t	wcscspn (const wchar_t *, const wchar_t *);

--- a/newlib/libc/stdio/stdio.h
+++ b/newlib/libc/stdio/stdio.h
@@ -337,6 +337,7 @@ char *	cuserid (char *);
 FILE *	tmpfile (void);
 char *	tmpnam (char *);
 #if __BSD_VISIBLE || __XSI_VISIBLE || __POSIX_VISIBLE >= 200112
+void	free (void *) _NOTHROW;
 char *	tempnam (const char *, const char *) __malloc_like __result_use_check;
 #endif
 int	fclose (FILE *);

--- a/newlib/libc/stdlib/nano-mallocr.c
+++ b/newlib/libc/stdlib/nano-mallocr.c
@@ -152,8 +152,8 @@ bool __malloc_grow_chunk(chunk_t *c, size_t new_size);
  * call to free.
  */
 #ifdef _HAVE_ALIAS_ATTRIBUTE
-extern __typeof(free) __malloc_free;
-extern __typeof(malloc) __malloc_malloc;
+extern void __malloc_free(void *);
+extern void *__malloc_malloc(size_t);
 #else
 #define __malloc_free(x) free(x)
 #define __malloc_malloc(x) malloc(x)

--- a/newlib/libc/tinystdio/stdio.h
+++ b/newlib/libc/tinystdio/stdio.h
@@ -44,6 +44,7 @@
 #include <inttypes.h>
 #include <stdarg.h>
 #include <sys/_types.h>
+#include <sys/cdefs.h>
 
 #ifndef __DOXYGEN__
 #define __need_NULL
@@ -919,10 +920,10 @@ extern int	fflush(FILE *stream);
 #endif
 __extension__ typedef long long fpos_t;
 extern int fgetpos(FILE *stream, fpos_t *pos);
-extern FILE *fopen(const char *path, const char *mode);
+extern FILE *fopen(const char *path, const char *mode) __malloc_like_with_free(fclose, 1);
 extern FILE *freopen(const char *path, const char *mode, FILE *stream);
-extern FILE *fdopen(int, const char *);
-extern FILE *fmemopen(void *buf, size_t size, const char *mode);
+extern FILE *fdopen(int, const char *) __malloc_like_with_free(fclose, 1);
+extern FILE *fmemopen(void *buf, size_t size, const char *mode) __malloc_like_with_free(fclose, 1);
 extern int fseek(FILE *stream, long offset, int whence);
 extern int fseeko(FILE *stream, __off_t offset, int whence);
 extern int fsetpos(FILE *stream, fpos_t *pos);

--- a/newlib/libm/test/math.c
+++ b/newlib/libm/test/math.c
@@ -613,7 +613,7 @@ run_vector_1 (int vector,
      }
     p++;
   }
-  if (vector)
+  if (vector && f)
   {
     VECCLOSE(f, name, args);
   }

--- a/test/malloc.c
+++ b/test/malloc.c
@@ -114,17 +114,21 @@ main(void)
 
 	void *big = malloc(1024);
 	memset(big, '1', 1024);
+        printf("big %p\n", big);
 	if (big) {
 		void *small = malloc(128);
 		memset(small, '2', 128);
+                printf("small %p\n", small);
 		if (small) {
+                        (void) atoi(small);
 			free(big);
 			char *med = realloc(small, 1024);
 			if (med) {
+                                printf("med %p\n", med);
 #ifdef _NANO_MALLOC
 				int i;
 				for (i = 128; i < 1024; i++)
-					if (med[i] != '1' && med[i] != 0) {
+					if (med[i] != 0) {
 						printf("looks like realloc read past old at %d (saw %d)\n", i, med[i]);
 						++result;
 					}

--- a/test/meson.build
+++ b/test/meson.build
@@ -242,6 +242,22 @@ foreach target : targets
 	 env: test_env)
   endif
 
+  t1 = 'math_errhandling'
+  if target == ''
+    t1_name = t1
+  else
+    t1_name = t1 + '_' + target
+  endif
+
+  test(t1_name,
+       executable(t1_name, ['math_errhandling.c'],
+		  c_args: arg_fnobuiltin + _c_args,
+		  link_args: _link_args,
+		  link_with: _libs,
+		  include_directories: inc),
+       depends: bios_bin,
+       env: test_env)
+
   t1 = 'rounding-mode'
   if target == ''
     t1_name = t1
@@ -251,7 +267,7 @@ foreach target : targets
 
   test(t1_name,
        executable(t1_name, ['rounding-mode.c', 'rounding-mode-sub.c'],
-		  c_args: _c_args,
+		  c_args: arg_fnobuiltin + _c_args,
 		  link_args: _link_args,
 		  link_with: _libs,
 		  include_directories: inc),
@@ -268,7 +284,7 @@ foreach target : targets
 
   test(t1_name,
        executable(t1_name, [t1_src, 'lock-valid.c'],
-		  c_args: double_printf_compile_args + _c_args,
+		  c_args: double_printf_compile_args + arg_fnobuiltin + _c_args,
 		  link_args: double_printf_link_args + _link_args,
 		  link_with: _libs,
 		  link_depends:  test_link_depends,
@@ -298,7 +314,7 @@ foreach target : targets
       )
 
   plain_tests = ['rand', 'regex', 'ungetc', 'fenv',
-		 'math_errhandling', 'malloc', 'tls',
+		 'malloc', 'tls',
 		 'ffs', 'setjmp', 'atexit', 'on_exit',
 		 'math-funcs', 'timegm', 'time-tests',
                  'test-strtod', 'test-strchr',

--- a/test/test-mktemp.c
+++ b/test/test-mktemp.c
@@ -101,6 +101,7 @@ main(void)
     check(f != NULL, "fopen w");
     fputs(MESSAGE, f);
     fclose(f);
+    f = NULL;
     check_contents(template, 1);
     (void) remove(template);
 
@@ -114,6 +115,7 @@ main(void)
     check(f != NULL, "fopen w");
     fputs(MESSAGE, f);
     fclose(f);
+    f = NULL;
     check_contents(template, 1);
     (void) remove(template);
 


### PR DESCRIPTION
This series applies the GCC 11 'malloc' attributes to various memory allocation functions, including stdio functions which allocate FILE handles. With these, GCC can catch some use-after-free bugs, as well as malloc buffer overruns.