### PR TITLE
picolibc: Support heap > 2GB on 32-bit targets

### DIFF
--- a/newlib/libc/picolib/picosbrk.c
+++ b/newlib/libc/picolib/picosbrk.c
@@ -44,12 +44,12 @@ static char *brk = __heap_start;
 void *sbrk(ptrdiff_t incr)
 {
 	if (incr < 0) {
-            if (brk - __heap_start < -incr) {
+                if ((size_t) (brk - __heap_start) < (size_t) (-incr)) {
                     errno = ENOMEM;
                     return (void *) -1;
             }
 	} else {
-		if (__heap_end - brk < incr) {
+                if ((size_t) (__heap_end - brk) < (size_t) incr) {
                         errno = ENOMEM;
 			return (void *) -1;
                 }


### PR DESCRIPTION
Sbrk needs to be careful about types when the heap size is larger than the maximum value represented by ptrdiff_t. Use unsigned computations to make this work. This works as the end of the heap variable (brk) must lie within heap the address range.