### PR TITLE
Make lld work again for TLS

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -698,12 +698,15 @@ picolibcpp_specs = configure_file(input: 'picolibc.specs.in',
 				  install: specs_install)
 
 picolibc_linker_type_data = configuration_data()
+# We need to use different alignment flags for .tdata/.tbss for ld.bfd
+# (ALIGN_WITH_INPUT, which is not supported by ld.lld) and ld.lld
+# (ALIGN(__tls_align), which is rejected as non-constant by ld.bfd), so we use
+# the {BFD,LLD}_{START,END} templates to comment out the incompatible flag.
 if cc.get_linker_id() == 'ld.lld'
-    # ld.lld does not implement ALIGN_WITH_INPUT, but this flag is not needed
-    # with ld.lld's output section LMA/VMA algorithm.
-    # An added ASSERT() statement in the linker script ensures that we don't
-    # get silent failures in case this changes in the future.
-    picolibc_linker_type_data.set('LDSCRIPT_ALIGN_WITH_INPUT', '')
+    picolibc_linker_type_data.set('BFD_START', '/* For ld.bfd: ')
+    picolibc_linker_type_data.set('BFD_END', '*/')
+    picolibc_linker_type_data.set('LLD_START', '')
+    picolibc_linker_type_data.set('LLD_END', '')
     if host_cpu_family == 'riscv'
         # ld.lld before version 15 did not support linker relaxations, disable
         # them if we are using an older version.
@@ -715,7 +718,10 @@ if cc.get_linker_id() == 'ld.lld'
         endif
     endif
 else
