### PR TITLE
CMakeLists.txt: use single-dash include option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -468,7 +468,7 @@ set(PREFIX "${PROJECT_BINARY_DIR}")
 configure_file(picolibc.specs.in "${PROJECT_BINARY_DIR}/picolibc.specs" @ONLY)
 
 set(PICOLIBC_COMPILE_OPTIONS
-  "--include" "${PICOLIBC_INCLUDE}/picolibc.h"
+  "-include" "${PICOLIBC_INCLUDE}/picolibc.h"
   "-nostdlib"
   "-D_LIBC"
   ${TLSMODEL}


### PR DESCRIPTION
GCC documents the option as '-include' in its
preprocessor options, and the meson build system
uses -include, so align the name with that.

With the double-dash option name, ccache detects
multiple inputs and refuses to cache.