### PR TITLE
test/rand.c: use int32_t as loop counter

### DIFF
--- a/test/rand.c
+++ b/test/rand.c
@@ -51,7 +51,7 @@ near(double got, double target, double close)
 int
 main(void)
 {
-	int i;
+	int32_t i;
 	int ret = 0;
 	double s1 = 0;
 	double s2 = 0;


### PR DESCRIPTION
This fixes a -Wtype-limits warning where
the comparison is always true on architectures
with 16 bit ints.