### PR TITLE
picocrt: Use generated crt0.o objects directly in tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1264,7 +1264,7 @@ endif
 # of meson newer than that.
 
 test_env = environment({'PICOLIBC_TEST' : '1'})
-test_env.prepend('PATH', meson.source_root() / 'scripts')
+test_env.prepend('PATH', meson.current_source_dir() / 'scripts')
 
 # CompCert needs the '-WUl,' prefix to correctly pass the --spec parameters to the linker
 specs_prefix = ''

--- a/meson.build
+++ b/meson.build
@@ -51,6 +51,21 @@ fs = import('fs')
 
 cc = meson.get_compiler('c')
 
+# Find the compiler installation directory by parsing the output of
+# cc -print-search-dirs
+
+cc_install_dir = ''
+foreach _line : run_command(cc.cmd_array() + ['-print-search-dirs'], check : false).stdout().split('\n')
+  if _line.startswith('install: ')
+    if meson.version().version_compare('>=0.56')
+      # trim off the leading 'install: '
+      cc_install_dir = _line.substring(9)
+    else
+      cc_install_dir = run_command(['expr', _line, ':', 'install: *\(.*\)'], check : false).stdout().split('\n')[0]
+    endif
+  endif
+endforeach
+
 # these options are required for all C compiler operations, including
 # detecting many C compiler features, as we cannot expect there
 # to be a working C library on the system.
@@ -390,8 +405,7 @@ else
 endif
 
 if host_cpu_family == ''
-  host_cmds = cc.cmd_array() + ['-dumpmachine']
-  host_cc_machine=run_command(host_cmds, check : true).stdout().strip().split('-')
+  host_cc_machine=run_command(cc.cmd_array() + ['-dumpmachine'], check : true).stdout().strip().split('-')
   host_cpu_family=host_cc_machine[0]
   message('Computed host_cpu_family as ' + host_cpu_family)
 endif
@@ -435,13 +449,7 @@ if sysroot_install
   if sysroot != ''
     specs_prefix_format = '%R/@0@'
   else
-    paths = run_command(cc.cmd_array() + ['-print-search-dirs'], check : true).stdout().split('\n')
-    foreach path : paths
-      if path.startswith('install: ')
-	sysroot = path.substring(9) + '../../../..'
-      endif
-    endforeach
-    message('computed sysroot is ' + sysroot)
+    sysroot = cc_install_dir + '../../../..'
     specs_prefix_format = '%:getenv(GCC_EXEC_PREFIX ../../@0@)'
   endif
   if not get_option('sysroot-install-skip-checks')
@@ -474,17 +482,14 @@ endif
 
 specs_dir_option = get_option('specsdir')
 if build_type_subdir != ''
-  specs_install = false
   specs_dir = ''
+  specs_install = false
 elif specs_dir_option == ''
-  search_cmds = cc.cmd_array() + ['-print-search-dirs']
-  install_dir=run_command(search_cmds, check : true).stdout().split('\n')[0]
-  # Meson 0.56 adds a 'substring' method which can be used here
-  specs_dir=run_command(['expr', install_dir, ':', 'install: *\(.*\)'], check : false).stdout().split('\n')[0]
+  specs_dir = cc_install_dir
   specs_install = specs_dir != ''
 elif specs_dir_option == 'none'
-  specs_install = false
   specs_dir = ''
+  specs_install = false
 else
   specs_dir = join_paths(prefix, specs_dir_option)
   specs_install = true
@@ -831,7 +836,7 @@ if enable_multilib
   # Ask the compiler for the set of available multilib configurations,
   # set up the build system to compile for all desired ones
 
-  target_list = run_command(cc, '--print-multi-lib', check : true).stdout().strip().split('\n')
+  target_list = run_command(cc.cmd_array() +  ['--print-multi-lib'], check : true).stdout().strip().split('\n')
 
   has_mcmodel = false
   foreach target : target_list

