### PR TITLE
Test MIPS support using Zephyr toolchain

### DIFF
--- a/.github/Dockerfile-zephyr
+++ b/.github/Dockerfile-zephyr
@@ -15,6 +15,22 @@ RUN apt-get update && \
      xargs -a zephyr-packages.txt apt-get install -y || \
      xargs -a zephyr-packages.txt apt-get install -y) && \
     mkdir -p /opt && \
-    (cd /opt && while read file; do wget $file || exit 1; tar xf `basename $file`; rm `basename $file`; done) < zephyr-files.txt
+    (cd /opt && \
+     for file in `cat /zephyr-files.txt`; do \
+	echo "Fetching $file"; \
+	wget "$file" || exit 1; \
+	echo "Unpacking $file"; \
+	tar xf `basename "$file"`; \
+	echo "Removing $file"; \
+	rm `basename "$file"`; \
+     done)
+
+RUN if [ -f /opt/zephyr-sdk-*-hosttools*.sh ]; then \
+	echo "Unpacking host tools"; \
+	/opt/zephyr-sdk-*-hosttools*.sh -y -d /opt/zephyr-sdk-hosttools; \
+	rm /opt/zephyr-sdk-*-hosttools*.sh; \
+    else \
+	echo "No host tools found"; \
+    fi
 
 RUN apt-get clean

--- a/.github/do-zephyr
+++ b/.github/do-zephyr
@@ -4,6 +4,7 @@ HERE=`dirname "$0"`
 "$HERE"/do-zephyr-test arc "$@"
 "$HERE"/do-zephyr-build arc64 "$@"
 "$HERE"/do-zephyr-build microblazeel "$@"
+"$HERE"/do-zephyr-test mips-zephyr "$@"
 "$HERE"/do-zephyr-build nios2 "$@"
 "$HERE"/do-zephyr-test x86_64-zephyr "$@"
 "$HERE"/do-zephyr-build xtensa-espressif_esp32 "$@"

--- a/.github/workflows/head-zephyr
+++ b/.github/workflows/head-zephyr
@@ -13,6 +13,7 @@ env:
   IMAGE: picolibc
   PACKAGES_FILE: picolibc/.github/zephyr-packages.txt
   EXTRA_FILE: picolibc/.github/zephyr-files.txt
+  SEQUENCE_FILE: picolibc/.github/zephyr-sequence.txt
 
 jobs:
   cache-maker:
@@ -28,7 +29,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.PACKAGES_FILE, env.EXTRA_FILE ) }}
+          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.PACKAGES_FILE, env.EXTRA_FILE, env.SEQUENCE_FILE ) }}
 
       - name: Set up Docker Buildx
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -13,6 +13,7 @@ env:
   IMAGE: picolibc
   PACKAGES_FILE: picolibc/.github/zephyr-packages.txt
   EXTRA_FILE: picolibc/.github/zephyr-files.txt
+  SEQUENCE_FILE: picolibc/.github/zephyr-sequence.txt
 
 jobs:
   cache-maker:
@@ -28,7 +29,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.PACKAGES_FILE, env.EXTRA_FILE ) }}
+          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.PACKAGES_FILE, env.EXTRA_FILE, env.SEQUENCE_FILE ) }}
 
       - name: Set up Docker Buildx
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/zephyr
+++ b/.github/zephyr
@@ -2,14 +2,14 @@
 here=`dirname "$0"`
 export ZEPHYR_SDK_INSTALL_DIR=/opt
 
