### PR TITLE
libc/include: Clean up sys/errno.h header

### DIFF
--- a/newlib/libc/include/sys/errno.h
+++ b/newlib/libc/include/sys/errno.h
@@ -66,116 +66,118 @@ extern NEWLIB_THREAD_LOCAL_ERRNO int errno;
 #define __errno_r(ptr)	(errno)
 #define _REENT_ERRNO(r) (errno)
 
-#define	EPERM 1		/* Not owner */
-#define	ENOENT 2	/* No such file or directory */
-#define	ESRCH 3		/* No such process */
-#define	EINTR 4		/* Interrupted system call */
-#define	EIO 5		/* I/O error */
-#define	ENXIO 6		/* No such device or address */
-#define	E2BIG 7		/* Arg list too long */
-#define	ENOEXEC 8	/* Exec format error */
-#define	EBADF 9		/* Bad file number */
-#define	ECHILD 10	/* No children */
-#define	EAGAIN 11	/* No more processes */
-#define	ENOMEM 12	/* Not enough space */
-#define	EACCES 13	/* Permission denied */
-#define	EFAULT 14	/* Bad address */
+#define	EPERM 1			/* Not owner */
+#define	ENOENT 2		/* No such file or directory */
+#define	ESRCH 3			/* No such process */
+#define	EINTR 4			/* Interrupted system call */
+#define	EIO 5			/* I/O error */
+#define	ENXIO 6			/* No such device or address */
+#define	E2BIG 7			/* Arg list too long */
+#define	ENOEXEC 8		/* Exec format error */
+#define	EBADF 9			/* Bad file number */
+#define	ECHILD 10		/* No children */
+#define	EAGAIN 11		/* No more processes */
+#define	ENOMEM 12		/* Not enough space */
+#define	EACCES 13		/* Permission denied */
+#define	EFAULT 14		/* Bad address */
 #ifdef __LINUX_ERRNO_EXTENSIONS__
-#define	ENOTBLK 15	/* Block device required */
+#define	ENOTBLK 15	        /* Block device required */
 #endif
-#define	EBUSY 16	/* Device or resource busy */
-#define	EEXIST 17	/* File exists */
-#define	EXDEV 18	/* Cross-device link */
-#define	ENODEV 19	/* No such device */
-#define	ENOTDIR 20	/* Not a directory */
-#define	EISDIR 21	/* Is a directory */
-#define	EINVAL 22	/* Invalid argument */
-#define	ENFILE 23	/* Too many open files in system */
-#define	EMFILE 24	/* File descriptor value too large */
-#define	ENOTTY 25	/* Not a character device */
-#define	ETXTBSY 26	/* Text file busy */
-#define	EFBIG 27	/* File too large */
-#define	ENOSPC 28	/* No space left on device */
-#define	ESPIPE 29	/* Illegal seek */
-#define	EROFS 30	/* Read-only file system */
-#define	EMLINK 31	/* Too many links */
-#define	EPIPE 32	/* Broken pipe */
-#define	EDOM 33		/* Mathematics argument out of domain of function */
-#define	ERANGE 34	/* Result too large */
-#define	ENOMSG 35	/* No message of desired type */
-#define	EIDRM 36	/* Identifier removed */
+#define	EBUSY 16		/* Device or resource busy */
+#define	EEXIST 17		/* File exists */
+#define	EXDEV 18		/* Cross-device link */
+#define	ENODEV 19		/* No such device */
+#define	ENOTDIR 20		/* Not a directory */
+#define	EISDIR 21		/* Is a directory */
+#define	EINVAL 22		/* Invalid argument */
+#define	ENFILE 23		/* Too many open files in system */
+#define	EMFILE 24		/* File descriptor value too large */
+#define	ENOTTY 25		/* Not a character device */
+#define	ETXTBSY 26		/* Text file busy */
+#define	EFBIG 27		/* File too large */
+#define	ENOSPC 28		/* No space left on device */
+#define	ESPIPE 29		/* Illegal seek */
+#define	EROFS 30		/* Read-only file system */
+#define	EMLINK 31		/* Too many links */
+#define	EPIPE 32		/* Broken pipe */
+#define	EDOM 33			/* Mathematics argument out of domain of function */
+#define	ERANGE 34		/* Result too large */
+#define	ENOMSG 35		/* No message of desired type */
+#define	EIDRM 36		/* Identifier removed */
 #ifdef __LINUX_ERRNO_EXTENSIONS__
