### PR TITLE
libc/posix: dirname is also broken on 12.3.1 for arm v8.1m

### DIFF
--- a/newlib/libc/posix/dirname.c
+++ b/newlib/libc/posix/dirname.c
@@ -8,9 +8,9 @@
 #include <libgen.h>
 #include <string.h>
 
-#if __GNUC__ == 12 && __GNUC_MINOR__ == 2 && __GNUC_PATCHLEVEL__ == 1 && __OPTIMIZE_SIZE__
+#if __GNUC__ == 12 && __GNUC_MINOR__ >= 2 && __OPTIMIZE_SIZE__
 /*
- * GCC 12.2.1 has a bug in -Os mode on (at least) arm v8.1-m which
+ * GCC 12.x has a bug in -Os mode on (at least) arm v8.1-m which
  * mis-compiles this function. Work around that by switching
  * optimization mode
  */


### PR DESCRIPTION
atod and atof work now, but dirname remains broken due to a compiler bug in -Os mode.