### PR TITLE
testsuite: silence unused argument warnings

### DIFF
--- a/newlib/testsuite/newlib.iconv/iconvjp.c
+++ b/newlib/testsuite/newlib.iconv/iconvjp.c
@@ -966,7 +966,7 @@ int main(void)
 }
 
 #else /* #if defined(_ICONV_FROM_ENCODING_UTF_8) || ... */
-int main(int argc, char **argv)
+int main(void)
 {
     puts("None of UTF-8, EUC-JP, SHIFT-JIS and UCS-2_INTERNAL converters "
          "linked, SKIP test");

--- a/newlib/testsuite/newlib.iconv/iconvru.c
+++ b/newlib/testsuite/newlib.iconv/iconvru.c
@@ -477,7 +477,7 @@ int main(void)
 }
 
 #else /* #if defined(_ICONV_FROM_ENCODING_UTF_8) || ... */
-int main(int argc, char **argv)
+int main(void)
 {
     puts("None of ISO-8859-5, KOI8-R and UTF-8 converters linked, SKIP test");
     exit(0);


### PR DESCRIPTION
This eliminates compiler warnings about
unused arguments.