### PR TITLE
Asan fixup

### DIFF
--- a/newlib/libc/include/sys/config.h
+++ b/newlib/libc/include/sys/config.h
@@ -353,6 +353,8 @@ SUCH DAMAGE.
 #if __has_feature(address_sanitizer)
 #define PICOLIBC_NO_OUT_OF_BOUNDS_READS
 #endif
+#elif defined(__SANITIZE_ADDRESS__)
+#define PICOLIBC_NO_OUT_OF_BOUNDS_READS
 #endif
 
 #endif /* __SYS_CONFIG_H__ */

--- a/newlib/libm/test/meson.build
+++ b/newlib/libm/test/meson.build
@@ -169,6 +169,7 @@ if enable_native_tests
     test('math-native',
 	 executable('math_test_native', math_test_src,
 		    c_args: native_c_args,
+		    link_args: native_c_args,
 		    dependencies: native_lib_m))
   endif
 endif


### PR DESCRIPTION
Missed the code to detect when GCC enables the address sanitizer.