--- a/newlib/libm/test/meson.build
+++ b/newlib/libm/test/meson.build
@@ -138,8 +138,10 @@ foreach target : targets
   if is_variable('lib_semihost' + target)
     libs += [get_variable('lib_semihost' + target)]
   endif
-  if is_variable('lib_crt_hosted' + target)
-    libs += [get_variable('lib_crt_hosted'+ target)]
+  if is_variable('crt0_hosted' + target)
+    objs = [get_variable('crt0_hosted'+ target)]
+  else
+    objs = []
   endif
 
   if target == ''
@@ -151,6 +153,7 @@ foreach target : targets
   test(test_name,
        executable(test_name, math_test_src,
 		  c_args: value[1] + double_printf_compile_args + test_c_args,
+		  objects: objs,
 		  link_with: libs,
 		  link_args: value[1] + double_printf_link_args + test_link_args,
 		  include_directories: inc),

--- a/newlib/testsuite/newlib.iconv/meson.build
+++ b/newlib/testsuite/newlib.iconv/meson.build
@@ -49,8 +49,10 @@ foreach target : targets
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]
   endif
-  if is_variable('lib_crt_hosted' + target)
-    _libs += [get_variable('lib_crt_hosted'+ target)]
+  if is_variable('crt0_hosted' + target)
+    _objs = [get_variable('crt0_hosted'+ target)]
+  else
+    _objs = []
   endif
   
   _c_args = value[1] + test_c_args
@@ -69,6 +71,7 @@ foreach target : targets
 	 executable(test_name, src,
 		    c_args: ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + _c_args + iconv_test_c_args,
 		    link_args: _link_args,
+		    objects: _objs,
 		    link_with: _libs,
 		    include_directories: test_inc),
 	 depends: [iconv_data_link, bios_bin],

--- a/newlib/testsuite/newlib.locale/UTF-8.c
+++ b/newlib/testsuite/newlib.locale/UTF-8.c
@@ -133,7 +133,7 @@ char illegal_pos[2][3] = {
   {0xff, 0xff}
 };
   
