### PR TITLE
libc/tinystdio: Fix building with -Dposix-io=false

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -91,7 +91,7 @@ jobs:
 
           # Tinystdio configurations
           "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true",
-          "-Dformat-default=integer -Dfreestanding=true",
+          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false",
 
           # Original stdio
           "-Dtinystdio=false",
@@ -142,7 +142,7 @@ jobs:
 
           # Tinystdio configurations
           "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true",
-          "-Dformat-default=integer -Dfreestanding=true",
+          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false",
 
           # Original stdio
           "-Dtinystdio=false",
@@ -193,7 +193,7 @@ jobs:
 
           # Tinystdio configurations
           "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true",
-          "-Dformat-default=integer -Dfreestanding=true",
+          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false",
 
           # Original stdio
           "-Dtinystdio=false",

--- a/.github/workflows/variants
+++ b/.github/workflows/variants
@@ -11,7 +11,7 @@
 
           # Tinystdio configurations
           "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true",
-          "-Dformat-default=integer -Dfreestanding=true",
+          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false",
 
           # Original stdio
           "-Dtinystdio=false",

--- a/meson.build
+++ b/meson.build
@@ -279,8 +279,8 @@ has_link_alias = meson.get_cross_property('has_link_alias', cc.has_link_argument
 lib_gcc = meson.get_cross_property('libgcc', '-lgcc')
 
 # tinystdio options
-posix_io = tinystdio and get_option('posix-io')
-posix_console = posix_io and get_option('posix-console')
+posix_console = tinystdio and get_option('posix-console')
+posix_io = tinystdio and (get_option('posix-io') or posix_console)
 io_float_exact = not tinystdio or get_option('io-float-exact')
 atomic_ungetc = tinystdio and get_option('atomic-ungetc')
 format_default = get_option('format-default')

--- a/newlib/libc/tinystdio/fmemopen.c
+++ b/newlib/libc/tinystdio/fmemopen.c
@@ -116,10 +116,10 @@ fmemopen(void *buf, size_t size, const char *mode)
 {
 	int stdio_flags;
         uint8_t mflags = 0;
-	int open_flags;
 	struct __file_mem *mf;
 
-	stdio_flags = __posix_sflags(mode, &open_flags);
+	stdio_flags = __stdio_sflags(mode);
+
 	if (stdio_flags == 0)
 		return NULL;
 

--- a/newlib/libc/tinystdio/meson.build
+++ b/newlib/libc/tinystdio/meson.build
@@ -67,7 +67,6 @@ srcs_tinystdio = [
     'fputwc.c',
     'fputws.c',
     'fread.c',
-    'freopen.c',
     'fscanf.c',
     'fseek.c',
     'fseeko.c',
@@ -96,6 +95,7 @@ srcs_tinystdio = [
     'setbuffer.c',
     'setlinebuf.c',
     'setvbuf.c',
+    'sflags.c',
     'snprintf.c',
     'sprintf.c',
     'snprintfd.c',
@@ -186,7 +186,7 @@ srcs_tinystdio_posix = [
     'fopen.c',
     'fdopen.c',
     'fclose.c',
-    'sflags.c'
+    'freopen.c',
 ]
 
 srcs_tinystdio_posix_console = [

--- a/newlib/libc/tinystdio/stdio_private.h
+++ b/newlib/libc/tinystdio/stdio_private.h
@@ -126,6 +126,18 @@ bool __matchcaseprefix(const char *input, const char *pattern);
 int
 __posix_sflags (const char *mode, int *optr);
 
+static inline int
+__stdio_sflags (const char *mode)
+{
+    int omode;
+    return __posix_sflags (mode, &omode);
+}
+
+#else
+
+int
+__stdio_sflags (const char *mode);
+
 #endif
 
 int	__d_vfprintf(FILE *__stream, const char *__fmt, va_list __ap) __FORMAT_ATTRIBUTE__(printf, 2, 0);


### PR DESCRIPTION
Two new functions that take a mode string were added, freopen and fmemopen. The former relies on POSIX I/O and so needed to only be built when posix-io=true. The latter still needs a way to convert the open mode string to the internal FILE operation flags. Do this by creating a new API, __stdio_sflags, which sits atop __posix_sflags when posix-io=true, but which directly uses a modified version of the __posix_sflags implementation when posix-io=false.

Closes: #486.