### PR TITLE
ld80: Fix several powl(x, oddint) cases

### DIFF
--- a/newlib/libm/ld/ld80/e_powl.c
+++ b/newlib/libm/ld/ld80/e_powl.c
@@ -206,9 +206,12 @@ w = floorl(y);
 /* Set iyflg to 1 if y is an integer.  */
 iyflg = (w == y);
 
-/* Test for odd integer y.  */
+/* flag = 1 if x is negative */
+nflg = signbit(x);
+
+/* Test for odd integer y and negative x (including negative zero)  */
 yoddint = 0;
-if( iyflg )
+if( iyflg && nflg )
 	{
         ya = ldexpl(y, -1);
         yoddint = (ya != floorl(ya));
@@ -216,7 +219,7 @@ if( iyflg )
 
 if( x == 0.0L) {
         if( y < 0 )
-                return __math_divzerol(__signbitl(x) && yoddint);
+                return __math_divzerol(yoddint);
 }
 
 if( isnanl(x) )
@@ -291,20 +294,19 @@ if( x <= -LDBL_MAX )
 	}
 
 
-nflg = 0;	/* flag = 1 if x<0 raised to integer power */
 if( x <= 0.0L )
 	{
 	if( x == 0.0L )
 		{
 		if( y < 0.0L )
 			{
-			if( signbit(x) && yoddint )
+                        if( yoddint )
 				return( -(long double)INFINITY );
 			return( (long double)INFINITY );
 			}
 		if( y > 0.0L )
 			{
-			if( signbit(x) && yoddint )
+			if( yoddint )
 				return( -0.0L );
 			return( 0.0L );
 			}
@@ -317,7 +319,6 @@ if( x <= 0.0L )
 		{
 		if( iyflg == 0 )
                         return __math_invalidl(x); /* (x<0)**(non-int) is NaN */
-		nflg = 1;
 		}
 	}
 
@@ -325,7 +326,6 @@ if( x <= 0.0L )
 
 if( iyflg )
 	{
-	i = w;
 	w = floorl(x);
 	if( (w == x) && (fabsl(y) < 32768.0L) )
 		{
@@ -416,10 +416,10 @@ w = ldexpl( Ga+Ha, LNXT );
 
 /* Test the power of 2 for overflow */
 if( w > MEXP )
-	return __math_oflowl(0);		/* overflow */
+	return __math_oflowl(yoddint);		/* overflow */
 
 if( w < MNEXP )
-	return __math_uflowl(0);	        /* underflow */
+	return __math_uflowl(yoddint);	        /* underflow */
 
 e = w;
 Hb = H - Ha;

--- a/test/math_errhandling.c
+++ b/test/math_errhandling.c
@@ -162,6 +162,13 @@ e_to_str(int e)
 #define PASTE_LDBL(exp) _PASTE_LDBL(exp)
 
 #define BIG PASTE_LDBL(__LDBL_MAX_EXP__)
+#if __LDBL_MANT_DIG__ >= 64
+#define BIGODD  0x1.123456789abcdef2p+63l
+#define BIGEVEN 0x1.123456789abcdef0p+63l
+#else
+#define BIGODD  0x1.123456789abcdp+52
+#define BIGEVEN 0x1.123456789abccp+52
+#endif
 #define SMALL __LDBL_DENORM_MIN__
 #define FLOAT_T long double
 #define MIN_VAL __LDBL_DENORM_MIN__
@@ -177,6 +184,8 @@ e_to_str(int e)
 #include "math_errhandling_tests.c"
 
 #undef BIG
+#undef BIGODD
+#undef BIGEVEN
 #undef SMALL
 #undef MIN_VAL
 #undef MAX_VAL
@@ -201,6 +210,8 @@ e_to_str(int e)
 #define DOUBLE_EXCEPTION_TEST EXCEPTION_TEST
 
 #define BIG 1.7e308
+#define BIGODD  0x1.123456789abcdp+52
+#define BIGEVEN 0x1.123456789abccp+52
 #define SMALL 5e-324
 #define FLOAT_T double
 #define MIN_VAL __DBL_DENORM_MIN__
@@ -217,6 +228,8 @@ e_to_str(int e)
 #include "math_errhandling_tests.c"
 
 #undef BIG
+#undef BIGODD
+#undef BIGEVEN
 #undef SMALL
 #undef MIN_VAL
 #undef MAX_VAL
@@ -232,6 +245,8 @@ e_to_str(int e)
 /* Tests with floats */
 #define EXCEPTION_TEST	MATH_ERREXCEPT
 #define BIG 3e38
+#define BIGODD  0x1.123456p+23
+#define BIGEVEN 0x1.123454p+23
 #define SMALL 1e-45
 #define MIN_VAL 0x8p-152f
 #define MAX_VAL 0xf.fffffp+124f

--- a/test/math_errhandling_tests.c
+++ b/test/math_errhandling_tests.c
@@ -42,6 +42,8 @@ volatile FLOAT_T makemathname(two) = (FLOAT_T) 2.0;
 volatile FLOAT_T makemathname(three) = (FLOAT_T) 3.0;
 volatile FLOAT_T makemathname(half) = (FLOAT_T) 0.5;
 volatile FLOAT_T makemathname(big) = BIG;
+volatile FLOAT_T makemathname(bigodd) = BIGODD;
+volatile FLOAT_T makemathname(bigeven) = BIGEVEN;
 volatile FLOAT_T makemathname(small) = SMALL;
 volatile FLOAT_T makemathname(infval) = (FLOAT_T) INFINITY;
 volatile FLOAT_T makemathname(minfval) = (FLOAT_T) -INFINITY;
@@ -591,6 +593,10 @@ FLOAT_T makemathname(test_pow_0_neghalf)(void) { return makemathname(pow)(makema
 FLOAT_T makemathname(test_pow_neg0_neghalf)(void) { return makemathname(pow)(-makemathname(zero), -makemathname(half)); }
 FLOAT_T makemathname(test_pow_0_neg3)(void) { return makemathname(pow)(makemathname(zero), -makemathname(three)); }
 FLOAT_T makemathname(test_pow_neg0_neg3)(void) { return makemathname(pow)(-makemathname(zero), -makemathname(three)); }
+FLOAT_T makemathname(test_pow_negsmall_negbigodd)(void) { return makemathname(pow)(-makemathname(small), -makemathname(bigodd)); }
+FLOAT_T makemathname(test_pow_negbig_bigodd)(void) { return makemathname(pow)(-makemathname(big), makemathname(bigodd)); }
+FLOAT_T makemathname(test_pow_negsmall_negbigeven)(void) { return makemathname(pow)(-makemathname(small), -makemathname(bigeven)); }
+FLOAT_T makemathname(test_pow_negbig_bigeven)(void) { return makemathname(pow)(-makemathname(big), makemathname(bigeven)); }
 
 #ifndef __PICOLIBC__
 #define pow10(x) exp10(x)
@@ -1091,6 +1097,10 @@ struct {
 	TEST(pow_neg0_neg2, (FLOAT_T)INFINITY, FE_DIVBYZERO, ERANGE),
 	TEST(pow_0_neg3, (FLOAT_T)INFINITY, FE_DIVBYZERO, ERANGE),
 	TEST(pow_neg0_neg3, (FLOAT_T)-INFINITY, FE_DIVBYZERO, ERANGE),
+	TEST(pow_negsmall_negbigodd, (FLOAT_T)-INFINITY, FE_OVERFLOW, ERANGE),
+	TEST(pow_negbig_bigodd, (FLOAT_T)-INFINITY, FE_OVERFLOW, ERANGE),
+	TEST(pow_negsmall_negbigeven, (FLOAT_T)INFINITY, FE_OVERFLOW, ERANGE),
+	TEST(pow_negbig_bigeven, (FLOAT_T)INFINITY, FE_OVERFLOW, ERANGE),
 
 	TEST(pow10_qnan, (FLOAT_T)NAN, 0, 0),
 	TEST(pow10_snan, (FLOAT_T)NAN, FE_INVALID, 0),


### PR DESCRIPTION
Eliminate a spurious exception generated on integer y values due to unnecessary conversion of float to int (i = w), the value of which was ignored. Fixes incorrect exceptions.
    
Make oflow/uflow cases with odd integer powers generate values with correct sign. Fixes incorrect return values.
    
Simplify control flow by making yoddint also depend on x being negative. Cleans up the code.

Also adds tests for these cases.