+if [ -d $ZEPHYR_SDK_INSTALL_DIR/zephyr-sdk-hosttools ]; then
+    . $ZEPHYR_SDK_INSTALL_DIR/zephyr-sdk-hosttools/environment-setup-*
+fi
+
 for dir in "$ZEPHYR_SDK_INSTALL_DIR"/*; do
     if [ -d "$dir" -a -d "$dir"/bin ]; then
-       PATH="$dir"/bin:$PATH
+	PATH="$dir"/bin:$PATH
     fi
 done
-
-if [ -d $ZEPHYR_SDK_INSTALL_DIR/sysroots/x86_64-pokysdk-linux/usr/bin ]; then
-    PATH=$ZEPHYR_SDK_INSTALL_DIR/sysroots/x86_64-pokysdk-linux/usr/bin:$PATH
-fi
 
 exec "$@"

--- a/.github/zephyr-files.txt
+++ b/.github/zephyr-files.txt
@@ -1,5 +1,4 @@
 https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/toolchain_linux-x86_64_arc-zephyr-elf.tar.xz
-https://maps.altusmetrum.org/qemu-arc.tar.xz
 https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/toolchain_linux-x86_64_arc64-zephyr-elf.tar.xz
 https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/toolchain_linux-x86_64_microblazeel-zephyr-elf.tar.xz
 https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/toolchain_linux-x86_64_nios2-zephyr-elf.tar.xz
@@ -11,3 +10,5 @@ https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/toolchain
 https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/toolchain_linux-x86_64_xtensa-nxp_imx8m_adsp_zephyr-elf.tar.xz
 https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/toolchain_linux-x86_64_xtensa-nxp_imx_adsp_zephyr-elf.tar.xz
 https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/toolchain_linux-x86_64_xtensa-sample_controller_zephyr-elf.tar.xz
+https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/hosttools_linux-x86_64.tar.xz
+https://maps.altusmetrum.org/qemu-arc.tar.xz

--- a/.github/zephyr-files.txt
+++ b/.github/zephyr-files.txt
@@ -1,6 +1,7 @@
 https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/toolchain_linux-x86_64_arc-zephyr-elf.tar.xz
 https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/toolchain_linux-x86_64_arc64-zephyr-elf.tar.xz
 https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/toolchain_linux-x86_64_microblazeel-zephyr-elf.tar.xz
+https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/toolchain_linux-x86_64_mips-zephyr-elf.tar.xz
 https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/toolchain_linux-x86_64_nios2-zephyr-elf.tar.xz
 https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/toolchain_linux-x86_64_x86_64-zephyr-elf.tar.xz
 https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/toolchain_linux-x86_64_xtensa-espressif_esp32s2_zephyr-elf.tar.xz

--- a/.github/zephyr-sequence.txt
+++ b/.github/zephyr-sequence.txt
@@ -1,0 +1,3 @@
+# A file that changes every time we want the Zephyr Docker image to change
+
+SEQUENCE 2

--- a/meson.build
+++ b/meson.build
@@ -296,7 +296,9 @@ endif
 # Select stdio implementation
 tinystdio = get_option('tinystdio')
 
-has_link_defsym = meson.get_cross_property('has_link_defsym', cc.has_link_argument('-Wl,--defsym=' + global_prefix + '_start=0'))
+has_link_defsym = meson.get_cross_property('has_link_defsym',
+                                           cc.has_link_argument('-Wl,--defsym=' + global_prefix + '_start=0') or
+                                           cc.has_link_argument('-Wl,--defsym=' + global_prefix + '__start=0') )
 has_link_alias = meson.get_cross_property('has_link_alias', cc.has_link_argument('-Wl,-alias,' + global_prefix + 'main,testalias'))
 lib_gcc = meson.get_cross_property('libgcc', '-lgcc')
 

--- a/newlib/libc/include/machine/ieeefp.h
+++ b/newlib/libc/include/machine/ieeefp.h
@@ -310,6 +310,13 @@ warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #define __IEEE_LITTLE_ENDIAN
 #endif
 
+#ifdef __mips__
+#define _IEEE_754_2008_SNAN 0
+#ifndef __mips_soft_float
+#define _SUPPORTS_ERREXCEPT
+#endif
+#endif
+
 #ifdef __MIPSEL__
 #define __IEEE_LITTLE_ENDIAN
 #endif

--- a/newlib/libc/include/math.h
+++ b/newlib/libc/include/math.h
@@ -243,6 +243,16 @@ extern int isnan (double);
 # define math_errhandling (_MATH_ERRHANDLING_ERRNO | _MATH_ERRHANDLING_ERREXCEPT)
 #endif
 
+/*
+ * Specifies whether the target uses the snan/nan discriminator
+ * definition from IEEE 754 2008 (top bit of significand is 1 for qNaN
+ * and 0 for sNaN). This is set to zero in machine/math.h for targets
+ * that don't do this (such as MIPS).
+ */
+#ifndef _IEEE_754_2008_SNAN
+# define _IEEE_754_2008_SNAN 1
+#endif
+
 extern int __isinff (float);
 extern int __isinfd (double);
 extern int __isnanf (float);

