### PR TITLE
various minor fixes

### DIFF
--- a/newlib/libc/include/stdlib.h
+++ b/newlib/libc/include/stdlib.h
@@ -366,7 +366,7 @@ extern long double strtold (const char *__restrict, char **__restrict);
  */
 #if __ISO_C_VISIBLE >= 2011
 void *	aligned_alloc(size_t, size_t) __malloc_like __alloc_align(1)
-	    __alloc_size(2) __result_use_check;
+	    __alloc_size(2) __result_use_check _NOTHROW;
 int	at_quick_exit(void (*)(void));
 _Noreturn void
 	quick_exit(int);

--- a/newlib/libc/stdlib/nano-mallocr.c
+++ b/newlib/libc/stdlib/nano-mallocr.c
@@ -38,6 +38,7 @@
 #include <stdbool.h>
 #include <errno.h>
 #include <malloc.h>
+#include <stdlib.h>
 #include <unistd.h>
 #include <sys/config.h>
 #include <sys/lock.h>

--- a/newlib/libc/time/meson.build
+++ b/newlib/libc/time/meson.build
@@ -53,10 +53,8 @@ srcs_time = [
     'tzcalc_limits.c',
     'tzset.c',
     'tzvars.c',
+    'wcsftime.c',
 ]
-if not tinystdio
-  srcs_time += 'wcsftime.c'
-endif
 
 hdrs_time = [
     'local.h',


### PR DESCRIPTION
three minor fixes:

 1. Need wcsftime for libstdc++ for full wchar_t support
 2. aligned_alloc was missing _NOTHROW attribute and only got that because the compiler knows about it
 3. nano-mallocr didn't get the definition of aligned_alloc because it didn't include stdlib.h