-#define	ECHRNG 37	/* Channel number out of range */
-#define	EL2NSYNC 38	/* Level 2 not synchronized */
-#define	EL3HLT 39	/* Level 3 halted */
-#define	EL3RST 40	/* Level 3 reset */
-#define	ELNRNG 41	/* Link number out of range */
-#define	EUNATCH 42	/* Protocol driver not attached */
-#define	ENOCSI 43	/* No CSI structure available */
-#define	EL2HLT 44	/* Level 2 halted */
+#define	ECHRNG 37       	/* Channel number out of range */
+#define	EL2NSYNC 38             /* Level 2 not synchronized */
+#define	EL3HLT 39	        /* Level 3 halted */
+#define	EL3RST 40       	/* Level 3 reset */
+#define	ELNRNG 41	        /* Link number out of range */
+#define	EUNATCH 42	        /* Protocol driver not attached */
+#define	ENOCSI 43	        /* No CSI structure available */
+#define	EL2HLT 44	        /* Level 2 halted */
 #endif
-#define	EDEADLK 45	/* Deadlock */
-#define	ENOLCK 46	/* No lock */
+#define	EDEADLK 45		/* Deadlock */
+#define	ENOLCK 46		/* No lock */
 #ifdef __LINUX_ERRNO_EXTENSIONS__
-#define EBADE 50	/* Invalid exchange */
-#define EBADR 51	/* Invalid request descriptor */
-#define EXFULL 52	/* Exchange full */
-#define ENOANO 53	/* No anode */
-#define EBADRQC 54	/* Invalid request code */
-#define EBADSLT 55	/* Invalid slot */
-#define EDEADLOCK 56	/* File locking deadlock error */
-#define EBFONT 57	/* Bad font file fmt */
+#define EBADE 50		/* Invalid exchange */
+#define EBADR 51		/* Invalid request descriptor */
+#define EXFULL 52		/* Exchange full */
+#define ENOANO 53		/* No anode */
+#define EBADRQC 54		/* Invalid request code */
+#define EBADSLT 55		/* Invalid slot */
+#define EDEADLOCK 56		/* File locking deadlock error */
+#define EBFONT 57		/* Bad font file fmt */
 #endif
-#define ENOSTR 60	/* Not a stream */
-#define ENODATA 61	/* No data (for no delay io) */
-#define ETIME 62	/* Stream ioctl timeout */
-#define ENOSR 63	/* No stream resources */
+#define ENOSTR 60		/* Not a stream */
+#define ENODATA 61		/* No data (for no delay io) */
+#define ETIME 62		/* Stream ioctl timeout */
+#define ENOSR 63		/* No stream resources */
 #ifdef __LINUX_ERRNO_EXTENSIONS__
-#define ENONET 64	/* Machine is not on the network */
-#define ENOPKG 65	/* Package not installed */
-#define EREMOTE 66	/* The object is remote */
+#define ENONET 64		/* Machine is not on the network */
+#define ENOPKG 65		/* Package not installed */
+#define EREMOTE 66		/* The object is remote */
 #endif
-#define ENOLINK 67	/* Virtual circuit is gone */
+#define ENOLINK 67		/* Virtual circuit is gone */
 #ifdef __LINUX_ERRNO_EXTENSIONS__
-#define EADV 68		/* Advertise error */
-#define ESRMNT 69	/* Srmount error */
-#define	ECOMM 70	/* Communication error on send */
+#define EADV 68			/* Advertise error */
+#define ESRMNT 69		/* Srmount error */
+#define	ECOMM 70		/* Communication error on send */
 #endif
-#define EPROTO 71	/* Protocol error */
-#define	EMULTIHOP 74	/* Multihop attempted */
+#define EPROTO 71		/* Protocol error */
+#define	EMULTIHOP 74		/* Multihop attempted */
 #ifdef __LINUX_ERRNO_EXTENSIONS__