--- a/newlib/libc/machine/mips/sys/fenv.h
+++ b/newlib/libc/machine/mips/sys/fenv.h
@@ -31,7 +31,16 @@
 #ifndef	_SYS_FENV_H_
 #define	_SYS_FENV_H_
 
-#include <sys/_types.h>
+#include <sys/cdefs.h>
+
+#ifdef __mips_soft_float
+typedef int fenv_t;
+typedef int fexcept_t;
+#else
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #ifndef	__fenv_static
 #define	__fenv_static	static
@@ -84,5 +93,11 @@ extern fenv_t		_fe_dfl_env;
 #define	__cfc1(__fcsr)	__asm __volatile("cfc1 %0, $31" : "=r" (__fcsr))
 #define	__ctc1(__fcsr)	__asm __volatile("ctc1 %0, $31" :: "r" (__fcsr))
 #endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !_SOFT_FLOAT */
 
 #endif	/* !_FENV_H_ */

--- a/newlib/libc/picolib/machine/mips/meson.build
+++ b/newlib/libc/picolib/machine/mips/meson.build
@@ -1,0 +1,38 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2021 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+if thread_local_storage
+  src_picolib += files('tls.c')
+endif

--- a/newlib/libc/picolib/machine/mips/tls.c
+++ b/newlib/libc/picolib/machine/mips/tls.c
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2022 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <picotls.h>
+#include <string.h>
+#include <stdint.h>
+
+void
+_set_tls(void *tls)
+{
+    __asm__(".set push\n"
+#if _MIPS_SZPTR == 32
+            ".set mips32r2\n"
+#else
+            ".set mips64r2\n"
+#endif
+            "mtc0 %z0, $4, %1\n"
+            ".set pop"
+            : : "Jr" (tls),
+              "i" (2));
+}

--- a/newlib/libm/common/math_config.h
+++ b/newlib/libm/common/math_config.h
@@ -252,25 +252,22 @@ _asdouble(int64_t i)
     return asdouble((uint64_t) i);
 }
 
-#ifndef IEEE_754_2008_SNAN
-# define IEEE_754_2008_SNAN 1
-#endif
 static ALWAYS_INLINE int
 issignalingf_inline (float x)
 {
   uint32_t ix = asuint (x);
-  if (!IEEE_754_2008_SNAN)
-    return (ix & 0x7fc00000) == 0x7fc00000;
-  return 2 * (ix ^ 0x00400000) > 0xFF800000u;
+  if (!_IEEE_754_2008_SNAN)
+    return (ix & 0x7fc00000u) == 0x7fc00000u;
+  return 2 * (ix ^ 0x00400000u) > 0xFF800000u;
 }
 
 static ALWAYS_INLINE int
 issignaling_inline (double x)
 {
   uint64_t ix = asuint64 (x);
-  if (!IEEE_754_2008_SNAN)
-    return (ix & 0x7ff8000000000000) == 0x7ff8000000000000;
-  return 2 * (ix ^ 0x0008000000000000) > 2 * 0x7ff8000000000000ULL;
+  if (!_IEEE_754_2008_SNAN)
+    return (ix & 0x7ff8000000000000ULL) == 0x7ff8000000000000ULL;
+  return 2 * (ix ^ 0x0008000000000000ULL) > 2 * 0x7ff8000000000000ULL;
 }
 
 #ifdef PICOLIBC_FLOAT_NOEXCEPT