-int main()
+int main(void)
   {
     wchar_t wchar;
     int retval;
@@ -151,7 +151,7 @@ int main()
     /* 2.1  First possible sequence of a certain length */
     retval = mbtowc(&wchar, first[0], MAX_BYTES);
     if (retval == 0)
-      printf("2.1.1: U-%08d\n", wchar);
+      printf("2.1.1: U-%08ld\n", (long) wchar);
     else
       printf("2.1.1: Invalid\n");
 
@@ -159,7 +159,7 @@ int main()
     {
       retval = mbtowc (&wchar, first[i-1], MAX_BYTES);
       if (retval == i)
-        printf("2.1.%d: U-%08x\n", i, wchar);
+        printf("2.1.%d: U-%08lx\n", i, (long) wchar);
       else
         printf("2.1.%d: Invalid\n", i);
     }
@@ -169,7 +169,7 @@ int main()
     {
       retval = mbtowc (&wchar, last[i-1], MAX_BYTES);
       if (retval == i)
-        printf("2.2.%d: U-%08x\n", i, wchar);
+        printf("2.2.%d: U-%08lx\n", i, (long) wchar);
       else
         printf("2.2.%d: Invalid\n", i);
     }
@@ -179,7 +179,7 @@ int main()
       {
         retval = mbtowc (&wchar, boundary[i-1], MAX_BYTES);
         if ((i < 4 && retval == 3) || (i > 3 && retval == 4))
-          printf("2.3.%d: U-%08x\n", i, wchar);
+          printf("2.3.%d: U-%08lx\n", i, (long) wchar);
         else
           printf("2.3.%d: Invalid\n", i);
       }
@@ -188,13 +188,13 @@ int main()
     /* 3.1  Unexpected continuation bytes */
     retval = mbtowc (&wchar, continuation_bytes[0], MAX_BYTES);
     if (retval == 1)
-      printf("3.1.1: U-%08x\n", wchar);
+      printf("3.1.1: U-%08lx\n", (long) wchar);
     else
       printf("3.1.1: 1 Invalid\n");
 
     retval = mbtowc (&wchar, continuation_bytes[1], MAX_BYTES);
     if (retval == 1)
-      printf("3.1.2: U-%08x\n", wchar);
+      printf("3.1.2: U-%08lx\n", (long) wchar);
     else
       printf("3.1.2: 1 Invalid\n");
 

--- a/newlib/testsuite/newlib.locale/meson.build
+++ b/newlib/testsuite/newlib.locale/meson.build
@@ -33,18 +33,46 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-cygwin_tests = ['UTF-8']
-
 tests = []
 
-foreach test : tests
-  src = test + '.c'
-  test(test,
-       executable(test, src,
-		  c_args: ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + test_c_args,
-		  link_args: test_link_args,
-		  link_with: [lib_c, lib_semihost, lib_crt],
-		  include_directories: inc),
-       depends: bios_bin,
-       env: test_env)
+mb_tests = ['UTF-8']
+
+if newlib_mb
+  tests += mb_tests
+endif
+
+foreach target : targets
+  value = get_variable('target_' + target)
+
+  _libs = [get_variable('lib_c' + target)]
+  if is_variable('lib_semihost' + target)
+    _libs += [get_variable('lib_semihost' + target)]
+  endif
+  if is_variable('crt0_hosted' + target)
+    _objs = [get_variable('crt0_hosted'+ target)]
+  else
+    _objs = []
+  endif
+  
+  _c_args = value[1] + test_c_args
+  _link_args = value[1] + test_link_args
+
+  foreach test : tests
+    if target == ''
+      test_name = test
+    else
+      test_name = test + '_' + target
+    endif
+
+    src = test + '.c'
+    test(test_name,
+	 executable(test_name, src,
+		    c_args: ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + _c_args,
+		    link_args: _link_args,
+		    objects: _objs,
+		    link_with: _libs,
+		    include_directories: inc),
+	 depends: bios_bin,
+	 env: test_env)
+  endforeach
 endforeach

--- a/newlib/testsuite/newlib.search/meson.build
+++ b/newlib/testsuite/newlib.search/meson.build
@@ -42,8 +42,10 @@ foreach target : targets
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]
   endif
-  if is_variable('lib_crt_hosted' + target)
-    _libs += [get_variable('lib_crt_hosted'+ target)]
+  if is_variable('crt0_hosted' + target)
+    _objs = [get_variable('crt0_hosted'+ target)]
+  else
+    _objs = []
   endif
   
   _c_args = value[1] + test_c_args
@@ -62,6 +64,7 @@ foreach target : targets
 	 executable(test_name, src,
 		    c_args: ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + _c_args,
 		    link_args: _link_args,
+		    objects: _objs,
 		    link_with: _libs,
 		    include_directories: test_inc),
          depends: bios_bin,

--- a/newlib/testsuite/newlib.stdio/meson.build
+++ b/newlib/testsuite/newlib.stdio/meson.build
@@ -46,8 +46,10 @@ foreach target : targets
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]
   endif
-  if is_variable('lib_crt_hosted' + target)
-    _libs += [get_variable('lib_crt_hosted'+ target)]
+  if is_variable('crt0_hosted' + target)
+    _objs = [get_variable('crt0_hosted'+ target)]
+  else
+    _objs = []
   endif
   
   _c_args = value[1] + test_c_args
@@ -66,6 +68,7 @@ foreach target : targets
 	 executable(test_name, src,
 		    c_args: ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + _c_args,
 		    link_args: _link_args,
+		    objects: _objs,
 		    link_with: _libs,
 		    include_directories: test_inc),
 	 depends: bios_bin,

