### PR TITLE
RFC: Add testing for additional arm targets.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,6 @@ insert_final_newline = true
 [*.{c,h}]
 indent_size = 4
 indent_style = space
+
+[meson*]
+indent_style = space

--- a/COPYING.picolibc
+++ b/COPYING.picolibc
@@ -1021,6 +1021,8 @@ Files: dummyhost/iob.c
  scripts/do-riscv-configure
  scripts/do-rv32imac-configure
  scripts/do-sparc64-configure
+ scripts/do-thumbv8_1m-configure
+ scripts/do-thumbv8m_main_fp-configure
  scripts/do-x86-configure
  scripts/do-x86_64-configure
  scripts/do-xtensa-espressif_esp32-configure
@@ -1035,6 +1037,8 @@ Files: dummyhost/iob.c
  scripts/do-zephyr-riscv-configure
  scripts/run-arm
  scripts/run-cortex-a9
+ scripts/run-cortex-m33
+ scripts/run-cortex-m55
  scripts/run-power9
  scripts/run-riscv
  scripts/run-thumbv6m
@@ -2692,6 +2696,8 @@ Files: .clang-format
  scripts/cross-rv32imac.txt
  scripts/cross-rv32imac_zicsr.txt
  scripts/cross-sparc64-linux-gnu.txt
+ scripts/cross-thumbv8_1m-none-eabi.txt
+ scripts/cross-thumbv8m_main_fp-none-eabi.txt
  scripts/cross-x86-linux-gnu.txt
  scripts/cross-x86_64-linux-gnu.txt
  scripts/cross-xtensa-esp32-elf.txt

--- a/meson.build
+++ b/meson.build
@@ -749,13 +749,34 @@ else
     picolibc_linker_type_data.set('LLD_END', '*/')
 endif
 
