### PR TITLE
Fix fma/fmaf when __FLT_EVAL_METHOD__ == 2

### DIFF
--- a/.github/linux-files.txt
+++ b/.github/linux-files.txt
@@ -1,3 +1,3 @@
-https://maps.altusmetrum.org/qemu-m68k.tar.xz
 https://dr-download.ti.com/software-development/ide-configuration-compiler-or-debugger/MD-LlCjWuAbzH/9.3.1.2/msp430-gcc-9.3.1.11_linux64.tar.bz2
+https://maps.altusmetrum.org/qemu-m68k.tar.xz
 https://github.com/ZakKemble/avr-gcc-build/releases/download/v12.1.0-1/avr-gcc-12.1.0-x64-linux.tar.bz2

--- a/.github/workflows/head
+++ b/.github/workflows/head
@@ -9,8 +9,8 @@ on:
       - main
 
 env:
-  IMAGE_FILE: dockerimg.tar.xz
-  IMAGE: picolibc
+  IMAGE_FILE: dockerimg-linux.tar.xz
+  IMAGE: picolibc-linux
   PACKAGES_FILE: picolibc/.github/linux-packages.txt
   EXTRA_FILE: picolibc/.github/linux-files.txt
 
@@ -29,6 +29,7 @@ jobs:
         with:
           path: ${{ env.IMAGE_FILE }}
           key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.PACKAGES_FILE, env.EXTRA_FILE ) }}
+          lookup-only: true
 
       - name: Set up Docker Buildx
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/head-zephyr
+++ b/.github/workflows/head-zephyr
@@ -29,6 +29,7 @@ jobs:
         with:
           path: ${{ env.IMAGE_FILE }}
           key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.PACKAGES_FILE, env.EXTRA_FILE ) }}
+          lookup-only: true
 
       - name: Set up Docker Buildx
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -9,8 +9,8 @@ on:
       - main
 
 env:
-  IMAGE_FILE: dockerimg.tar.xz
-  IMAGE: picolibc
+  IMAGE_FILE: dockerimg-linux.tar.xz
+  IMAGE: picolibc-linux
   PACKAGES_FILE: picolibc/.github/linux-packages.txt
   EXTRA_FILE: picolibc/.github/linux-files.txt
 
@@ -29,6 +29,7 @@ jobs:
         with:
           path: ${{ env.IMAGE_FILE }}
           key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.PACKAGES_FILE, env.EXTRA_FILE ) }}
+          lookup-only: true
 
       - name: Set up Docker Buildx
         if: steps.cache.outputs.cache-hit != 'true'
@@ -54,8 +55,8 @@ jobs:
           "-D__IO_FLOAT=y -D_IO_FLOAT_EXACT=n -D_WANT_IO_LONG_LONG=y -D_MB_CAPABLE=y -D_WANT_IO_POS_ARGS=y -D__HAVE_LOCALE_INFO__=y -D__HAVE_LOCALE_INFO_EXTENDED__=y ",
         ]
         test: [
-	  "./.github/do-cmake-linux",
-	]
+          "./.github/do-cmake-linux",
+        ]
     steps:
       - name: Clone picolibc
         uses: actions/checkout@v3
@@ -67,6 +68,7 @@ jobs:
         with:
           path: ${{ env.IMAGE_FILE }}
           key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.PACKAGES_FILE, env.EXTRA_FILE ) }}
+          fail-on-cache-miss: true
 
       - name: Load and Check the Docker Image
         run: |
@@ -105,8 +107,8 @@ jobs:
           "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dtinystdio=false",
         ]
         test: [
-	  "./.github/do-linux",
-	]
+          "./.github/do-linux",
+        ]
     steps:
       - name: Clone picolibc
         uses: actions/checkout@v3
@@ -118,6 +120,7 @@ jobs:
         with:
           path: ${{ env.IMAGE_FILE }}
           key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.PACKAGES_FILE, env.EXTRA_FILE ) }}
+          fail-on-cache-miss: true
 
       - name: Load and Check the Docker Image
         run: |
