### PR TITLE
Test nios2 builds using Zephyr toolchain

### DIFF
--- a/.github/do-zephyr
+++ b/.github/do-zephyr
@@ -5,7 +5,7 @@ HERE=`dirname "$0"`
 "$HERE"/do-zephyr-test arc64 "$@"
 "$HERE"/do-zephyr-build microblazeel "$@"
 "$HERE"/do-zephyr-test mips-zephyr "$@"
-"$HERE"/do-zephyr-build nios2 "$@"
+"$HERE"/do-zephyr-test nios2 "$@"
 "$HERE"/do-zephyr-test x86_64-zephyr "$@"
 "$HERE"/do-zephyr-build xtensa-espressif_esp32 "$@"
 "$HERE"/do-zephyr-build xtensa-espressif_esp32s2 "$@"

--- a/.github/zephyr-files.txt
+++ b/.github/zephyr-files.txt
@@ -12,4 +12,5 @@ https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/toolchain
 https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/toolchain_linux-x86_64_xtensa-nxp_imx_adsp_zephyr-elf.tar.xz
 https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/toolchain_linux-x86_64_xtensa-sample_controller_zephyr-elf.tar.xz
 https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/hosttools_linux-x86_64.tar.xz
+https://maps.altusmetrum.org/qemu-nios2.tar.xz
 https://maps.altusmetrum.org/qemu-arc.tar.xz

--- a/picocrt/machine/nios2/crt0.c
+++ b/picocrt/machine/nios2/crt0.c
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2023 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../../crt0.h"
+
+static void __attribute__((used)) __section(".init")
+_cstart(void)
+{
+	__start();
+}
+
+extern char __stack[];
+extern char _gp[];
+
+void __section(".init") __attribute__((used))
+_start(void)
+{
+	/* Initialize stack pointer */
+	__asm__("movhi sp,%%hiadj(%0)" : : "i" (__stack));
+	__asm__("addi  sp,sp,%%lo(%0)" : : "i" (__stack));
+
+        /* Initialize GP */
+        __asm__("movhi gp,%%hiadj(%0)" : : "i" (_gp));
+        __asm__("addi gp,gp,%%lo(%0)" : : "i" (_gp));
+
+	/* Branch to C code */
+	__asm__("br _cstart");
+}

--- a/picocrt/machine/nios2/meson.build
+++ b/picocrt/machine/nios2/meson.build
@@ -1,0 +1,35 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2021 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+src_picocrt += files('crt0.c')

--- a/picolibc.ld.in
+++ b/picolibc.ld.in
@@ -154,6 +154,7 @@ SECTIONS
 		. = ALIGN(8);
 
 		PROVIDE( __global_pointer$ = . + 0x800 );
+		PROVIDE( _gp = . + 0x8000);
 		*(.sdata .sdata.* .sdata2.*)
 		*(.gnu.linkonce.s.*)
 	} >ram AT>flash :ram_init

--- a/scripts/cross-nios2-zephyr-elf.txt
+++ b/scripts/cross-nios2-zephyr-elf.txt
@@ -3,11 +3,13 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['nios2-zephyr-elf-gcc', '-nostdlib']
+c = ['nios2-zephyr-elf-gcc', '-nostdlib', '-fno-pic', '-fno-pie', '--param=min-pagesize=0', '-mgpopt=global']
 ar = 'nios2-zephyr-elf-ar'
 as = 'nios2-zephyr-elf-as'
 nm = 'nios2-zephyr-elf-nm'
 strip = 'nios2-zephyr-elf-strip'
+# only needed to run tests
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-nios2 "$@"', 'run-nios2']
 
 [host_machine]
 system = 'zephyr'
@@ -17,3 +19,7 @@ endian = 'little'
 
 [properties]
 skip_sanity_check = true
+default_flash_addr = '0xc8000000'
+default_flash_size = '0x04000000'
+default_ram_addr   = '0xcc000000'
+default_ram_size   = '0x04000000'