-picolibc_linker_type_data.set('DEFAULT_FLASH_ADDR',
-			      meson.get_cross_property('default_flash_addr',
-						       '0x10000000'))
-
-picolibc_linker_type_data.set('DEFAULT_FLASH_SIZE',
-			      meson.get_cross_property('default_flash_size',
-						       '0x00010000'))
+if meson.get_cross_property('separate_boot_flash', false)
+    default_boot_flash_addr = meson.get_cross_property(
+        'default_boot_flash_addr',
+        '0x10000000')
+    default_boot_flash_size = meson.get_cross_property(
+        'default_boot_flash_size',
+        '0x00000400')
+    picolibc_linker_type_data.set('MEMORY_BOOT_FLASH', '''
+	boot_flash (rx!w) :
+		ORIGIN = DEFINED(__boot_flash) ? __boot_flash : ''' + default_boot_flash_addr + ''',
+		LENGTH = DEFINED(__boot_flash_size) ? __boot_flash_size : ''' + default_boot_flash_size)
+    picolibc_linker_type_data.set('INIT_MEMORY', 'boot_flash')
+    picolibc_linker_type_data.set(
+        'DEFAULT_FLASH_ADDR',
+        meson.get_cross_property('default_flash_addr', '0x10000400'))
+    picolibc_linker_type_data.set(
+        'DEFAULT_FLASH_SIZE',
+        meson.get_cross_property('default_flash_size', '0x0000fc00'))
+else
+    picolibc_linker_type_data.set('MEMORY_BOOT_FLASH', '')
+    picolibc_linker_type_data.set('INIT_MEMORY', 'flash')
+    picolibc_linker_type_data.set(
+        'DEFAULT_FLASH_ADDR',
+        meson.get_cross_property('default_flash_addr', '0x10000000'))
+    picolibc_linker_type_data.set(
+        'DEFAULT_FLASH_SIZE',
+        meson.get_cross_property('default_flash_size', '0x00010000'))
+endif
 
 picolibc_linker_type_data.set('DEFAULT_RAM_ADDR',
 			      meson.get_cross_property('default_ram_addr',

--- a/newlib/libc/picolib/machine/arm/arm_tls.h
+++ b/newlib/libc/picolib/machine/arm/arm_tls.h
@@ -33,6 +33,6 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if (__ARM_FEATURE_COPROC & 1) && __ARM_ARCH_PROFILE != 'M' && __ARM_ARCH >= 6
+#if ((__ARM_FEATURE_COPROC & 1) || __ARM_ARCH >= 8) && __ARM_ARCH_PROFILE != 'M' && __ARM_ARCH >= 6
 #define ARM_TLS_CP15
 #endif

--- a/newlib/libc/picolib/picosbrk.c
+++ b/newlib/libc/picolib/picosbrk.c
@@ -34,6 +34,7 @@
  */
 
 #include <unistd.h>
+#include <errno.h>
 
 extern char __heap_start[];
 extern char __heap_end[];
@@ -43,11 +44,15 @@ static char *brk = __heap_start;
 void *sbrk(ptrdiff_t incr)
 {
 	if (incr < 0) {
-		if (brk - __heap_start < -incr)
-			return (void *) -1;
+            if (brk - __heap_start < -incr) {
+                    errno = ENOMEM;
+                    return (void *) -1;
+            }
 	} else {
-		if (__heap_end - brk < incr)
+		if (__heap_end - brk < incr) {
+                        errno = ENOMEM;
 			return (void *) -1;
+                }
 	}
 	void *ret = brk;
 	brk += incr;

--- a/newlib/libc/posix/dirname.c
+++ b/newlib/libc/posix/dirname.c
@@ -8,6 +8,15 @@
 #include <libgen.h>
 #include <string.h>
 
+#if __GNUC__ == 12 && __GNUC_MINOR__ == 2 && __GNUC_PATCHLEVEL__ == 1 && __OPTIMIZE_SIZE__
+/*
+ * GCC 12.2.1 has a bug in -Os mode on (at least) arm v8.1-m which
+ * mis-compiles this function. Work around that by switching
+ * optimization mode
+ */
+#pragma GCC optimize("O2")
+#endif
+
 char *
 dirname (char *path)
 {

--- a/newlib/libc/tinystdio/atod_engine.c
+++ b/newlib/libc/tinystdio/atod_engine.c
@@ -32,6 +32,15 @@
 
 #include "dtoa_engine.h"
 
+#if __GNUC__ == 12 && __GNUC_MINOR__ == 2 && __GNUC_PATCHLEVEL__ == 1 && __OPTIMIZE_SIZE__
+/*
+ * GCC 12.2.1 has a bug in -Os mode on (at least) arm v8.1-m which
+ * mis-compiles this function resulting in an infinite loop. Work
+ * around that by switching optimization mode
+ */
+#pragma GCC optimize("O2")
+#endif
+
 double
 __atod_engine(uint64_t u64, int exp)
 {

--- a/newlib/libc/tinystdio/atof_engine.c
+++ b/newlib/libc/tinystdio/atof_engine.c
@@ -34,6 +34,15 @@
 
 #include "dtoa_engine.h"
 
+#if __GNUC__ == 12 && __GNUC_MINOR__ == 2 && __GNUC_PATCHLEVEL__ == 1 && __OPTIMIZE_SIZE__
+/*
+ * GCC 12.2.1 has a bug in -Os mode on (at least) arm v8.1-m which
+ * mis-compiles this function resulting in an infinite loop. Work
+ * around that by switching optimization mode
+ */
+#pragma GCC optimize("O2")
+#endif
+
 float
 __atof_engine(uint32_t u32, int exp)
 {

--- a/newlib/libm/test/test.h
+++ b/newlib/libm/test/test.h
@@ -176,7 +176,7 @@ typedef struct
 } question_struct_type;
 
 
-typedef struct 
+typedef const struct 
 {
   char error_bit;
   char errno_val;
@@ -224,7 +224,7 @@ int fmag_of_error (float, float);
 
 
 
-typedef struct 
+typedef const struct 
 {
   int line;
   
@@ -237,13 +237,13 @@ typedef struct
 #define ENDSCAN_IS_ZERO	0x80
 #define ENDSCAN_IS_INF	0x80
 
-typedef struct {
+typedef const struct {
   long int value;
   char end;
   char errno_val;
 } int_scan_type;
 
-typedef struct 
+typedef const struct 
 {
   int line;
   int_scan_type octal;
@@ -255,7 +255,7 @@ typedef struct
 } int_type;
 
 
-typedef struct 
+typedef const struct 
 {
   int line;
   double value;
@@ -272,7 +272,7 @@ typedef struct
   char *gfstring;
 } ddouble_type;
 
-typedef struct
+typedef const struct
 {
   int line;
   double value;
@@ -282,7 +282,7 @@ typedef struct
 } sprint_double_type;
 
 
-typedef struct
+typedef const struct
 {
   int line;
   int value;

--- a/newlib/testsuite/include/check.h
+++ b/newlib/testsuite/include/check.h
@@ -6,12 +6,14 @@ is freely granted, provided that this notice is preserved.
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <errno.h>
 
 #define CHECK(a) { \
   if (!(a)) \
     { \
+      int err = errno; \
       printf ("Failed " #a " in <%s> at line %d\n", __FILE__, __LINE__); \
       fflush(stdout); \
-      exit(1); \
+      exit(err == ENOMEM ? 77 : 1); \
     } \
 }

--- a/newlib/testsuite/newlib.string/tstring.c
+++ b/newlib/testsuite/newlib.string/tstring.c
@@ -56,14 +56,17 @@ void myset (char *target, char ch, int size)
     }
 }
 
-static char target[MAX_1] = "A";
-static char buffer2[MAX_1];
-static char buffer3[MAX_1];
-static char buffer4[MAX_1];
-static char buffer5[MAX_2];
-static char buffer6[MAX_2];
-static char buffer7[MAX_2];
-static char expected[MAX_1];
+char *getbuf(size_t size, const char *template)
+{
+    char *buf = calloc(size, 1);
+    if (!buf) {
+        printf("not enough memory\n");
+        exit(77);
+    }
+    if (template)
+        strcpy(buf, template);
+    return buf;
+}
 
 int main(void)
 {
@@ -75,6 +78,15 @@ int main(void)
   unsigned i, j, k, x, z = 0, align_test_iterations;
 
   int test_failed = 0;
+
+  char *target = getbuf(MAX_1, "A");
+  char *buffer2 = getbuf(MAX_1, NULL);
+  char *buffer3 = getbuf(MAX_1, NULL);
+  char *buffer4 = getbuf(MAX_1, NULL);
+  char *buffer5 = getbuf(MAX_2, NULL);
+  char *buffer6 = getbuf(MAX_2, NULL);
+  char *buffer7 = getbuf(MAX_2, NULL);
+  char *expected = getbuf(MAX_1, NULL);
 
   tmp1 = target;
   tmp2 = buffer2;

--- a/picocrt/machine/arm/crt0.c
+++ b/picocrt/machine/arm/crt0.c
@@ -109,8 +109,10 @@ _start(void)
 	__asm__("mcr p15, 0, %0, c1, c0, 0" : : "r" (sctlr));
 #endif
 #if defined __ARM_FP || defined __ARM_FEATURE_MVE
+#if __ARM_ARCH > 6
 	/* Set CPACR for access to CP10 and 11 */
 	__asm__("mcr p15, 0, %0, c1, c0, 2" : : "r" (0xf << 20));
+#endif
 	/* Enable FPU */
 	__asm__("vmsr fpexc, %0" : : "r" (0x40000000));
 #endif

--- a/picocrt/machine/arm/crt0.c
+++ b/picocrt/machine/arm/crt0.c
@@ -55,7 +55,10 @@ _start(void)
 {
 	/* Generate a reference to __interrupt_vector so we get one loaded */
 	__asm__(".equ __my_interrupt_vector, __interrupt_vector");
-#ifndef __SOFTFP__
+    /* Access to the coprocessor has to be enabled in CPACR, if either FPU or
+     * MVE is used. This is described in "Arm v8-M Architecture Reference
+     * Manual". */
+#if defined __ARM_FP || defined __ARM_FEATURE_MVE
 	/* Enable FPU */
 	*CPACR |= 0xf << 20;
 	/*

--- a/picocrt/machine/arm/crt0.c
+++ b/picocrt/machine/arm/crt0.c
@@ -101,20 +101,18 @@ _start(void)
 	/* Initialize stack pointer */
 	__asm__("mov sp, %0" : : "r" (__stack));
 
-#if __ARM_ARCH == 7
-#ifdef __thumb__
+#ifdef __thumb2__
 	/* Make exceptions run in Thumb mode */
 	uint32_t sctlr;
 	__asm__("mrc p15, 0, %0, c1, c0, 0" : "=r" (sctlr));
 	sctlr |= (1 << 30);
 	__asm__("mcr p15, 0, %0, c1, c0, 0" : : "r" (sctlr));
 #endif
-#ifndef __SOFTFP__
+#if defined __ARM_FP || defined __ARM_FEATURE_MVE
 	/* Set CPACR for access to CP10 and 11 */
 	__asm__("mcr p15, 0, %0, c1, c0, 2" : : "r" (0xf << 20));
 	/* Enable FPU */
 	__asm__("vmsr fpexc, %0" : : "r" (0x40000000));
-#endif
 #endif
 
 	/* Branch to C code */

--- a/picolibc.ld.in
+++ b/picolibc.ld.in
@@ -41,9 +41,13 @@ ENTRY(_start)
  */
 
 MEMORY
-{
-	flash (rx!w) : ORIGIN = DEFINED(__flash) ? __flash : @DEFAULT_FLASH_ADDR@, LENGTH = DEFINED(__flash_size) ? __flash_size : @DEFAULT_FLASH_SIZE@
-	ram (w!rx)   : ORIGIN = DEFINED(__ram  ) ? __ram   : @DEFAULT_RAM_ADDR@, LENGTH = DEFINED(__ram_size  ) ? __ram_size   : @DEFAULT_RAM_SIZE@
+{@MEMORY_BOOT_FLASH@
+	flash (rx!w) :
+		ORIGIN = DEFINED(__flash) ? __flash : @DEFAULT_FLASH_ADDR@,
+		LENGTH = DEFINED(__flash_size) ? __flash_size : @DEFAULT_FLASH_SIZE@
+	ram (w!rx) :
+		ORIGIN = DEFINED(__ram) ? __ram : @DEFAULT_RAM_ADDR@,
+		LENGTH = DEFINED(__ram_size) ? __ram_size : @DEFAULT_RAM_SIZE@
 }
 
 PHDRS
@@ -62,7 +66,7 @@ SECTIONS
 		KEEP (*(.text.init.enter))
 		KEEP (*(.data.init.enter))
 		KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))
-	} >flash AT>flash :text
+	} >@INIT_MEMORY@ AT>@INIT_MEMORY@ :text
 
 	.text : {
 

--- a/scripts/cross-thumbv8_1m-none-eabi.txt
+++ b/scripts/cross-thumbv8_1m-none-eabi.txt
@@ -3,13 +3,13 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['arm-none-eabi-gcc', '-nostdlib']
+c = ['arm-none-eabi-gcc', '-nostdlib', '-mthumb', '-march=armv8.1-m.main+mve', '-mfloat-abi=hard']
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eabi-as'
 nm = 'arm-none-eabi-nm'
 strip = 'arm-none-eabi-strip'
 # only needed to run tests
-exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-arm "$@"', 'run-arm']
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-cortex-m55 "$@"', 'run-cortex-m55']
 
 [host_machine]
 system = 'none'
@@ -21,8 +21,8 @@ endian = 'little'
 skip_sanity_check = true
 separate_boot_flash = true
 default_boot_flash_addr = '0x00000000'
-default_boot_flash_size = '0x00000400'
-default_flash_addr = '0x00000400'
-default_flash_size = '0x003ffc00'
-default_ram_addr   = '0x20000000'
-default_ram_size   = '0x00200000'
+default_boot_flash_size = '0x00080000'
+default_flash_addr = '0x01000000'
+default_flash_size = '0x00200000'
+default_ram_addr   = '0x60000000'
+default_ram_size   = '0x01000000'

--- a/scripts/cross-thumbv8m_main_fp-none-eabi.txt
+++ b/scripts/cross-thumbv8m_main_fp-none-eabi.txt
@@ -3,13 +3,13 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['arm-none-eabi-gcc', '-nostdlib']
+c = ['arm-none-eabi-gcc', '-nostdlib', '-mthumb', '-march=armv8-m.main+fp', '-mfloat-abi=hard']
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eabi-as'
 nm = 'arm-none-eabi-nm'
 strip = 'arm-none-eabi-strip'
 # only needed to run tests
-exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-arm "$@"', 'run-arm']
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-cortex-m33 "$@"', 'run-cortex-m33']
 
 [host_machine]
 system = 'none'
@@ -20,9 +20,9 @@ endian = 'little'
 [properties]
 skip_sanity_check = true
 separate_boot_flash = true
-default_boot_flash_addr = '0x00000000'
-default_boot_flash_size = '0x00000400'
-default_flash_addr = '0x00000400'
-default_flash_size = '0x003ffc00'
-default_ram_addr   = '0x20000000'
-default_ram_size   = '0x00200000'
+default_boot_flash_addr = '0x10000000'
+default_boot_flash_size = '0x10000400'
+default_flash_addr = '0x10000400'
+default_flash_size = '0x103ffc00'
+default_ram_addr   = '0x80000000'
+default_ram_size   = '0x01000000'

--- a/scripts/do-thumbv8_1m-configure
+++ b/scripts/do-thumbv8_1m-configure
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2019 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+exec "$(dirname "$0")"/do-configure thumbv8_1m-none-eabi \
+     -Dtests=true \
+     -Dmultilib=false "$@"

--- a/scripts/do-thumbv8m_main_fp-configure
+++ b/scripts/do-thumbv8m_main_fp-configure
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2019 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+exec "$(dirname "$0")"/do-configure thumbv8m_main_fp-none-eabi \
+     -Dtests=true \
+     -Dmultilib=false "$@"

--- a/scripts/run-arm
+++ b/scripts/run-arm
@@ -124,6 +124,10 @@ case "$elf" in
     *thumb_v8_m_main_dp_hard*)
 	;;
 
+    *thumb_v8_1_m_main_mve_hard*)
+    cpu=cortex-m55
+    ;;
+
     # v7 - Cortex-A7
     *thumb_v7_nofp*)
 	cpu=cortex-a7
@@ -153,6 +157,16 @@ case $cpu in
     cortex-m3)
 	machine=mps2-an385
 	;;
+
+    # mps2-an386 offers a cortex-m4 processor
+    cortex-m4)
+    machine=mps2-an386
+    ;;
+
+    # mps2-an500 offers a cortex-m7 processor
+    cortex-m7)
+    machine=mps2-an500
+    ;;
 
     # Maybe qemu upstream will take this machine
     # which supports all Cortex-M processors

--- a/scripts/run-cortex-m33
+++ b/scripts/run-cortex-m33
@@ -1,0 +1,99 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2019 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+qemu="qemu-system-arm"
+
+# select the program
+elf="$1"
+shift
+
+cpu=cortex-m33
+machine=mps2-an505
+
+#
+# Make sure the target machine is supported by qemu
+#
+if "$qemu" -machine help | grep -q "^$machine "; then
+    :
+else
+    echo "Skipping $elf" unsupported machine
+    exit 77
+fi
+
+# Map stdio to a multiplexed character device so we can use it
+# for the monitor and semihosting output
+
+chardev=stdio,mux=on,id=stdio0
+
+# Point the semihosting driver at our new chardev
+
+semi=enable=on,chardev=stdio0
+
+input=""
+
+case "$1" in
+    --)
+	semi="$semi",arg="$2"
+	shift
+	shift
+	;;
+    -*|"")
+	;;
+    *)
+	semi="$semi",arg="$1"
+	input="$1"
+	shift
+	;;
+esac
+
+# Disable monitor
+
+mon=none
+
+# Disable serial
+
+serial=none
+
+echo "$input" | "$qemu" \
+      -chardev "$chardev" \
+      -semihosting-config "$semi" \
+      -monitor "$mon" \
+      -serial "$serial" \
+      -machine "$machine",accel=tcg \
+      -cpu "$cpu" \
+      -device loader,file="$elf",cpu-num=0 \
+      -nographic \
+      "$@"

