### PR TITLE
assert: consider failed condition unreachable with NDEBUG

### DIFF
--- a/newlib/libc/include/assert.h
+++ b/newlib/libc/include/assert.h
@@ -43,8 +43,8 @@ extern "C" {
 
 #undef assert
 
-#ifdef NDEBUG           /* required by ANSI standard */
-# define assert(__e) ((void)0)
+#ifdef NDEBUG
+# define assert(__e) ((__e) ? (void)0 : __unreachable())
 #else
 # define assert(__e) ((__e) ? (void)0 : __assert_func (__FILE__, __LINE__, \
 						       __ASSERT_FUNC, #__e))

--- a/newlib/libc/posix/regexec.c
+++ b/newlib/libc/posix/regexec.c
@@ -58,9 +58,7 @@ static char sccsid[] = "@(#)regexec.c	8.3 (Berkeley) 3/20/94";
 #include "utils.h"
 #include "regex2.h"
 
-#ifndef NDEBUG
-static int nope = 0;		/* for use in asserts; shuts lint up */
-#endif
+static const int nope = 0;	/* for use in asserts; shuts lint up */
 
 /* macros for manipulating states, small version */
 #define	states	long


### PR DESCRIPTION
When `NDEBUG` is set, asserts are usually removed from the code. But we can do better: With debugging enabled, the `__assert_func()` that is called on the failed condition is marked as noreturn, so the compiler optimizes the remaining code as if the failed condition would never be taken.

By marking the failed condition as `__assert_func()` the compiler is able to do the same optimization with `NDEBUG` set. 