-#define	ELBIN 75	/* Inode is remote (not really error) */
-#define	EDOTDOT 76	/* Cross mount point (not really error) */
+#define	ELBIN 75		/* Inode is remote (not really error) */
+#define	EDOTDOT 76		/* Cross mount point (not really error) */
 #endif
-#define EBADMSG 77	/* Bad message */
-#define EFTYPE 79	/* Inappropriate file type or format */
+#define EBADMSG 77		/* Bad message */
 #ifdef __LINUX_ERRNO_EXTENSIONS__
-#define ENOTUNIQ 80	/* Given log. name not unique */
-#define EBADFD 81	/* f.d. invalid for this operation */
-#define EREMCHG 82	/* Remote address changed */
-#define ELIBACC 83	/* Can't access a needed shared lib */
-#define ELIBBAD 84	/* Accessing a corrupted shared lib */
-#define ELIBSCN 85	/* .lib section in a.out corrupted */
-#define ELIBMAX 86	/* Attempting to link in too many libs */
-#define ELIBEXEC 87	/* Attempting to exec a shared library */
+#define EFTYPE 79		/* Inappropriate file type or format */
+#define ENOTUNIQ 80		/* Given log. name not unique */
+#define EBADFD 81		/* File descriptor in bad state */
+#define EREMCHG 82		/* Remote address changed */
+#define ELIBACC 83		/* Can't access a needed shared lib */
+#define ELIBBAD 84		/* Accessing a corrupted shared lib */
+#define ELIBSCN 85		/* .lib section in a.out corrupted */
+#define ELIBMAX 86		/* Attempting to link in too many libs */
+#define ELIBEXEC 87		/* Attempting to exec a shared library */
 #endif
-#define ENOSYS 88	/* Function not implemented */
+#define ENOSYS 88		/* Function not implemented */
 #ifdef __CYGWIN__
-#define ENMFILE 89      /* No more files */
+#define ENMFILE 89      	/* No more files */
 #endif
-#define ENOTEMPTY 90	/* Directory not empty */
-#define ENAMETOOLONG 91	/* File or path name too long */
-#define ELOOP 92	/* Too many symbolic links */
-#define EOPNOTSUPP 95	/* Operation not supported on socket */
-#define EPFNOSUPPORT 96 /* Protocol family not supported */
-#define ECONNRESET 104  /* Connection reset by peer */
-#define ENOBUFS 105	/* No buffer space available */
-#define EAFNOSUPPORT 106 /* Address family not supported by protocol family */
-#define EPROTOTYPE 107	/* Protocol wrong type for socket */
-#define ENOTSOCK 108	/* Socket operation on non-socket */
-#define ENOPROTOOPT 109	/* Protocol not available */
+#define ENOTEMPTY 90		/* Directory not empty */
+#define ENAMETOOLONG 91		/* File or path name too long */
+#define ELOOP 92		/* Too many symbolic links */
+#define EOPNOTSUPP 95		/* Operation not supported on socket */
 #ifdef __LINUX_ERRNO_EXTENSIONS__
-#define ESHUTDOWN 110	/* Can't send after socket shutdown */
+#define EPFNOSUPPORT 96 	/* Protocol family not supported */
+#endif
+#define ECONNRESET 104  	/* Connection reset by peer */
+#define ENOBUFS 105		/* No buffer space available */
+#define EAFNOSUPPORT 106	/* Address family not supported by protocol family */
+#define EPROTOTYPE 107		/* Protocol wrong type for socket */
+#define ENOTSOCK 108		/* Socket operation on non-socket */
+#define ENOPROTOOPT 109		/* Protocol not available */
+#ifdef __LINUX_ERRNO_EXTENSIONS__
+#define ESHUTDOWN 110		/* Can't send after socket shutdown */
 #endif
 #define ECONNREFUSED 111	/* Connection refused */
 #define EADDRINUSE 112		/* Address already in use */