@@ -156,8 +159,8 @@ jobs:
           "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dtinystdio=false",
         ]
         test: [
-	  "./.github/do-linux",
-	]
+          "./.github/do-linux",
+        ]
     steps:
       - name: Clone picolibc
         uses: actions/checkout@v3
@@ -169,6 +172,7 @@ jobs:
         with:
           path: ${{ env.IMAGE_FILE }}
           key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.PACKAGES_FILE, env.EXTRA_FILE ) }}
+          fail-on-cache-miss: true
 
       - name: Load and Check the Docker Image
         run: |
@@ -207,8 +211,8 @@ jobs:
           "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dtinystdio=false",
         ]
         test: [
-	  "./.github/do-linux",
-	]
+          "./.github/do-linux",
+        ]
     steps:
       - name: Clone picolibc
         uses: actions/checkout@v3
@@ -220,6 +224,7 @@ jobs:
         with:
           path: ${{ env.IMAGE_FILE }}
           key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.PACKAGES_FILE, env.EXTRA_FILE ) }}
+          fail-on-cache-miss: true
 
       - name: Load and Check the Docker Image
         run: |

--- a/.github/workflows/steps-head
+++ b/.github/workflows/steps-head
@@ -9,6 +9,7 @@
         with:
           path: ${{ env.IMAGE_FILE }}
           key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.PACKAGES_FILE, env.EXTRA_FILE ) }}
+          fail-on-cache-miss: true
 
       - name: Load and Check the Docker Image
         run: |

--- a/.github/workflows/targets-cmake-linux
+++ b/.github/workflows/targets-cmake-linux
@@ -1,3 +1,3 @@
         test: [
-	  "./.github/do-cmake-linux",
-	]
+          "./.github/do-cmake-linux",
+        ]

--- a/.github/workflows/targets-linux
+++ b/.github/workflows/targets-linux
@@ -1,3 +1,3 @@
         test: [
-	  "./.github/do-linux",
-	]
+          "./.github/do-linux",
+        ]

--- a/.github/workflows/targets-zephyr
+++ b/.github/workflows/targets-zephyr
@@ -1,3 +1,3 @@
         test: [
-	  "./.github/do-zephyr",
-	]
+          "./.github/do-zephyr",
+        ]

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           path: ${{ env.IMAGE_FILE }}
           key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.PACKAGES_FILE, env.EXTRA_FILE ) }}
+          lookup-only: true
 
       - name: Set up Docker Buildx
         if: steps.cache.outputs.cache-hit != 'true'
@@ -71,8 +72,8 @@ jobs:
           "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dtinystdio=false",
         ]
         test: [
-	  "./.github/do-zephyr",
-	]
+          "./.github/do-zephyr",
+        ]
     steps:
       - name: Clone picolibc
         uses: actions/checkout@v3
@@ -84,6 +85,7 @@ jobs:
         with:
           path: ${{ env.IMAGE_FILE }}
           key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.PACKAGES_FILE, env.EXTRA_FILE ) }}
+          fail-on-cache-miss: true
 
       - name: Load and Check the Docker Image
         run: |
@@ -122,8 +124,8 @@ jobs:
           "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dtinystdio=false",
         ]
         test: [
-	  "./.github/do-zephyr",
-	]
+          "./.github/do-zephyr",
+        ]
     steps:
       - name: Clone picolibc
         uses: actions/checkout@v3
@@ -135,6 +137,7 @@ jobs:
         with:
           path: ${{ env.IMAGE_FILE }}
           key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.PACKAGES_FILE, env.EXTRA_FILE ) }}
+          fail-on-cache-miss: true
 
       - name: Load and Check the Docker Image
         run: |
@@ -173,8 +176,8 @@ jobs:
           "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dtinystdio=false",
         ]
         test: [
-	  "./.github/do-zephyr",
-	]
+          "./.github/do-zephyr",
+        ]
     steps:
       - name: Clone picolibc
         uses: actions/checkout@v3
