### PR TITLE
Fix arc64 setjmp, then test with Zephyr toolchain

### DIFF
--- a/.github/do-zephyr
+++ b/.github/do-zephyr
@@ -2,7 +2,7 @@
 set -e
 HERE=`dirname "$0"`
 "$HERE"/do-zephyr-test arc "$@"
-"$HERE"/do-zephyr-build arc64 "$@"
+"$HERE"/do-zephyr-test arc64 "$@"
 "$HERE"/do-zephyr-build microblazeel "$@"
 "$HERE"/do-zephyr-test mips-zephyr "$@"
 "$HERE"/do-zephyr-build nios2 "$@"

--- a/newlib/libc/machine/arc/setjmp.S
+++ b/newlib/libc/machine/arc/setjmp.S
@@ -32,13 +32,7 @@
    these are the stack mappings for the registers
    as stored in the ABI for ARC */
 
-#ifdef __ARC64__
-#define ARC_REGSIZE	8
-#else
-#define ARC_REGSIZE	4
-#endif
-
-       .file "setjmp.S"
+#define ARC_REGSIZE	__SIZEOF_LONG__
 
 ABIr13	= 0
 ABIr14	= ABIr13 + ARC_REGSIZE
@@ -91,8 +85,9 @@ setjmp:
 	st	r29, [r0, ABIr29]
 	st	r30, [r0, ABIr30]
 	st	blink, [r0, ABIr31]
+#ifndef __ARCV3__
 	st	lp_count, [r0, ABIlpc]
-
+#endif
 	lr	r2, [lp_start]
 	lr	r3, [lp_end]
 	st	r2, [r0, ABIlps]
@@ -143,8 +138,10 @@ longjmp:
 
 	ld	blink, [r0, ABIr31]
 
+#ifndef __ARCV3__
 	ld	r3,  [r0, ABIlpc]
 	mov	lp_count, r3
+#endif
 
 	ld	r2, [r0, ABIlps]
 	ld	r3, [r0, ABIlpe]

--- a/scripts/cross-arc64-zephyr-elf.txt
+++ b/scripts/cross-arc64-zephyr-elf.txt
@@ -8,6 +8,7 @@ ar = 'arc64-zephyr-elf-ar'
 as = 'arc64-zephyr-elf-as'
 nm = 'arc64-zephyr-elf-nm'
 strip = 'arc64-zephyr-elf-strip'
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-arc "$@"', 'run-arc']
 
 [host_machine]
 system = 'zephyr'
@@ -17,3 +18,7 @@ endian = 'little'
 
 [properties]
 skip_sanity_check = true
+default_flash_addr = '0x80000000'
+default_flash_size = '0x00400000'
+default_ram_addr   = '0x80400000'
+default_ram_size   = '0x00400000'

--- a/scripts/do-arc64-configure
+++ b/scripts/do-arc64-configure
@@ -33,4 +33,5 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-exec "$(dirname "$0")"/do-configure arc64-zephyr-elf "$@"
+multilib_list="fpus,hs58,hs5x,m128"
+exec "$(dirname "$0")"/do-configure arc64-zephyr-elf -Dposix-console=true -Dtests=true -Dthread-local-storage=false -Dmultilib-list="$multilib_list" "$@"

--- a/scripts/run-arc
+++ b/scripts/run-arc
@@ -34,8 +34,6 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-qemu="qemu-system-arc"
-
 # select the program
 elf="$1"
 shift
@@ -47,17 +45,31 @@ readelf="arc-zephyr-elf-readelf"
 if command -v "$readelf" >/dev/null 2>/dev/null; then
     # LLVM-based toolchains readelf produces different output from GNU, so
     # check --version output first.
-    if readelf --version | grep LLVM >/dev/null; then
+    if "$readelf" --version | grep LLVM >/dev/null; then
         archstring=$("$readelf" --arch-specific "$elf" | grep "Value: rv" | cut -d: -f2)
     else
-        archstring=$("$readelf" --arch-specific "$elf" | grep Tag_ARC_CPU_name | cut -d: -f2 | tr -d '"')
+        archstring=$("$readelf" --arch-specific "$elf" | grep Tag_ARC_CPU_name | cut -d: -f2 | tr -d '" ')
     fi
 fi
 if [ -z "$archstring" ]; then
     echo "Could not determine architecture for $elf, is readelf installed?" >&2
     exit 77
 fi
+
 cpu=$archstring
+
+case "$cpu" in
+    hs5*)
+        qemu=qemu-system-arc
+        cpu=hs5x
+        ;;
+    hs6x|fpud)
+        qemu=qemu-system-arc64
+        ;;
+    *)
+        qemu=qemu-system-arc
+        ;;
+esac
 
 # Map stdio to a multiplexed character device so we can use it
 # for the monitor and semihosting output


### PR DESCRIPTION
Found and fixed a couple of setjmp/longjmp bugs on arc64. Then enabled testing under qemu.