--- a/scripts/run-nios2
+++ b/scripts/run-nios2
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
-# Copyright © 2019 Keith Packard
+# Copyright © 2020 Keith Packard
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -33,5 +33,52 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-multilib_list='.,nomul,mulx'
-exec "$(dirname "$0")"/do-configure nios2-zephyr-elf -Dposix-console=true -Dtests=true -Dmultilib-list="$multilib_list" "$@"
+
+dir="$(dirname "$0")"
+
+# select the program
+elf="$1"
+shift
+
+qemu="qemu-system-nios2"
+
+# Point the semihosting driver at our new chardev
+
+semi=enable=on,chardev=stdio0
+
+input=""
+
+case "$1" in
+    --)
+	semi="$semi",arg="$2"
+	shift
+	shift
+	;;
+    -*|"")
+	;;
+    *)
+	semi="$semi",arg="$1"
+	input="$1"
+	shift
+	;;
+esac
+
+# Disable monitor
+
+mon=none
+
+# Point serial port at new chardev
+
+serial=stdio
+
+machine=10m50-ghrd
+
+echo "$input" | $qemu \
+  -chardev stdio,id=stdio0,mux=on \
+  -machine $machine \
+  -serial none \
+  -semihosting-config "$semi" \
+  -mon chardev=stdio0,mode=readline \
+  -net none \
+  -nographic \
+  -kernel "$elf" "$@"

--- a/semihost/machine/nios2/meson.build
+++ b/semihost/machine/nios2/meson.build
@@ -1,0 +1,74 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2021 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+lib_semihost_srcs = [
+  'nios2_close.c',
+  'nios2_exit.c',
+  'nios2_fstat.c',
+  'nios2_lseek.c',
+  'nios2_open.c',
+  'nios2_read.c',
+  'nios2_semihost.c',
+  'nios2_stat.c',
+  'nios2_stub.c',
+  'nios2_unlink.c',
+  'nios2_write.c',
+  ]
+
+has_semihost = true
+
+foreach target : targets
+  value = get_variable('target_' + target)
+
+  instdir = join_paths(lib_dir, value[0])
+
+  if target == ''
+    libsemihost_name = 'semihost'
+  else
+    libsemihost_name = join_paths(target, 'libsemihost')
+  endif
+
+  local_lib_semihost_target = static_library(libsemihost_name,
+				       lib_semihost_srcs,
+				       install : true,
+				       install_dir : instdir,
+				       include_directories : inc,
+				       c_args : value[1],
+				       pic: false)
+
+  set_variable('lib_semihost' + target, local_lib_semihost_target)
+
+endforeach
+

--- a/semihost/machine/nios2/nios2_close.c
+++ b/semihost/machine/nios2/nios2_close.c
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2023 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "nios2_semihost.h"
+#include <sys/cdefs.h>
+#include <unistd.h>
+
+int
+close(int fd)
+{
+    return nios2_semihost1(HOSTED_CLOSE, fd);
+}

--- a/semihost/machine/nios2/nios2_exit.c
+++ b/semihost/machine/nios2/nios2_exit.c
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2023 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "nios2_semihost.h"
+#include <sys/cdefs.h>
+#include <unistd.h>
+
+void _ATTRIBUTE((__noreturn__))
+_exit(int code)
+{
+    nios2_semihost1_immediate(HOSTED_EXIT, code);
+    __unreachable();
+}

--- a/semihost/machine/nios2/nios2_fstat.c
+++ b/semihost/machine/nios2/nios2_fstat.c
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2023 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "nios2_semihost.h"
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <stdarg.h>
+
+int
+fstat(int fd, struct stat *restrict statbuf)
+{
+    struct nios2_stat nios2_stat;
+
+    int ret = nios2_semihost2(HOSTED_FSTAT, fd, (uintptr_t) &nios2_stat);
+    if (ret >= 0)
+        copy_stat(statbuf, &nios2_stat);
+    return ret;
+}

--- a/semihost/machine/nios2/nios2_lseek.c
+++ b/semihost/machine/nios2/nios2_lseek.c
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2023 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#undef __LARGE64_FILES
+#define __LARGE64_FILES 1
+#include "nios2_semihost.h"
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+
+_off64_t
+lseek64(int fd, _off64_t offset, int whence)
+{
+    uint32_t    a = offset >> 32;
+    uint32_t    b = offset;
+    return nios2_semihost4_64(HOSTED_LSEEK, fd, a, b, whence);
+}

--- a/semihost/machine/nios2/nios2_open.c
+++ b/semihost/machine/nios2/nios2_open.c
@@ -1,0 +1,73 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2023 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "nios2_semihost.h"
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <stdarg.h>
+
+static int gdb_flags(int flags) {
+    int gdb = 0;
+
+    gdb = flags & 3;
+    if (flags & O_RDWR)
+        gdb |= GDB_O_RDWR;
+    if (flags & O_APPEND)
+        gdb |= GDB_O_APPEND;
+    if (flags & O_CREAT)
+        gdb |= GDB_O_CREAT;
+    if (flags & O_TRUNC)
+        gdb |= GDB_O_TRUNC;
+    if (flags & O_EXCL)
+        gdb |= GDB_O_EXCL;
+    return gdb;
+}
+
+int
+open(const char *pathname, int flags, ...)
+{
+    va_list ap;
+
+    va_start(ap,flags);
+    uintptr_t mode = va_arg(ap, uintptr_t);
+    va_end(ap);
+    return nios2_semihost4(HOSTED_OPEN, (uintptr_t) pathname,
+                           strlen(pathname) + 1,
+                           gdb_flags(flags), mode);
+}