--- a/newlib/testsuite/newlib.stdlib/meson.build
+++ b/newlib/testsuite/newlib.stdlib/meson.build
@@ -42,8 +42,10 @@ foreach target : targets
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]
   endif
-  if is_variable('lib_crt_hosted' + target)
-    _libs += [get_variable('lib_crt_hosted'+ target)]
+  if is_variable('crt0_hosted' + target)
+    _objs = [get_variable('crt0_hosted'+ target)]
+  else
+    _objs = []
   endif
   
   _c_args = value[1] + test_c_args
@@ -62,6 +64,7 @@ foreach target : targets
 	 executable(test_name, src,
 		    c_args: ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + _c_args,
 		    link_args: _link_args,
+		    objects: _objs,
 		    link_with: _libs,
 		    include_directories: test_inc),
          depends: bios_bin,

--- a/newlib/testsuite/newlib.string/meson.build
+++ b/newlib/testsuite/newlib.string/meson.build
@@ -42,8 +42,10 @@ foreach target : targets
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]
   endif
-  if is_variable('lib_crt_hosted' + target)
-    _libs += [get_variable('lib_crt_hosted'+ target)]
+  if is_variable('crt0_hosted' + target)
+    _objs = [get_variable('crt0_hosted'+ target)]
+  else
+    _objs = []
   endif
   
   _c_args = value[1] + test_c_args
@@ -62,6 +64,7 @@ foreach target : targets
 	 executable(test_name, [src],
 		    c_args: ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + _c_args,
 		    link_args: _link_args,
+		    objects: _objs,
 		    link_with: _libs,
 		    include_directories: test_inc),
          depends: bios_bin,

--- a/newlib/testsuite/newlib.time/meson.build
+++ b/newlib/testsuite/newlib.time/meson.build
@@ -42,8 +42,10 @@ foreach target : targets
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]
   endif
-  if is_variable('lib_crt_hosted' + target)
-    _libs += [get_variable('lib_crt_hosted'+ target)]
+  if is_variable('crt0_hosted' + target)
+    _objs = [get_variable('crt0_hosted'+ target)]
+  else
+    _objs = []
   endif
   
   _c_args = value[1] + test_c_args
@@ -62,6 +64,7 @@ foreach target : targets
 	 executable(test_name, [src],
 		    c_args: ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + _c_args,
 		    link_args: _link_args,
+		    objects: _objs,
 		    link_with: _libs,
 		    include_directories: test_inc),
          depends: bios_bin,

--- a/newlib/testsuite/newlib.wctype/meson.build
+++ b/newlib/testsuite/newlib.wctype/meson.build
@@ -44,8 +44,10 @@ foreach target : targets
   if is_variable('lib_semihost' + target)
     _libs += [get_variable('lib_semihost' + target)]
   endif
-  if is_variable('lib_crt_hosted' + target)
-    _libs += [get_variable('lib_crt_hosted'+ target)]
+  if is_variable('crt0_hosted' + target)
+    _objs = [get_variable('crt0_hosted'+ target)]
+  else
+    _objs = []
   endif
   
   _c_args = value[1] + test_c_args
@@ -64,6 +66,7 @@ foreach target : targets
 	 executable(test_name, src,
 		    c_args: ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + _c_args,
 		    link_args: _link_args,
+		    objects: _objs,
 		    link_with: _libs,
 		    include_directories: test_inc),
          depends: bios_bin,

--- a/picocrt/meson.build
+++ b/picocrt/meson.build
@@ -64,89 +64,70 @@ foreach target : targets
     crt_hosted_name = 'crt0-hosted.o'
     crt_minimal_name = 'crt0-minimal.o'
     crt_semihost_name = 'crt0-semihost.o'
