### PR TITLE
stdlib: malloc.h requires <sys/cdefs.h>

### DIFF
--- a/newlib/libc/include/malloc.h
+++ b/newlib/libc/include/malloc.h
@@ -41,6 +41,7 @@ SUCH DAMAGE.
 #define __need_size_t
 #include <stddef.h>
 
+#include <sys/cdefs.h>
 /* include any machine-specific extensions */
 #include <machine/malloc.h>
 


### PR DESCRIPTION
The malloc.h header file references a bunch of stuff from sys/cdefs.h but fails to directly include it leading to errors when applications use this header without first including some header that happens to pull in sys/cdefs.h.

Closes: #432 