### PR TITLE
scripts/run-arm: Configure qemu microbit memory large enough for tests

### DIFF
--- a/scripts/cross-arm-none-eabi.txt
+++ b/scripts/cross-arm-none-eabi.txt
@@ -48,15 +48,3 @@ default_flash_addr_mps2_an505 = '0x10000400'
 default_flash_size_mps2_an505 = '0x103ffc00'
 default_ram_addr_mps2_an505 = '0x80000000'
 default_ram_size_mps2_an505 = '0x01000000'
-
-custom_mem_config_thumb_v6_m_nofp = 'microbit'
-
-# The microbit has only 256k of flash, but
-# we pretend it has lots more so that tests
-# will successfully link and then report
-# "SKIP" when run
-default_flash_addr_microbit = '0x00000000'
-default_flash_size_microbit = '0x00400000'
-default_ram_addr_microbit   = '0x20000000'
-default_ram_size_microbit   = '0x00004000'
-default_stack_size_microbit = '0x00000800'

--- a/scripts/run-arm
+++ b/scripts/run-arm
@@ -113,18 +113,7 @@ case "$cpu_arch"/"$cpu_profile" in
         esac
         ;;
     v8.1-M.mainline/Microcontroller)
-        case "$fp_arch" in
-            FPv5/FP-D16)
-                case "$fp_use" in
-                    SP)
-                        cpu=cortex-m55
-                        ;;
-                esac
-                ;;
-            *)
-                cpu=cortex-m55
-                ;;
-        esac
+        cpu=cortex-m55
         ;;
     v8/Application)
         cpu=cortex-a57

--- a/scripts/run-arm
+++ b/scripts/run-arm
@@ -127,40 +127,7 @@ case $cpu in
 
     cortex-m0)
         machine=microbit
-        # Microbit only allows for 256kB of flash and 16kB of ram
-        # check the size of the binary and bail if it's too large
-
-        # check which awk version we've got and adapt
-        if awk --version | grep -q GNU; then
-            STRTONUM="strtonum"
-        else
-            STRTONUM=""
-        fi
-        sizes=`arm-none-eabi-objdump -h "$elf" |
-        awk '/^ *[0-9]/ {
-		size = '$STRTONUM'("0x" $3) + 0;
-		name = $2;
-	}
-	/ALLOC/ {
-		if (name == ".stack")
-			size = 0;
-		if ($0 ~ ".*LOAD.*") {
-			rom += size;
-		}
-		if ($0 !~ ".*READONLY.*" && name != ".init" && $0 !~ ".*THREAD_LOCAL.*") {
-			ram += size
-		}
-	}
-	END {
-		printf("%d %d\n", rom, ram);
-	}'`
-        rom_size=`echo "$sizes" | awk '{print $1}'`
-        ram_size=`echo "$sizes" | awk '{print $2}'`
-        echo "rom_size $rom_size ram_size $ram_size"
-        if [ "$rom_size" -gt 262144 -o "$ram_size" -gt 16384 ]; then
-            echo "$elf: too big"
-            exit 77
-        fi
+        memory="-global nrf51-soc.sram-size=2097152 -global nrf51-soc.flash-size=4194304"
         ;;
 
     # mps2-an385 offers a cortex-m3 processor


### PR DESCRIPTION
Set nrf51-soc.sram-size to 2MB and nrf51-soc.flash-size to 4MB which is large enough to run all of the picolibc tests.