-    libcrt_name = 'crt'
-    libcrt_hosted_name = 'crt-hosted'
-    libcrt_minimal_name = 'crt-minimal'
-    libcrt_semihost_name = 'crt-semihost'
   else
     crt_name = join_paths(target, 'crt0.o')
     crt_hosted_name = join_paths(target, 'crt0-hosted.o')
     crt_minimal_name = join_paths(target, 'crt0-minimal.o')
     crt_semihost_name = join_paths(target, 'crt0-semihost.o')
-    libcrt_name = join_paths(target, 'libcrt')
-    libcrt_hosted_name = join_paths(target, 'libcrt-hosted')
-    libcrt_minimal_name = join_paths(target, 'libcrt-minimal')
-    libcrt_semihost_name = join_paths(target, 'libcrt-semihost')
   endif
 
-  # The normal variant does not call 'exit' after return from main (c lingo: freestanding execution environment)
-  executable(crt_name,
-	     src_picocrt,
-	     include_directories : inc,
-	     install : true,
-	     install_dir : instdir,
-	     c_args : value[1] + arg_fnobuiltin + ['-ffreestanding'],
-	     link_args : value[1] + ['-r', '-ffreestanding'])
+  crt0_name = 'crt0' + target
+  crt0_hosted_name = 'crt0_hosted' + target
+  crt0_minimal_name = 'crt0_minimal' + target
+  crt0_semihost_name = 'crt0_semihost' + target
 
-  # Tests link against this because using the .o isn't supported under meson
-  set_variable('lib_crt' + target,
-	       static_library(libcrt_name,
-			      src_picocrt,
-			      install : false,
-			      include_directories : inc,
-			      c_args : value[1]))
+  # The normal variant does not call 'exit' after return from main (c lingo: freestanding execution environment)
+  _crt = executable(crt_name,
+		    src_picocrt,
+		    include_directories : inc,
+		    install : true,
+		    install_dir : instdir,
+		    c_args : value[1] + arg_fnobuiltin + ['-ffreestanding'],
+		    link_args : value[1] + ['-r', '-ffreestanding'])
+
+  set_variable(crt0_name,
+	       _crt.extract_objects(src_picocrt)
+	      )
 
   # The 'hosted' variant calls 'exit' after return from main (c lingo: hosted execution environment)
-  executable(crt_hosted_name,
-             src_picocrt,
-             include_directories : inc,
-             install : true,
-             install_dir : instdir,
-             c_args : value[1] + arg_fnobuiltin + ['-ffreestanding', '-DCRT0_EXIT'],
-             link_args : value[1] + ['-r', '-ffreestanding'])
+  _crt = executable(crt_hosted_name,
+		    src_picocrt,
+		    include_directories : inc,
+		    install : true,
+		    install_dir : instdir,
+		    c_args : value[1] + arg_fnobuiltin + ['-ffreestanding', '-DCRT0_EXIT'],
+		    link_args : value[1] + ['-r', '-ffreestanding'])
 
-  # Tests link against this because using the .o isn't supported under meson
-  set_variable('lib_crt_hosted' + target,
-	       static_library(libcrt_hosted_name,
-			      src_picocrt,
-			      install : false,
-			      include_directories : inc,
-			      c_args : value[1] + ['-DCRT0_EXIT']))
+  set_variable(crt0_hosted_name,
+	       _crt.extract_objects(src_picocrt)
+	      )
 
   # The 'minimal' variant doesn't call exit, nor does it invoke any constructors
-  executable(crt_minimal_name,
-             src_picocrt,
-             include_directories : inc,
-             install : true,
-             install_dir : instdir,
-             c_args : value[1] + arg_fnobuiltin + ['-ffreestanding', '-DCONSTRUCTORS=0'],
-             link_args : value[1] + ['-r', '-ffreestanding'])
+  _crt = executable(crt_minimal_name,
+		    src_picocrt,
+		    include_directories : inc,
+		    install : true,
+		    install_dir : instdir,
+		    c_args : value[1] + arg_fnobuiltin + ['-ffreestanding', '-DCONSTRUCTORS=0'],
+		    link_args : value[1] + ['-r', '-ffreestanding'])
 
