### PR TITLE
Support -msoft-float on x86 targets

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -15,6 +15,6 @@ RUN apt-get update && \
      xargs -a linux-packages.txt apt-get install -y --no-install-recommends || \
      xargs -a linux-packages.txt apt-get install -y --no-install-recommends) && \
     mkdir -p /opt && \
-    (cd /opt && while read file; do wget $file || exit 1; tar xf `basename $file`; done) < linux-files.txt
+    (cd /opt && while read file; do wget $file || exit 1; tar xf `basename $file`; rm `basename $file`; done) < linux-files.txt
 
 RUN apt-get clean

--- a/.github/Dockerfile-zephyr
+++ b/.github/Dockerfile-zephyr
@@ -1,6 +1,6 @@
 FROM debian:testing
 
-COPY .github/packages.txt /
+COPY .github/zephyr-packages.txt /
 
 COPY .github/zephyr-files.txt /
 
@@ -8,11 +8,11 @@ RUN apt-get update && \
     apt-get install -y wget gnupg && \
     (apt-get update || apt-get update || apt-get update) && \
     (apt-get upgrade -y || apt-get upgrade -y || apt-get upgrade -y) && \
-    (xargs -a packages.txt apt-get install -y || \
-     xargs -a packages.txt apt-get install -y || \
-     xargs -a packages.txt apt-get install -y || \
-     xargs -a packages.txt apt-get install -y) && \
+    (xargs -a zephyr-packages.txt apt-get install -y || \
+     xargs -a zephyr-packages.txt apt-get install -y || \
+     xargs -a zephyr-packages.txt apt-get install -y || \
+     xargs -a zephyr-packages.txt apt-get install -y) && \
     mkdir -p /opt && \
-    (cd /opt && while read file; do wget $file || exit 1; tar xf `basename $file`; done) < zephyr-files.txt
+    (cd /opt && while read file; do wget $file || exit 1; tar xf `basename $file`; rm `basename $file`; done) < zephyr-files.txt
 
 RUN apt-get clean

--- a/.github/do-zephyr
+++ b/.github/do-zephyr
@@ -5,6 +5,7 @@ HERE=`dirname "$0"`
 "$HERE"/do-zephyr-build arc64 "$@"
 "$HERE"/do-zephyr-build microblazeel "$@"
 "$HERE"/do-zephyr-build nios2 "$@"
+"$HERE"/do-zephyr-test x86_64-zephyr "$@"
 "$HERE"/do-zephyr-build xtensa-espressif_esp32 "$@"
 "$HERE"/do-zephyr-build xtensa-espressif_esp32s2 "$@"
 "$HERE"/do-zephyr-build xtensa-nxp_imx_adsp "$@"

--- a/.github/do-zephyr-test
+++ b/.github/do-zephyr-test
@@ -1,0 +1,3 @@
+#!/bin/bash
+here=`dirname "$0"`
+"$here"/zephyr "$here"/do-test "$@"

--- a/.github/workflows/head-zephyr
+++ b/.github/workflows/head-zephyr
@@ -11,7 +11,7 @@ on:
 env:
   IMAGE_FILE: dockerimg-zephyr.tar.xz
   IMAGE: picolibc
-  PACKAGES_FILE: picolibc/.github/packages.txt
+  PACKAGES_FILE: picolibc/.github/zephyr-packages.txt
   EXTRA_FILE: picolibc/.github/zephyr-files.txt
 
 jobs:

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -11,7 +11,7 @@ on:
 env:
   IMAGE_FILE: dockerimg-zephyr.tar.xz
   IMAGE: picolibc
-  PACKAGES_FILE: picolibc/.github/packages.txt
+  PACKAGES_FILE: picolibc/.github/zephyr-packages.txt
   EXTRA_FILE: picolibc/.github/zephyr-files.txt
 
 jobs:
@@ -61,7 +61,7 @@ jobs:
 
           # Original stdio
           "-Dtinystdio=false",
-          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true -Dnewlib-fvwrite-in-streamio=true",
+          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true -Dnewlib-fvwrite-in-streamio=true -Dio-pos-args=true",
 
           # Locale, iconv, original malloc and original atexit/onexit configurations
           "-Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",
@@ -112,7 +112,7 @@ jobs:
 
           # Original stdio
           "-Dtinystdio=false",
-          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true -Dnewlib-fvwrite-in-streamio=true",
+          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true -Dnewlib-fvwrite-in-streamio=true -Dio-pos-args=true",
 
           # Locale, iconv, original malloc and original atexit/onexit configurations
           "-Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",
@@ -163,7 +163,7 @@ jobs:
 
           # Original stdio
           "-Dtinystdio=false",
