### PR TITLE
Define wint_t type for the Arm Compiler

### DIFF
--- a/newlib/libc/include/sys/_types.h
+++ b/newlib/libc/include/sys/_types.h
@@ -50,6 +50,14 @@ SUCH DAMAGE.
 #define __need_size_t
 #define __need_wint_t
 #include <stddef.h>
+
+/* The Arm Compiler doesn't define wint_t as part of stddef.h so
+ * define it here.
+ */
+#if defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6100100)
+typedef __WINT_TYPE__ wint_t;
+#endif
+
 #include <newlib.h>
 #include <sys/config.h>
 #include <machine/_types.h>


### PR DESCRIPTION
The Arm Compiler doesn't define the type wint_t in stddef.h so define it in _types.h based on define __WINT_TYPE__.