--- a/scripts/run-cortex-m55
+++ b/scripts/run-cortex-m55
@@ -1,0 +1,113 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2019 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+qemu="qemu-system-arm"
+
+# select the program
+elf="$1"
+shift
+
+cpu=cortex-m55
+machine=mps3-an547
+
+#
+# Make sure the target machine is supported by qemu
+#
+if "$qemu" -machine help | grep -q "^$machine "; then
+    :
+else
+    echo "Skipping $elf" unsupported machine
+    exit 77
+fi
+
+# Map stdio to a multiplexed character device so we can use it
+# for the monitor and semihosting output
+
+chardev=stdio,mux=on,id=stdio0
+
+# Point the semihosting driver at our new chardev
+
+semi=enable=on,chardev=stdio0
+
+input=""
+
+case "$1" in
+    --)
+	semi="$semi",arg="$2"
+	shift
+	shift
+	;;
+    -*|"")
+	;;
+    *)
+	semi="$semi",arg="$1"
+	input="$1"
+	shift
+	;;
+esac
+
+# Disable monitor
+
+mon=none
+
+# Disable serial
+
+serial=none
+
+echo "$input" | "$qemu" \
+      -chardev "$chardev" \
+      -semihosting-config "$semi" \
+      -monitor "$mon" \
+      -serial "$serial" \
+      -machine "$machine",accel=tcg \
+      -cpu "$cpu" \
+      -device loader,file="$elf",cpu-num=0 \
+      -nographic \
+      "$@"
+
+result=$?
+
+if [ $result != 0 ]; then
+    case $elf in
+    # The "dirname" test hits a bug in GCC
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=110791
+    *dirname)
+        echo "GCC has a bug on armv8.1-m.main with -Os"
+        result=77
+        ;;
+    esac
+fi
+exit $result