-          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true -Dnewlib-fvwrite-in-streamio=true",
+          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true -Dnewlib-fvwrite-in-streamio=true -Dio-pos-args=true",
 
           # Locale, iconv, original malloc and original atexit/onexit configurations
           "-Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",

--- a/.github/zephyr-files.txt
+++ b/.github/zephyr-files.txt
@@ -2,6 +2,7 @@ https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/toolchain
 https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/toolchain_linux-x86_64_arc64-zephyr-elf.tar.xz
 https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/toolchain_linux-x86_64_microblazeel-zephyr-elf.tar.xz
 https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/toolchain_linux-x86_64_nios2-zephyr-elf.tar.xz
+https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/toolchain_linux-x86_64_x86_64-zephyr-elf.tar.xz
 https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/toolchain_linux-x86_64_xtensa-espressif_esp32s2_zephyr-elf.tar.xz
 https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/toolchain_linux-x86_64_xtensa-espressif_esp32_zephyr-elf.tar.xz
 https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/toolchain_linux-x86_64_xtensa-intel_ace15_mtpm_zephyr-elf.tar.xz

--- a/.github/zephyr-packages.txt
+++ b/.github/zephyr-packages.txt
@@ -1,0 +1,6 @@
+build-essential
+meson
+cmake
+file
+ninja-build
+qemu-system-x86

--- a/meson.build
+++ b/meson.build
@@ -136,12 +136,13 @@ long_double_code = '''
 #ifndef __LDBL_MANT_DIG__
 #error No long double support in float.h
 #endif
-long double test()
+long double test(void)
 {
 	long double ld = 0.0L;
-	 return ld;
+	return ld;
 }
 '''
+
 have_long_double = cc.compiles(long_double_code, name : 'long double check', args: core_c_args)
 
 have_sizeof_float = cc.get_define('__SIZEOF_FLOAT__') != ''
@@ -1321,6 +1322,10 @@ if tests_enable_stack_protector
   else
     tests_enable_stack_protector = false
   endif
+endif
+
+if have_long_double and get_option('test-long-double')
+  test_c_args += ['-D_TEST_LONG_DOUBLE']
 endif
 
 # Meson version 0.53.2 doesn't check for the skip_sanity_check value

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -114,6 +114,8 @@ option('tests-enable-full-malloc-stress', type: 'boolean', value: false,
        description: 'tests enable stress test for full malloc')
 option('tests-enable-posix-io', type: 'boolean', value: true,
        description: 'tests enable posix-io when available')
+option('test-long-double', type: 'boolean', value: true,
+       description: 'Enable long double tests on targets with long double type')
 
 option('tinystdio', type: 'boolean', value: true,
        description: 'Use tiny stdio from avr libc')

--- a/newlib/libc/include/machine/ieeefp.h
+++ b/newlib/libc/include/machine/ieeefp.h
@@ -97,18 +97,6 @@ warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 # define _LONG_DOUBLE_IS_32BITS
 #endif
 
-#if defined(__SIZEOF_LONG_DOUBLE__)
-#define _HAVE_LONG_DOUBLE
-#endif
-
-#if defined(__SIZEOF_DOUBLE__) && defined(__SIZEOF_LONG_DOUBLE__)
-# if __SIZEOF_DOUBLE__ == __SIZEOF_LONG_DOUBLE__
-#  define _LDBL_EQ_DBL
-# else
-#  undef _LDBL_EQ_DBL
-# endif
-#endif
-
 #if defined(__SIZEOF_FLOAT__) && defined(__SIZEOF_DOUBLE__)
 # if __SIZEOF_FLOAT__ == __SIZEOF_DOUBLE__
 #  define _DBL_EQ_FLT
@@ -259,7 +247,9 @@ warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 #ifdef __i386__
 #define __IEEE_LITTLE_ENDIAN
+#ifndef _SOFT_FLOAT
 # define _SUPPORTS_ERREXCEPT
+#endif
 #endif
 
 #ifdef __riscv
@@ -488,7 +478,9 @@ warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 #ifdef __x86_64__
 #define __IEEE_LITTLE_ENDIAN
+#ifndef _SOFT_FLOAT
 # define _SUPPORTS_ERREXCEPT
+#endif
 #endif
 
 #ifdef __mep__

--- a/newlib/libc/machine/sparc/sys/fenv.h
+++ b/newlib/libc/machine/sparc/sys/fenv.h
@@ -31,6 +31,11 @@
 #ifndef	_SYS_FENV_H_
 #define	_SYS_FENV_H_
 
+#ifdef _SOFT_FLOAT
+typedef int fenv_t;
+typedef int fexcept_t;
+#else
+
 #include <stdint.h>
 
 #ifdef __arch64__
@@ -78,4 +83,5 @@ typedef	uint32_t	fexcept_t;
 
 
 
