### PR TITLE
stdio: remove struct _reent in macro

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -92,7 +92,8 @@ jobs:
           "-Dformat-default=integer -Dfreestanding=true",
 
           # Original stdio
-          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true",
+          "-Dtinystdio=false",
+          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true -Dnewlib-fvwrite-in-streamio=true",
 
           # Locale, iconv, original malloc and original atexit/onexit configurations
           "-Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",
@@ -142,7 +143,8 @@ jobs:
           "-Dformat-default=integer -Dfreestanding=true",
 
           # Original stdio
-          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true",
+          "-Dtinystdio=false",
+          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true -Dnewlib-fvwrite-in-streamio=true",
 
           # Locale, iconv, original malloc and original atexit/onexit configurations
           "-Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",
@@ -192,7 +194,8 @@ jobs:
           "-Dformat-default=integer -Dfreestanding=true",
 
           # Original stdio
-          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true",
+          "-Dtinystdio=false",
+          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true -Dnewlib-fvwrite-in-streamio=true",
 
           # Locale, iconv, original malloc and original atexit/onexit configurations
           "-Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",

--- a/.github/workflows/variants
+++ b/.github/workflows/variants
@@ -14,7 +14,8 @@
           "-Dformat-default=integer -Dfreestanding=true",
 
           # Original stdio
-          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true",
+          "-Dtinystdio=false",
+          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true -Dnewlib-fvwrite-in-streamio=true",
 
           # Locale, iconv, original malloc and original atexit/onexit configurations
           "-Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",

--- a/newlib/libc/stdio/vfprintf.c
+++ b/newlib/libc/stdio/vfprintf.c
@@ -720,7 +720,7 @@ VFPRINTF (
 	uio.uio_resid += (len); \
 	iovp++; \
 	if (++uio.uio_iovcnt >= NIOV) { \
-		if (__SPRINT(data, fp, &uio)) \
+		if (__SPRINT(fp, &uio)) \
 			goto error; \
 		iovp = iov; \
 	} \
@@ -743,7 +743,7 @@ VFPRINTF (
 	PAD((len) - (n > 0 ? n : 0), (with)); \
 }
 #define	FLUSH() { \
-	if (uio.uio_resid && __SPRINT(data, fp, &uio)) \
+	if (uio.uio_resid && __SPRINT(fp, &uio)) \
 		goto error; \
 	uio.uio_iovcnt = 0; \
 	iovp = iov; \

--- a/newlib/libc/stdio/vfwprintf.c
+++ b/newlib/libc/stdio/vfwprintf.c
@@ -454,7 +454,7 @@ VFWPRINTF (
 	uio.uio_resid += (len) * sizeof (wchar_t); \
 	iovp++; \
 	if (++uio.uio_iovcnt >= NIOV) { \
-		if (__SPRINT(data, fp, &uio)) \
+		if (__SPRINT(fp, &uio)) \
 			goto error; \
 		iovp = iov; \
 	} \
@@ -477,7 +477,7 @@ VFWPRINTF (
 	PAD((len) - (n > 0 ? n : 0), (with)); \
 }
 #define	FLUSH() { \
-	if (uio.uio_resid && __SPRINT(data, fp, &uio)) \
+	if (uio.uio_resid && __SPRINT(fp, &uio)) \
 		goto error; \
 	uio.uio_iovcnt = 0; \
 	iovp = iov; \


### PR DESCRIPTION
Encounter error when use "-Dnewlib-fvwrite-in-streamio=true" option.