### PR TITLE
Cmake fixes

### DIFF
--- a/.github/workflows/variants-cmake
+++ b/.github/workflows/variants-cmake
@@ -4,4 +4,6 @@
       matrix:
         cmake_flags: [
           "",
+          # optional configurations
+          "-D__IO_FLOAT=y -D_IO_FLOAT_EXACT=n -D_WANT_IO_LONG_LONG=y -D_MB_CAPABLE=y -D_WANT_IO_POS_ARGS=y -D__HAVE_LOCALE_INFO__=y -D__HAVE_LOCALE_INFO_EXTENDED__=y ",
         ]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -404,6 +404,10 @@ if(NOT DEFINED __HAVE_LOCALE_INFO_EXTENDED__)
   option(__HAVE_LOCALE_INFO_EXTENDED__ "Provide even more locale support" 0)
 endif()
 
+if(__HAVE_LOCALE_INFO_EXTENDED__ AND NOT __HAVE_LOCALE_INFO__)
+  message(FATAL_ERROR "Must have locale support to enable extended locale support")
+endif()
+
 # Use old math code for double funcs (0 no, 1 yes)
 set(__OBSOLETE_MATH_FLOAT 1)
 

--- a/newlib/libc/posix/CMakeLists.txt
+++ b/newlib/libc/posix/CMakeLists.txt
@@ -42,7 +42,7 @@ picolibc_sources(
   regfree.c
   )
 
-if(__HAVE_LOCALE_INFO)
+if(__HAVE_LOCALE_INFO__)
   picolibc_sources(
     collate.c
     collcmp.c

--- a/newlib/libc/posix/CMakeLists.txt
+++ b/newlib/libc/posix/CMakeLists.txt
@@ -44,7 +44,7 @@ picolibc_sources(
 
 if(__HAVE_LOCALE_INFO)
   picolibc_sources(
-    'collate.c',
-    'collcmp.c',
+    collate.c
+    collcmp.c
     )
 endif()

--- a/newlib/libc/posix/fnmatch.c
+++ b/newlib/libc/posix/fnmatch.c
@@ -206,7 +206,7 @@ rangematch(const char *pattern, char test, int flags, char **newp)
 				c2 = tolower((unsigned char)c2);
 
 			if (
-#ifdef __HAVE_LOCALE_INFO
+#ifdef __HAVE_LOCALE_INFO__
                             __collate_load_error ?
 			    c <= test && test <= c2 :
 			       __collate_range_cmp(c, test) <= 0


### PR DESCRIPTION
There were bugs in the names of the options in various places and how the relevant files were listed in the CMake files. Add tests to make sure things continue to work.