+#endif  /* !_SOFT_FLOAT */
 #endif	/* !_SYS_FENV_H_ */

--- a/newlib/libc/machine/x86/sys/fenv.h
+++ b/newlib/libc/machine/x86/sys/fenv.h
@@ -31,6 +31,11 @@
 
 #include <sys/cdefs.h>
 
+#ifdef _SOFT_FLOAT
+typedef int fenv_t;
+typedef int fexcept_t;
+#else
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -160,5 +165,7 @@ int fesetprec (int __prec);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* !_SOFT_FLOAT */
 
 #endif /* _FENV_H */

--- a/newlib/libm/common/math_config.h
+++ b/newlib/libm/common/math_config.h
@@ -612,9 +612,9 @@ force_eval_long_double (long double x)
 #  endif
 # endif
 #else
-# if __SIZEOF_LONG_DOUBLE__ == 8
+# if __SIZEOF_LONG_DOUBLE__ == 8 && !defined(_LDBL_EQ_DBL)
 #  define _NAME_64(x) _LD_NAME_REG(x)
-# define _NAME_64_SPECIAL(d,l) l
+#  define _NAME_64_SPECIAL(d,l) l
    typedef long double __float64;
 #  define FORCE_FLOAT64 FORCE_LONG_DOUBLE
 #  define pick_float64_except(a,b) pick_long_double_except(a,b)

--- a/newlib/libm/common/s_log2.c
+++ b/newlib/libm/common/s_log2.c
@@ -71,7 +71,7 @@ C99, POSIX, System V Interface Definition (Issue 6).
 __float64
 log264(__float64 x)		/* wrapper log2 */
 {
-    return (log64(x) / (__float64) _M_LN2_LD);
+    return (log64(x) / _F_64(_M_LN2));
 }
 
 _MATH_ALIAS_d_d(log2)

--- a/newlib/libm/machine/sparc/CMakeLists.txt
+++ b/newlib/libm/machine/sparc/CMakeLists.txt
@@ -35,9 +35,6 @@
 
 picolibc_sources(
   fenv.c
-  )
-
-picolibc_sources_fake(
   feclearexcept.c
   fedisableexcept.c
   feenableexcept.c

--- a/newlib/libm/machine/sparc/feclearexcept.c
+++ b/newlib/libm/machine/sparc/feclearexcept.c
@@ -1,0 +1,3 @@
+#ifdef _SOFT_FLOAT
+#include "../../fenv/feclearexcept.c"
+#endif

--- a/newlib/libm/machine/sparc/fedisableexcept.c
+++ b/newlib/libm/machine/sparc/fedisableexcept.c
@@ -1,0 +1,3 @@
+#ifdef _SOFT_FLOAT
+#include "../../fenv/fedisableexcept.c"
+#endif

--- a/newlib/libm/machine/sparc/feenableexcept.c
+++ b/newlib/libm/machine/sparc/feenableexcept.c
@@ -1,0 +1,3 @@
+#ifdef _SOFT_FLOAT
+#include "../../fenv/feenableexcept.c"
+#endif

--- a/newlib/libm/machine/sparc/fegetenv.c
+++ b/newlib/libm/machine/sparc/fegetenv.c
@@ -1,0 +1,3 @@
+#ifdef _SOFT_FLOAT
+#include "../../fenv/fegetenv.c"
+#endif

--- a/newlib/libm/machine/sparc/fegetexcept.c
+++ b/newlib/libm/machine/sparc/fegetexcept.c
@@ -1,0 +1,3 @@
+#ifdef _SOFT_FLOAT
+#include "../../fenv/fegetexcept.c"
+#endif

--- a/newlib/libm/machine/sparc/fegetexceptflag.c
+++ b/newlib/libm/machine/sparc/fegetexceptflag.c
@@ -1,0 +1,3 @@
+#ifdef _SOFT_FLOAT
+#include "../../fenv/fegetexceptflag.c"
+#endif

--- a/newlib/libm/machine/sparc/fegetround.c
+++ b/newlib/libm/machine/sparc/fegetround.c
@@ -1,0 +1,3 @@
+#ifdef _SOFT_FLOAT
+#include "../../fenv/fegetround.c"
+#endif

--- a/newlib/libm/machine/sparc/feholdexcept.c
+++ b/newlib/libm/machine/sparc/feholdexcept.c
@@ -1,0 +1,3 @@
+#ifdef _SOFT_FLOAT
+#include "../../fenv/feholdexcept.c"
+#endif

--- a/newlib/libm/machine/sparc/fenv.c
+++ b/newlib/libm/machine/sparc/fenv.c
@@ -23,11 +23,10 @@
  * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
  */
+
+#ifndef _SOFT_FLOAT
+
 #include <sys/cdefs.h>
-__RCSID("$NetBSD: fenv.c,v 1.2 2017/03/22 23:11:09 chs Exp $");
-
-
-
 #include <assert.h>
 #include <fenv.h>
 
@@ -348,3 +347,5 @@ fegetexcept(void)
 	__stfsr(&r);
 	return (r & _ENABLE_MASK) >> _FPUSW_SHIFT;
 }
