### PR TITLE
Reduce size of Docker images

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && \
      xargs -a linux-packages.txt apt-get install -y --no-install-recommends || \
      xargs -a linux-packages.txt apt-get install -y --no-install-recommends) && \
     mkdir -p /opt && \
-    (cd /opt && while read file; do wget $file || exit 1; tar xf `basename $file`; rm `basename $file`; done) < linux-files.txt
+    (cd /opt && while read file; do wget $file || exit 1; tar xf `basename $file`; rm `basename $file`; done) < linux-files.txt && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN apt-get clean

--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -5,7 +5,7 @@ COPY .github/linux-packages.txt /
 COPY .github/linux-files.txt /
 
 RUN apt-get update && \
-    apt-get install -y wget gnupg && \
+    apt-get install -y --no-install-recommends ca-certificates wget gnupg && \
     wget -O /etc/apt/trusted.gpg.d/altusmetrum.gpg https://maps.altusmetrum.org/archive/archive-key.gpg && \
     echo "deb http://maps.altusmetrum.org/archive unstable/" > /etc/apt/sources.list.d/keithp.list && \
     (apt-get update || apt-get update || apt-get update) && \

--- a/.github/Dockerfile-zephyr
+++ b/.github/Dockerfile-zephyr
@@ -23,14 +23,13 @@ RUN apt-get update && \
 	tar xf `basename "$file"`; \
 	echo "Removing $file"; \
 	rm `basename "$file"`; \
-     done)
-
-RUN if [ -f /opt/zephyr-sdk-*-hosttools*.sh ]; then \
+     done) && \
+    if [ -f /opt/zephyr-sdk-*-hosttools*.sh ]; then \
 	echo "Unpacking host tools"; \
 	/opt/zephyr-sdk-*-hosttools*.sh -y -d /opt/zephyr-sdk-hosttools; \
 	rm /opt/zephyr-sdk-*-hosttools*.sh; \
     else \
 	echo "No host tools found"; \
-    fi
-
-RUN apt-get clean
+    fi && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*

--- a/.github/Dockerfile-zephyr
+++ b/.github/Dockerfile-zephyr
@@ -7,7 +7,7 @@ COPY .github/zephyr-files.txt /
 COPY .github/zephyr-setup /
 
 RUN apt-get update && \
-    apt-get install -y wget gnupg && \
+    apt-get install -y --no-install-recommends ca-certificates wget gnupg && \
     (apt-get update || apt-get update || apt-get update) && \
     (apt-get upgrade -y || apt-get upgrade -y || apt-get upgrade -y) && \
     (xargs -a zephyr-packages.txt apt-get install -y || \

--- a/.github/Dockerfile-zephyr
+++ b/.github/Dockerfile-zephyr
@@ -10,10 +10,10 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates wget gnupg && \
     (apt-get update || apt-get update || apt-get update) && \
     (apt-get upgrade -y || apt-get upgrade -y || apt-get upgrade -y) && \
-    (xargs -a zephyr-packages.txt apt-get install -y || \
-     xargs -a zephyr-packages.txt apt-get install -y || \
-     xargs -a zephyr-packages.txt apt-get install -y || \
-     xargs -a zephyr-packages.txt apt-get install -y) && \
+    (xargs -a zephyr-packages.txt apt-get install -y --no-install-recommends || \
+     xargs -a zephyr-packages.txt apt-get install -y --no-install-recommends || \
+     xargs -a zephyr-packages.txt apt-get install -y --no-install-recommends || \
+     xargs -a zephyr-packages.txt apt-get install -y --no-install-recommends) && \
     mkdir -p /opt && \
     (cd /opt && \
      for file in `cat /zephyr-files.txt`; do \

--- a/.github/workflows/head
+++ b/.github/workflows/head
@@ -9,6 +9,7 @@ on:
       - main
 
 env:
+  DOCKERFILE: picolibc/.github/Dockerfile
   IMAGE_FILE: dockerimg-linux.tar.xz
   IMAGE: picolibc-linux
   PACKAGES_FILE: picolibc/.github/linux-packages.txt
@@ -28,7 +29,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.PACKAGES_FILE, env.EXTRA_FILE ) }}
+          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.DOCKERFILE, env.PACKAGES_FILE, env.EXTRA_FILE ) }}
           lookup-only: true
 
       - name: Set up Docker Buildx

--- a/.github/workflows/head-zephyr
+++ b/.github/workflows/head-zephyr
@@ -9,6 +9,7 @@ on:
       - main
 
 env:
+  DOCKERFILE: picolibc/.github/Dockerfile-zephyr
   IMAGE_FILE: dockerimg-zephyr.tar.xz
   IMAGE: picolibc
   PACKAGES_FILE: picolibc/.github/zephyr-packages.txt
