### PR TITLE
cdefs.h: Use __PICOLIBC_FALLTHROUGH instead of FALLTHROUGH

### DIFF
--- a/newlib/libc/include/sys/cdefs.h
+++ b/newlib/libc/include/sys/cdefs.h
@@ -773,12 +773,12 @@
  */
 #if __cplusplus >= 201703L || __STDC_VERSION__ > 201710L
 /* Standard C++17/C23 attribute */
-#define FALLTHROUGH [[fallthrough]]
+#define __PICOLIBC_FALLTHROUGH [[fallthrough]]
 #elif __has_attribute(fallthrough)
 /* Non-standard but supported by at least gcc and clang */
-#define FALLTHROUGH __attribute__((fallthrough))
+#define __PICOLIBC_FALLTHROUGH __attribute__((fallthrough))
 #else
-#define FALLTHROUGH do { } while(0)
+#define __PICOLIBC_FALLTHROUGH do { } while(0)
 #endif
 
 /* Guard variables and structure members by lock. */

--- a/newlib/libc/posix/fnmatch.c
+++ b/newlib/libc/posix/fnmatch.c
@@ -139,7 +139,7 @@ fnmatch(const char *pattern, const char *string, int flags)
 					--pattern;
 				}
 			}
-			/* FALLTHROUGH */
+			__PICOLIBC_FALLTHROUGH;
 		default:
 		norm:
 			if (c == *string)

--- a/newlib/libc/posix/regcomp.c
+++ b/newlib/libc/posix/regcomp.c
@@ -416,7 +416,7 @@ p_ere_exp(struct parse *p)
 		break;
 	case '{':		/* okay as ordinary except if digit follows */
 		(void)REQUIRE(!MORE() || !isdigit((uch)PEEK()), REG_BADRPT);
-		FALLTHROUGH;
+		__PICOLIBC_FALLTHROUGH;
 	default:
 		ordinary(p, c);
 		break;
@@ -616,7 +616,7 @@ p_simp_re(struct parse *p,
 		break;
 	case '*':
 		(void)REQUIRE(starordinary, REG_BADRPT);
-		FALLTHROUGH;
+		__PICOLIBC_FALLTHROUGH;
 	default:
 		ordinary(p, (char)c);
 		break;
@@ -1668,7 +1668,7 @@ findmust(struct parse *p, struct re_guts *g)
 					return;
 				}
 			} while (OP(s) != O_QUEST && OP(s) != O_CH);
-			FALLTHROUGH;
+			__PICOLIBC_FALLTHROUGH;
 		case OBOW:		/* things that break a sequence */
 		case OEOW:
 		case OBOL:
@@ -1823,7 +1823,7 @@ altoffset(sop *scan, int offset, int mccs)
 		case OANYOF:
 			if (mccs)
 				return -1;
-                        FALLTHROUGH;
+                        __PICOLIBC_FALLTHROUGH;
 		case OCHAR:
 		case OANY:
 			try++;

--- a/newlib/libc/search/hash_func.c
+++ b/newlib/libc/search/hash_func.c
@@ -134,25 +134,25 @@ hash3(keyarg, len)
 		case 0:
 			do {
 				HASHC;
-				FALLTHROUGH;
+				__PICOLIBC_FALLTHROUGH;
 		case 7:
 				HASHC;
-				FALLTHROUGH;
+				__PICOLIBC_FALLTHROUGH;
 		case 6:
 				HASHC;
-				FALLTHROUGH;
+				__PICOLIBC_FALLTHROUGH;
 		case 5:
 				HASHC;
-				FALLTHROUGH;
+				__PICOLIBC_FALLTHROUGH;
 		case 4:
 				HASHC;
-				FALLTHROUGH;
+				__PICOLIBC_FALLTHROUGH;
 		case 3:
 				HASHC;
-				FALLTHROUGH;
+				__PICOLIBC_FALLTHROUGH;
 		case 2:
 				HASHC;
-				FALLTHROUGH;
+				__PICOLIBC_FALLTHROUGH;
 		case 1:
 				HASHC;
 			} while (--loop);