--- a/semihost/machine/nios2/nios2_read.c
+++ b/semihost/machine/nios2/nios2_read.c
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2023 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "nios2_semihost.h"
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+
+ssize_t
+read(int fd, void *buf, size_t count)
+{
+    return nios2_semihost3(HOSTED_READ, fd, (uintptr_t) buf, count);
+}

--- a/semihost/machine/nios2/nios2_semihost.c
+++ b/semihost/machine/nios2/nios2_semihost.c
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2023 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "nios2_semihost.h"
+
+int
+nios2_semihost(int func, struct nios2_semihost *args)
+{
+    register int r_op __asm__("r4") = func;
+    register struct nios2_semihost *r_args __asm__("r5") = args;
+    register int r_ret __asm__("r2");
+    __asm__("break 1" : "=r" (r_ret): "r" (r_op), "r" (r_args));
+    return r_ret;
+}

--- a/semihost/machine/nios2/nios2_semihost.h
+++ b/semihost/machine/nios2/nios2_semihost.h
@@ -1,0 +1,186 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2023 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _NIOS2_SEMIHOST_H_
+#define _NIOS2_SEMIHOST_H_
+
+#include <stdio.h>
+#include <errno.h>
+#include <endian.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#define HOSTED_EXIT  0
+#define HOSTED_INIT_SIM 1
+#define HOSTED_OPEN 2
+#define HOSTED_CLOSE 3
+#define HOSTED_READ 4
+#define HOSTED_WRITE 5
+#define HOSTED_LSEEK 6
+#define HOSTED_RENAME 7
+#define HOSTED_UNLINK 8
+#define HOSTED_STAT 9
+#define HOSTED_FSTAT 10
+#define HOSTED_GETTIMEOFDAY 11
+#define HOSTED_ISATTY 12
+#define HOSTED_SYSTEM 13
+
+#define GDB_O_RDONLY  0
+#define GDB_O_WRONLY  1
+#define GDB_O_RDWR    2
+#define GDB_O_APPEND  8
+#define GDB_O_CREAT   0x200
+#define GDB_O_TRUNC   0x400
+#define GDB_O_EXCL    0x800
+
+typedef uint32_t my_mode_t;
+typedef uint32_t my_time_t;
+
+struct nios2_stat
+{
+    uint32_t   my_dev;     /* device */
+    uint32_t   my_ino;     /* inode */
+    my_mode_t  my_mode;    /* protection */
+    uint32_t   my_nlink;   /* number of hard links */
+    uint32_t   my_uid;     /* user ID of owner */
+    uint32_t   my_gid;     /* group ID of owner */
+    uint32_t   my_rdev;    /* device type (if inode device) */
+    uint64_t   my_size;    /* total size, in bytes */
+    uint64_t   my_blksize; /* blocksize for filesystem I/O */
+    uint64_t   my_blocks;  /* number of blocks allocated */
+    my_time_t  my_atime;   /* time of last access */
+    my_time_t  my_mtime;   /* time of last modification */
+    my_time_t  my_ctime;   /* time of last change */
+};
+
+static inline
+copy_stat(struct stat *restrict statbuf, struct nios2_stat *nios2_stat)
+{
+        statbuf->st_dev = be32toh(nios2_stat->my_dev);
+        statbuf->st_ino = be32toh(nios2_stat->my_ino);
+        statbuf->st_mode = be32toh(nios2_stat->my_mode);
+        statbuf->st_nlink = be32toh(nios2_stat->my_nlink);
+        statbuf->st_uid = be32toh(nios2_stat->my_uid);
+        statbuf->st_gid = be32toh(nios2_stat->my_gid);
+        statbuf->st_rdev = be32toh(nios2_stat->my_rdev);
+        statbuf->st_size = be32toh(nios2_stat->my_size);
+        statbuf->st_blksize = be32toh(nios2_stat->my_blksize);
+        statbuf->st_blocks = be32toh(nios2_stat->my_blocks);
+        statbuf->st_atime = be32toh(nios2_stat->my_atime);
+        statbuf->st_mtime = be32toh(nios2_stat->my_mtime);
+        statbuf->st_ctime = be32toh(nios2_stat->my_ctime);
+}
+
+struct nios2_semihost {
+    uintptr_t   args[4];
+};
+
+intptr_t
+nios2_semihost(int func, struct nios2_semihost *args);
+
+static inline intptr_t nios2_semihost1_immediate(int func, uintptr_t arg0) {
+    return nios2_semihost(func, (struct nios2_semihost *) arg0);
+};
+
+static inline intptr_t nios2_semihost1(int func, uintptr_t arg0) {
+    struct nios2_semihost args;
+    intptr_t ret;
+
+    args.args[0] = arg0;
+    nios2_semihost(func, &args);
+    ret = args.args[0];
+    if (ret < 0)
+        errno = args.args[1];
+    return ret;
+};
+
+static inline intptr_t nios2_semihost2(int func, uintptr_t arg0, uintptr_t arg1) {
+    struct nios2_semihost args;
+    intptr_t ret;
+
+    args.args[0] = arg0;
+    args.args[1] = arg1;
+    nios2_semihost(func, &args);
+    ret = args.args[0];
+    if (ret < 0)
+        errno = args.args[1];
+    return ret;
+};
+
+static inline intptr_t nios2_semihost3(int func, uintptr_t arg0, uintptr_t arg1, uintptr_t arg2) {
+    struct nios2_semihost args;
+    intptr_t ret;
+
+    args.args[0] = arg0;
+    args.args[1] = arg1;
+    args.args[2] = arg2;
+    nios2_semihost(func, &args);
+    ret = args.args[0];
+    if (ret < 0)
+        errno = args.args[1];
+    return ret;
+};
+
+static inline uint64_t nios2_semihost4_64(int func, uintptr_t arg0, uintptr_t arg1, uintptr_t arg2, uintptr_t arg3) {
+    struct nios2_semihost args;
+    uint64_t ret;
+
+    args.args[0] = arg0;
+    args.args[1] = arg1;
+    args.args[2] = arg2;
+    args.args[3] = arg3;
+    nios2_semihost(func, &args);
+    ret = ((uint64_t) args.args[0] << 32) | args.args[1];
+    if ((int64_t) ret < 0)
+        errno = args.args[2];
+    return ret;
+};
+
+static inline intptr_t nios2_semihost4(int func, uintptr_t arg0, uintptr_t arg1, uintptr_t arg2, uintptr_t arg3) {
+    struct nios2_semihost args;
+    intptr_t ret;
+
+    args.args[0] = arg0;
+    args.args[1] = arg1;
+    args.args[2] = arg2;
+    args.args[3] = arg3;
+    nios2_semihost(func, &args);
+    ret = args.args[0];
+    if (ret < 0)
+        errno = args.args[1];
+    return ret;
+};
+
+#endif /* _NIOS2_SEMIHOST_H_ */

