### PR TITLE
math_errhandling_tests: 16-bit int fixes

### DIFF
--- a/test/math_errhandling_tests.c
+++ b/test/math_errhandling_tests.c
@@ -688,8 +688,8 @@ FLOAT_T makemathname(test_scalb_neg1_big)(void) { return makemathname(scalb)(-ma
 FLOAT_T makemathname(test_scalb_1_negbig)(void) { return makemathname(scalb)(makemathname(one), -makemathname(big)); }
 FLOAT_T makemathname(test_scalb_neg1_negbig)(void) { return makemathname(scalb)(-makemathname(one), -makemathname(big)); }
 
-FLOAT_T makemathname(test_scalbn_big)(void) { return makemathname(scalbn)(makemathname(one), 0x7fffffff); }
-FLOAT_T makemathname(test_scalbn_tiny)(void) { return makemathname(scalbn)(makemathname(one), -0x7fffffff); }
+FLOAT_T makemathname(test_scalbn_big)(void) { return makemathname(scalbn)(makemathname(one), INT_MAX); }
+FLOAT_T makemathname(test_scalbn_tiny)(void) { return makemathname(scalbn)(makemathname(one), -INT_MAX); }
 
 #ifndef FE_DIVBYZERO
 #define FE_DIVBYZERO 0

--- a/test/math_errhandling_tests.c
+++ b/test/math_errhandling_tests.c
@@ -351,8 +351,8 @@ FLOAT_T makemathname(test_ldexp_qnan_0)(void) { return makemathname(ldexp)(makem
 FLOAT_T makemathname(test_ldexp_snan_0)(void) { return makemathname(ldexp)(makemathname(snanval), 0); }
 FLOAT_T makemathname(test_ldexp_inf_0)(void) { return makemathname(ldexp)(makemathname(infval), 0); }
 FLOAT_T makemathname(test_ldexp_neginf_0)(void) { return makemathname(ldexp)(-makemathname(infval), 0); }
-FLOAT_T makemathname(test_ldexp_1_negbig)(void) { return makemathname(ldexp)(makemathname(one), -(__DBL_MAX_EXP__ * 100)); }
-FLOAT_T makemathname(test_ldexp_1_big)(void) { return makemathname(ldexp)(makemathname(one),(__DBL_MAX_EXP__ * 100)); }
+FLOAT_T makemathname(test_ldexp_1_negbig)(void) { return makemathname(ldexp)(makemathname(one), -(__DBL_MAX_EXP__ * 20)); }
+FLOAT_T makemathname(test_ldexp_1_big)(void) { return makemathname(ldexp)(makemathname(one),(__DBL_MAX_EXP__ * 20)); }
 
 FLOAT_T makemathname(test_rint_qnan)(void) { return makemathname(rint)(makemathname(qnanval)); }
 FLOAT_T makemathname(test_rint_snan)(void) { return makemathname(rint)(makemathname(snanval)); }


### PR DESCRIPTION
Not really sure about this one, I arbitrarily chose 20 as value since the result of the multiplication then fits in a 16-bit int. If the constant 100 is chosen to hit some corner case on 32-bit architectures, my choice of 20 is not the right one.