### PR TITLE
libc/stdio: Fix legacy stdio positional arguments

### DIFF
--- a/.github/workflows/variants
+++ b/.github/workflows/variants
@@ -15,7 +15,7 @@
 
           # Original stdio
           "-Dtinystdio=false",
-          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true -Dnewlib-fvwrite-in-streamio=true",
+          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true -Dnewlib-fvwrite-in-streamio=true -Dio-pos-args=true",
 
           # Locale, iconv, original malloc and original atexit/onexit configurations
           "-Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",

--- a/newlib/libc/stdio/vfprintf.c
+++ b/newlib/libc/stdio/vfprintf.c
@@ -586,9 +586,13 @@ union arg_val
   wint_t val_wint_t;
 };
 
+typedef struct {
+    va_list ap;
+} my_va_list;
+
 static union arg_val *
-get_arg (struct _reent *data, int n, char *fmt,
-                 va_list *ap, int *numargs, union arg_val *args,
+get_arg (int n, char *fmt,
+                 my_va_list *ap, int *numargs, union arg_val *args,
                  int *arg_type, char **last_fmt);
 #endif /* !_NO_POS_ARGS */
 
@@ -643,6 +647,8 @@ VFPRINTF (
 	int arg_index;          /* index into args processed directly */
 	int numargs;            /* number of varargs read */
 	char *saved_fmt;        /* saved fmt pointer */
+        my_va_list my_ap;
+        va_copy(my_ap.ap, ap);
 	union arg_val args[MAX_POS_ARGS];
 	int arg_type[MAX_POS_ARGS];
 	int is_pos_arg;         /* is current format positional? */
@@ -779,13 +785,13 @@ VFPRINTF (
 	(is_pos_arg							\
 	 ? (n < numargs							\
 	    ? args[n].val_##type					\
-	    : get_arg (data, n, fmt_anchor, &ap, &numargs, args,	\
+	    : get_arg (n, fmt_anchor, &my_ap, &numargs, args,     \
 		       arg_type, &saved_fmt)->val_##type)		\
 	 : (arg_index++ < numargs					\
 	    ? args[n].val_##type					\
 	    : (numargs < MAX_POS_ARGS					\
-	       ? args[numargs++].val_##type = va_arg (ap, type)		\
-	       : va_arg (ap, type))))
+	       ? args[numargs++].val_##type = va_arg (my_ap.ap, type)		\
+	       : va_arg (my_ap.ap, type))))
 #else
 # define GET_ARG(n, ap, type) (va_arg (ap, type))
 #endif
@@ -2012,10 +2018,10 @@ const __ACTION __action_table[MAX_STATE][MAX_CH_CLASS] = {
 
 /* function to get positional parameter N where n = N - 1 */
 static union arg_val *
-get_arg (struct _reent *data,
+get_arg (
        int n,
        char *fmt,
-       va_list *ap,
+       my_va_list *ap,
        int *numargs_p,
        union arg_val *args,
        int *arg_type,
@@ -2221,25 +2227,25 @@ get_arg (struct _reent *data,
 		    switch (spec_type)
 		      {
 		      case LONG_INT:
-			args[numargs++].val_long = va_arg (*ap, long);
+			args[numargs++].val_long = va_arg (ap->ap, long);
 			break;
 		      case QUAD_INT:
-			args[numargs++].val_quad_t = va_arg (*ap, quad_t);
+			args[numargs++].val_quad_t = va_arg (ap->ap, quad_t);
 			break;
 		      case WIDE_CHAR:
-			args[numargs++].val_wint_t = va_arg (*ap, wint_t);
+			args[numargs++].val_wint_t = va_arg (ap->ap, wint_t);
 			break;
 		      case INT:
-			args[numargs++].val_int = va_arg (*ap, int);
+			args[numargs++].val_int = va_arg (ap->ap, int);
 			break;
 		      case CHAR_PTR:
-			args[numargs++].val_char_ptr_t = va_arg (*ap, char *);
+			args[numargs++].val_char_ptr_t = va_arg (ap->ap, char *);
 			break;
 		      case DOUBLE:
-			args[numargs++].val_double = va_arg (*ap, double);
+			args[numargs++].val_double = va_arg (ap->ap, double);
 			break;
 		      case LONG_DOUBLE:
-			args[numargs++].val__LONG_DOUBLE = va_arg (*ap, _LONG_DOUBLE);
+			args[numargs++].val__LONG_DOUBLE = va_arg (ap->ap, _LONG_DOUBLE);
 			break;
 		      }
 		  }
@@ -2262,7 +2268,7 @@ get_arg (struct _reent *data,
 	      --fmt;
 	      __PICOLIBC_FALLTHROUGH;
 	    case GETPW:  /* we have a variable precision or width to acquire */
-	      args[numargs++].val_int = va_arg (*ap, int);
+	      args[numargs++].val_int = va_arg (ap->ap, int);
 	      break;
 	    case NUMBER: /* we have a number to process */
 	      number = (ch - '0');
@@ -2295,26 +2301,26 @@ get_arg (struct _reent *data,
       switch (arg_type[numargs])
 	{
 	case LONG_INT:
-	  args[numargs++].val_long = va_arg (*ap, long);
+	  args[numargs++].val_long = va_arg (ap->ap, long);
 	  break;
 	case QUAD_INT:
-	  args[numargs++].val_quad_t = va_arg (*ap, quad_t);
+	  args[numargs++].val_quad_t = va_arg (ap->ap, quad_t);
 	  break;
 	case CHAR_PTR:
-	  args[numargs++].val_char_ptr_t = va_arg (*ap, char *);
+	  args[numargs++].val_char_ptr_t = va_arg (ap->ap, char *);
 	  break;
 	case DOUBLE:
-	  args[numargs++].val_double = va_arg (*ap, double);
+	  args[numargs++].val_double = va_arg (ap->ap, double);
 	  break;
 	case LONG_DOUBLE:
-	  args[numargs++].val__LONG_DOUBLE = va_arg (*ap, _LONG_DOUBLE);
+	  args[numargs++].val__LONG_DOUBLE = va_arg (ap->ap, _LONG_DOUBLE);
 	  break;
 	case WIDE_CHAR:
-	  args[numargs++].val_wint_t = va_arg (*ap, wint_t);
+	  args[numargs++].val_wint_t = va_arg (ap->ap, wint_t);
 	  break;
 	case INT:
 	default:
-	  args[numargs++].val_int = va_arg (*ap, int);
+	  args[numargs++].val_char_ptr_t = va_arg (ap->ap, char *);
 	  break;
 	}
     }

--- a/newlib/libc/stdio/vfscanf.c
+++ b/newlib/libc/stdio/vfscanf.c
@@ -160,7 +160,11 @@ Supporting OS subroutines required:
 #  define MAX_POS_ARGS 32
 # endif
 
-static void * get_arg (int, va_list *, int *, void **);
+typedef struct {
+    va_list ap;
+} my_va_list;
+
+static void * get_arg (int, my_va_list *, int *, void **);
 #endif /* _WANT_IO_POS_ARGS */
 
 /*
@@ -388,6 +392,8 @@ _SVFSCANF (
   int N;			/* arg number */
   int arg_index = 0;		/* index into args processed directly */
   int numargs = 0;		/* number of varargs read */
+  my_va_list my_ap;
+  va_copy(my_ap.ap, ap);
   void *args[MAX_POS_ARGS];	/* positional args read */
   int is_pos_arg;		/* is current format positional? */
 #endif
@@ -550,12 +556,12 @@ _SVFSCANF (
   ((type) (is_pos_arg						\
 	   ? (n < numargs					\
 	      ? args[n]						\
-	      : get_arg (n, &ap, &numargs, args))		\
+	      : get_arg (n, &my_ap, &numargs, args))      \
 	   : (arg_index++ < numargs				\
 	      ? args[n]						\
 	      : (numargs < MAX_POS_ARGS				\
-		 ? args[numargs++] = va_arg (ap, void *)	\
-		 : va_arg (ap, void *)))))
+		 ? args[numargs++] = va_arg (my_ap.ap, void *)	\
+		 : va_arg (my_ap.ap, void *)))))
 #else
 # define GET_ARG(n, ap, type) (va_arg (ap, type))
 #endif
@@ -1953,11 +1959,11 @@ all_done:
    intermediate arguments are sizeof(void*), so we don't need to scan
    ahead in the format string.  */
 static void *
-get_arg (int n, va_list *ap, int *numargs_p, void **args)
+get_arg (int n, my_va_list *ap, int *numargs_p, void **args)
 {
   int numargs = *numargs_p;
   while (n >= numargs)
-    args[numargs++] = va_arg (*ap, void *);
+    args[numargs++] = va_arg (ap->ap, void *);
   *numargs_p = numargs;
   return args[n];
 }

--- a/test/testcases.c
+++ b/test/testcases.c
@@ -120,6 +120,7 @@
     result |= test(__LINE__, "Hot Pocket", "%1$s %2$s", "Hot", "Pocket");
     result |= test(__LINE__, "Pocket Hot", "%2$s %1$s", "Hot", "Pocket");
     result |= test(__LINE__, "0002   1 hi", "%2$04d %1$*3$d %4$s", 1, 2, 3, "hi");
+    result |= test(__LINE__, "   ab", "%1$*2$.*3$s", "abc", 5, 2);
 #ifndef NO_FLOAT
     result |= test(__LINE__, "12.0 Hot Pockets", "%1$.1f %2$s %3$ss", printf_float(12.0), "Hot", "Pocket");
     result |= test(__LINE__, "12.0 Hot Pockets", "%1$.*4$f %2$s %3$ss", printf_float(12.0), "Hot", "Pocket", 1);


### PR DESCRIPTION
va_list might be declared as an array (as on x86_64), in which
case we must wrap the value inside a struct to support passing it
by address. Use va_copy to move it into the right place. This probably
messes up targets that do something in va_end.
    
On targets with sizeof(char *) > sizeof(int), the printf code that
attempts to stash intermediate values gets confused sometimes by *
arguments. Deal with this by just treating all 'int' args as 'char *'
in get_arg so that bits aren't lost. This assumes that these targets
align all arguments on char * instead of int boundaries.