@@ -186,6 +189,7 @@ jobs:
         with:
           path: ${{ env.IMAGE_FILE }}
           key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.PACKAGES_FILE, env.EXTRA_FILE ) }}
+          fail-on-cache-miss: true
 
       - name: Load and Check the Docker Image
         run: |

--- a/newlib/libc/tinystdio/conv_flt.c
+++ b/newlib/libc/tinystdio/conv_flt.c
@@ -448,7 +448,7 @@ conv_flt (FLT_STREAM *stream, int *lenp, width_t width, void *addr, uint16_t fla
             if (exp >= FLOAT_MAX_EXP) {
                 flt = (FLOAT) INFINITY;
             } else {
-#if !defined(UINTFLOAT_128) || __LDBL_IS_IEC_60559__ != 0
+#if !defined(UINTFLOAT_128) || __LDBL_IS_IEC_60559__ != 0 || defined(__m68k__)
                 if (UF_LT(uint, UF_LSHIFT_64(1, (FLOAT_MANT_DIG-1)))) {
                     exp = 0;
                 } else {
@@ -461,6 +461,8 @@ conv_flt (FLT_STREAM *stream, int *lenp, width_t width, void *addr, uint16_t fla
                      * the integer bit
                      */
 #define EXP_SHIFT       FLOAT_MANT_DIG
+#elif defined(UINTFLOAT_128) && defined(__m68k__)
+#define EXP_SHIFT   FLOAT_MANT_DIG + 16
 #else
                     uint = UF_AND(uint, UF_NOT(UF_LSHIFT_64(1, (FLOAT_MANT_DIG-1))));
 #define EXP_SHIFT       (FLOAT_MANT_DIG-1)

--- a/newlib/libc/tinystdio/vfprintf.c
+++ b/newlib/libc/tinystdio/vfprintf.c
@@ -631,11 +631,13 @@ int vfprintf (FILE * stream, const CHAR *fmt, va_list ap_orig)
 
 
 #if __LDBL_MANT_DIG__ == 64
-#define LDENORM_EXP_BIAS 1
 #define LEXP_BIAS       (__LDBL_MAX_EXP__ + 2)
 #define LEXP_INF        (__LDBL_MAX_EXP__ - 3)
 #define LSIG_BITS       (__LDBL_MANT_DIG__)
-#ifndef __m68k__
+#ifdef __m68k__
+#define LDENORM_EXP_BIAS 0
+#else
+#define LDENORM_EXP_BIAS 1
 #define LSIG_MSB_INF    _u128_lshift(to_u128(1), __LDBL_MANT_DIG__-1)
 #endif
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__

--- a/newlib/libm/common/s_fma.c
+++ b/newlib/libm/common/s_fma.c
@@ -48,6 +48,16 @@ ANSI C, POSIX.
 
 #ifdef _NEED_FLOAT64
 
+#if __FLT_EVAL_METHOD__ == 2 && defined(_HAVE_LONG_DOUBLE)
+
+__float64
+fma64(__float64 x, __float64 y, __float64 z)
+{
+    return (__float64) fmal((long double) x, (long double) y, (long double) z);
+}
+
+#else
+
 typedef __float64 FLOAT_T;
 
 #define FMA fma64
@@ -80,6 +90,8 @@ EXPONENT(FLOAT_T x)
 #endif
 
 #include "fma_inc.h"
+
+#endif
 
 _MATH_ALIAS_d_ddd(fma)
 

--- a/newlib/libm/common/sf_fma.c
+++ b/newlib/libm/common/sf_fma.c
@@ -8,6 +8,16 @@
 
 #if !_HAVE_FAST_FMAF
 
+#if __FLT_EVAL_METHOD__ == 2 && defined(_HAVE_LONG_DOUBLE)
+
+float
+fmaf(float x, float y, float z)
+{
+    return (float) fmal((long double) x, (long double) y, (long double) z);
+}
+
+#else
+
 typedef float FLOAT_T;
 
 #define FMA fmaf
@@ -35,6 +45,8 @@ EXPONENT(FLOAT_T x)
 }
 
 #include "fma_inc.h"
+
+#endif
 
 _MATH_ALIAS_f_fff(fma)
 

--- a/newlib/libm/ld/ld80/s_nextafterl.c
+++ b/newlib/libm/ld/ld80/s_nextafterl.c
@@ -22,7 +22,7 @@
 long double
 nextafterl(long double x, long double y)
 {
-	int32_t hx,hy,ix,iy;
+	u_int32_t hx,hy,ix,iy;
 	u_int32_t lx,ly;
         int32_t esx,esy;
 

--- a/newlib/libm/ld/s_fmal.c
+++ b/newlib/libm/ld/s_fmal.c
@@ -49,6 +49,9 @@ typedef long double FLOAT_T;
 
 #if LDBL_MANT_DIG == 64
 #define SPLIT (0x1p32L + 1.0L)
+#if __LDBL_MIN_EXP__ == -16382
+#define FLOAT_DENORM_BIAS       0
+#endif
 #endif
 #if LDBL_MANT_DIG == 113
 #define SPLIT (0x1p57L + 1.0L)

--- a/newlib/libm/machine/m68k/fegetexceptflag.c
+++ b/newlib/libm/machine/m68k/fegetexceptflag.c
@@ -55,5 +55,5 @@ int fegetexceptflag(fexcept_t *flagp, int excepts)
     return 0;
 }
 #else
-#include "../../fenv/fetestexcept.c"
+#include "../../fenv/fegetexceptflag.c"
 #endif

--- a/newlib/libm/machine/m68k/fegetround.c
+++ b/newlib/libm/machine/m68k/fegetround.c
@@ -46,5 +46,5 @@ int fegetround(void)
     return (fpcr >> 4) & 3;
 }
 #else
-#include "../../fenv/fegetenv.c"
+#include "../../fenv/fegetround.c"
 #endif

--- a/newlib/libm/machine/m68k/feholdexcept.c
+++ b/newlib/libm/machine/m68k/feholdexcept.c
@@ -63,5 +63,5 @@ int feholdexcept(fenv_t *envp)
     return 0;
 }
 #else
-#include "../../fenv/feraiseexcept.c"
+#include "../../fenv/feholdexcept.c"
 #endif

--- a/newlib/libm/machine/m68k/fesetenv.c
+++ b/newlib/libm/machine/m68k/fesetenv.c
@@ -70,5 +70,5 @@ int fesetenv(const fenv_t *envp)
 
 }
 #else