+
+#endif /* !_SOFT_FLOAT */

--- a/newlib/libm/machine/sparc/feraiseexcept.c
+++ b/newlib/libm/machine/sparc/feraiseexcept.c
@@ -1,0 +1,3 @@
+#ifdef _SOFT_FLOAT
+#include "../../fenv/feraiseexcept.c"
+#endif

--- a/newlib/libm/machine/sparc/fesetenv.c
+++ b/newlib/libm/machine/sparc/fesetenv.c
@@ -1,0 +1,3 @@
+#ifdef _SOFT_FLOAT
+#include "../../fenv/fesetenv.c"
+#endif

--- a/newlib/libm/machine/sparc/fesetexceptflag.c
+++ b/newlib/libm/machine/sparc/fesetexceptflag.c
@@ -1,0 +1,3 @@
+#ifdef _SOFT_FLOAT
+#include "../../fenv/fesetexceptflag.c"
+#endif

--- a/newlib/libm/machine/sparc/fesetround.c
+++ b/newlib/libm/machine/sparc/fesetround.c
@@ -1,0 +1,3 @@
+#ifdef _SOFT_FLOAT
+#include "../../fenv/fesetround.c"
+#endif

--- a/newlib/libm/machine/sparc/fetestexcept.c
+++ b/newlib/libm/machine/sparc/fetestexcept.c
@@ -1,0 +1,3 @@
+#ifdef _SOFT_FLOAT
+#include "../../fenv/fetestexcept.c"
+#endif

--- a/newlib/libm/machine/sparc/feupdateenv.c
+++ b/newlib/libm/machine/sparc/feupdateenv.c
@@ -1,0 +1,3 @@
+#ifdef _SOFT_FLOAT
+#include "../../fenv/feupdateenv.c"
+#endif

--- a/newlib/libm/machine/sparc/meson.build
+++ b/newlib/libm/machine/sparc/meson.build
@@ -33,11 +33,8 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-srcs_libm_machine_real = [
+srcs_libm_machine = [
   'fenv.c',
-]
-
-srcs_libm_machine = srcs_libm_machine_real + [
   'feclearexcept.c',
   'fedisableexcept.c',
   'feenableexcept.c',
@@ -54,4 +51,4 @@ srcs_libm_machine = srcs_libm_machine_real + [
   'feupdateenv.c',
 ]
 
-src_libm_machine = files(srcs_libm_machine_real)
+src_libm_machine = files(srcs_libm_machine)

--- a/newlib/libm/machine/x86/CMakeLists.txt
+++ b/newlib/libm/machine/x86/CMakeLists.txt
@@ -34,6 +34,20 @@
 #
 picolibc_sources(
   fenv.c
+  feclearexcept.c
+  fedisableexcept.c
+  feenableexcept.c
+  fegetenv.c
+  fegetexcept.c
+  fegetexceptflag.c
+  fegetround.c
+  feholdexcept.c
+  feraiseexcept.c
+  fesetenv.c
+  fesetexceptflag.c
+  fesetround.c
+  fetestexcept.c
+  feupdateenv.c
   )
 
 if(${CMAKE_SYSTEM_SUB_PROCESSOR} STREQUAL "i686")
@@ -65,20 +79,3 @@ if(${CMAKE_SYSTEM_SUB_PROCESSOR} STREQUAL "i686")
     f_tan.S
     )
 endif()
-
-picolibc_sources_fake(
-  feclearexcept.c
-  fedisableexcept.c
-  feenableexcept.c
-  fegetenv.c
-  fegetexcept.c
-  fegetexceptflag.c
-  fegetround.c
-  feholdexcept.c
-  feraiseexcept.c
-  fesetenv.c
-  fesetexceptflag.c
-  fesetround.c
-  fetestexcept.c
-  feupdateenv.c
-  )

--- a/newlib/libm/machine/x86/feclearexcept.c
+++ b/newlib/libm/machine/x86/feclearexcept.c
@@ -1,0 +1,3 @@
+#ifdef _SOFT_FLOAT
+#include "../../fenv/feclearexcept.c"
+#endif

--- a/newlib/libm/machine/x86/fedisableexcept.c
+++ b/newlib/libm/machine/x86/fedisableexcept.c
@@ -1,0 +1,3 @@
+#ifdef _SOFT_FLOAT
+#include "../../fenv/fedisableexcept.c"
+#endif

--- a/newlib/libm/machine/x86/feenableexcept.c
+++ b/newlib/libm/machine/x86/feenableexcept.c
@@ -1,0 +1,3 @@
+#ifdef _SOFT_FLOAT
+#include "../../fenv/feenableexcept.c"
+#endif

--- a/newlib/libm/machine/x86/fegetenv.c
+++ b/newlib/libm/machine/x86/fegetenv.c
@@ -1,0 +1,3 @@
+#ifdef _SOFT_FLOAT
+#include "../../fenv/fegetenv.c"
+#endif

--- a/newlib/libm/machine/x86/fegetexcept.c
+++ b/newlib/libm/machine/x86/fegetexcept.c
@@ -1,0 +1,3 @@
+#ifdef _SOFT_FLOAT
+#include "../../fenv/fegetexcept.c"
+#endif

--- a/newlib/libm/machine/x86/fegetexceptflag.c
+++ b/newlib/libm/machine/x86/fegetexceptflag.c
@@ -1,0 +1,3 @@
+#ifdef _SOFT_FLOAT
+#include "../../fenv/fegetexceptflag.c"
+#endif

--- a/newlib/libm/machine/x86/fegetround.c
+++ b/newlib/libm/machine/x86/fegetround.c
@@ -1,0 +1,3 @@
+#ifdef _SOFT_FLOAT
+#include "../../fenv/fegetround.c"
+#endif

--- a/newlib/libm/machine/x86/feholdexcept.c
+++ b/newlib/libm/machine/x86/feholdexcept.c
@@ -1,0 +1,3 @@
+#ifdef _SOFT_FLOAT
+#include "../../fenv/feholdexcept.c"
+#endif

--- a/newlib/libm/machine/x86/fenv.c
+++ b/newlib/libm/machine/x86/fenv.c
@@ -4,6 +4,8 @@
  * Copyright (c) 2010-2019 Red Hat, Inc.
  */
 
+#ifndef _SOFT_FLOAT
+
 #define _GNU_SOURCE        // for FE_NOMASK_ENV
 
 #include <fenv.h>
@@ -473,3 +475,5 @@ _feinitialise (void)
   /* Finally cache state as default environment. */
   fegetenv (&_fe_dfl_env);
 }