--- a/test/long_double.c
+++ b/test/long_double.c
@@ -93,32 +93,32 @@ check_long_long(const char *name, int i, long long expect, long long result)
     return 0;
 }
 
-typedef struct {
+typedef const struct {
     const char *name;
     int (*test)(void);
 } long_double_test_t;
 
-typedef struct {
+typedef const struct {
     int line;
     long double x;
     long double y;
 } long_double_test_f_f_t;
 
-typedef struct {
+typedef const struct {
     int line;
     long double x0;
     long double x1;
     long double y;
 } long_double_test_f_ff_t;
 
-typedef struct {
+typedef const struct {
     int line;
     long double x0;
     int x1;
     long double y;
 } long_double_test_f_fi_t;
 
-typedef struct {
+typedef const struct {
     int line;
     long double x;
     long long y;

--- a/test/math_errhandling_tests.c
+++ b/test/math_errhandling_tests.c
@@ -35,23 +35,23 @@
 
 #define makelname(s) scat(s,l)
 
-volatile FLOAT_T makemathname(zero) = (FLOAT_T) 0.0;
-volatile FLOAT_T makemathname(negzero) = (FLOAT_T) -0.0;
-volatile FLOAT_T makemathname(one) = (FLOAT_T) 1.0;
-volatile FLOAT_T makemathname(two) = (FLOAT_T) 2.0;
-volatile FLOAT_T makemathname(three) = (FLOAT_T) 3.0;
-volatile FLOAT_T makemathname(half) = (FLOAT_T) 0.5;
-volatile FLOAT_T makemathname(big) = BIG;
-volatile FLOAT_T makemathname(bigodd) = BIGODD;
-volatile FLOAT_T makemathname(bigeven) = BIGEVEN;
-volatile FLOAT_T makemathname(small) = SMALL;
-volatile FLOAT_T makemathname(infval) = (FLOAT_T) INFINITY;
-volatile FLOAT_T makemathname(minfval) = (FLOAT_T) -INFINITY;
-volatile FLOAT_T makemathname(qnanval) = (FLOAT_T) NAN;
-volatile FLOAT_T makemathname(snanval) = (FLOAT_T) sNAN;
-volatile FLOAT_T makemathname(pio2) = (FLOAT_T) (PI_VAL/(FLOAT_T)2.0);
-volatile FLOAT_T makemathname(min_val) = (FLOAT_T) MIN_VAL;
-volatile FLOAT_T makemathname(max_val) = (FLOAT_T) MAX_VAL;
+volatile const FLOAT_T makemathname(zero) = (FLOAT_T) 0.0;
+volatile const FLOAT_T makemathname(negzero) = (FLOAT_T) -0.0;
+volatile const FLOAT_T makemathname(one) = (FLOAT_T) 1.0;
+volatile const FLOAT_T makemathname(two) = (FLOAT_T) 2.0;
+volatile const FLOAT_T makemathname(three) = (FLOAT_T) 3.0;
+volatile const FLOAT_T makemathname(half) = (FLOAT_T) 0.5;
+volatile const FLOAT_T makemathname(big) = BIG;
+volatile const FLOAT_T makemathname(bigodd) = BIGODD;
+volatile const FLOAT_T makemathname(bigeven) = BIGEVEN;
+volatile const FLOAT_T makemathname(small) = SMALL;
+volatile const FLOAT_T makemathname(infval) = (FLOAT_T) INFINITY;
+volatile const FLOAT_T makemathname(minfval) = (FLOAT_T) -INFINITY;
+volatile const FLOAT_T makemathname(qnanval) = (FLOAT_T) NAN;
+volatile const FLOAT_T makemathname(snanval) = (FLOAT_T) sNAN;
+volatile const FLOAT_T makemathname(pio2) = (FLOAT_T) (PI_VAL/(FLOAT_T)2.0);
+volatile const FLOAT_T makemathname(min_val) = (FLOAT_T) MIN_VAL;
+volatile const FLOAT_T makemathname(max_val) = (FLOAT_T) MAX_VAL;
 
 FLOAT_T makemathname(scalb)(FLOAT_T, FLOAT_T);
 
@@ -723,7 +723,7 @@ FLOAT_T makemathname(test_scalbn_tiny)(void) { return makemathname(scalbn)(makem
 #define sNAN_EXCEPTION  0
 #endif
 
-struct {
+const struct {
 	FLOAT_T	(*func)(void);
 	char	*name;
 	FLOAT_T	value;

--- a/test/timegm.c
+++ b/test/timegm.c
@@ -40,7 +40,7 @@
 
 #define NUM_TEST	1024
 
-struct _test {
+const struct _test {
 	struct tm	tm;
 	time_t		time;
 } tests[NUM_TEST] = {
@@ -117,8 +117,10 @@ int main(void)
 			ret++;
 		}
 
+                struct tm tmp = tests[i].tm;
+
 		/* timegm */
-		time = timegm(&tests[i].tm);
+		time = timegm(&tmp);
 		if (time != tests[i].time) {
 			printf("time: got %ld want %ld\n", (long) time, (long) tests[i].time);
 			ret++;


### PR DESCRIPTION
This is more of a starting point for discussion than a final patch.

Set proper QEMU machine for some cortex-m* tests.
QEMU has specific boards for some cortex-m processors. Using them enables testing on QEMU without the virtm patch.

Added boot_flash to the link script.
The mps3-547 board has just 512 KB of flash at address 0. This is not enough to hold the math_test test. There is more memory at 0x0100_0000, but the interrupt vector has to stay at 0. To resolve this I added boot_flash memory region to hold the interrupt vector separately from the rest of the code. This modification to link script could also be useful to final users on arm targets, making them more likely to be able to use unmodified picolibc.ld.

Add cortex-m33 and cortex-m55 test configurations.
I had to create separate non-multilib configurations for armv8-m.main+fp and armv8.1-m.main+mve as I wasn't able to provide proper link script parameters for these variants in the multilib build. Ideally, these would be tested in multilib build, but a mechanism to provide separate memory layout for tests would be needed.

Fix for coprocessor not enabled with mve.