--- a/newlib/libm/ld/math_private_openbsd.h
+++ b/newlib/libm/ld/math_private_openbsd.h
@@ -112,7 +112,7 @@ issignalingl(long double x)
     if (!isnanl(x))
         return 0;
     GET_LDOUBLE_MSW64(high, x);
-    if (!IEEE_754_2008_SNAN)
+    if (!_IEEE_754_2008_SNAN)
         return (high & 0x0000800000000000ULL) != 0;
     else
         return (high & 0x0000800000000000ULL) == 0;
@@ -479,7 +479,7 @@ issignalingl(long double x)
     if (!isnanl(x))
         return 0;
     GET_LDOUBLE_MSW64(high, x);
-    if (!IEEE_754_2008_SNAN)
+    if (!_IEEE_754_2008_SNAN)
         return (high & 0x0008000000000000ULL) != 0;
     else
         return (high & 0x0008000000000000ULL) == 0;

--- a/picocrt/machine/mips/crt0.c
+++ b/picocrt/machine/mips/crt0.c
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2023 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../../crt0.h"
+
+static void __attribute__((used)) __section(".init")
+_cstart(void)
+{
+	__start();
+}
+
+extern char __stack[];
+
+void __section(".init") __attribute__((used))
+_start(void)
+{
+	/* Initialize stack pointer */
+	__asm__("la $sp,%0" : : "i" (__stack));
+
+#ifndef __mips_soft_float
+        /* Enable FPU */
+        uint32_t        cp0_status;
+        __asm__("mfc0 %0,$12" : "=r" (cp0_status));
+        cp0_status |= (1 << 29);
+        __asm__("mtc0 %0,$12" : : "r" (cp0_status));
+#endif
+	/* Branch to C code */
+	__asm__("j _cstart");
+        __asm__("nop");
+}

--- a/picocrt/machine/mips/meson.build
+++ b/picocrt/machine/mips/meson.build
@@ -1,0 +1,35 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2021 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+src_picocrt += files('crt0.c')

--- a/scripts/cross-mips-zephyr-elf.txt
+++ b/scripts/cross-mips-zephyr-elf.txt
@@ -1,0 +1,26 @@
+[binaries]
+# Meson 0.53.2 doesn't use any cflags when doing basic compiler tests,
+# so we have to add -nostdlib to the compiler configuration itself or
+# early compiler tests will fail. This can be removed when picolibc
+# requires at least version 0.54.2 of meson.
+c = ['mips-zephyr-elf-gcc', '-nostdlib', '-mips32', '-G0']
+ar = 'mips-zephyr-elf-ar'
+as = 'mips-zephyr-elf-as'
+nm = 'mips-zephyr-elf-nm'
+strip = 'mips-zephyr-elf-strip'
+# only needed to run tests
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-mips "$@"', 'run-mips']
+
+[host_machine]
+system = 'zephyr'
+cpu_family = 'mips'
+cpu = 'mips'
+endian = 'little'
+
+[properties]
+skip_sanity_check = true
+has_link_defsym = true
+default_flash_addr = '0x80200000'
+default_flash_size = '0x00400000'
+default_ram_addr   = '0x80600000'
+default_ram_size   = '0x00200000'

--- a/scripts/do-mips-zephyr-configure
+++ b/scripts/do-mips-zephyr-configure
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2019 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+exec "$(dirname "$0")"/do-configure mips-zephyr-elf -Dtests=true -Dtests-enable-posix-io=false "$@"