+
+#endif /* _SOFT_FLOAT */

--- a/newlib/libm/machine/x86/feraiseexcept.c
+++ b/newlib/libm/machine/x86/feraiseexcept.c
@@ -1,0 +1,3 @@
+#ifdef _SOFT_FLOAT
+#include "../../fenv/feraiseexcept.c"
+#endif

--- a/newlib/libm/machine/x86/fesetenv.c
+++ b/newlib/libm/machine/x86/fesetenv.c
@@ -1,0 +1,3 @@
+#ifdef _SOFT_FLOAT
+#include "../../fenv/fesetenv.c"
+#endif

--- a/newlib/libm/machine/x86/fesetexceptflag.c
+++ b/newlib/libm/machine/x86/fesetexceptflag.c
@@ -1,0 +1,3 @@
+#ifdef _SOFT_FLOAT
+#include "../../fenv/fesetexceptflag.c"
+#endif

--- a/newlib/libm/machine/x86/fesetround.c
+++ b/newlib/libm/machine/x86/fesetround.c
@@ -1,0 +1,3 @@
+#ifdef _SOFT_FLOAT
+#include "../../fenv/fesetround.c"
+#endif

--- a/newlib/libm/machine/x86/fetestexcept.c
+++ b/newlib/libm/machine/x86/fetestexcept.c
@@ -1,0 +1,3 @@
+#ifdef _SOFT_FLOAT
+#include "../../fenv/fetestexcept.c"
+#endif

--- a/newlib/libm/machine/x86/feupdateenv.c
+++ b/newlib/libm/machine/x86/feupdateenv.c
@@ -1,0 +1,3 @@
+#ifdef _SOFT_FLOAT
+#include "../../fenv/feupdateenv.c"
+#endif