-#include "../../fenv/feupdateenv.c"
+#include "../../fenv/fesetenv.c"
 #endif

--- a/newlib/libm/machine/m68k/fesetexceptflag.c
+++ b/newlib/libm/machine/m68k/fesetexceptflag.c
@@ -53,5 +53,5 @@ int fesetexceptflag(const fexcept_t *flagp, int excepts)
     return 0;
 }
 #else
-#include "../../fenv/feraiseexcept.c"
+#include "../../fenv/fesetexceptflag.c"
 #endif

--- a/newlib/libm/machine/m68k/fesetround.c
+++ b/newlib/libm/machine/m68k/fesetround.c
@@ -50,5 +50,5 @@ int fesetround(int rounding_mode)
     return 0;
 }
 #else
-#include "../../fenv/fegetenv.c"
+#include "../../fenv/fesetround.c"
 #endif

--- a/test/fma_gen.5c
+++ b/test/fma_gen.5c
@@ -55,24 +55,6 @@ typedef struct {
 } float_t;
 
 /*
- * Exponent range for the specified number of bits in the
- * exponent. Note that the minimum is off-by one for the 80-bit m68k
- * format, which uses a slightly different form for denorm.
- */
-
-int
-min_exp(int exp_bits)
-{
-	return -(2**(exp_bits-1) - 3);
-}
-
-int
-max_exp(int exp_bits)
-{
-	return (2**(exp_bits-1));
-}
-
-/*
  * Construct our fancy float_t from a number
  */
 float_t