@@ -28,7 +29,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.PACKAGES_FILE, env.EXTRA_FILE ) }}
+          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.DOCKERFILE, env.PACKAGES_FILE, env.EXTRA_FILE ) }}
           lookup-only: true
 
       - name: Set up Docker Buildx

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -9,6 +9,7 @@ on:
       - main
 
 env:
+  DOCKERFILE: picolibc/.github/Dockerfile
   IMAGE_FILE: dockerimg-linux.tar.xz
   IMAGE: picolibc-linux
   PACKAGES_FILE: picolibc/.github/linux-packages.txt
@@ -28,7 +29,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.PACKAGES_FILE, env.EXTRA_FILE ) }}
+          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.DOCKERFILE, env.PACKAGES_FILE, env.EXTRA_FILE ) }}
           lookup-only: true
 
       - name: Set up Docker Buildx
@@ -67,7 +68,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.PACKAGES_FILE, env.EXTRA_FILE ) }}
+          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.DOCKERFILE, env.PACKAGES_FILE, env.EXTRA_FILE ) }}
           fail-on-cache-miss: true
 
       - name: Load and Check the Docker Image
@@ -119,7 +120,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.PACKAGES_FILE, env.EXTRA_FILE ) }}
+          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.DOCKERFILE, env.PACKAGES_FILE, env.EXTRA_FILE ) }}
           fail-on-cache-miss: true
 
       - name: Load and Check the Docker Image
@@ -171,7 +172,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.PACKAGES_FILE, env.EXTRA_FILE ) }}
+          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.DOCKERFILE, env.PACKAGES_FILE, env.EXTRA_FILE ) }}
           fail-on-cache-miss: true
 
       - name: Load and Check the Docker Image
@@ -223,7 +224,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.PACKAGES_FILE, env.EXTRA_FILE ) }}
+          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.DOCKERFILE, env.PACKAGES_FILE, env.EXTRA_FILE ) }}
           fail-on-cache-miss: true
 
       - name: Load and Check the Docker Image

--- a/.github/workflows/steps-head
+++ b/.github/workflows/steps-head
@@ -8,7 +8,7 @@
         uses: actions/cache@v3
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.PACKAGES_FILE, env.EXTRA_FILE ) }}
+          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.DOCKERFILE, env.PACKAGES_FILE, env.EXTRA_FILE ) }}
           fail-on-cache-miss: true
 
       - name: Load and Check the Docker Image

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -9,6 +9,7 @@ on:
       - main
 
 env:
+  DOCKERFILE: picolibc/.github/Dockerfile-zephyr
   IMAGE_FILE: dockerimg-zephyr.tar.xz
   IMAGE: picolibc
   PACKAGES_FILE: picolibc/.github/zephyr-packages.txt
@@ -28,7 +29,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.PACKAGES_FILE, env.EXTRA_FILE ) }}
+          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.DOCKERFILE, env.PACKAGES_FILE, env.EXTRA_FILE ) }}
           lookup-only: true
 
       - name: Set up Docker Buildx
@@ -84,7 +85,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.PACKAGES_FILE, env.EXTRA_FILE ) }}
+          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.DOCKERFILE, env.PACKAGES_FILE, env.EXTRA_FILE ) }}
           fail-on-cache-miss: true
 
       - name: Load and Check the Docker Image
@@ -136,7 +137,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.PACKAGES_FILE, env.EXTRA_FILE ) }}
+          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.DOCKERFILE, env.PACKAGES_FILE, env.EXTRA_FILE ) }}
           fail-on-cache-miss: true
 
       - name: Load and Check the Docker Image
@@ -188,7 +189,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.PACKAGES_FILE, env.EXTRA_FILE ) }}
+          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.DOCKERFILE, env.PACKAGES_FILE, env.EXTRA_FILE ) }}
           fail-on-cache-miss: true
 
       - name: Load and Check the Docker Image

--- a/.github/zephyr-packages.txt
+++ b/.github/zephyr-packages.txt
@@ -1,6 +1,12 @@
 build-essential
-meson
 cmake
 file
+libgtk-3-0
+libjack0
+libpulse0
+librados2
+librbd1
+libvte-2.91-0
+meson
 ninja-build
 qemu-system-x86


### PR DESCRIPTION
The docker build cache will either hit everything or nothing, so put the commands together into a single RUN statement so everything ends up in the same layer.

Remove the apt-get-related data (packages + list files) after use.

Stop installing packages recommended by apt-get.

This saves 20 MB for the image built from Dockefile, and 640 MB for the image built from Dockerfile-zephyr.