-  # Tests link against this because using the .o isn't supported under meson
-  set_variable('lib_crt_minimal' + target,
-	       static_library(libcrt_minimal_name,
-			      src_picocrt,
-			      install : false,
-			      include_directories : inc,
-			      c_args : value[1] + ['-DCONSTRUCTORS=0']))
+  set_variable(crt0_minimal_name,
+	       _crt.extract_objects(src_picocrt)
+	      )
 
   if has_arm_semihost
     # The 'semihost' variant calls sys_semihost_get_cmdline to build argv
     # and calls exit when main returns
-    executable(crt_semihost_name,
-               src_picocrt,
-               include_directories : inc,
-               install : true,
-               install_dir : instdir,
-               c_args : value[1] + arg_fnobuiltin + ['-ffreestanding', '-DCRT0_EXIT', '-DCRT0_SEMIHOST'],
-               link_args : value[1] + ['-r', '-ffreestanding'])
+    _crt = executable(crt_semihost_name,
+		      src_picocrt,
+		      include_directories : inc,
+		      install : true,
+		      install_dir : instdir,
+		      c_args : value[1] + arg_fnobuiltin + ['-ffreestanding', '-DCRT0_EXIT', '-DCRT0_SEMIHOST'],
+		      link_args : value[1] + ['-r', '-ffreestanding'])
 
-    # Tests link against this because using the .o isn't supported under meson
-    set_variable('lib_crt_semihost' + target,
-		 static_library(libcrt_semihost_name,
-				src_picocrt,
-				install : false,
-				include_directories : inc,
-				c_args : value[1] + ['-DCRT0_EXIT', '-DCRT0_SEMIHOST']))
+    set_variable(crt0_semihost_name,
+		 _crt.extract_objects(src_picocrt)
+		)
   endif
 endforeach

--- a/test/libc-testsuite/meson.build
+++ b/test/libc-testsuite/meson.build
@@ -35,22 +35,15 @@
 foreach target : targets
   value = get_variable('target_' + target)
 