@@ -183,7 +185,9 @@ extern NEWLIB_THREAD_LOCAL_ERRNO int errno;
 #define ENETUNREACH 114		/* Network is unreachable */
 #define ENETDOWN 115		/* Network interface is not configured */
 #define ETIMEDOUT 116		/* Connection timed out */
+#ifdef __LINUX_ERRNO_EXTENSIONS__
 #define EHOSTDOWN 117		/* Host is down */
+#endif
 #define EHOSTUNREACH 118	/* Host is unreachable */
 #define EINPROGRESS 119		/* Connection already in progress */
 #define EALREADY 120		/* Socket already connected */
@@ -194,35 +198,40 @@ extern NEWLIB_THREAD_LOCAL_ERRNO int errno;
 #define ESOCKTNOSUPPORT 124	/* Socket type not supported */
 #endif
 #define EADDRNOTAVAIL 125	/* Address not available */
-#define ENETRESET 126		/* Connection aborted by network */
+#define ENETRESET 126   	/* Connection aborted by network */
 #define EISCONN 127		/* Socket is already connected */
 #define ENOTCONN 128		/* Socket is not connected */
-#define ETOOMANYREFS 129
 #ifdef __LINUX_ERRNO_EXTENSIONS__
-#define EPROCLIM 130
-#define EUSERS 131
+#define ETOOMANYREFS 129        /* Too many references: cannot splice */
+#define EPROCLIM 130            /* Too many processes */
+#define EUSERS 131              /* Too many users */
 #endif
-#define EDQUOT 132
-#define ESTALE 133
-#define ENOTSUP 134		/* Not supported */
+#define EDQUOT 132      	/* Reserved */
+#define ESTALE 133      	/* Reserved */
+#define ENOTSUP 134     	/* Not supported */
 #ifdef __LINUX_ERRNO_EXTENSIONS__
-#define ENOMEDIUM 135   /* No medium (in tape drive) */
+#define ENOMEDIUM 135   	/* No medium found */
 #endif
 #ifdef __CYGWIN__
-#define ENOSHARE 136    /* No such host or network path */
-#define ECASECLASH 137  /* Filename exists with different case */
+#define ENOSHARE 136    	/* No such host or network path */
+#define ECASECLASH 137  	/* Filename exists with different case */
 #endif
 #define EILSEQ 138		/* Illegal byte sequence */
-#define EOVERFLOW 139	/* Value too large for defined data type */
-#define ECANCELED 140	/* Operation canceled */
+#define EOVERFLOW 139		/* Value too large for defined data type */
+#define ECANCELED 140		/* Operation canceled */
 #define ENOTRECOVERABLE 141	/* State not recoverable */
-#define EOWNERDEAD 142	/* Previous owner died */
+#define EOWNERDEAD 142		/* Previous owner died */
 #ifdef __LINUX_ERRNO_EXTENSIONS__
-#define ESTRPIPE 143	/* Streams pipe error */
+#define ESTRPIPE 143		/* Streams pipe error */
+#define EHWPOISON 144           /* Memory page has hardware error */
+#define EISNAM 145              /* Is a named type file */
+#define EKEYEXPIRED 146         /* Key has expired */
+#define EKEYREJECTED 147        /* Key was rejected by service */
+#define EKEYREVOKED 148         /* Key has been revoked */
 #endif
 #define EWOULDBLOCK EAGAIN	/* Operation would block */
 
-#define __ELASTERROR 2000	/* Users can add values starting here */
+#define __ELASTERROR 2000       /* Users can add values starting here */
 
 #ifdef __cplusplus
 }

--- a/newlib/libc/include/sys/lock.h
+++ b/newlib/libc/include/sys/lock.h
@@ -20,8 +20,6 @@ typedef int _LOCK_RECURSIVE_T;
 #define __lock_close_recursive(lock) ((void) 0)
 #define __lock_acquire(lock) ((void) 0)
 #define __lock_acquire_recursive(lock) ((void) 0)
-#define __lock_try_acquire(lock) ((void) 0)
-#define __lock_try_acquire_recursive(lock) ((void) 0)
 #define __lock_release(lock) ((void) 0)
 #define __lock_release_recursive(lock) ((void) 0)
 