--- a/scripts/run-mips
+++ b/scripts/run-mips
@@ -1,0 +1,69 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2020 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+dir="$(dirname "$0")"
+
+# select the program
+elf="$1"
+shift
+
+qemu="qemu-system-mips"
+
+if file "$elf" | grep -q LSB; then
+    qemu="qemu-system-mipsel"
+fi
+
+# Disable monitor
+
+mon=none
+
+# Point serial port at new chardev
+
+serial=stdio
+
+cpu=24Kf
+
+"$dir"/monitor-e9 $qemu \
+  -chardev stdio,id=con,mux=on \
+  -machine malta \
+  -cpu $cpu \
+  -serial null \
+  -serial null \
+  -serial chardev:con \
+  -mon chardev=con,mode=readline \
+  -net none \
+  -nographic \
+  -kernel "$elf" "$@" < /dev/null

--- a/semihost/machine/mips/meson.build
+++ b/semihost/machine/mips/meson.build
@@ -1,0 +1,66 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2021 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+lib_semihost_srcs = [
+  'mips_stub.c',
+  'mips_exit.c',
+  'mips_iob.c',
+  ]
+
+has_semihost = true
+
+foreach target : targets
+  value = get_variable('target_' + target)
+
+  instdir = join_paths(lib_dir, value[0])
+
+  if target == ''
+    libsemihost_name = 'semihost'
+  else
+    libsemihost_name = join_paths(target, 'libsemihost')
+  endif
+
+  local_lib_semihost_target = static_library(libsemihost_name,
+				       lib_semihost_srcs,
+				       install : true,
+				       install_dir : instdir,
+				       include_directories : inc,
+				       c_args : value[1],
+				       pic: false)
+
+  set_variable('lib_semihost' + target, local_lib_semihost_target)
+
+endforeach
+

--- a/semihost/machine/mips/mips-semihost.h
+++ b/semihost/machine/mips/mips-semihost.h
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2023 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _MIPS_SEMIHOST_H_
+#define _MIPS_SEMIHOST_H_
+
+#include <stdio.h>
+
+int
+mips_putc(char c, FILE *file);
+
+#endif /* _MIPS_SEMIHOST_H_ */

--- a/semihost/machine/mips/mips_exit.c
+++ b/semihost/machine/mips/mips_exit.c
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2021 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "mips-semihost.h"
+
+void  _ATTRIBUTE((__noreturn__))
+_exit(int code)
+{
+        char buf[15];
+        int n;
+        /* Can't use printf because stdout has already been cleaned up */
+        n = snprintf(buf, sizeof(buf), "%cexit %d\n", 0xe9, code);
+        write(1, buf, n);
+	while(1);
+}

