### PR TITLE
libc/string: Keep string code from reading out-of-bounds when asan enabled

### DIFF
--- a/newlib/libc/include/sys/config.h
+++ b/newlib/libc/include/sys/config.h
@@ -344,4 +344,15 @@ SUCH DAMAGE.
 #define _HAVE_LONG_DOUBLE_MATH
 #endif
 
+/*
+ * When the address sanitizer is enabled, we must prevent the library
+ * from even reading beyond the end of input data. This happens in
+ * many optimized string functions.
+ */
+#ifdef __has_feature
+#if __has_feature(address_sanitizer)
+#define PICOLIBC_NO_OUT_OF_BOUNDS_READS
+#endif
+#endif
+
 #endif /* __SYS_CONFIG_H__ */

--- a/newlib/libc/string/memccpy.c
+++ b/newlib/libc/string/memccpy.c
@@ -64,7 +64,8 @@ memccpy (void *__restrict dst0,
 	size_t len0)
 {
 
-#if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
+#if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__) || \
+    defined(PICOLIBC_NO_OUT_OF_BOUNDS_READS)
   void *ptr = NULL;
   char *dst = (char *) dst0;
   char *src = (char *) src0;

--- a/newlib/libc/string/memchr.c
+++ b/newlib/libc/string/memchr.c
@@ -86,7 +86,8 @@ memchr (const void *src_void,
   const unsigned char *src = (const unsigned char *) src_void;
   unsigned char d = c;
 
-#if !defined(PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__)
+#if !defined(PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__) && \
+    !defined(PICOLIBC_NO_OUT_OF_BOUNDS_READS)
   unsigned long *asrc;
   unsigned long  mask;
   unsigned int i;

--- a/newlib/libc/string/memrchr.c
+++ b/newlib/libc/string/memrchr.c
@@ -71,7 +71,8 @@ memrchr (const void *src_void,
   const unsigned char *src = (const unsigned char *) src_void + length - 1;
   unsigned char d = c;
 
-#if !defined(PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__)
+#if !defined(PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__) && \
+    !defined(PICOLIBC_NO_OUT_OF_BOUNDS_READS)
   unsigned long *asrc;
   unsigned long  mask;
   unsigned int i;

--- a/newlib/libc/string/rawmemchr.c
+++ b/newlib/libc/string/rawmemchr.c
@@ -69,7 +69,8 @@ rawmemchr (const void *src_void,
   const unsigned char *src = (const unsigned char *) src_void;
   unsigned char d = c;
 
-#if !defined(PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__)
+#if !defined(PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__) && \
+    !defined(PICOLIBC_NO_OUT_OF_BOUNDS_READS)
   unsigned long *asrc;
   unsigned long  mask;
   unsigned int i;

--- a/newlib/libc/string/stpcpy.c
+++ b/newlib/libc/string/stpcpy.c
@@ -58,7 +58,8 @@ char*
 stpcpy (char *__restrict dst,
 	const char *__restrict src)
 {
-#if !defined(PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__)
+#if !defined(PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__) && \
+    !defined(PICOLIBC_NO_OUT_OF_BOUNDS_READS)
   long *aligned_dst;
   const long *aligned_src;
 

--- a/newlib/libc/string/stpncpy.c
+++ b/newlib/libc/string/stpncpy.c
@@ -71,7 +71,8 @@ stpncpy (char *__restrict dst,
 {
   char *ret = NULL;
 
-#if !defined(PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__)
+#if !defined(PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__) && \
+    !defined(PICOLIBC_NO_OUT_OF_BOUNDS_READS)
   long *aligned_dst;
   const long *aligned_src;
 

--- a/newlib/libc/string/strcat.c
+++ b/newlib/libc/string/strcat.c
@@ -76,7 +76,8 @@ char *
 strcat (char *__restrict s1,
 	const char *__restrict s2)
 {
-#if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
+#if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__) || \
+    defined(PICOLIBC_NO_OUT_OF_BOUNDS_READS)
   char *s = s1;
 
   while (*s1)

--- a/newlib/libc/string/strchr.c
+++ b/newlib/libc/string/strchr.c
@@ -75,7 +75,8 @@ strchr (const char *s1,
   const unsigned char *s = (const unsigned char *)s1;
   unsigned char c = i;
 
-#if !defined(PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__)
+#if !defined(PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__) && \
+    !defined(PICOLIBC_NO_OUT_OF_BOUNDS_READS)
   unsigned long mask,j;
   unsigned long *aligned_addr;
 

--- a/newlib/libc/string/strcmp.c
+++ b/newlib/libc/string/strcmp.c
@@ -72,7 +72,8 @@ int
 strcmp (const char *s1,
 	const char *s2)
 { 
-#if (defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)) && !defined(FAST_STRCMP)
+#if ((defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)) && !defined(FAST_STRCMP)) \
+    || defined(PICOLIBC_NO_OUT_OF_BOUNDS_READS)
   while (*s1 != '\0' && *s1 == *s2)
     {
       s1++;

--- a/newlib/libc/string/strcpy.c
+++ b/newlib/libc/string/strcpy.c
@@ -74,7 +74,8 @@ char*
 strcpy (char *dst0,
 	const char *src0)
 {
-#if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
+#if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__) || \
+    defined(PICOLIBC_NO_OUT_OF_BOUNDS_READS)
   char *s = dst0;
 
   while ((*dst0++ = *src0++))

--- a/newlib/libc/string/strlen.c
+++ b/newlib/libc/string/strlen.c
@@ -70,7 +70,8 @@ strlen (const char *str)
 {
   const char *start = str;
 
-#if !defined(PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__)
+#if !defined(PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__) && \
+    !defined(PICOLIBC_NO_OUT_OF_BOUNDS_READS)
   unsigned long *aligned_addr;
 
   /* Align the pointer, so we can search a word at a time.  */

--- a/newlib/libc/string/strncat.c
+++ b/newlib/libc/string/strncat.c
@@ -81,7 +81,8 @@ strncat (char *__restrict s1,
 	const char *__restrict s2,
 	size_t n)
 {
-#if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
+#if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__) || \
+    defined(PICOLIBC_NO_OUT_OF_BOUNDS_READS)
   char *s = s1;
 
   while (*s1)

--- a/newlib/libc/string/strncmp.c
+++ b/newlib/libc/string/strncmp.c
@@ -73,7 +73,8 @@ strncmp (const char *s1,
 	const char *s2,
 	size_t n)
 {
-#if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
+#if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__) || \
+    defined(PICOLIBC_NO_OUT_OF_BOUNDS_READS)
   if (n == 0)
     return 0;
 

--- a/newlib/libc/string/strncpy.c
+++ b/newlib/libc/string/strncpy.c
@@ -82,7 +82,8 @@ strncpy (char *__restrict dst0,
 	const char *__restrict src0,
 	size_t count)
 {
-#if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
+#if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__) || \
+    defined(PICOLIBC_NO_OUT_OF_BOUNDS_READS)
   char *dscan;
   const char *sscan;
 


### PR DESCRIPTION
When the llvm address sanitizer is enabled while building the library, we need to bypass the optimized string functions which read past the end of the strings looking for null bytes.

Closes: #506 