@@ -50,11 +48,6 @@ extern void __retarget_lock_acquire(_LOCK_T lock);
 #define __lock_acquire(lock) __retarget_lock_acquire(lock)
 extern void __retarget_lock_acquire_recursive(_LOCK_T lock);
 #define __lock_acquire_recursive(lock) __retarget_lock_acquire_recursive(lock)
-extern int __retarget_lock_try_acquire(_LOCK_T lock);
-#define __lock_try_acquire(lock) __retarget_lock_try_acquire(lock)
-extern int __retarget_lock_try_acquire_recursive(_LOCK_T lock);
-#define __lock_try_acquire_recursive(lock) \
-  __retarget_lock_try_acquire_recursive(lock)
 extern void __retarget_lock_release(_LOCK_T lock);
 #define __lock_release(lock) __retarget_lock_release(lock)
 extern void __retarget_lock_release_recursive(_LOCK_T lock);

--- a/newlib/libc/misc/lock.c
+++ b/newlib/libc/misc/lock.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2016 Thomas Preud'homme <thomas.preudhomme@arm.com> */
 /*
 FUNCTION
-<<__retarget_lock_init>>, <<__retarget_lock_init_recursive>>, <<__retarget_lock_close>>, <<__retarget_lock_close_recursive>>, <<__retarget_lock_acquire>>, <<__retarget_lock_acquire_recursive>>, <<__retarget_lock_try_acquire>>, <<__retarget_lock_try_acquire_recursive>>, <<__retarget_lock_release>>, <<__retarget_lock_release_recursive>>---locking routines
+<<__retarget_lock_init>>, <<__retarget_lock_init_recursive>>, <<__retarget_lock_close>>, <<__retarget_lock_close_recursive>>, <<__retarget_lock_acquire>>, <<__retarget_lock_acquire_recursive>>, <<__retarget_lock_release>>, <<__retarget_lock_release_recursive>>---locking routines
 
 INDEX
 	__lock___sfp_recursive_mutex
@@ -31,10 +31,6 @@ INDEX
 INDEX
 	__retarget_lock_acquire_recursive
 INDEX
-	__retarget_lock_try_acquire
-INDEX
-	__retarget_lock_try_acquire_recursive
-INDEX
 	__retarget_lock_release
 INDEX
 	__retarget_lock_release_recursive
@@ -55,8 +51,6 @@ SYNOPSIS
 	void __retarget_lock_close_recursive (_LOCK_T <[lock]>);
 	void __retarget_lock_acquire (_LOCK_T <[lock]>);
 	void __retarget_lock_acquire_recursive (_LOCK_T <[lock]>);
-	int __retarget_lock_try_acquire (_LOCK_T <[lock]>);
-	int __retarget_lock_try_acquire_recursive (_LOCK_T <[lock]>);
 	void __retarget_lock_release (_LOCK_T <[lock]>);
 	void __retarget_lock_release_recursive (_LOCK_T <[lock]>);
 
@@ -123,20 +117,6 @@ void
 __retarget_lock_acquire_recursive (_LOCK_T lock)
 {
   (void) lock;
-}
-
-int
-__retarget_lock_try_acquire(_LOCK_T lock)
-{
-  (void) lock;
-  return 1;
-}
-
-int
-__retarget_lock_try_acquire_recursive(_LOCK_T lock)
-{
-  (void) lock;
-  return 1;
 }
 
 void

--- a/newlib/libc/search/hash.c
+++ b/newlib/libc/search/hash.c
@@ -31,6 +31,7 @@
  */
 
 #define _DEFAULT_SOURCE
+#define __LINUX_ERRNO_EXTENSIONS__
 #include <sys/param.h>
 #if defined(LIBC_SCCS) && !defined(lint)
 static char sccsid[] = "@(#)hash.c	8.9 (Berkeley) 6/16/94";