--- a/newlib/libm/machine/x86/meson.build
+++ b/newlib/libm/machine/x86/meson.build
@@ -34,6 +34,20 @@
 #
 srcs_libm_machine_common = [
   'fenv.c',
+  'feclearexcept.c',
+  'fedisableexcept.c',
+  'feenableexcept.c',
+  'fegetenv.c',
+  'fegetexcept.c',
+  'fegetexceptflag.c',
+  'fegetround.c',
+  'feholdexcept.c',
+  'feraiseexcept.c',
+  'fesetenv.c',
+  'fesetexceptflag.c',
+  'fesetround.c',
+  'fetestexcept.c',
+  'feupdateenv.c',
 ]
 
 srcs_libm_machine_32 = [
@@ -65,22 +79,7 @@ srcs_libm_machine_32 = [
   'f_tan.S',
 ]
 
-srcs_libm_machine = srcs_libm_machine_common + [
-  'feclearexcept.c',
-  'fedisableexcept.c',
-  'feenableexcept.c',
-  'fegetenv.c',
-  'fegetexcept.c',
-  'fegetexceptflag.c',
-  'fegetround.c',
-  'feholdexcept.c',
-  'feraiseexcept.c',
-  'fesetenv.c',
-  'fesetexceptflag.c',
-  'fesetround.c',
-  'fetestexcept.c',
-  'feupdateenv.c',
-]
+srcs_libm_machine = srcs_libm_machine_common
 
 src_libm_machine = []
 

--- a/newlib/libm/test/convert.c
+++ b/newlib/libm/test/convert.c
@@ -89,7 +89,7 @@ test_strtof (void)
   test_iok(tail - pd->string, pd->endscan & ENDSCAN_MASK);
 }
 
-#if defined(_HAVE_LONG_DOUBLE) && (__LDBL_MANT_DIG__ == 64 || defined(TINY_STDIO))
+#if defined(_TEST_LONG_DOUBLE) && (__LDBL_MANT_DIG__ == 64 || defined(TINY_STDIO))
 #define HAVE_STRTOLD
 #endif
 

--- a/scripts/cross-x86_64-zephyr-elf.txt
+++ b/scripts/cross-x86_64-zephyr-elf.txt
@@ -1,0 +1,28 @@
+[binaries]
+# Meson 0.53.2 doesn't use any cflags when doing basic compiler tests,
+# so we have to add -nostdlib to the compiler configuration itself or
+# early compiler tests will fail. This can be removed when picolibc
+# requires at least version 0.54.2 of meson.
+c = ['x86_64-zephyr-elf-gcc', '-m32', '-msoft-float', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
+ar = 'x86_64-zephyr-elf-ar'
+as = 'x86_64-zephyr-elf-as'
+nm = 'x86_64-zephyr-elf-nm'
+strip = 'x86_64-zephyr-elf-strip'
+objcopy = 'x86_64-zephyr-elf-objcopy'
+# only needed to run tests
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-i386 "$@"', 'run-i386']
+
+[host_machine]
+system='linux'
+cpu_family='x86_64'
+cpu='x86_64'
+endian='little'
+
+[properties]
+skip_sanity_check = true
+needs_exe_wrapper = true
+link_spec = '--build-id=none'
+default_flash_addr = '0x00100000'
+default_flash_size = '0x00400000'
+default_ram_addr   = '0x00500000'
+default_ram_size   = '0x00200000'

--- a/scripts/do-configure
+++ b/scripts/do-configure
@@ -82,6 +82,12 @@ case "$*" in
 		exit 77
 		;;
 	esac
+	case "$*" in
+	    *-Dtest-long-double=false*)
+		echo "skipping io-long-double when test-long-double=false"
+		exit 77
+		;;
+	esac
 	;;
 esac
 

--- a/scripts/do-x86_64-zephyr-configure
+++ b/scripts/do-x86_64-zephyr-configure
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2019 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+exec "$(dirname "$0")"/do-configure x86_64-zephyr-elf -Dtests=true -Dtests-enable-posix-io=false -Dmultilib=false -Dtest-long-double=false "$@"

--- a/test/complex-funcs.c
+++ b/test/complex-funcs.c
@@ -6,7 +6,7 @@
 
 double complex c1, c2;
 float complex f1, f2;
-#ifdef _HAVE_LONG_DOUBLE
+#ifdef _TEST_LONG_DOUBLE
 long double complex l1, l2;
 #endif
 
@@ -93,7 +93,9 @@ main(void)
        float cabsf(f1) __RENAME(__c99_cabsf);
        #endif
     */
+#ifdef _TEST_LONG_DOUBLE
     (void) cabsl(l1) ;
+#endif
     (void) cabs(c1) ;
     (void) cabsf(f1) ;
 
@@ -104,7 +106,9 @@ main(void)
     /* 7.3.8.3 The csqrt functions */
     (void) csqrt(c1);
     (void) csqrtf(f1);
+#ifdef _TEST_LONG_DOUBLE
     (void) csqrtl(l1);
+#endif
 
     /* 7.3.9 Manipulation functions */
     /* 7.3.9.1 The carg functions */ 
@@ -117,7 +121,9 @@ main(void)
     /* 7.3.9.2 The cimag functions */
     (void) cimag(c1);
     (void) cimagf(f1);
+#ifdef _TEST_LONG_DOUBLE
     (void) cimagl(l1);
+#endif
 
     /* 7.3.9.3 The conj functions */
     (void) conj(c1);
@@ -130,7 +136,9 @@ main(void)
     /* 7.3.9.5 The creal functions */
     (void) creal(c1);
     (void) crealf(f1);