--- a/newlib/libc/stdio/nano-vfprintf_i.c
+++ b/newlib/libc/stdio/nano-vfprintf_i.c
@@ -153,7 +153,7 @@ _printf_i (struct _prt_data_t *pdata, FILE *fp,
       pdata->flags |= HEXPREFIX;
       if (sizeof (void*) > sizeof (int))
 	pdata->flags |= LONGINT;
-      FALLTHROUGH;
+      __PICOLIBC_FALLTHROUGH;
       /* NOSTRICT.  */
     case 'x':
       pdata->l_buf[2] = 'x';
@@ -208,7 +208,7 @@ number:
 	*GET_ARG (N, *ap, short_ptr_t) = pdata->ret;
       else
 	*GET_ARG (N, *ap, int_ptr_t) = pdata->ret;
-      FALLTHROUGH;
+      __PICOLIBC_FALLTHROUGH;
     case '\0':
       pdata->size = 0;
       break;

--- a/newlib/libc/stdio/nano-vfscanf.c
+++ b/newlib/libc/stdio/nano-vfscanf.c
@@ -310,7 +310,7 @@ _SVFSCANF (
 
 	case 'p':
 	  scan_data.flags |= POINTER;
-          FALLTHROUGH;
+          __PICOLIBC_FALLTHROUGH;
 	case 'x':
 	case 'X':
 	  scan_data.flags |= PFXOK;

--- a/newlib/libc/stdio/vfprintf.c
+++ b/newlib/libc/stdio/vfprintf.c
@@ -990,7 +990,7 @@ reswitch:	switch (ch) {
 			if (width >= 0)
 				goto rflag;
 			width = -width;
-			FALLTHROUGH;
+			__PICOLIBC_FALLTHROUGH;
 		case '-':
 			flags |= LADJUST;
 			goto rflag;
@@ -1161,7 +1161,7 @@ reswitch:	switch (ch) {
 			break;
 		case 'D':  /* extension */
 			flags |= LONGINT;
-			FALLTHROUGH;
+			__PICOLIBC_FALLTHROUGH;
 		case 'd':
 		case 'i':
 			_uquad = SARG ();
@@ -1382,7 +1382,7 @@ reswitch:	switch (ch) {
 			continue;	/* no output */
 		case 'O': /* extension */
 			flags |= LONGINT;
-			FALLTHROUGH;
+			__PICOLIBC_FALLTHROUGH;
 		case 'o':
 			_uquad = UARG ();
 			base = OCT;
@@ -1504,7 +1504,7 @@ string:
 			break;
 		case 'U': /* extension */
 			flags |= LONGINT;
-			FALLTHROUGH;
+			__PICOLIBC_FALLTHROUGH;
 		case 'u':
 			_uquad = UARG ();
 			base = DEC;
@@ -2260,7 +2260,7 @@ get_arg (struct _reent *data,
 	      break;
 	    case GETPWB: /* we require format pushback */
 	      --fmt;
-	      FALLTHROUGH;
+	      __PICOLIBC_FALLTHROUGH;
 	    case GETPW:  /* we have a variable precision or width to acquire */
 	      args[numargs++].val_int = va_arg (*ap, int);
 	      break;

--- a/newlib/libc/stdio/vfscanf.c
+++ b/newlib/libc/stdio/vfscanf.c
@@ -761,7 +761,7 @@ _SVFSCANF (
 
 	case 'D':		/* compat */
 	  flags |= LONG;
-	  FALLTHROUGH;
+	  __PICOLIBC_FALLTHROUGH;
 	case 'd':
 	  c = CT_INT;
 	  ccfn = (u_long (*)CCFN_PARAMS)strtol;
@@ -776,7 +776,7 @@ _SVFSCANF (
 
 	case 'O':		/* compat */
 	  flags |= LONG;
-	  FALLTHROUGH;
+	  __PICOLIBC_FALLTHROUGH;
 	case 'o':
 	  c = CT_INT;
 	  ccfn = strtoul;
@@ -815,7 +815,7 @@ _SVFSCANF (
 #ifdef _WANT_IO_C99_FORMATS
 	case 'S':
 	  flags |= LONG;
-          FALLTHROUGH;
+          __PICOLIBC_FALLTHROUGH;
 #endif
 
 	case 's':
@@ -831,7 +831,7 @@ _SVFSCANF (
 #ifdef _WANT_IO_C99_FORMATS
 	case 'C':
 	  flags |= LONG;
-          FALLTHROUGH;
+          __PICOLIBC_FALLTHROUGH;
 #endif
 
 	case 'c':

--- a/newlib/libc/stdio/vfwprintf.c
+++ b/newlib/libc/stdio/vfwprintf.c
@@ -721,7 +721,7 @@ reswitch:	switch (ch) {
 			if (width >= 0)
 				goto rflag;
 			width = -width;
-			FALLTHROUGH;
+			__PICOLIBC_FALLTHROUGH;
 		case L'-':
 			flags |= LADJUST;
 			goto rflag;
@@ -1921,7 +1921,7 @@ get_arg (
 	      break;
 	    case GETPWB: /* we require format pushback */
 	      --fmt;
-	      FALLTHROUGH;
+	      __PICOLIBC_FALLTHROUGH;
 	    case GETPW:  /* we have a variable precision or width to acquire */
 	      args[numargs++].val_int = va_arg (*ap, int);
 	      break;

--- a/newlib/libc/stdio/vfwscanf.c
+++ b/newlib/libc/stdio/vfwscanf.c
@@ -708,7 +708,7 @@ _SVFWSCANF (
 #ifdef _WANT_IO_C99_FORMATS
 	case L'S':
 	  flags |= LONG;
-          FALLTHROUGH;
+          __PICOLIBC_FALLTHROUGH;
 #endif
 
 	case L's':
@@ -737,7 +737,7 @@ _SVFWSCANF (
 #ifdef _WANT_IO_C99_FORMATS
 	case 'C':
 	  flags |= LONG;
-          FALLTHROUGH;
+          __PICOLIBC_FALLTHROUGH;
 #endif
 
 	case 'c':

--- a/newlib/libc/stdlib/dtoa.c
+++ b/newlib/libc/stdlib/dtoa.c
@@ -399,7 +399,7 @@ __dtoa (
       break;
     case 2:
       leftright = 0;
-      FALLTHROUGH;
+      __PICOLIBC_FALLTHROUGH;
     case 4:
       if (ndigits <= 0)
 	ndigits = 1;
@@ -407,7 +407,7 @@ __dtoa (
       break;
     case 3:
       leftright = 0;
-      FALLTHROUGH;
+      __PICOLIBC_FALLTHROUGH;
     case 5:
       i = ndigits + k + 1;
       ilim = i;

--- a/newlib/libc/stdlib/gdtoa-gethex.c
+++ b/newlib/libc/stdlib/gdtoa-gethex.c
@@ -212,7 +212,7 @@ gethex (const char **sp, const FPI *fpi,
 		switch(*++s) {
 		  case '-':
 			esign = 1;
-			FALLTHROUGH;
+			__PICOLIBC_FALLTHROUGH;
 		  case '+':
 			s++;
 		  }

--- a/newlib/libc/stdlib/strtod.c
+++ b/newlib/libc/stdlib/strtod.c
@@ -279,11 +279,11 @@ strtod_l (const char *__restrict s00, char **__restrict se,
 	for(s = s00;;s++) switch(*s) {
 		case '-':
 			sign = 1;
-                        FALLTHROUGH;
+                        __PICOLIBC_FALLTHROUGH;
 		case '+':
 			if (*++s)
 				goto break2;
-                        FALLTHROUGH;
+                        __PICOLIBC_FALLTHROUGH;
 		case 0:
 			goto ret0;
 		case '\t':
@@ -324,7 +324,7 @@ strtod_l (const char *__restrict s00, char **__restrict se,
 			  case STRTOG_NoNumber:
 				s = s00;
 				sign = 0;
-				FALLTHROUGH;
+				__PICOLIBC_FALLTHROUGH;
 			  case STRTOG_Zero:
 				break;
 			  default:
@@ -400,7 +400,7 @@ strtod_l (const char *__restrict s00, char **__restrict se,
 		switch(c = *++s) {
 			case '-':
 				esign = 1;
-                                FALLTHROUGH;
+                                __PICOLIBC_FALLTHROUGH;
 			case '+':
 				c = *++s;
 			}

--- a/newlib/libc/stdlib/strtodg.c
+++ b/newlib/libc/stdlib/strtodg.c
@@ -461,11 +461,11 @@ _strtodg_l (const char *s00, char **se, FPI *fpi, Long *exp,
 	for(s = s00;;s++) switch(*s) {
 		case '-':
 			sign = 1;
-                        FALLTHROUGH;
+                        __PICOLIBC_FALLTHROUGH;
 		case '+':
 			if (*++s)
 				goto break2;
-                        FALLTHROUGH;
+                        __PICOLIBC_FALLTHROUGH;
 		case 0:
 			sign = 0;
 			irv = STRTOG_NoNumber;
@@ -563,7 +563,7 @@ _strtodg_l (const char *s00, char **se, FPI *fpi, Long *exp,
 		switch(c = *++s) {
 			case '-':
 				esign = 1;
-                                FALLTHROUGH;
+                                __PICOLIBC_FALLTHROUGH;
 			case '+':
 				c = *++s;
 			}

--- a/newlib/libc/time/strptime.c
+++ b/newlib/libc/time/strptime.c
@@ -434,7 +434,7 @@ strptime_l (const char *buf, const char *format, struct tm *timeptr,
 		break;
 	    case '\0' :
 		--format;
-		FALLTHROUGH;
+		__PICOLIBC_FALLTHROUGH;
 	    case '%' :
 		if (*buf == '%')
 		    ++buf;

--- a/newlib/libc/tinystdio/conv_flt.c
+++ b/newlib/libc/tinystdio/conv_flt.c
@@ -208,7 +208,7 @@ conv_flt (FLT_STREAM *stream, int *lenp, width_t width, void *addr, uint16_t fla
     switch ((unsigned char)i) {
     case '-':
         flags |= FL_MINUS;
-	FALLTHROUGH;
+	__PICOLIBC_FALLTHROUGH;
     case '+':
 	if (!CHECK_WIDTH() || (i = scanf_getc (stream, lenp)) < 0)
 	    return 0;
@@ -330,7 +330,7 @@ conv_flt (FLT_STREAM *stream, int *lenp, width_t width, void *addr, uint16_t fla
 	    switch ((unsigned char)esign) {
             case '-':
 		flags |= FL_MEXP;
-		FALLTHROUGH;
+		__PICOLIBC_FALLTHROUGH;
             case '+':
                 if (!CHECK_WIDTH()) {
                     scanf_ungetc(esign, stream, lenp);

--- a/newlib/libc/tinystdio/strtoi.h
+++ b/newlib/libc/tinystdio/strtoi.h
@@ -82,7 +82,7 @@ strtoi(const char *__restrict nptr, char **__restrict endptr, int ibase)
     switch (i) {
     case '-':
         flags = FLAG_NEG;
-	FALLTHROUGH;
+	__PICOLIBC_FALLTHROUGH;
     case '+':
         i = *s++;
     }

--- a/newlib/libc/tinystdio/vfprintf.c
+++ b/newlib/libc/tinystdio/vfprintf.c
@@ -437,7 +437,7 @@ int vfprintf (FILE * stream, const CHAR *fmt, va_list ap_orig)
 		    continue;
 		  case '+':
 		    flags |= FL_PLUS;
-		    FALLTHROUGH;
+		    __PICOLIBC_FALLTHROUGH;
 		  case ' ':
 		    flags |= FL_SPACE;
 		    continue;

--- a/newlib/libc/tinystdio/vfscanf.c
+++ b/newlib/libc/tinystdio/vfscanf.c
@@ -126,7 +126,7 @@ conv_int (FILE *stream, int *lenp, width_t width, void *addr, uint16_t flags, un
     switch (i) {
       case '-':
         flags |= FL_MINUS;
-	FALLTHROUGH;
+	__PICOLIBC_FALLTHROUGH;
       case '+':
         if (!--width || IS_EOF(i = scanf_getc(stream, lenp)))
 	    goto err;
@@ -657,7 +657,7 @@ int vfscanf (FILE * stream, const CHAR *fmt, va_list ap_orig)
 	          case 'p':
                       if (sizeof(void *) > sizeof(int))
                           flags |= FL_LONG;
-                      FALLTHROUGH;
+                      __PICOLIBC_FALLTHROUGH;
 		  case 'x':
 	          case 'X':
                     base = 16;
@@ -676,7 +676,7 @@ int vfscanf (FILE * stream, const CHAR *fmt, va_list ap_orig)
 
 	          case 'o':
                     base = 8;
-		    FALLTHROUGH;
+		    __PICOLIBC_FALLTHROUGH;
 		  case 'i':
 		  conv_int:
                     c = conv_int (stream, lenp, width, addr, flags, base);
@@ -698,14 +698,14 @@ int vfscanf (FILE * stream, const CHAR *fmt, va_list ap_orig)
 
 	          case 'o':
                     base = 8;
-		    FALLTHROUGH;
+		    __PICOLIBC_FALLTHROUGH;
 		  case 'i':
 		    goto conv_int;
 
                   case 'p':
                       if (sizeof(void *) > sizeof(int))
                           flags |= FL_LONG;
-                      FALLTHROUGH;
+                      __PICOLIBC_FALLTHROUGH;
 		  default:			/* p,x,X	*/
                     base = 16;
 		  conv_int:

--- a/newlib/libc/xdr/xdr.c
+++ b/newlib/libc/xdr/xdr.c
@@ -569,7 +569,7 @@ xdr_enum (XDR * xdrs,
           if (!XDR_GETLONG (xdrs, &l))
             return FALSE;
           *ep = l;
-          FALLTHROUGH;
+          __PICOLIBC_FALLTHROUGH;
         case XDR_FREE:
           return TRUE;
         }
@@ -672,7 +672,7 @@ xdr_bytes (XDR * xdrs,
           errno = ENOMEM;
           return FALSE;
         }
-      FALLTHROUGH;
+      __PICOLIBC_FALLTHROUGH;
 
     case XDR_ENCODE:
       return xdr_opaque (xdrs, sp, nodesize);
@@ -779,7 +779,7 @@ xdr_string (XDR * xdrs,
       if (sp == NULL)
         return TRUE;        /* already free */
 
-      FALLTHROUGH;
+      __PICOLIBC_FALLTHROUGH;
     case XDR_ENCODE:
       if (sp == NULL)
         return FALSE;
@@ -821,7 +821,7 @@ xdr_string (XDR * xdrs,
           return FALSE;
         }
       sp[size] = 0;
-      FALLTHROUGH;
+      __PICOLIBC_FALLTHROUGH;
 
     case XDR_ENCODE:
       return xdr_opaque (xdrs, sp, size);


### PR DESCRIPTION
Avoid placing an internal symbol in a globally visible header file.

Closes: #488.