### PR TITLE
machine: add Microblaze support for Zephyr toolchain (32-bit, little-endian)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ at this point only has code to build for the following targets:
  * ARC (32- and 64- bit)
  * ARM (32- and 64- bit)
  * i386 (Native and Linux hosted, for testing)
+ * Microblaze (32-bit, big and little endian)
  * Motorola 68000 (m68k)
  * MIPS
  * MSP430

--- a/meson.build
+++ b/meson.build
@@ -93,6 +93,8 @@ cpu_family_aliases = {
 		       'fido' : 'm68k',
 		       # m88k
 		       'm88110' : 'm88k',
+		       # Microblaze
+		       'microblazeel' : 'microblaze',
 		       # or1k
 		       'or1knd': 'or1k',
 		       # powerpc

--- a/newlib/libc/machine/microblaze/CMakeLists.txt
+++ b/newlib/libc/machine/microblaze/CMakeLists.txt
@@ -1,0 +1,47 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2023 Advanced Micro Devices, Inc. (AMD)
+# Copyright © 2023 Alp Sayin
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+add_subdirectory(sys)
+add_subdirectory(machine)
+
+picolibc_sources_flags("-fno-builtin"
+  abort.c
+  longjmp.S
+  setjmp.S
+  strcmp.S
+  strcpy.c
+  strlen.c
+  )

--- a/newlib/libc/machine/microblaze/abort.c
+++ b/newlib/libc/machine/microblaze/abort.c
@@ -88,3 +88,4 @@ abort (void)
       exit(1);
     }
 }
+#endif

--- a/newlib/libc/machine/microblaze/meson.build
+++ b/newlib/libc/machine/microblaze/meson.build
@@ -1,0 +1,46 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2023 Advanced Micro Devices, Inc. (AMD)
+# Copyright © 2023 Alp Sayin
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+srcs_machine = [
+  'abort.c',
+  'longjmp.S',
+  'setjmp.S',
+  'strcmp.c',
+  'strcpy.c',
+  'strlen.c',
+]
+
+src_machine = files(srcs_machine)

--- a/newlib/libc/machine/microblaze/strcpy.c
+++ b/newlib/libc/machine/microblaze/strcpy.c
@@ -90,7 +90,7 @@ strcpy (char *__restrict dst0,
 #if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
   char *s = dst0;
 
-  while (*dst0++ = *src0++)
+  while ((*dst0++ = *src0++))
     ;
 
   return s;

--- a/scripts/cross-microblazeel-zephyr-elf.txt
+++ b/scripts/cross-microblazeel-zephyr-elf.txt
@@ -1,0 +1,20 @@
+[binaries]
+# Meson 0.53.2 doesn't use any cflags when doing basic compiler tests,
+# so we have to add -nostdlib to the compiler configuration itself or
+# early compiler tests will fail. This can be removed when picolibc
+# requires at least version 0.54.2 of meson.
+c = ['microblazeel-zephyr-elf-gcc', '-nostdlib']
+ar = 'microblazeel-zephyr-elf-ar'
+as = 'microblazeel-zephyr-elf-as'
+ld = 'microblazeel-zephyr-elf-ld'
+nm = 'microblazeel-zephyr-elf-nm'
+strip = 'microblazeel-zephyr-elf-strip'
+
+[host_machine]
+system = 'zephyr'
+cpu_family = 'microblaze'
+cpu = 'microblazeel'
+endian = 'little'
+
+[properties]
+skip_sanity_check = true

--- a/scripts/do-microblazeel-configure
+++ b/scripts/do-microblazeel-configure
@@ -1,0 +1,42 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2023 Advanced Micro Devices, Inc. (AMD)
+# Copyright © 2023 Alp Sayin
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+exec "$(dirname "$0")"/do-configure microblazeel-zephyr-elf \
+  -Dtests-enable-stack-protector=false \
+  -Dfake-semihost=true \
+  -Datomic-ungetc=false \
+  -Dtests=true \
+  "$@"

--- a/scripts/test-microblaze.ld
+++ b/scripts/test-microblaze.ld
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2023 Advanced Micro Devices, Inc. (AMD)
+ * Copyright © 2023 Alp Sayin
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+__flash =      0x00000000;
+__flash_size = 0x08000000;
+__ram =        0x08000000;
+__ram_size   = 0x10000000;
+__stack_size = 4k;


### PR DESCRIPTION
Utilises the existing sources. Forked off of `zephyr`'s `picolibc` mirror to be able to collect consistent results from its CI.

Helps meson pick the `microblaze` cpu family from `microblazeel` tool.
`do-microblazeel-configure` then picks `cross-microblazeel-zephyr-elf.txt`
`zephyr` only supports `little-endian` so far _(last I checked)_, thus I never bothered to make Zephyr `sdk-ng` produce a big-endian toolchain. Hence no picolibc support for `microblaze-zephyr-elf` (big-endian is default).

No QEMU test set because QEMU invokation would need a `-hw-dtb` file such as 
https://github.com/zephyrproject-rtos/zephyr/blob/713b955801c44aadf2e66ed972b83da8ca03d837/boards/microblaze/qemu_microblaze/board-qemu-microblaze-demo.dtb

But @keith-packard and I agree that, that's the next step. Let's see with this PR first if it builds.

Future work?
1. Vitis shipped `microblaze-xilinx-elf` toolchain support?

EDIT/Update: it seems there is no CI here.
EDIT/Update2: Of course there isn't. I'll open a draft PR in `sdk-ng` as usual.
EDIT/Update3: Future work.