### PR TITLE
scripts: Simplify run-arm by making cortex-m55 handle all v8.1m

### DIFF
--- a/scripts/run-arm
+++ b/scripts/run-arm
@@ -113,18 +113,7 @@ case "$cpu_arch"/"$cpu_profile" in
         esac
         ;;
     v8.1-M.mainline/Microcontroller)
-        case "$fp_arch" in
-            FPv5/FP-D16)
-                case "$fp_use" in
-                    SP)
-                        cpu=cortex-m55
-                        ;;
-                esac
-                ;;
-            *)
-                cpu=cortex-m55
-                ;;
-        esac
+        cpu=cortex-m55
         ;;
     v8/Application)
         cpu=cortex-a57


### PR DESCRIPTION
Dominik Wójt notes that we're using cortex-m55 for v8 DP mode, but explicitly skipping that for v8.1M DP. That wasn't caught in testing as GCC's current multilib setup doesn't include that target.