--- a/newlib/libc/search/hash_bigkey.c
+++ b/newlib/libc/search/hash_bigkey.c
@@ -484,9 +484,11 @@ collect_data(HTAB *hashp,
 		}
 	} else {
 		xbp = __get_buf(hashp, bp[bp[0] - 1], bufp, 0);
-		if (!xbp || ((totlen =
-		    collect_data(hashp, xbp, len + mylen, set)) < 1))
-			return (-1);
+                if (!xbp)
+                        return (-1);
+                totlen = collect_data(hashp, xbp, len + mylen, set);
+		if (totlen < 1 || totlen == (size_t) -1)
+                        return (-1);
 	}
 	if (bufp->addr != save_addr) {
 		errno = EINVAL;			/* Out of buffers. */

--- a/newlib/libc/search/hash_page.c
+++ b/newlib/libc/search/hash_page.c
@@ -31,6 +31,7 @@
  */
 
 #define _DEFAULT_SOURCE
+#define __LINUX_ERRNO_EXTENSIONS__
 #include <sys/param.h>
 #if defined(LIBC_SCCS) && !defined(lint)
 static char sccsid[] = "@(#)hash_page.c	8.7 (Berkeley) 8/16/94";

--- a/test/lock-valid.c
+++ b/test/lock-valid.c
@@ -63,6 +63,7 @@ void __retarget_lock_init(_LOCK_T *lock)
 /* Create a new dynamic recursive lock */
 void __retarget_lock_init_recursive(_LOCK_T *lock)
 {
+        assert(lock_id < MAX_LOCKS);
         *lock = &locks[lock_id++];
         **lock = 0;
 }

--- a/test/lock-valid.c
+++ b/test/lock-valid.c
@@ -108,15 +108,6 @@ void __retarget_lock_release_recursive(_LOCK_T lock)
         --(*lock);
 }
 
-#ifdef _PICO_EXIT
-#define LIBC_LOCK_EXIT_COUNT 0
-#else
-/*
- * Legacy onexit handler holds libc lock while calling hooks
- */
-#define LIBC_LOCK_EXIT_COUNT 1
-#endif
-
 __attribute__((destructor))
 static void lock_validate(void)
 {
@@ -124,5 +115,5 @@ static void lock_validate(void)
         for (i = 0; i < MAX_LOCKS; i++)
                 assert(locks[i] == 0);
 
-        assert(__lock___libc_recursive_mutex == LIBC_LOCK_EXIT_COUNT);
+        assert(__lock___libc_recursive_mutex == 0);
 }

--- a/test/lock-valid.c
+++ b/test/lock-valid.c
@@ -130,19 +130,12 @@ void __retarget_lock_release_recursive(_LOCK_T lock)
 #define LIBC_LOCK_EXIT_COUNT 1
 #endif
 
-static void lock_validate(int ret, void *arg)
+__attribute__((destructor))
+static void lock_validate(void)
 {
         int i;
-        (void) ret;
-        (void) arg;
         for (i = 0; i < MAX_LOCKS; i++)
                 assert(locks[i] == 0);
 
         assert(__lock___libc_recursive_mutex == LIBC_LOCK_EXIT_COUNT);
-}
-
-__attribute__((constructor))
-static void add_lock_validate(void)
-{
-    on_exit(lock_validate, NULL);
 }

--- a/test/lock-valid.c
+++ b/test/lock-valid.c
@@ -94,20 +94,6 @@ void __retarget_lock_acquire_recursive(_LOCK_T lock)
         ++(*lock);
 }
 
-/* Try acquiring non-recursive lock */
-int __retarget_lock_try_acquire(_LOCK_T lock)
-{
-        assert(*lock == 0);
-        *lock = 1;
-}
-
-/* Try acquiring recursive lock */
-int __retarget_lock_try_acquire_recursive(_LOCK_T lock)
-{
-        assert(*lock >= 0);
-        ++(*lock);
-}
-
 /* Release non-recursive lock */
 void __retarget_lock_release(_LOCK_T lock)
 {


### PR DESCRIPTION
Move non-POSIX values EFTYPE, EPFNOSUPPORT, EHOSTDOWN and ETOOMANYREFS into __LINUX_ERRNO_EXTENSIONS__ blocks. Add missing LINUX errno values EHWPOISON, EISNAM, EKEYEXPIRED, EKEYREJECTED and EKEYREVOKED. Reformat to align comments vertically.