--- a/semihost/machine/mips/mips_iob.c
+++ b/semihost/machine/mips/mips_iob.c
@@ -1,0 +1,125 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2023 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "mips-semihost.h"
+
+#define UART0   0x3f8
+
+typedef volatile uint8_t vuint8_t;
+
+#define REG_SPACING     8
+
+#if REG_SPACING
+#define __cat(a,b)      a ## b
+#define reg_pad(n)      uint8_t __cat(pad, n)[REG_SPACING-1];
+#else
+#define reg_pad(n)
+#endif
+
+
+struct uart_8250 {
+    vuint8_t     data;
+    reg_pad(0)
+    vuint8_t     ier;
+    reg_pad(1)
+    vuint8_t     iir;
+    reg_pad(2)
+    vuint8_t     lcr;
+    reg_pad(3)
+
+    vuint8_t     mcr;
+    reg_pad(4)
+    vuint8_t     lsr;
+    reg_pad(5)
+    vuint8_t     msr;
+    reg_pad(6)
+    vuint8_t     scr;
+    reg_pad(7)
+};
+
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
+/* 'bsize' is used directly with malloc/realloc which confuses -fanalyzer */
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
+
+/* malta serial port */
+#define uart    (*((struct uart_8250 *) 0xbf000900))
+
+#define UART_LSR_FIFOE		0x80 /* Fifo error */
+#define UART_LSR_TEMT		0x40 /* Transmitter empty */
+#define UART_LSR_THRE		0x20 /* Transmit-hold-register empty */
+#define UART_LSR_BI		0x10 /* Break interrupt indicator */
+#define UART_LSR_FE		0x08 /* Frame error indicator */
+#define UART_LSR_PE		0x04 /* Parity error indicator */
+#define UART_LSR_OE		0x02 /* Overrun error indicator */
+#define UART_LSR_DR		0x01 /* Receiver data ready */
+
+int
+mips_putc(char c, FILE *file)
+{
+	(void) file;
+        while ((uart.lsr & (UART_LSR_TEMT|UART_LSR_THRE)) != (UART_LSR_TEMT|UART_LSR_THRE))
+               ;
+        uart.data = (uint8_t) c;
+	return (unsigned char) c;
+}
+
+#ifdef TINY_STDIO
+
+static int
+mips_getc(FILE *file)
+{
+	(void) file;
+	return EOF;
+}
+
+static FILE __stdio = FDEV_SETUP_STREAM(mips_putc, mips_getc, NULL, _FDEV_SETUP_RW);
+
+#ifdef __strong_reference
+#define STDIO_ALIAS(x) __strong_reference(stdin, x);
+#else
+#define STDIO_ALIAS(x) FILE *const x = &__stdio;
+#endif
+
+FILE *const stdin = &__stdio;
+STDIO_ALIAS(stdout);
+STDIO_ALIAS(stderr);
+
+#endif

--- a/semihost/machine/mips/mips_stub.c
+++ b/semihost/machine/mips/mips_stub.c
@@ -1,0 +1,113 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2021 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include "mips-semihost.h"
+
+ssize_t
+read(int fd, void *buf, size_t count)
+{
+        (void) fd;
+        (void) buf;
+        (void) count;
+	return 0;
+}
+
+ssize_t
+write(int fd, const void *buf, size_t count)
+{
+	const char *b = buf;
+	size_t c = count;
+
+        (void) fd;
+	while (c--)
+                mips_putc(*b++, NULL);
+	return count;
+}
+
+int
+open(const char *pathname, int flags, ...)
+{
+        (void) pathname;
+        (void) flags;
+	return -1;
+}
+
+int
+close(int fd)
+{
+        (void) fd;
+	return 0;
+}
+
+off_t lseek(int fd, off_t offset, int whence)
+{
+        (void) fd;
+        (void) offset;
+        (void) whence;
+	return (off_t) -1;
+}
+
+_off64_t lseek64(int fd, _off64_t offset, int whence)
+{
+	return (_off64_t) lseek(fd, (off_t) offset, whence);
+}
+
+int
+unlink(const char *pathname)
+{
+        (void) pathname;
+	return 0;
+}
+
+int
+fstat (int fd, struct stat *sbuf)
+{
+        (void) fd;
+        (void) sbuf;
+	return -1;
+}
+
+int
+isatty (int fd)
+{
+        (void) fd;
+	return 1;
+}

--- a/test/testcases.c
+++ b/test/testcases.c
@@ -539,7 +539,9 @@
 #endif
 #endif
 #ifndef _NANO_FORMATTED_IO
-    result |= test(__LINE__, "1, 1", "%-*.llu, %-*.llu",1,(int64_t)1,1,(int64_t)1);
+#ifndef NO_LONGLONG
+    result |= test(__LINE__, "1, 1", "%-*.llu, %-*.llu",1,1ULL,1,1ULL);
+#endif
 #endif
 #ifndef NO_FLOAT
     result |= test(__LINE__, "1e-09", "%g", 0.000000001);


### PR DESCRIPTION
This series includes a few MIPS-related fixes and a pile of MIPS enabling code for picocrt, picolib and semihost. With those, we can use the Zephyr toolchain to test all of the multilib configurations provided there.