-    picolibc_linker_type_data.set('LDSCRIPT_ALIGN_WITH_INPUT', 'ALIGN_WITH_INPUT')
+    picolibc_linker_type_data.set('BFD_START', '')
+    picolibc_linker_type_data.set('BFD_END', '')
+    picolibc_linker_type_data.set('LLD_START', '/* For ld.lld: ')
+    picolibc_linker_type_data.set('LLD_END', '*/')
 endif
 
 picolibc_linker_type_data.set('DEFAULT_FLASH_ADDR',

--- a/picolibc.ld.in
+++ b/picolibc.ld.in
@@ -162,9 +162,13 @@ SECTIONS
 	 * allocated at runtime. We're slightly abusing that
 	 * by placing the data in flash where it will be copied
 	 * into the allocate ram addresses by the existing
-	 * data initialization code in crt0
+	 * data initialization code in crt0.
+	 * BFD includes .tbss alignment when computing .tdata
+	 * alignment, but for ld.lld we have to explicitly pad
+	 * as it only guarantees usage as a TLS template works
+	 * rather than supporting this use case.
 	 */
-	.tdata : @LDSCRIPT_ALIGN_WITH_INPUT@ {
+	.tdata : @LLD_START@ ALIGN(__tls_align) @LLD_END@ @BFD_START@ ALIGN_WITH_INPUT @BFD_END@ {
 		*(.tdata .tdata.* .gnu.linkonce.td.*)
 		PROVIDE(__data_end = .);
 		PROVIDE(__tdata_end = .);
@@ -199,19 +203,17 @@ SECTIONS
 	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
 
 	/*
-	 * The linker special cases .tbss segments which are
-	 * identified as segments which are not loaded and are
-	 * thread_local.
-	 *
-	 * For these segments, the linker does not advance 'dot'
-	 * across them.  We actually need memory allocated for tbss,
-	 * so we create a special segment here just to make room
+	 * Unlike ld.lld, ld.bfd does not advance the location counter for
+	 * .tbss, but we actually need memory allocated for .tbss as we use
+	 * it for the initial TLS storage.
+	 * Create special section here just to make room.
 	 */
-	.tbss_space (NOLOAD) : {
+        @BFD_START@
+        .tbss_space (NOLOAD) : {
 		. = ADDR(.tbss);
 		. = . + SIZEOF(.tbss);
 	} >ram AT>ram :ram
-
+	@BFD_END@
 	.bss (NOLOAD) : {
 		*(.sbss*)
 		*(.gnu.linkonce.sb.*)

--- a/test/tls.c
+++ b/test/tls.c
@@ -45,6 +45,7 @@
 
 #define OVERALIGN_DATA  128
 #define OVERALIGN_BSS   256
+#define OVERALIGN_NON_TLS_BSS   512
 
 #define TLS_ALIGN      (OVERALIGN_DATA > OVERALIGN_BSS ? OVERALIGN_DATA : OVERALIGN_BSS)
 
@@ -52,6 +53,7 @@ NEWLIB_THREAD_LOCAL volatile int data_var = DATA_VAL;
 NEWLIB_THREAD_LOCAL volatile int bss_var;
 _Alignas(OVERALIGN_DATA) NEWLIB_THREAD_LOCAL volatile int overaligned_data_var = DATA_VAL2;
 _Alignas(OVERALIGN_BSS) NEWLIB_THREAD_LOCAL volatile int overaligned_bss_var;
+_Alignas(OVERALIGN_NON_TLS_BSS) volatile int overaligned_non_tls_bss_var;
 
 volatile int *volatile data_addr;
 volatile int *volatile overaligned_data_addr;
@@ -115,6 +117,11 @@ check_tls(char *where, bool check_addr, void *tls_region)
                        &overaligned_bss_var, (unsigned long) OVERALIGN_BSS);
                 result++;
         }
+	if (!__is_aligned((uintptr_t)&overaligned_non_tls_bss_var, OVERALIGN_NON_TLS_BSS)) {
+                printf("overaligned_non_tls_bss_var (%p) is not %ld aligned\n",
+                       &overaligned_non_tls_bss_var, (unsigned long) OVERALIGN_NON_TLS_BSS);
+                result++;
+        }
 	if (data_var != DATA_VAL) {
 		printf("%s: initialized thread var has wrong value (0x%x instead of 0x%x)\n",
 		       where, data_var, DATA_VAL);
@@ -134,6 +141,11 @@ check_tls(char *where, bool check_addr, void *tls_region)
         if (overaligned_bss_var != 0) {
 		printf("%s: overaligned uninitialized thread var has wrong value (0x%x instead of 0x%x)\n",
 		       where, overaligned_bss_var, 0);
+		result++;
+        }
+	if (overaligned_non_tls_bss_var != 0) {
+		printf("%s: overaligned uninitialized var has wrong value (0x%x instead of 0x%x)\n",
+		       where, overaligned_non_tls_bss_var, 0);
 		result++;
         }
 
@@ -196,9 +208,21 @@ check_tls(char *where, bool check_addr, void *tls_region)
 	check_inside_tls_region(&bss_var, tls_region);
 	check_inside_tls_region(&overaligned_bss_var, tls_region);
 
-        if (__non_tls_bss_start < __tdata_start + _tls_size() || __tdata_start + _tls_size() + 64 < __non_tls_bss_start) {
-                printf("non-TLS bss data doesn't start after TLS data (is %p should be %p)\n",
-                       __non_tls_bss_start, __tdata_start + _tls_size());
+        char *tdata_end = __tdata_start + _tls_size();
+        /*
+         * We allow for up to OVERALIGN_NON_TLS_BSS -1 bytes of padding after
+         * the end of .tbss and the start of aligned .bss since in theory the
+         * linker could fill this space with smaller .bss variables before the
+         * overaligned value that we define in this file.
+         */
+        char *non_tls_bss_start_latest = __align_up(
+            tdata_end + OVERALIGN_NON_TLS_BSS, OVERALIGN_NON_TLS_BSS);
+        if (__non_tls_bss_start < tdata_end ||
+            __non_tls_bss_start > non_tls_bss_start_latest) {
+                printf("non-TLS bss data doesn't start shortly after TLS data "
+                       "(is %p should be between %p and %p)\n",
+                       __non_tls_bss_start, tdata_end,
+                       non_tls_bss_start_latest);
                 result++;
         }
 #endif


### PR DESCRIPTION
picolibc.ld: Ensure .tdata alignment matches .tbss

If no TLS block has been assigned yet, picolibc uses the template inside
the binary directly. However, ld.lld only guarantees that .tdata/.tbss
are valid as a TLS template and not necessarily directly usable when using
picolibc's existing initialization logic. Add an explicit alignment
expression to the start of .tdata to ensure .tdata variables are at least
as aligned as the .tbss ones. This fixes the tls test when linking with
ld.lld while allowing to keep the single memcpy() call.
For context on linker behaviour: https://github.com/picolibc/picolibc/pull/411