### PR TITLE
Re-enable xtensa debug

### DIFF
--- a/.github/packages.txt
+++ b/.github/packages.txt
@@ -21,5 +21,5 @@ qemu-system-x86
 qemu-system-arm
 qemu-system-misc
 qemu-system-ppc64
-clang
 lld
+clang

--- a/scripts/do-lx106-configure
+++ b/scripts/do-lx106-configure
@@ -33,4 +33,4 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-exec "$(dirname "$0")"/do-configure xtensa-lx106-elf "$@" -Ddebug=false
+exec "$(dirname "$0")"/do-configure xtensa-lx106-elf "$@"


### PR DESCRIPTION
The fix for https://bugs.debian.org/1032564 has landed in debian testing, so we can re-enable -Ddebug=true for
xtensa-lx106.