-  _libs_base = [get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c' + target)]
   if is_variable('lib_semihost' + target)
-    _libs_base += [get_variable('lib_semihost' + target)]
+    _libs += [get_variable('lib_semihost' + target)]
   endif
 
-  if is_variable('lib_crt_hosted' + target)
-    _libs = [get_variable('lib_crt_hosted'+ target)] + _libs_base
+  if is_variable('crt0_hosted' + target)
+    _objs = [get_variable('crt0_hosted'+ target)]
   else
-    _libs = _libs_base
-  endif
-
-  have_crt_minimal = is_variable('lib_crt_minimal' + target)
-  if have_crt_minimal
-    _libs_minimal = [get_variable('lib_crt_minimal'+ target)] + _libs_base
-  else
-    _libs_minimal = _libs_base
+    _objs = []
   endif
 
   _c_args = value[1] + test_c_args
@@ -89,6 +82,7 @@ foreach target : targets
 	 executable(t1_name, [t1_src],
 		    c_args: double_printf_compile_args + _c_args,
 		    link_args: double_printf_link_args + _link_args,
+		    objects: _objs,
 		    link_with: _libs,
 		    link_depends:  test_link_depends,
 		    include_directories: inc),

--- a/test/meson.build
+++ b/test/meson.build
@@ -35,24 +35,24 @@
 foreach target : targets
   value = get_variable('target_' + target)
 
-  _libs_base = [get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c' + target)]
   if is_variable('lib_semihost' + target)
-    _libs_base += [get_variable('lib_semihost' + target)]
+    _libs += [get_variable('lib_semihost' + target)]
   endif
 
-  if is_variable('lib_crt_semihost' + target)
-    _libs = [get_variable('lib_crt_semihost'+ target)] + _libs_base
-  elif is_variable('lib_crt_hosted' + target)
-    _libs = [get_variable('lib_crt_hosted'+ target)] + _libs_base
+  if is_variable('crt0_semihost' + target)
+    _objs = [get_variable('crt0_semihost'+ target)]
+  elif is_variable('crt0_hosted' + target)
+    _objs = [get_variable('crt0_hosted'+ target)]
   else
-    _libs = _libs_base
+    _objs = []
   endif
 
-  have_crt_minimal = is_variable('lib_crt_minimal' + target)
+  have_crt_minimal = is_variable('crt0_minimal' + target)
   if have_crt_minimal
-    _libs_minimal = [get_variable('lib_crt_minimal'+ target)] + _libs_base
+    _objs_minimal = [get_variable('crt0_minimal'+ target)]
   else
-    _libs_minimal = _libs_base
+    _objs_minimal = _objs
   endif
 
   _c_args = value[1] + test_c_args
@@ -69,6 +69,7 @@ foreach target : targets
        executable(t1_name, ['printf_scanf.c', 'lock-valid.c'],
 		  c_args: double_printf_compile_args + _c_args,
 		  link_args: double_printf_link_args + _link_args,
+		  objects: _objs,
 		  link_with: _libs,
 		  link_depends:  test_link_depends,
 		  include_directories: inc),
@@ -86,6 +87,7 @@ foreach target : targets
        executable(t1_name, ['printf_scanf.c', 'lock-valid.c'],
 		  c_args: float_printf_compile_args + _c_args,
 		  link_args: float_printf_link_args + _link_args,
+		  objects: _objs,
 		  link_with: _libs,
 		  link_depends:  test_link_depends,
 		  include_directories: inc),
@@ -103,6 +105,7 @@ foreach target : targets
        executable(t1_name, ['printf-tests.c', 'lock-valid.c'],
 		  c_args: double_printf_compile_args + _c_args,
 		  link_args: double_printf_link_args + _link_args,
+		  objects: _objs,
 		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
@@ -119,6 +122,7 @@ foreach target : targets
        executable(t1_name, ['printf-tests.c', 'lock-valid.c'],
 		  c_args: float_printf_compile_args + _c_args,
 		  link_args: float_printf_link_args + _link_args,
+		  objects: _objs,
 		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
@@ -135,6 +139,7 @@ foreach target : targets
        executable(t1_name, ['printf-tests.c', 'lock-valid.c'],
 		  c_args: int_printf_compile_args + _c_args,
 		  link_args: int_printf_link_args + _link_args,
+		  objects: _objs,
 		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
@@ -158,6 +163,7 @@ foreach target : targets
        executable(t1_name, ['time-sprintf.c', 'lock-valid.c'],
 		  c_args: int_printf_compile_args + _c_args + ['-fno-builtin'],
 		  link_args: int_printf_link_args + _link_args,
+		  objects: _objs,
 		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
@@ -174,6 +180,7 @@ foreach target : targets
        executable(t1_name, ['try-ilp32.c', 'try-ilp32-sub.c', 'lock-valid.c'],
 		  c_args: _c_args,
 		  link_args: _link_args,
+		  objects: _objs,
 		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
@@ -190,6 +197,7 @@ foreach target : targets
        executable(t1_name, ['hosted-exit.c', 'lock-valid.c'],
 		  c_args: _c_args,
 		  link_args:  _link_args,
+		  objects: _objs,
 		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
@@ -199,6 +207,7 @@ foreach target : targets
        executable(t1_name + '-fail', ['hosted-exit.c', 'lock-valid.c'],
 		  c_args: _c_args + ['-DRETVAL=1'],
 		  link_args:  _link_args,
+		  objects: _objs,
 		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
@@ -217,6 +226,7 @@ foreach target : targets
        executable(t1_name, ['abort.c', 'lock-valid.c'],
 		  c_args: _c_args,
 		  link_args:  _link_args,
+		  objects: _objs,
 		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
@@ -236,7 +246,8 @@ foreach target : targets
 	 executable(t1_name, ['constructor-skip.c', 'lock-valid.c'],
 		    c_args: _c_args,
 		    link_args:  _link_args,
-		    link_with: _libs_minimal,
+		    objects: _objs_minimal,
+		    link_with: _libs,
 		    include_directories: inc),
          depends: bios_bin,
 	 env: test_env)
@@ -253,6 +264,7 @@ foreach target : targets
        executable(t1_name, ['math_errhandling.c'],
 		  c_args: arg_fnobuiltin + _c_args,
 		  link_args: _link_args,
+		  objects: _objs,
 		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
@@ -269,6 +281,7 @@ foreach target : targets
        executable(t1_name, ['rounding-mode.c', 'rounding-mode-sub.c'],
 		  c_args: arg_fnobuiltin + _c_args,
 		  link_args: _link_args,
+		  objects: _objs,
 		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
@@ -286,6 +299,7 @@ foreach target : targets
        executable(t1_name, [t1_src, 'lock-valid.c'],
 		  c_args: double_printf_compile_args + arg_fnobuiltin + _c_args,
 		  link_args: double_printf_link_args + _link_args,
+		  objects: _objs,
 		  link_with: _libs,
 		  link_depends:  test_link_depends,
 		  include_directories: inc),
@@ -306,6 +320,7 @@ foreach target : targets
        executable(t1_name, t1_src,
 		  c_args: double_printf_compile_args + _c_args,
 		  link_args: double_printf_link_args + _link_args,
+		  objects: _objs,
 		  link_with: _libs,
 		  link_depends:  test_link_depends,
 		  include_directories: inc),
@@ -359,6 +374,7 @@ foreach target : targets
 	 executable(t1_name, [t1_src, 'lock-valid.c'],
 		    c_args: double_printf_compile_args + _c_args,
 		    link_args: double_printf_link_args + _link_args,
+		    objects: _objs,
 		    link_with: _libs,
 		    link_depends:  test_link_depends,
 		    include_directories: inc),

--- a/test/semihost/meson.build
+++ b/test/semihost/meson.build
@@ -77,10 +77,12 @@ foreach target : targets
 
   _libs = [get_variable('lib_c' + target)]
   _libs += [get_variable('lib_semihost' + target)]
-  if is_variable('lib_crt_semihost' + target)
-    _libs += [get_variable('lib_crt_semihost'+ target)]
-  elif is_variable('lib_crt_hosted' + target)
-    _libs += [get_variable('lib_crt_hosted'+ target)]
+  if is_variable('crt0_semihost' + target)
+    _objs = [get_variable('crt0_semihost'+ target)]
+  elif is_variable('crt0_hosted' + target)
+    _objs = [get_variable('crt0_hosted'+ target)]
+  else
+    _objs = []
   endif
   
   _c_args = value[1] + test_c_args + ['-DCOMMAND_LINE="' + command_line + '"']
@@ -99,6 +101,7 @@ foreach target : targets
 	 executable(semihost_test_name, [semihost_test_src],
 		    c_args: _c_args,
 		    link_args: double_printf_link_args + _link_args,
+		    objects: _objs,
 		    link_with: _libs,
 		    link_depends:  test_link_depends,
 		    include_directories: inc),
@@ -119,6 +122,7 @@ foreach target : targets
 	 executable(semihost_fail_test_name, [semihost_fail_test_src],
 		    c_args: _c_args,
 		    link_args: _link_args,
+		    objects: _objs,
 		    link_with: _libs,
 		    link_depends:  test_link_depends,
 		    include_directories: inc),


### PR DESCRIPTION
Somehow I missed that 'extract_objects' results could be used
in 'executable' and created static libraries for each of the
crt0 variants. Switch to using the relevant object files directly.
    
Signed-off-by: Keith Packard <keithp@keithp.com>