--- a/semihost/machine/nios2/nios2_stat.c
+++ b/semihost/machine/nios2/nios2_stat.c
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2023 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "nios2_semihost.h"
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <stdarg.h>
+
+int
+stat(const char *pathname, struct stat *restrict statbuf)
+{
+    struct nios2_stat nios2_stat;
+
+    int ret = nios2_semihost2(HOSTED_STAT, (uintptr_t) pathname, (uintptr_t) &nios2_stat);
+    if (ret >= 0)
+        copy_stat(statbuf, &nios2_stat);
+    return ret;
+}

--- a/semihost/machine/nios2/nios2_stub.c
+++ b/semihost/machine/nios2/nios2_stub.c
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2021 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#undef __LARGE64_FILES
+#define __LARGE64_FILES 1
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+
+off_t lseek(int fd, off_t offset, int whence)
+{
+	return (off_t) lseek64(fd, (_off64_t) offset, whence);
+}
+
+int
+isatty (int fd)
+{
+        (void) fd;
+	return 1;
+}

--- a/semihost/machine/nios2/nios2_unlink.c
+++ b/semihost/machine/nios2/nios2_unlink.c
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2023 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "nios2_semihost.h"
+#include <unistd.h>
+
+int
+unlink(const char *pathname)
+{
+    return nios2_semihost1(HOSTED_UNLINK, (uintptr_t) pathname);
+}

--- a/semihost/machine/nios2/nios2_write.c
+++ b/semihost/machine/nios2/nios2_write.c
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2023 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "nios2_semihost.h"
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+
+ssize_t
+write(int fd, const void *buf, size_t count)
+{
+    return nios2_semihost3(HOSTED_WRITE, fd, (uintptr_t) buf, count);
+}


### PR DESCRIPTION
Add nios2 semihosting and crt support, fix up the linker script and run tests in github CI.