### PR TITLE
picolibc.ld: Fixup for lld alignment changes

### DIFF
--- a/picolibc.ld.in
+++ b/picolibc.ld.in
@@ -142,7 +142,7 @@ SECTIONS
 		PROVIDE(__preserve_end__ = .);
 	} >ram AT>ram :ram
 
-	.data : @LDSCRIPT_ALIGN_WITH_INPUT@ {
+	.data : @BFD_START@ ALIGN_WITH_INPUT @BFD_END@ {
 		*(.data .data.*)
 		*(.gnu.linkonce.d.*)
 

--- a/scripts/do-native-configure
+++ b/scripts/do-native-configure
@@ -36,6 +36,7 @@
 DIR="$(dirname "$0")"
 meson setup \
         --buildtype debug \
+	--fatal-meson-warnings \
         -Dtls-model=global-dynamic \
 	-Derrno-function=auto \
         -Dmultilib=false \


### PR DESCRIPTION
Making the linker script work with lld changed how the script enabled the ALIGN_WITH_INPUT mode for .tdata but missed that change for .data