@@ -84,14 +66,41 @@ make_float(real num)
 	};
 }
 
+typedef struct {
+	int	bits;
+	int	exp_bits;
+	int	min_exp;
+	int	max_exp;
+
+	int	first_exp;
+	int	last_exp;
+} format_t;
+
+typedef union {
+	format_t	format;
+	void		none;
+} format_or_none_t;
+
+format_or_none_t none_format = { .none = <> };
+
 /*
  * Round the given float to the specified sizes under the given
  * rounding mode.
  */
 
 float_t
-round(float_t f, int bits, int exp_bits, rounding_mode_t rm)
+round(float_t f, format_t format, format_or_none_t i_format, rounding_mode_t rm)
 {
+	union switch (i_format) {
+	case format format:
+		f = round(f, format, none_format, rm);
+		break;
+	case none:
+		break;
+	}
+
+	int bits = format.bits;
+
 	union switch(f.u) {
 	case num x:
 		if (f.sign)
@@ -101,7 +110,7 @@ round(float_t f, int bits, int exp_bits, rounding_mode_t rm)
 			exp = 0;
 		else
 			exp = ceil(log2(x));
-		int denorm = min_exp(exp_bits) - exp;
+		int denorm = format.min_exp - exp;
 
 		/* Denorm means our available precision is reduced */
 		if (denorm > 0) {
@@ -115,7 +124,7 @@ round(float_t f, int bits, int exp_bits, rounding_mode_t rm)
 		 * we usually want to use rationals instead to
 		 * preserve all of the bits until rounding happens
 		 */
-		real mant = abs(x / (2**(exp-bits)));;
+		real mant = abs(x / (2**(exp-bits)));
 
 		/*
 		 * Split into integer and fractional portions. The
@@ -126,7 +135,7 @@ round(float_t f, int bits, int exp_bits, rounding_mode_t rm)
 		int ipart = floor(mant);
 		real fpart = mant - ipart;
 
-#		printf("%a: mant %f ipart %d fpart %f\n", x, mant, ipart, fpart);
+#		printf("%a: mant %e ipart %d fpart %f\n", x, mant, ipart, fpart);
 
 		union switch(rm) {
 		case TONEAREST:
@@ -149,8 +158,8 @@ round(float_t f, int bits, int exp_bits, rounding_mode_t rm)
 				 * of greatest magnitude instead of
 				 * rounding down to -infinity
 				 */
-				if (exp > max_exp(exp_bits)) {
-					exp = max_exp(exp_bits);
+				if (exp > format.max_exp) {
+					exp = format.max_exp;
 					ipart = (2**bits) - 1;
 				}
 			}
@@ -166,8 +175,8 @@ round(float_t f, int bits, int exp_bits, rounding_mode_t rm)
 				 * of greatest magnitude instead of
 				 * rounding up to infinity
 				 */
-				if (exp > max_exp(exp_bits)) {
-					exp = max_exp(exp_bits);
+				if (exp > format.max_exp) {
+					exp = format.max_exp;
 					ipart = (2**bits) - 1;
 				}
 			}
@@ -179,8 +188,8 @@ round(float_t f, int bits, int exp_bits, rounding_mode_t rm)
 			 * sign instead of away from zero to
 			 * +/-infinity.
 			 */
-			if (exp > max_exp(exp_bits)) {
-				exp = max_exp(exp_bits);
+			if (exp > format.max_exp) {
+				exp = format.max_exp;
 				ipart = (2**bits) - 1;
 			}
 			break;
@@ -195,6 +204,8 @@ round(float_t f, int bits, int exp_bits, rounding_mode_t rm)
 			bits = 0;
 		}
 
+#		printf("rounded ipart %d exp %d bits %d\n", ipart, exp, bits);
+
 		/*
 		 * Compute the final significand, which
 		 * is always >= 0.5 and < 1
@@ -206,7 +217,7 @@ round(float_t f, int bits, int exp_bits, rounding_mode_t rm)
 		}
 
 		/* Overflow to infinity */
-		if (exp > max_exp(exp_bits)) {
+		if (exp > format.max_exp) {
 			f.u.inf = <>;
 		} else {
 			f.u.num = mant * 2 ** exp;
@@ -338,62 +349,70 @@ fma(float_t x, float_t y, float_t z)
 	return plus(times(x, y), z);
 }
 
-/*
- * A kludge -- place the current floating point format values in these
- * globals to make next_exp work without needing to pass a bunch of
- * state in.
- */
-
-int MIN_EXP;
-int MAX_EXP;
-int MANT_DIG;
-int FIRST_EXP;
-int LAST_EXP;
-
-int next_exp(int e)
+int next_exp(int e, format_t format)
 {
 	switch (e) {
-	case FIRST_EXP + 1:
-		return MIN_EXP - 2;
-	case MIN_EXP:
+	case format.first_exp + 1:
+		return format.min_exp - 2;
+	case format.min_exp:
 		return -1;
 	case 1:
-		return LAST_EXP - 2;
+		return format.last_exp - 2;
 	default:
 		return e + 1;
 	}
 }
 
 /*
+ * Usual Exponent range for the specified number of bits in the
+ * exponent. Note that the minimum is off-by one for the 80-bit m68k
+ * format, which uses a slightly different form for denorm.
+ */
+
+int
+min_exp(int exp_bits)
+{
+	return -(2**(exp_bits-1) - 3);
+}
+
+int
+max_exp(int exp_bits)
+{
+	return (2**(exp_bits-1));
+}
+
+/*
  * Generate a set of test vectors for the specified floating point
  * format
  */
-void generate(string suf, int bits, int exp_bits)
+void generate(string suf, format_t format, format_or_none_t i_format)
 {
-	MIN_EXP = -(2**(exp_bits-1) -3);
-	MAX_EXP = 2**(exp_bits-1);
-	MANT_DIG = bits;
-	FIRST_EXP = (MIN_EXP - MANT_DIG - 2);
-	LAST_EXP = (MAX_EXP);
+	int bits = format.bits;
+
+	format.first_exp = (format.min_exp - bits - 2);
+	format.last_exp = (format.max_exp);
 
 	real val = 1 + 2**-(bits-1);
 
+	int i = 0;
+
 	/* Check +/- z */
 	for (int zs = -1; zs <= 1; zs += 2) {
-		for (int ze = FIRST_EXP; ze <= LAST_EXP; ze = next_exp(ze)) {
-			float_t z = round(make_float(zs * val * (2 ** ze)), bits, exp_bits, rounding_mode_t.TONEAREST);
-			for (int ye = FIRST_EXP; ye <= LAST_EXP; ye = next_exp(ye)) {
-				float_t y = round(make_float(val * (2 ** ye)), bits, exp_bits, rounding_mode_t.TONEAREST);
+		for (int ze = format.first_exp; ze <= format.last_exp; ze = next_exp(ze, format)) {
+			float_t z = round(make_float(zs * val * (2 ** ze)), format, none_format, rounding_mode_t.TONEAREST);
+			for (int ye = format.first_exp; ye <= format.last_exp; ye = next_exp(ye, format)) {
+				float_t y = round(make_float(val * (2 ** ye)), format, none_format, rounding_mode_t.TONEAREST);
 				for (int xs = -1; xs <= 1; xs += 2) {
-					for (int xe = FIRST_EXP; xe <= LAST_EXP; xe = next_exp(xe)) {
-						float_t x = round(make_float(xs * val * (2 ** xe)), bits, exp_bits, rounding_mode_t.TONEAREST);
-						printf("    { %-17s, %-17s, %-17s, {", strfromfloat(x, suf), strfromfloat(y, suf), strfromfloat(z, suf));
+					for (int xe = format.first_exp; xe <= format.last_exp; xe = next_exp(xe, format)) {
+						float_t x = round(make_float(xs * val * (2 ** xe)), format, none_format, rounding_mode_t.TONEAREST);
+						printf(" /* %4d */ { %-17s, %-17s, %-17s, {", i, strfromfloat(x, suf), strfromfloat(y, suf), strfromfloat(z, suf));
 						float_t r = plus(times(x, y), z);
-						printf(" %s,", strfromfloat(round(r, bits, exp_bits, rounding_mode_t.TONEAREST), suf));
-						printf(" %s,", strfromfloat(round(r, bits, exp_bits, rounding_mode_t.UPWARD), suf));
-						printf(" %s,", strfromfloat(round(r, bits, exp_bits, rounding_mode_t.DOWNWARD), suf));
-						printf(" %s" , strfromfloat(round(r, bits, exp_bits, rounding_mode_t.TOWARDZERO), suf));
+						printf(" %s,", strfromfloat(round(r, format, i_format, rounding_mode_t.TONEAREST), suf));
+						printf(" %s,", strfromfloat(round(r, format, i_format, rounding_mode_t.UPWARD), suf));
+						printf(" %s,", strfromfloat(round(r, format, i_format, rounding_mode_t.DOWNWARD), suf));
+						printf(" %s" , strfromfloat(round(r, format, i_format, rounding_mode_t.TOWARDZERO), suf));
 						printf(" } },\n");
+						i++;
 					}
 				}
 			}
@@ -401,23 +420,117 @@ void generate(string suf, int bits, int exp_bits)
 	}
 }
 
+format_t ieee_32 = {
+	.bits = 24,
+	.exp_bits = 8,
+	.min_exp = min_exp(8),
+	.max_exp = max_exp(8),
+};
+
+format_t ieee_64 = {
+	.bits = 53,
+	.exp_bits = 11,
+	.min_exp = min_exp(11),
+	.max_exp = max_exp(11),
+};
+
+format_t ieee_128 = {
+	.bits = 113,
+	.exp_bits = 15,
+	.min_exp = min_exp(15),
+	.max_exp = max_exp(15),
+};
+
+format_t intel_80 = {
+	.bits = 64,
+	.exp_bits = 15,
+	.min_exp = min_exp(15),
+	.max_exp = max_exp(15),
+};
+
+format_t moto_80 = {
+	.bits = 64,
+	.exp_bits = 15,
+	.min_exp = -16382,
+	.max_exp = max_exp(15),
+};
+
+format_or_none_t intel_80_optional = { .format = intel_80 };
+format_or_none_t moto_80_optional = { .format = moto_80 };
+
 void main()
 {
 	printf("/* This file is automatically generated with fma_gen.5c */\n");
+	printf("\n");
+
+	printf("#if __FLT_EVAL_METHOD__ == 0 && FLT_MANT_DIG == 24\n");
+	printf("#define HAVE_FLOAT_FMA_VEC\n");
 	printf("static const struct fmaf_vec fmaf_vec[] = {\n");
-	generate("f", 24, 8);
-	printf("};\n");
-	printf("static const struct fma_vec fma_vec[] = {\n");
-	generate("", 53, 11);
-	printf("};\n");
-	printf("#if LDBL_MANT_DIG == 64\n");
-	printf("static const struct fmal_vec fmal_vec[] = {\n");
-	generate("l", 64, 15);
+	generate("f", ieee_32, none_format);
 	printf("};\n");
 	printf("#endif\n");
-	printf("#if LDBL_MANT_DIG == 113\n");
+	printf("\n");
+
+	printf("#if __FLT_EVAL_METHOD__ == 2 && FLT_MANT_DIG == 24 && LDBL_MANT_DIG == 64 && LDBL_MIN_EXP == -16381\n");
+	printf("#define HAVE_FLOAT_FMA_VEC\n");
+	printf("static const struct fmaf_vec fmaf_vec[] = {\n");
+	generate("f", ieee_32, intel_80_optional);
+	printf("};\n");
+	printf("#endif\n");
+	printf("\n");
+
+	printf("#if __FLT_EVAL_METHOD__ == 2 && FLT_MANT_DIG == 24 && LDBL_MANT_DIG == 64 && LDBL_MIN_EXP == -16382\n");
+	printf("#define HAVE_FLOAT_FMA_VEC\n");
+	printf("static const struct fmaf_vec fmaf_vec[] = {\n");
+	generate("f", ieee_32, moto_80_optional);
+	printf("};\n");
+	printf("#endif\n");
+	printf("\n");
+
+	printf("#if __FLT_EVAL_METHOD__ <= 1 && DBL_MANT_DIG == 53\n");
+	printf("#define HAVE_DOUBLE_FMA_VEC\n");
+	printf("static const struct fma_vec fma_vec[] = {\n");
+	generate("", ieee_64, none_format);
+	printf("};\n");
+	printf("#endif\n");
+	printf("\n");
+
+	printf("#if __FLT_EVAL_METHOD__ == 2 && DBL_MANT_DIG == 53 && LDBL_MANT_DIG == 64 && LDBL_MIN_EXP == -16381\n");
+	printf("#define HAVE_DOUBLE_FMA_VEC\n");
+	printf("static const struct fma_vec fma_vec[] = {\n");
+	generate("", ieee_64, intel_80_optional);
+	printf("};\n");
+	printf("#endif\n");
+	printf("\n");
+
+	printf("#if __FLT_EVAL_METHOD__ == 2 && DBL_MANT_DIG == 53 && LDBL_MANT_DIG == 64 && LDBL_MIN_EXP == -16382\n");
+	printf("#define HAVE_DOUBLE_FMA_VEC\n");
+	printf("static const struct fma_vec fma_vec[] = {\n");
+	generate("", ieee_64, moto_80_optional);
+	printf("};\n");
+	printf("#endif\n");
+	printf("\n");
+
+	printf("#if LDBL_MANT_DIG == 64 && LDBL_MIN_EXP == -16381\n");
+	printf("#define HAVE_LONG_DOUBLE_FMA_VEC\n");
 	printf("static const struct fmal_vec fmal_vec[] = {\n");
-	generate("l", 113, 15);
+	generate("l", intel_80, none_format);
+	printf("};\n");
+	printf("#endif\n");
+	printf("\n");
+
+	printf("#if LDBL_MANT_DIG == 64 && LDBL_MIN_EXP == -16382\n");
+	printf("#define HAVE_LONG_DOUBLE_FMA_VEC\n");
+	printf("static const struct fmal_vec fmal_vec[] = {\n");
+	generate("l", moto_80, none_format);
+	printf("};\n");
+	printf("#endif\n");
+	printf("\n");
+
+	printf("#if LDBL_MANT_DIG == 113\n");
+	printf("#define HAVE_LONG_DOUBLE_FMA_VEC\n");
+	printf("static const struct fmal_vec fmal_vec[] = {\n");
+	generate("l", ieee_128, none_format);
 	printf("};\n");
 	printf("#endif\n");
 }

--- a/test/libc-testsuite/strtol.c
+++ b/test/libc-testsuite/strtol.c
@@ -140,7 +140,7 @@ int test_strtol(void)
                 ('A' <= j && j <= 'F') ||
                 ('a' <= j && j <= 'f'))
             {
-                int k;
+                long k;
                 if ('0' <= j && j <= '9')
                     k = j - '0';
                 else if ('A' <= j && j <= 'Z')

--- a/test/long_double.c
+++ b/test/long_double.c
@@ -185,6 +185,10 @@ typedef const struct {
 #define TEST_IO_LONG_DOUBLE
 #endif
 
+#if defined(__PICOLIBC__) && defined(__m68k__) && !defined(TINY_STDIO)
+#undef TEST_IO_LONG_DOUBLE
+#endif
+
 #ifdef TEST_IO_LONG_DOUBLE
 static long double vals[] = {
     1.0L,


### PR DESCRIPTION
68881 and 8087 FPUs perform all computations in long double precision and then convert to target format. Emulate this for fma and fmaf by using fmal instead of doing computations in the target precision.

Enable testing of these formats, although qemu appears to have bugs with 68881 denorms which means skipping fmal tests on that target.