### PR TITLE
picocrt: Disable minimal crt0 when using POSIX IO for std[out/err/in]

### DIFF
--- a/picocrt/meson.build
+++ b/picocrt/meson.build
@@ -129,25 +129,29 @@ foreach target : targets
   endif
 
   # The 'minimal' variant doesn't call exit, nor does it invoke any constructors
-  _crt = executable(crt_minimal_name,
-		    src_picocrt,
-		    include_directories : inc,
-		    install : true,
-		    install_dir : instdir,
-		    c_args : value[1] + arg_fnobuiltin + ['-ffreestanding', '-DCONSTRUCTORS=0'],
-		    link_args : value[1] + ['-r', '-ffreestanding'])
+  # This is incompatible with posix buffered IO, because the posix_exit destructor assumes
+  # that a lock constructor has run.
+  if not posix_console
+    _crt = executable(crt_minimal_name,
+                      src_picocrt,
+                      include_directories : inc,
+                      install : true,
+                      install_dir : instdir,
+                      c_args : value[1] + arg_fnobuiltin + ['-ffreestanding', '-DCONSTRUCTORS=0'],
+                      link_args : value[1] + ['-r', '-ffreestanding'])
 
-  set_variable(crt0_minimal_name,
-	       _crt.extract_objects(src_picocrt)
-	      )
+    set_variable(crt0_minimal_name,
+                 _crt.extract_objects(src_picocrt)
+                )
 
-  if enable_picocrt_lib
-    static_library(libcrt_minimal_name,
-                   [],
-                   install : true,
-                   install_dir : instdir,
-                   pic: false,
-                   objects : [_crt.extract_objects(src_picocrt)])
+    if enable_picocrt_lib
+      static_library(libcrt_minimal_name,
+                     [],
+                     install : true,
+                     install_dir : instdir,
+                     pic: false,
+                     objects : [_crt.extract_objects(src_picocrt)])
+    endif
   endif
 
   if has_arm_semihost


### PR DESCRIPTION
The posix_exit destructor attempts to flush stdout, which assumes a lock has been initialised for the FILE. This is done in a constructor, but Minimal crt0 is built without constructors.

I'm not sure this is the solution to this problem. I've opened this PR in part as a discussion point. This was discovered when the 'constructor-skip' test was failing. Could an alternative be disabling destructors in minimal crt0?