### PR TITLE
math/test: Build native math test with test generation enabled

### DIFF
--- a/newlib/libm/test/math.c
+++ b/newlib/libm/test/math.c
@@ -47,10 +47,6 @@ double mretval = 64;
 int traperror = 1;
 char *mname;
 
-/*
-  #define INCLUDE_GENERATE
-*/
-
 void
 translate_to (FILE *file,
 	    double r)
@@ -460,7 +456,7 @@ run_vector_1 (int vector,
   double result;
   float fresult;
 
-#if 0
+#ifdef INCLUDE_GENERATE
   if (vector)
   {
 

--- a/newlib/libm/test/meson.build
+++ b/newlib/libm/test/meson.build
@@ -176,7 +176,7 @@ if enable_native_tests
   if native_lib_m.found()
     test('math-native',
 	 executable('math_test_native', math_test_src,
-		    c_args: native_c_args,
+		    c_args: native_c_args + ['-DINCLUDE_GENERATE'],
 		    link_args: native_c_args,
 		    dependencies: native_lib_m))
   endif

--- a/newlib/libm/test/test.h
+++ b/newlib/libm/test/test.h
@@ -24,6 +24,12 @@
 #include <stdio.h>
 #include <stdint.h>
 
+#ifdef INCLUDE_GENERATE
+#define TEST_CONST
+#else
+#define TEST_CONST const
+#endif
+
 /* FIXME FIXME FIXME:
    Neither of __ieee_{float,double}_shape_type seem to be used anywhere
    except in libm/test.  If that is the case, please delete these from here.
@@ -176,7 +182,7 @@ typedef struct
 } question_struct_type;
 
 
-typedef const struct 
+typedef TEST_CONST struct 
 {
   char error_bit;
   char errno_val;
@@ -224,7 +230,7 @@ int fmag_of_error (float, float);
 
 
 
-typedef const struct 
+typedef TEST_CONST struct 
 {
   int line;
   
@@ -237,13 +243,13 @@ typedef const struct
 #define ENDSCAN_IS_ZERO	0x80
 #define ENDSCAN_IS_INF	0x80
 
-typedef const struct {
+typedef TEST_CONST struct {
   long int value;
   char end;
   char errno_val;
 } int_scan_type;
 
-typedef const struct 
+typedef TEST_CONST struct 
 {
   int line;
   int_scan_type octal;
@@ -255,7 +261,7 @@ typedef const struct
 } int_type;
 
 
-typedef const struct 
+typedef TEST_CONST struct 
 {
   int line;
   double value;
@@ -272,7 +278,7 @@ typedef const struct
   char *gfstring;
 } ddouble_type;
 
-typedef const struct
+typedef TEST_CONST struct
 {
   int line;
   double value;
@@ -282,7 +288,7 @@ typedef const struct
 } sprint_double_type;
 
 
-typedef const struct
+typedef TEST_CONST struct
 {
   int line;
   int value;


### PR DESCRIPTION
This lets us re-create the math function test vectors based upon the native math library values.