### PR TITLE
libm: Fix pow for x close to 1, y between 2^31 and 2^64

### DIFF
--- a/newlib/libm/math/s_pow.c
+++ b/newlib/libm/math/s_pow.c
@@ -207,11 +207,11 @@ pow64(__float64 x, __float64 y)
         return __math_invalid(x);
 
     /* |y| is huge */
-    if (iy > 0x41e00000) { /* if |y| > 2**31 */
-        if (iy > 0x43f00000) { /* if |y| > 2**64, must o/uflow */
+    if (iy > 0x42000000) { /* if |y| > ~2**33 */
+        if (iy > 0x43f00000) { /* if |y| > ~2**64, must o/uflow */
             if (ix <= 0x3fefffff)
                 return (hy < 0) ? __math_oflow(0) : __math_uflow(0);
-            if (ix >= 0x3ff00000)
+            else
                 return (hy > 0) ? __math_oflow(0) : __math_uflow(0);
         }
         /* over/underflow if x is not close to one */

--- a/newlib/libm/test/pow_vec.c
+++ b/newlib/libm/test/pow_vec.c
@@ -140,5 +140,9 @@
 /* If x is positive infinity, and y greater than 0, the result is positive infinity. */
 {64, 0,123,__LINE__, 0x7ff00000, 0x00000000, 0x7ff00000, 0x00000000, 0x40100000, 0x00000000 },   /* +inf=f(+inf, 4) */
 
+/* x is close to one and y is large */
+{64, 0,123,__LINE__, 0x792ffffe, 0x0bc9e399, 0x3ff00000, 0x2c5e2e99, 0x41ec9eee, 0x35374af6},
+{64, 0,123,__LINE__, 0x18bfffff, 0xec16bafd, 0x3fefffff, 0xd2e3e669, 0x41f344c9, 0x823eb66c},
+
 {0},};
 void test_pow_vec(int m)   {run_vector_1(m,pow_vec,(char *)(pow),"pow","ddd");   }


### PR DESCRIPTION
E.g. known errors:
    
x = 0x1.000002c5e2e99p+0, y = 0x1.c9eee35374af6p+31 had an error of 639
ULP and is now correctly rounded.
    
x = 0x1.fffffd2e3e669p-1, y = 0x1.344c9823eb66cp+32 had an error of 428
ULP and is now correctly rounded.