### PR TITLE
cmake: Add -Werror=attribute-optimize when testing compiler support

### DIFF
--- a/cmake/picolibc.cmake
+++ b/cmake/picolibc.cmake
@@ -126,6 +126,7 @@ _picolibc_supported_compile_options(PICOLIBC_FLAG_OPTIONS
   -Werror=attributes
   -Werror=unsupported-floating-point-opt
   -Werror=ignored-optimization-argument
+  -Werror=attribute-optimize
   -Wno-unused-command-line-argument
   )
 


### PR DESCRIPTION
Older clang versions appear to use this flag to control handling of messages related to `__optimize__` attribute values.