### PR TITLE
math: Add barriers in nextafter*/nexttoward* uses of force_eval*

### DIFF
--- a/newlib/libm/common/math_config.h
+++ b/newlib/libm/common/math_config.h
@@ -326,6 +326,13 @@ force_eval_double (double x)
 }
 
 #ifdef _HAVE_LONG_DOUBLE
+static ALWAYS_INLINE long double
+opt_barrier_long_double (long double x)
+{
+  FORCE_LONG_DOUBLE y = x;
+  return y;
+}
+
 static ALWAYS_INLINE void
 force_eval_long_double (long double x)
 {
@@ -339,11 +346,13 @@ force_eval_long_double (long double x)
  * to force evaluation order where needed
  */
 #ifdef __clang__
+#define clang_barrier_long_double(x) opt_barrier_long_double(x)
 #define clang_barrier_double(x) opt_barrier_double(x)
 #define clang_barrier_float(x) opt_barrier_float(x)
 #define clang_force_double(x) force_eval_double(x)
 #define clang_force_float(x) force_eval_float(x)
 #else
+#define clang_barrier_long_double(x) (x)
 #define clang_barrier_double(x) (x)
 #define clang_barrier_float(x) (x)
 #define clang_force_double(x) (x)
@@ -615,6 +624,7 @@ force_eval_long_double (long double x)
 #  define _FLOAT64_MIN  LDBL_MIN
 #  define _FLOAT64_MAX  LDBL_MAX
 #  define force_eval_float64 force_eval_long_double
+#  define opt_barrier_float64 opt_barrier_long_double
 # endif
 # define _MATH_ALIAS_l_to_f(name)
 # define _MATH_ALIAS_l_l_to_f(name)
@@ -662,6 +672,7 @@ typedef double __float64;
 # define FORCE_FLOAT64 FORCE_DOUBLE
 # define pick_float64_except(a,b) pick_double_except(a,b)
 # define force_eval_float64 force_eval_double
+# define opt_barrier_float64 opt_barrier_double
 #endif
 
 #if __SIZEOF_LONG_DOUBLE__ > 8

--- a/newlib/libm/common/nexttowardf.c
+++ b/newlib/libm/common/nexttowardf.c
@@ -54,7 +54,7 @@ nexttowardf (float x, long double y)
     if (signbit(y))
       ux |= 0x80000000;
     x = asfloat(ux);
-    force_eval_float(x*x);
+    force_eval_float(opt_barrier_float(x) * x);
     return x;
   } else if ((long double) x < y) {
     if (signbit(x))

--- a/newlib/libm/common/s_nextafter.c
+++ b/newlib/libm/common/s_nextafter.c
@@ -69,7 +69,7 @@ nextafter64(__float64 x, __float64 y)
 	if(x==y) return y;		/* x=y, return y (follow y sign for 0) */
 	if((ix|lx)==0) {			/* x == 0 */
 	    INSERT_WORDS(x,hy&0x80000000,1);	/* return +-minsubnormal */
-            force_eval_float64(x*x);
+            force_eval_float64(opt_barrier_float64(x)*x);
             return x;
 	} 
 	if(hx>=0) {				/* x > 0 */

--- a/newlib/libm/common/sf_nextafter.c
+++ b/newlib/libm/common/sf_nextafter.c
@@ -30,7 +30,7 @@ float nextafterf(float x, float y)
 	if(x==y) return y;		/* x=y, return y */
 	if(FLT_UWORD_IS_ZERO(ix)) {		/* x == 0 */
 	    SET_FLOAT_WORD(x,(hy&0x80000000)|FLT_UWORD_MIN);
-            force_eval_float(x*x);
+            force_eval_float(opt_barrier_float(x)*x);
             return x;
 	}
 	if(hx>=0) {				/* x > 0 */

--- a/newlib/libm/ld/ld128/s_nextafterl.c
+++ b/newlib/libm/ld/ld128/s_nextafterl.c
@@ -36,7 +36,7 @@ nextafterl(long double x, long double y)
 	if(x==y) return y;		/* x=y, return y */
 	if((ix|lx)==0) {			/* x == 0 */
 	    SET_LDOUBLE_WORDS64(x,hy&0x8000000000000000ULL,1);/* return +-minsubnormal */
-            force_eval_long_double(x*x);
+            force_eval_long_double(opt_barrier_long_double(x)*x);
             return x;
 	}
 	if(hx>=0) {			/* x > 0 */

--- a/newlib/libm/ld/ld128/s_nexttoward.c
+++ b/newlib/libm/ld/ld128/s_nexttoward.c
@@ -33,7 +33,7 @@ nexttoward64(__float64 x, long double y)
 	iy = hy&0x7fffffffffffffffLL;	/* |y| */
 
 	if((ix>=0x7ff00000)&&((ix-0x7ff00000)|lx)!=0) {   /* x is nan */
-            force_eval_long_double(y+y);
+            force_eval_long_double(opt_barrier_long_double(y)+y);
             return x + x;
         }
 	if((iy>=0x7fff000000000000LL)&&((iy-0x7fff000000000000LL)|ly)!=0) { /* y is nan */
@@ -42,7 +42,7 @@ nexttoward64(__float64 x, long double y)
 	if((long double) x==y) return y;	/* x=y, return y */
 	if((ix|lx)==0) {			/* x == 0 */
 	    INSERT_WORDS(x,(u_int32_t)((hy>>32)&0x80000000),1);/* return +-minsub */
-            force_eval_float64(x*x);
+            force_eval_float64(opt_barrier_float64(x)*x);
 	    return x;
 	}
 	if(hx>=0) {				/* x > 0 */

--- a/newlib/libm/ld/ld128/s_nexttowardf.c
+++ b/newlib/libm/ld/ld128/s_nexttowardf.c
@@ -25,7 +25,7 @@ nexttowardf(float x, long double y)
 	iy = hy&0x7fffffffffffffffLL;	/* |y| */
 
 	if(ix>0x7f800000) {       /* x is nan */
-            force_eval_long_double(y+y);
+            force_eval_long_double(opt_barrier_long_double(y)+y);
             return x + x;
         }
         if((iy>=0x7fff000000000000LL)&&((iy-0x7fff000000000000LL)|ly)!=0) { /* y is nan */
@@ -34,7 +34,7 @@ nexttowardf(float x, long double y)
 	if((long double) x==y) return y;	/* x=y, return y */
 	if(ix==0) {				/* x == 0 */
 	    SET_FLOAT_WORD(x,(u_int32_t)((hy>>32)&0x80000000)|1);/* return +-minsub*/
-            force_eval_float(x*x);
+            force_eval_float(opt_barrier_float(x)*x);
 	    return x;
 	}
 	if(hx>=0) {				/* x > 0 */

--- a/newlib/libm/ld/ld80/s_nextafterl.c
+++ b/newlib/libm/ld/ld80/s_nextafterl.c
@@ -37,7 +37,7 @@ nextafterl(long double x, long double y)
 	if(x==y) return y;		/* x=y, return y */
 	if((ix|hx|lx)==0) {			/* x == 0 */
             SET_LDOUBLE_WORDS(x,esy & 0x8000,hx,1);
-            force_eval_long_double(x*x);
+            force_eval_long_double(opt_barrier_long_double(x)*x);
             return x;
 	}
 	if(esx<0x8000) {			/* x > 0 */

--- a/newlib/libm/ld/ld80/s_nexttoward.c
+++ b/newlib/libm/ld/ld80/s_nexttoward.c
@@ -37,7 +37,7 @@ nexttoward(__float64 x, long double y)
 	if((long double) x==y) return y;	/* x=y, return y */
 	if((ix|lx)==0) {			/* x == 0 */
 	    INSERT_WORDS(x,(esy&0x8000)<<16,1); /* return +-minsub */
-            force_eval_double(x*x);
+            force_eval_float64(opt_barrier_float64(x)*x);
 	    return x;
 	}
 	if(hx>=0) {				/* x > 0 */

--- a/newlib/libm/ld/ld80/s_nexttowardf.c
+++ b/newlib/libm/ld/ld80/s_nexttowardf.c
@@ -30,7 +30,7 @@ nexttowardf(float x, long double y)
 	if((long double) x==y) return y;	/* x=y, return y */
 	if(ix==0) {				/* x == 0 */
 	    SET_FLOAT_WORD(x,((esy&0x8000)<<16)|1);/* return +-minsub*/
-            force_eval_float(x*x);
+            force_eval_float(opt_barrier_float(x)*x);
 	    return x;
 	}
 	if(hx>=0) {				/* x > 0 */


### PR DESCRIPTION
Make sure the compiler actually performs the computation being passed to one of the force_eval_ functions so that the right exceptions are generated.

This fixes various clang bugs with the nextafter/nexttoward functions where they were not raising the FE_UNDERFLOW exception.

Refer to discussion in #500