### PR TITLE
libm/common: Disable FP contractions on clang for fma/fmaf/fmal

### DIFF
--- a/newlib/libm/common/s_fma.c
+++ b/newlib/libm/common/s_fma.c
@@ -48,6 +48,10 @@ ANSI C, POSIX.
 
 #ifdef _NEED_FLOAT64
 
+#ifdef __clang__
+#pragma STDC FP_CONTRACT OFF
+#endif
+
 __float64
 fma64(__float64 x, __float64 y, __float64 z)
 {

--- a/newlib/libm/common/sf_fma.c
+++ b/newlib/libm/common/sf_fma.c
@@ -8,6 +8,10 @@
 
 #if !_HAVE_FAST_FMAF
 
+#ifdef __clang__
+#pragma STDC FP_CONTRACT OFF
+#endif
+
 float fmaf(float x, float y, float z)
 {
   /*

--- a/newlib/libm/ld/common/s_fmal.c
+++ b/newlib/libm/ld/common/s_fmal.c
@@ -160,6 +160,10 @@ _scalbnl_no_errno(long double x, int n)
 #define _scalbnl_no_errno(a,b) scalbnl(a,b)
 #endif
 
+#ifdef __clang__
+#pragma STDC FP_CONTRACT OFF
+#endif
+
 /*
  * Fused multiply-add: Compute x * y + z with a single rounding error.
  *


### PR DESCRIPTION
Clang enables conversion of 'a*b+c' into an FMA operation by default, which compiles the fallback implementation of fma and fmaf into infinite loops. Add '#pragma STDC FP_CONTRACT OFF' when building with clang to disable this behavior.

Closes: #467