### PR TITLE
Revert ".github: Disable mips/mipsel targets while Testing is broken"

### DIFF
--- a/.github/do-linux
+++ b/.github/do-linux
@@ -6,6 +6,8 @@ HERE=`dirname "$0"`
 "$HERE"/do-test clang-thumbv7e+fp "$@"
 "$HERE"/do-test clang-thumbv7m "$@"
 "$HERE"/do-test clang-thumbv6m "$@"
+"$HERE"/do-build mips "$@"
+"$HERE"/do-build mipsel "$@"
 "$HERE"/do-test native "$@"
 "$HERE"/do-test aarch64 "$@"
 "$HERE"/do-build lx106 "$@"

--- a/.github/linux-packages.txt
+++ b/.github/linux-packages.txt
@@ -15,6 +15,10 @@ libc6-dev-arm64-cross
 gcc-xtensa-lx106
 gcc-m68k-linux-gnu
 libc6-dev-m68k-cross
+gcc-mips-linux-gnu
+libc6-dev-mips-cross
+gcc-mipsel-linux-gnu
+libc6-dev-mipsel-cross
 gcc-powerpc64-linux-gnu
 libc6-dev-ppc64-cross
 gcc-powerpc64le-linux-gnu

--- a/newlib/libc/iconv/ces/euc.c
+++ b/newlib/libc/iconv/ces/euc.c
@@ -143,7 +143,7 @@ euc_from_ucs_init (
   goto error1;
 
 ok:
-  for (i = 0; data->desc[i].csname != NULL; i++)
+  for (i = 0; i < MAX_CS_NUM && data->desc[i].csname != NULL; i++)
     {
       data->data[i] = _iconv_from_ucs_ces_handlers_table.init (
                                                         data->desc[i].csname);
@@ -298,7 +298,7 @@ euc_to_ucs_init (
   goto error1;
 
 ok:
-  for (i = 0; data->desc[i].csname != NULL; i++)
+  for (i = 0; i < MAX_CS_NUM && data->desc[i].csname != NULL; i++)
     {
       data->data[i] = _iconv_to_ucs_ces_handlers_table.init (
                                                         data->desc[i].csname);

--- a/newlib/libc/posix/regcomp.c
+++ b/newlib/libc/posix/regcomp.c
@@ -1916,7 +1916,7 @@ computematchjumps(struct parse *p, struct re_guts *g)
 	if (p->error != 0)
 		return;
 
-	pmatches = (int*) calloc(g->mlen, sizeof(unsigned int));
+	pmatches = (int*) calloc(g->mlen + 1, sizeof(unsigned int));
 	if (pmatches == NULL) {
 		g->matchjump = NULL;
 		return;

--- a/newlib/libc/search/hash.h
+++ b/newlib/libc/search/hash.h
@@ -77,6 +77,13 @@ struct _bufhead {
 
 typedef BUFHEAD **SEGMENT;
 
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
+/* 'bsize' is used directly with malloc/realloc which confuses -fanalyzer */
+#pragma GCC diagnostic ignored "-Wanalyzer-allocation-size"
+#endif
+
 /* Hash Table Information */
 typedef struct hashhdr {		/* Disk resident portion */
 	int32_t		magic;		/* Magic NO for hash tables */

--- a/newlib/libc/tinystdio/vfscanf.c
+++ b/newlib/libc/tinystdio/vfscanf.c
@@ -722,13 +722,13 @@ int vfscanf (FILE * stream, const CHAR *fmt, va_list ap_orig)
 	    if (!(flags & FL_STAR)) nconvs += 1;
 	} /* else */
     } /* while */
-#ifdef PRINTF_POSITIONAL
+#ifdef SCANF_POSITIONAL
     va_end(ap);
 #endif
     return nconvs;
 
   eof:
-#ifdef PRINTF_POSITIONAL
+#ifdef SCANF_POSITIONAL
     va_end(ap);
 #endif
 #undef ap

--- a/newlib/libc/tinystdio/vfscanf.c
+++ b/newlib/libc/tinystdio/vfscanf.c
@@ -99,7 +99,7 @@ scanf_ungetc(INT c, FILE *stream, int *lenp)
 static void
 putval (void *addr, int_scanf_t val, uint16_t flags)
 {
-    if (!(flags & FL_STAR)) {
+    if (addr) {
 	if (flags & FL_CHAR)
 	    *(char *)addr = val;
 #ifdef SCANF_LONGLONG

--- a/newlib/libm/ld/math_private_openbsd.h
+++ b/newlib/libm/ld/math_private_openbsd.h
@@ -493,6 +493,18 @@ __signbitl(long double x)
     return exp < 0;
 }
 
+#ifdef __PPC__
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
+/* the bitfields confuse the ppc compiler into thinking accessing
+ * manl will be 'out of bounds'
+ */
+#pragma GCC diagnostic ignored "-Wanalyzer-out-of-bounds"
+#define yup_all_good
+#endif
+#endif
+
 union IEEEl2bits {
 	long double	e;
 	struct {

--- a/test/printf-tests.c
+++ b/test/printf-tests.c
@@ -38,6 +38,13 @@ static void failmsg(int serial, char *fmt, ...) {
     va_end(ap);
 }
 
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
+/* 'bsize' is used directly with malloc/realloc which confuses -fanalyzer */
+#pragma GCC diagnostic ignored "-Wanalyzer-va-arg-type-mismatch"
+#endif
+
 static int test(int serial, char *expect, char *fmt, ...) {
     va_list ap;
     char *abuf = NULL;

--- a/test/test-ubsan.c
+++ b/test/test-ubsan.c
@@ -70,6 +70,13 @@ abrt_handler(int sig)
 
 static volatile int ten = 10;
 
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
+/* 'bsize' is used directly with malloc/realloc which confuses -fanalyzer */
+#pragma GCC diagnostic ignored "-Wanalyzer-out-of-bounds"
+#endif
+
 int main(void)
 {
     int array[10];


### PR DESCRIPTION
This reverts commit 8dd225aa1469c03805617106020d494912c6d265.

Testing has been fixed; we can re-enable mips tests now.