### PR TITLE
Fix atomic use in ungetc, test atomics everywhere

### DIFF
--- a/newlib/libc/tinystdio/stdio_private.h
+++ b/newlib/libc/tinystdio/stdio_private.h
@@ -485,8 +485,9 @@ static inline bool
 __atomic_compare_exchange_ungetc(__ungetc_t *p, __ungetc_t d, __ungetc_t v)
 {
 	_Atomic __ungetc_t *pa = (_Atomic __ungetc_t *) p;
-	return atomic_compare_exchange_weak(pa, &d, v);
+        return atomic_compare_exchange_strong(pa, &d, v);
 }
+
 static inline __ungetc_t
 __atomic_exchange_ungetc(__ungetc_t *p, __ungetc_t v)
 {

--- a/test/meson.build
+++ b/test/meson.build
@@ -334,7 +334,7 @@ foreach target : targets
 		 'math-funcs', 'timegm', 'time-tests',
                  'test-strtod', 'test-strchr',
 		 'test-memset', 'test-put',
-		 'test-efcvt',
+		 'test-efcvt', 'test-atomic',
 		]
 
   if have_attr_ctor_dtor
@@ -424,6 +424,11 @@ if enable_native_tests
 		    c_args: native_c_args,
 		    dependencies: native_lib_m))
   endif
+
+  test('test-atomic-native',
+       executable('test-atomic-native', 'test-atomic.c',
+		  c_args: native_c_args))
+
 endif
 
 subdir('libc-testsuite')

--- a/test/test-atomic.c
+++ b/test/test-atomic.c
@@ -1,0 +1,56 @@
+#include <stdatomic.h>
+#include <inttypes.h>
+#include <stdio.h>
+
+#ifdef __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4
+_Atomic uint32_t    atomic_4;
+#endif
+#ifdef __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2
+_Atomic uint16_t    atomic_2;
+#endif
+
+int
+main(void)
+{
+    int ret = 0;
+#ifdef __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4
+    uint32_t    zero_4 = 0;
+    if (atomic_compare_exchange_strong(&atomic_4, &zero_4, 1)) {
+        printf("atomic_compare_exchange 4 worked, value %" PRIu32 " zero %" PRIu32 "\n",
+               atomic_4, zero_4);
+        uint32_t        old;
+        old = atomic_exchange_explicit(&atomic_4, 0, memory_order_relaxed);
+        if (atomic_4 == 0 && old == 1) {
+            printf("atomic_exchange_explicit 4 worked %" PRIu32 " value now %" PRIu32 "\n",
+                   old, atomic_4);
+        } else {
+            printf("atomic_exchange_explicit failed %" PRIu32 " value now %" PRIu32 "\n",
+                   old, atomic_4);
+            ret = 1;
+        }
+    } else {
+        printf("atomic_compare_exchange 4 failed, value %" PRIu32 "\n", atomic_4);
+        ret = 1;
+    }
+#endif
+#ifdef __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2
+    uint16_t zero_2 = 0;
+    if (atomic_compare_exchange_strong(&atomic_2, &zero_2, 1)) {
+        printf("atomic_compare_exchange 2 worked, value %" PRIu16 " zero %" PRIu16 "\n", atomic_2, zero_2);
+        uint16_t        old;
+        old = atomic_exchange_explicit(&atomic_2, 0, memory_order_relaxed);
+        if (atomic_2 == 0 && old == 1) {
+            printf("atomic_exchange_explicit 2 worked %" PRIu16 " value now %" PRIu16 "\n",
+                   old, atomic_2);
+        } else {
+            printf("atomic_exchange_explicit 2 failed %" PRIu16 " value now %" PRIu16 "\n",
+                   old, atomic_2);
+            ret = 1;
+        }
+    } else {
+        printf("atomic_compare_exchange 2 failed, value %" PRIu16 "\n", atomic_2);
+        ret = 1;
+    }
+#endif
+    return ret;
+}


### PR DESCRIPTION
I finally found docs on what _weak vs _strong means, and _weak is not what we need for ungetc -- that allows the operation to transiently fail, assuming it would be used in a loop of some sort.

And, add a test for atomics to at least make sure they work correctly in a trivial test.