+#ifdef _TEST_LONG_DOUBLE
     (void) creall(l1);
+#endif
 
     (void) clog10(c1);
     (void) clog10f(f1);
@@ -149,8 +157,10 @@ main(void)
     (void) cexpl(l1);
     (void) cpowl(l1, l2);
 #endif
+#ifdef _TEST_LONG_DOUBLE
     (void) conjl(l1);
     (void) cprojl(l1);
+#endif
 
     return 0;
 }

--- a/test/long_double.c
+++ b/test/long_double.c
@@ -39,7 +39,7 @@
 #include <stdio.h>
 #include <float.h>
 
-#ifdef LDBL_MANT_DIG
+#ifdef _TEST_LONG_DOUBLE
 
 static long double max_error;
 

--- a/test/math-funcs.c
+++ b/test/math-funcs.c
@@ -47,7 +47,7 @@ int i1;
 long int li1;
 long long int lli1;
 
-#ifdef _HAVE_LONG_DOUBLE
+#ifdef _TEST_LONG_DOUBLE
 long double l1, l2, l3;
 #endif
 
@@ -55,7 +55,7 @@ long double l1, l2, l3;
 double complex cd1, cd2, cd3;
 float complex cf1, cf2, cf3;
 
-#ifdef _HAVE_LONG_DOUBLE
+#ifdef _TEST_LONG_DOUBLE
 long double complex cl1, cl2, cl3;
 #endif
 
@@ -95,17 +95,19 @@ main(void)
 
     i1 = finite (d1);
     i1 = finitef (f1);
+#ifdef _TEST_LONG_DOUBLE
 #if defined(_HAVE_BUILTIN_FINITEL) || defined(_HAVE_BUILTIN_ISFINITE)
     i1 = finitel (l1);
 #endif
-    i1 = isinff (f1);
-    i1 = isnanf (f1);
 #ifdef _HAVE_BUILTIN_ISINFL
     i1 = isinfl (l1);
 #endif
 #ifdef _HAVE_BUILTIN_ISNANL
     i1 = isnanl (l1);
 #endif
+#endif
+    i1 = isinff (f1);
+    i1 = isnanf (f1);
     i1 = isinf (d1);
     i1 = isnan (d1);
 
@@ -230,7 +232,7 @@ main(void)
     f1 = log2f (f1);
     f1 = hypotf (f1, f2);
 
-#ifdef _HAVE_LONG_DOUBLE
+#ifdef _TEST_LONG_DOUBLE
     l1 = frexpl (l1, &i1);
     l1 = ldexpl (l1, i1);
     l1 = sqrtl (l1);
@@ -302,7 +304,7 @@ main(void)
     l1 = nextafterl (l1, l2);
     l1 = nexttowardl (l1, l2);
 #endif /* _HAVE_LONG_DOUBLE_MATH */
-#endif /* _HAVE_LONG_DOUBLE */
+#endif /* _TEST_LONG_DOUBLE */
 
     d1 = drem (d1, d2);
     f1 = dremf (f1, f2);
@@ -427,7 +429,7 @@ main(void)
     cf1 = clog10f(cf1);
 #endif
 
-#ifdef _HAVE_LONG_DOUBLE
+#ifdef _TEST_LONG_DOUBLE
     cl1 =  csqrtl(cl1);
     l1 = cabsl(cl1) ;
     cl1 = cprojl(cl1);
@@ -457,7 +459,7 @@ main(void)
 #endif
 #endif /* _HAVE_LONG_DOUBLE_MATH */
 
-#endif /* _HAVE_LONG_DOUBLE */
+#endif /* _TEST_LONG_DOUBLE */
 
 #endif /* _HAVE_COMPLEX */
     

--- a/test/math_errhandling.c
+++ b/test/math_errhandling.c
@@ -175,7 +175,7 @@ e_to_str(int e)
 #define scat(a,b) a ## b
 
 /* Tests with long doubles */
-#ifdef __SIZEOF_LONG_DOUBLE__
+#ifdef _TEST_LONG_DOUBLE
 
 #if defined(__PICOLIBC__) && !defined(_HAVE_LONG_DOUBLE_MATH)
 #define SIMPLE_MATH_ONLY
@@ -311,7 +311,7 @@ int main(void)
 
 	printf("Double tests:\n");
 	result += run_tests();
-#ifdef __SIZEOF_LONG_DOUBLE__
+#ifdef _TEST_LONG_DOUBLE
 	printf("Long double tests:\n");
 	result += run_testsl();
 #endif

