### PR TITLE
scripts: support Zawrs option from qemu version 8 for riscv

### DIFF
--- a/scripts/run-riscv
+++ b/scripts/run-riscv
@@ -88,6 +88,10 @@ if $qemu --version | grep -q 'version [789]'; then
     all_options="h $all_options"
 fi
 
+if $qemu --version | grep -q 'version [89]'; then
+    all_options="Zawrs $all_options"
+fi
+
 for o in $all_options; do
     if echo "$options" | grep -q "$o"; then
 	value=true


### PR DESCRIPTION
qemu added support for another risc-v option, Zawrs, and enabled it by default. It requires the 'a' option though, so targets that aren't using that option won't be able to support it.

Picolibc doesn't need the Zawrs option at all, so add it to the list of available options but leave it disabled.