### PR TITLE
Check for FENV_ACCESS support, conditional checks in math_errorhandling

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -154,7 +154,7 @@ if set_double_equals_float
   float_double_code = '''
 char size_test[sizeof(float) == sizeof(double) ? 1 : -1];
 '''
-  set_double_equals_float = 
+  set_double_equals_float =
   double_equals_float = cc.compiles(float_double_code, name : 'double same as float', args : core_c_args)
 endif
 
@@ -167,6 +167,14 @@ char size_test[sizeof(double) == sizeof(long double) ? 1 : -1];
 '''
   long_double_equals_double = cc.compiles(long_double_size_code, name : 'long double same as double', args: core_c_args)
 endif
+
+fenv_access_code = '''
+#pragma STDC FENV_ACCESS ON
+'''
+fenv_access_supported = cc.compiles(
+  fenv_access_code,
+  name : 'FENV_ACCESS supported',
+  args : cc.get_supported_arguments(['-Werror=ignored-pragmas']))
 
 enable_multilib = get_option('multilib')
 multilib_list = get_option('multilib-list')
@@ -503,7 +511,7 @@ else
   specs_install = true
 endif
 
-# Let targets add more support libraries 
+# Let targets add more support libraries
 additional_libs_list = meson.get_cross_property('additional_libs', [])
 
 if cc.get_id() == 'ccomp'
@@ -648,7 +656,7 @@ if enable_multilib
   gen_multilib_crt0_path = specs_prefix_format.format(get_option('libdir') / '%M' / crt0_expr)
   crt0_gen = gen_format.format(gen_multilib_crt0_path)
 endif
-  
+
 #
 # Construct the *startfile value from the options computed
 # above. As there's only one value, it's either the

--- a/test/math_errhandling.c
+++ b/test/math_errhandling.c
@@ -147,7 +147,6 @@ e_to_str(int e)
 #else
 #define EXCEPTION_TEST	MATH_ERREXCEPT
 #endif
-#define LONG_DOUBLE_EXCEPTION_TEST EXCEPTION_TEST
 #ifdef _M_PI_L
 #define PI_VAL _M_PI_L
 #else
@@ -207,7 +206,6 @@ e_to_str(int e)
 #else
 #define EXCEPTION_TEST	MATH_ERREXCEPT
 #endif
-#define DOUBLE_EXCEPTION_TEST EXCEPTION_TEST
 
 #define BIG 1.7e308
 #define BIGODD  0x1.123456789abcdp+52
@@ -264,14 +262,12 @@ int main(void)
 {
 	int result = 0;
 
-#if DOUBLE_EXCEPTION_TEST
 	printf("Double tests:\n");
 	result += run_tests();
-#endif
-#ifdef LONG_DOUBLE_EXCEPTION_TEST
+
 	printf("Long double tests:\n");
 	result += run_testsl();
-#endif
+
 	printf("Float tests:\n");
 	result += run_testsf();
 	return result;

--- a/test/math_errhandling_tests.c
+++ b/test/math_errhandling_tests.c
@@ -1420,6 +1420,7 @@ makemathname(run_tests)(void) {
                         printf("\n");
 			++result;
 		}
+#if ENABLE_FE_EXCEPTION_CHECKS
 		if (math_errhandling & EXCEPTION_TEST) {
                     int expect_except = makemathname(tests)[t].except;
                     int mask = MY_EXCEPT;
@@ -1443,6 +1444,7 @@ makemathname(run_tests)(void) {
 				++result;
 			}
 		}
+#endif
 		if (math_errhandling & MATH_ERRNO) {
 			if (err != makemathname(tests)[t].errno_expect) {
                                 PRINT;
@@ -1474,6 +1476,7 @@ makemathname(run_tests)(void) {
 			printf("\tbad value got %ld expect %ld\n", iv, makemathname(itests)[t].value);
 			++result;
 		}
+#if ENABLE_FE_EXCEPTION_CHECKS
 		if (math_errhandling & EXCEPTION_TEST) {
                         int expect_except = makemathname(itests)[t].except;
                         int mask = MY_EXCEPT;
@@ -1497,6 +1500,7 @@ makemathname(run_tests)(void) {
 				++result;
 			}
 		}
+#endif
 		if (math_errhandling & MATH_ERRNO) {
 			if (err != makemathname(itests)[t].errno_expect) {
                                 IPRINT;

--- a/test/meson.build
+++ b/test/meson.build
@@ -258,9 +258,14 @@ foreach target : targets
     t1_name = t1 + '_' + target
   endif
 
+  math_errhandling_c_args = []
+  if fenv_access_supported
+    math_errhandling_c_args += ['-DENABLE_FE_EXCEPTION_CHECKS']
+  endif
+
   test(t1_name,
        executable(t1_name, ['math_errhandling.c'],
-		  c_args: arg_fnobuiltin + _c_args,
+		  c_args: arg_fnobuiltin + math_errhandling_c_args + _c_args,
 		  link_args: _link_args,
 		  objects: _objs,
 		  link_with: _libs,


### PR DESCRIPTION
Added 'fenv_access_supported' compiler check to detect compilers, which do not support "#pragma STDC FENV_ACCESS ON".

Removed misleading LONG_DOUBLE_EXCEPTION_TEST and DOUBLE_EXCEPTION_TEST defines. These both took the current value of EXCEPTION_TEST not the one from the assignment time. Both `long double` and `double` tests were run, even when PICOLIBC_LONG_DOUBLE_NOEXCEPT or PICOLIBC_DOUBLE_NOEXCEPT were defined. As the tests passed anyway and the exceptions were intentionally not set, the tests are left enabled.