--- a/test/math_errhandling_tests.c
+++ b/test/math_errhandling_tests.c
@@ -405,7 +405,7 @@ FLOAT_T makemathname(test_nextafter_negmin_0)(void) { return makemathname(nextaf
 FLOAT_T makemathname(test_nextafter_1_2)(void) {return makemathname(nextafter)(makemathname(one), makemathname(two)); }
 FLOAT_T makemathname(test_nextafter_neg1_neg2)(void) {return makemathname(nextafter)(-makemathname(one), -makemathname(two)); }
 
-#if defined(__SIZEOF_LONG_DOUBLE__) && !defined(NO_NEXTTOWARD)
+#if defined(_TEST_LONG_DOUBLE) && !defined(NO_NEXTTOWARD)
 
 FLOAT_T makemathname(test_nexttoward_0_neg0)(void) { return makemathname(nexttoward)(makemathname(zero), -makelname(zero)); }
 FLOAT_T makemathname(test_nexttoward_neg0_0)(void) { return makemathname(nexttoward)(-makemathname(zero), makelname(zero)); }
@@ -711,7 +711,7 @@ FLOAT_T makemathname(test_scalbn_tiny)(void) { return makemathname(scalbn)(makem
 
 #undef sNAN_RET
 #undef sNAN_EXCEPTION
-#if defined(__i386__) && !defined(TEST_LONG_DOUBLE)
+#if defined(__i386__) && !defined(TEST_LONG_DOUBLE) && !defined(_SOFT_FLOAT)
 /*
  * i386 ABI returns floats in the 8087 registers, which convert sNAN
  * to NAN on load, so you can't ever return a sNAN value successfully.
@@ -1167,7 +1167,7 @@ struct {
         TEST(nextafter_1_2, (FLOAT_T)1.0 + EPSILON_VAL, 0, 0),
         TEST(nextafter_neg1_neg2, -(FLOAT_T)1.0 - EPSILON_VAL, 0, 0),
 
-#if defined(__SIZEOF_LONG_DOUBLE__) && !defined(NO_NEXTTOWARD)
+#if defined(_TEST_LONG_DOUBLE) && !defined(NO_NEXTTOWARD)
         TEST(nexttoward_0_neg0, -(FLOAT_T)0, 0, 0),
         TEST(nexttoward_neg0_0, (FLOAT_T)0, 0, 0),
         TEST(nexttoward_0_1, (FLOAT_T) MIN_VAL, FE_UNDERFLOW, 0),

--- a/test/test-strtod.c
+++ b/test/test-strtod.c
@@ -76,6 +76,7 @@ struct {
     { "0x1.fffffffffffffp1022@",  0x1.fffffffffffffp1022, (float) INFINITY, 0x1.fffffffffffffp1022l },
     { "0x1.fffffffffffff8p1022@", 0x1.0000000000000p1023, (float) INFINITY, 0x1.fffffffffffff8p1022l }, /* rounds up for double */
     { "0x1.fffffffffffffp1023@",  0x1.fffffffffffffp1023, (float) INFINITY, 0x1.fffffffffffffp1023l },
+#ifdef _TEST_LONG_DOUBLE
 #if __LDBL_MANT_DIG__ > __DBL_MANT_DIG__
     { "0x1.fffffffffffff8p1023@",      (double) INFINITY, (float) INFINITY, 0x1.fffffffffffff8p1023l }, /* rounds up to INFINITY for double */
 #else
@@ -94,6 +95,7 @@ struct {
     { "0x1.ffffffffffffffffp16383@", (double) INFINITY, (float) INFINITY, (long double) INFINITY },             /* rounds up to INFINITY for long double */
 #endif
 #endif
+#endif
 };
 
 #define NTESTS (sizeof(tests)/sizeof(tests[0]))
@@ -103,8 +105,10 @@ int main(void)
     int i;
     double d;
     float f;
+#ifdef _TEST_LONG_DOUBLE
 #ifdef FULL_TESTS
     long double ld;
+#endif
 #endif
     char *end;
     int ret = 0;
@@ -131,6 +135,7 @@ int main(void)
             printf("strtof(\"%s\") end is \"%s\"\n", tests[i].string, end);
             ret = 1;
         }
+#ifdef _TEST_LONG_DOUBLE
 #ifdef FULL_TESTS
         if (sizeof(long double) > sizeof(double)) {
             ld = strtold(tests[i].string, &end);
@@ -144,6 +149,7 @@ int main(void)
                 ret = 1;
             }
         }
+#endif
 #endif
     }
     return ret;


### PR DESCRIPTION
Fix the x86 target-specific code to look for `_SOFT_FLOAT`.

Add `have-long-double` meson option so that we can disable long double on x86 soft float under gcc as the compiler supports the type but the runtime library (libgcc.a) is missing long double soft float code.

Fix the library to check for `_HAVE_LONG_DOUBLE` in "a few" places that were looking for other signs of long double support.

Test the whole mess using the Zephyr toolchain.