### PR TITLE
Reduce CI variations and add ccache meson support

### DIFF
--- a/.github/workflows/Makefile
+++ b/.github/workflows/Makefile
@@ -2,6 +2,7 @@ LINUX_DEPS=\
 	make-workflow \
 	head \
 	variants-cmake \
+	variants \
 	targets-cmake-linux \
 	steps-head \
 	steps-cmake \

--- a/.github/workflows/Makefile
+++ b/.github/workflows/Makefile
@@ -6,9 +6,8 @@ LINUX_DEPS=\
 	targets-cmake-linux \
 	steps-head \
 	steps-cmake \
-	steps-fortify-source\
 	steps-minsize \
-	steps-release
+	steps-fortify-source
 
 all: linux.yml zephyr.yml
 
@@ -21,9 +20,8 @@ ZEPHYR_DEPS=\
 	variants \
 	targets-zephyr \
 	steps-head \
-	steps-fortify-source\
 	steps-minsize \
-	steps-release
+	steps-fortify-source
 
 zephyr.yml: $(ZEPHYR_DEPS)
 	./make-workflow-zephyr > $@

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -80,47 +80,6 @@ jobs:
         run: |
           docker run -v $(readlink -f picolibc):/picolibc -w /picolibc $IMAGE ${{ matrix.test }} ${{ matrix.cmake_flags }}
 
-  fortify-source-linux:
-    needs: cache-maker
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        meson_flags: [
-          "",
-
-          # Tinystdio and math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
-          "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",
-          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false -Dnewlib-obsolete-math=true -Dwant-math-errno=true",
-
-          # Original stdio, one with multithread disabled
-          "-Dtinystdio=false",
-          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true -Dnewlib-fvwrite-in-streamio=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false",
-        ]
-        test: [
-          "./.github/do-linux",
-        ]
-    steps:
-      - name: Clone picolibc
-        uses: actions/checkout@v3
-        with:
-          path: picolibc
-
-      - name: Restore the Docker Image
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.DOCKERFILE, env.PACKAGES_FILE, env.EXTRA_FILE ) }}
-          fail-on-cache-miss: true
-
-      - name: Load and Check the Docker Image
-        run: |
-          docker load -i $IMAGE_FILE
-          docker images -a $IMAGE
-
-      - name: Fortity source test
-        run: |
-          docker run -v $(readlink -f picolibc):/picolibc -w /picolibc $IMAGE ${{ matrix.test }} ${{ matrix.meson_flags }} -Dfortify-source=2
-
   minsize-linux:
     needs: cache-maker
     runs-on: ubuntu-latest
@@ -162,7 +121,7 @@ jobs:
         run: |
           docker run -v $(readlink -f picolibc):/picolibc -w /picolibc $IMAGE ${{ matrix.test }} ${{ matrix.meson_flags }} --buildtype minsize
 
-  release-linux:
+  fortify-source-linux:
     needs: cache-maker
     runs-on: ubuntu-latest
     strategy:
@@ -199,7 +158,7 @@ jobs:
           docker load -i $IMAGE_FILE
           docker images -a $IMAGE
 
-      - name: Release test
+      - name: Fortity source test
         run: |
-          docker run -v $(readlink -f picolibc):/picolibc -w /picolibc $IMAGE ${{ matrix.test }} ${{ matrix.meson_flags }} --buildtype release
+          docker run -v $(readlink -f picolibc):/picolibc -w /picolibc $IMAGE ${{ matrix.test }} ${{ matrix.meson_flags }} -Dfortify-source=2 --buildtype release
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -88,24 +88,13 @@ jobs:
         meson_flags: [
           "",
 
-          # Math configurations
-          "-Dnewlib-obsolete-math=false -Dwant-math-errno=true",
-          "-Dnewlib-obsolete-math=true -Dwant-math-errno=true",
+          # Tinystdio and math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
+          "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",
+          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false -Dnewlib-obsolete-math=true -Dwant-math-errno=true",
 
-          # Tinystdio configurations
-          "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true",
-          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false",
-
-          # Original stdio
+          # Original stdio, one with multithread disabled
           "-Dtinystdio=false",
-          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true -Dnewlib-fvwrite-in-streamio=true",
-
-          # Locale, iconv, original malloc and original atexit/onexit configurations
-          "-Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",
-
-          # Multithread disabled
-          "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false",
-          "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dtinystdio=false",
+          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true -Dnewlib-fvwrite-in-streamio=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false",
         ]
         test: [
           "./.github/do-linux",
@@ -140,24 +129,13 @@ jobs:
         meson_flags: [
           "",
 
-          # Math configurations
-          "-Dnewlib-obsolete-math=false -Dwant-math-errno=true",
-          "-Dnewlib-obsolete-math=true -Dwant-math-errno=true",
+          # Tinystdio and math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
+          "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",
+          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false -Dnewlib-obsolete-math=true -Dwant-math-errno=true",
 
-          # Tinystdio configurations
-          "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true",
-          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false",
-
-          # Original stdio
+          # Original stdio, one with multithread disabled
           "-Dtinystdio=false",
-          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true -Dnewlib-fvwrite-in-streamio=true",
-
-          # Locale, iconv, original malloc and original atexit/onexit configurations
-          "-Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",
-
-          # Multithread disabled
-          "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false",
-          "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dtinystdio=false",
+          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true -Dnewlib-fvwrite-in-streamio=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false",
         ]
         test: [
           "./.github/do-linux",
@@ -192,24 +170,13 @@ jobs:
         meson_flags: [
           "",
 
-          # Math configurations
-          "-Dnewlib-obsolete-math=false -Dwant-math-errno=true",
-          "-Dnewlib-obsolete-math=true -Dwant-math-errno=true",
+          # Tinystdio and math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
+          "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",
+          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false -Dnewlib-obsolete-math=true -Dwant-math-errno=true",
 
-          # Tinystdio configurations
-          "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true",
-          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false",
-
-          # Original stdio
+          # Original stdio, one with multithread disabled
           "-Dtinystdio=false",
-          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true -Dnewlib-fvwrite-in-streamio=true",
-
-          # Locale, iconv, original malloc and original atexit/onexit configurations
-          "-Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",
-
-          # Multithread disabled
-          "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false",
-          "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dtinystdio=false",
+          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true -Dnewlib-fvwrite-in-streamio=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false",
         ]
         test: [
           "./.github/do-linux",

--- a/.github/workflows/make-workflow
+++ b/.github/workflows/make-workflow
@@ -12,7 +12,7 @@ for build in cmake; do
     done
 done
 
-for build in fortify-source minsize release; do
+for build in minsize fortify-source; do
     for arch in linux; do
 	echo "  $build-$arch:"
 	cat variants

--- a/.github/workflows/make-workflow-zephyr
+++ b/.github/workflows/make-workflow-zephyr
@@ -2,7 +2,7 @@
 
 cat head-zephyr
 
-for build in fortify-source minsize release; do
+for build in minsize fortify-source; do
     for arch in zephyr; do
 	echo "  $build-$arch:"
 	cat variants

--- a/.github/workflows/steps-fortify-source
+++ b/.github/workflows/steps-fortify-source
@@ -1,4 +1,4 @@
       - name: Fortity source test
         run: |
-          docker run -v $(readlink -f picolibc):/picolibc -w /picolibc $IMAGE ${{ matrix.test }} ${{ matrix.meson_flags }} -Dfortify-source=2
+          docker run -v $(readlink -f picolibc):/picolibc -w /picolibc $IMAGE ${{ matrix.test }} ${{ matrix.meson_flags }} -Dfortify-source=2 --buildtype release
 

--- a/.github/workflows/steps-release
+++ b/.github/workflows/steps-release
@@ -1,4 +1,0 @@
-      - name: Release test
-        run: |
-          docker run -v $(readlink -f picolibc):/picolibc -w /picolibc $IMAGE ${{ matrix.test }} ${{ matrix.meson_flags }} --buildtype release
-

--- a/.github/workflows/variants
+++ b/.github/workflows/variants
@@ -5,22 +5,11 @@
         meson_flags: [
           "",
 
-          # Math configurations
-          "-Dnewlib-obsolete-math=false -Dwant-math-errno=true",
-          "-Dnewlib-obsolete-math=true -Dwant-math-errno=true",
+          # Tinystdio and math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
+          "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",
+          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false -Dnewlib-obsolete-math=true -Dwant-math-errno=true",
 
-          # Tinystdio configurations
-          "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true",
-          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false",
-
-          # Original stdio
+          # Original stdio, one with multithread disabled
           "-Dtinystdio=false",
-          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true -Dnewlib-fvwrite-in-streamio=true",
-
-          # Locale, iconv, original malloc and original atexit/onexit configurations
-          "-Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",
-
-          # Multithread disabled
-          "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false",
-          "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dtinystdio=false",
+          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true -Dnewlib-fvwrite-in-streamio=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false",
         ]

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -45,47 +45,6 @@ jobs:
           tags: ${{ env.IMAGE }}:latest
           outputs: type=docker,dest=${{ env.IMAGE_FILE }}
 
-  fortify-source-zephyr:
-    needs: cache-maker
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        meson_flags: [
-          "",
-
-          # Tinystdio and math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
-          "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",
-          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false -Dnewlib-obsolete-math=true -Dwant-math-errno=true",
-
-          # Original stdio, one with multithread disabled
-          "-Dtinystdio=false",
-          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true -Dnewlib-fvwrite-in-streamio=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false",
-        ]
-        test: [
-          "./.github/do-zephyr",
-        ]
-    steps:
-      - name: Clone picolibc
-        uses: actions/checkout@v3
-        with:
-          path: picolibc
-
-      - name: Restore the Docker Image
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.IMAGE_FILE }}
-          key: ${{ env.IMAGE_FILE }}-${{ hashFiles( env.DOCKERFILE, env.PACKAGES_FILE, env.EXTRA_FILE ) }}
-          fail-on-cache-miss: true
-
-      - name: Load and Check the Docker Image
-        run: |
-          docker load -i $IMAGE_FILE
-          docker images -a $IMAGE
-
-      - name: Fortity source test
-        run: |
-          docker run -v $(readlink -f picolibc):/picolibc -w /picolibc $IMAGE ${{ matrix.test }} ${{ matrix.meson_flags }} -Dfortify-source=2
-
   minsize-zephyr:
     needs: cache-maker
     runs-on: ubuntu-latest
@@ -127,7 +86,7 @@ jobs:
         run: |
           docker run -v $(readlink -f picolibc):/picolibc -w /picolibc $IMAGE ${{ matrix.test }} ${{ matrix.meson_flags }} --buildtype minsize
 
-  release-zephyr:
+  fortify-source-zephyr:
     needs: cache-maker
     runs-on: ubuntu-latest
     strategy:
@@ -164,7 +123,7 @@ jobs:
           docker load -i $IMAGE_FILE
           docker images -a $IMAGE
 
-      - name: Release test
+      - name: Fortity source test
         run: |
-          docker run -v $(readlink -f picolibc):/picolibc -w /picolibc $IMAGE ${{ matrix.test }} ${{ matrix.meson_flags }} --buildtype release
+          docker run -v $(readlink -f picolibc):/picolibc -w /picolibc $IMAGE ${{ matrix.test }} ${{ matrix.meson_flags }} -Dfortify-source=2 --buildtype release
 

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -53,24 +53,13 @@ jobs:
         meson_flags: [
           "",
 
-          # Math configurations
-          "-Dnewlib-obsolete-math=false -Dwant-math-errno=true",
-          "-Dnewlib-obsolete-math=true -Dwant-math-errno=true",
+          # Tinystdio and math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
+          "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",
+          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false -Dnewlib-obsolete-math=true -Dwant-math-errno=true",
 
-          # Tinystdio configurations
-          "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true",
-          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false",
-
-          # Original stdio
+          # Original stdio, one with multithread disabled
           "-Dtinystdio=false",
-          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true -Dnewlib-fvwrite-in-streamio=true",
-
-          # Locale, iconv, original malloc and original atexit/onexit configurations
-          "-Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",
-
-          # Multithread disabled
-          "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false",
-          "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dtinystdio=false",
+          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true -Dnewlib-fvwrite-in-streamio=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false",
         ]
         test: [
           "./.github/do-zephyr",
@@ -105,24 +94,13 @@ jobs:
         meson_flags: [
           "",
 
-          # Math configurations
-          "-Dnewlib-obsolete-math=false -Dwant-math-errno=true",
-          "-Dnewlib-obsolete-math=true -Dwant-math-errno=true",
+          # Tinystdio and math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
+          "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",
+          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false -Dnewlib-obsolete-math=true -Dwant-math-errno=true",
 
-          # Tinystdio configurations
-          "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true",
-          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false",
-
-          # Original stdio
+          # Original stdio, one with multithread disabled
           "-Dtinystdio=false",
-          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true -Dnewlib-fvwrite-in-streamio=true",
-
-          # Locale, iconv, original malloc and original atexit/onexit configurations
-          "-Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",
-
-          # Multithread disabled
-          "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false",
-          "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dtinystdio=false",
+          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true -Dnewlib-fvwrite-in-streamio=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false",
         ]
         test: [
           "./.github/do-zephyr",
@@ -157,24 +135,13 @@ jobs:
         meson_flags: [
           "",
 
-          # Math configurations
-          "-Dnewlib-obsolete-math=false -Dwant-math-errno=true",
-          "-Dnewlib-obsolete-math=true -Dwant-math-errno=true",
+          # Tinystdio and math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
+          "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",
+          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false -Dnewlib-obsolete-math=true -Dwant-math-errno=true",
 
-          # Tinystdio configurations
-          "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true",
-          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false",
-
-          # Original stdio
+          # Original stdio, one with multithread disabled
           "-Dtinystdio=false",
-          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true -Dnewlib-fvwrite-in-streamio=true",
-
-          # Locale, iconv, original malloc and original atexit/onexit configurations
-          "-Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",
-
-          # Multithread disabled
-          "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false",
-          "-Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dtinystdio=false",
+          "-Dtinystdio=false -Dnewlib-io-float=true -Dio-long-long=true -Dio-long-double=true -Dnewlib-fvwrite-in-streamio=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false",
         ]
         test: [
           "./.github/do-zephyr",

--- a/scripts/cross-aarch64-linux-gnu.txt
+++ b/scripts/cross-aarch64-linux-gnu.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['aarch64-linux-gnu-gcc', '-nostdlib']
+c = ['ccache', 'aarch64-linux-gnu-gcc', '-nostdlib']
 ar = 'aarch64-linux-gnu-ar'
 as = 'aarch64-linux-gnu-as'
 ld = 'aarch64-linux-gnu-ld'

--- a/scripts/cross-aarch64-zephyr-elf.txt
+++ b/scripts/cross-aarch64-zephyr-elf.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['aarch64-zephyr-elf-gcc', '-nostdlib']
+c = ['ccache', 'aarch64-zephyr-elf-gcc', '-nostdlib']
 ar = 'aarch64-zephyr-elf-ar'
 as = 'aarch64-zephyr-elf-as'
 nm = 'aarch64-zephyr-elf-nm'

--- a/scripts/cross-arc-zephyr-elf.txt
+++ b/scripts/cross-arc-zephyr-elf.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['arc-zephyr-elf-gcc', '-nostdlib', '-mno-sdata', '-fno-delayed-branch']
+c = ['ccache', 'arc-zephyr-elf-gcc', '-nostdlib', '-mno-sdata', '-fno-delayed-branch']
 ar = 'arc-zephyr-elf-ar'
 as = 'arc-zephyr-elf-as'
 nm = 'arc-zephyr-elf-nm'

--- a/scripts/cross-arc64-zephyr-elf.txt
+++ b/scripts/cross-arc64-zephyr-elf.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['arc64-zephyr-elf-gcc', '-nostdlib']
+c = ['ccache', 'arc64-zephyr-elf-gcc', '-nostdlib']
 ar = 'arc64-zephyr-elf-ar'
 as = 'arc64-zephyr-elf-as'
 nm = 'arc64-zephyr-elf-nm'

--- a/scripts/cross-arm-none-eabi.txt
+++ b/scripts/cross-arm-none-eabi.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['arm-none-eabi-gcc', '-nostdlib']
+c = ['ccache', 'arm-none-eabi-gcc', '-nostdlib']
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eabi-as'
 nm = 'arm-none-eabi-nm'

--- a/scripts/cross-arm-zephyr-eabi.txt
+++ b/scripts/cross-arm-zephyr-eabi.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['arm-zephyr-eabi-gcc', '-nostdlib']
+c = ['ccache', 'arm-zephyr-eabi-gcc', '-nostdlib']
 ar = 'arm-zephyr-eabi-ar'
 as = 'arm-zephyr-eabi-as'
 nm = 'arm-zephyr-eabi-nm'

--- a/scripts/cross-avr.txt
+++ b/scripts/cross-avr.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['avr-gcc', '-nostdlib', '-D__COMPILING_AVR_LIBC__']
+c = ['ccache', 'avr-gcc', '-nostdlib', '-D__COMPILING_AVR_LIBC__']
 ar = 'avr-ar'
 as = 'avr-as'
 nm = 'avr-nm'

--- a/scripts/cross-clang-msp430.txt
+++ b/scripts/cross-clang-msp430.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['clang', '-target', 'msp430', '-nostdlib']
+c = ['ccache', 'clang', '-target', 'msp430', '-nostdlib']
 ar = 'msp430-elf-ar'
 as = 'msp430-elf-as'
 nm = 'msp430-elf-nm'

--- a/scripts/cross-clang-riscv64-unknown-elf.txt
+++ b/scripts/cross-clang-riscv64-unknown-elf.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['clang', '-target', 'riscv64-unknown-elf', '-mcmodel=medany', '-nostdlib']
+c = ['ccache', 'clang', '-target', 'riscv64-unknown-elf', '-mcmodel=medany', '-nostdlib']
 c_ld = '/usr/bin/riscv64-unknown-elf-ld'
 ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'

--- a/scripts/cross-clang-rv32imafdc-unknown-elf.txt
+++ b/scripts/cross-clang-rv32imafdc-unknown-elf.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['clang', '-m32', '-target', 'riscv32-unknown-elf', '-march=rv32imafdc', '-mabi=ilp32d', '-nostdlib']
+c = ['ccache', 'clang', '-m32', '-target', 'riscv32-unknown-elf', '-march=rv32imafdc', '-mabi=ilp32d', '-nostdlib']
 c_ld = '/usr/bin/riscv64-unknown-elf-ld'
 ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'

--- a/scripts/cross-clang-thumbv6m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv6m-none-eabi.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['clang', '-m32', '--target=thumbv6m-none-eabi', '-nostdlib']
+c = ['ccache', 'clang', '-m32', '--target=thumbv6m-none-eabi', '-nostdlib']
 c_ld = '/usr/bin/arm-none-eabi-ld'
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eab-as'

--- a/scripts/cross-clang-thumbv6m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv6m-none-eabi.txt
@@ -20,7 +20,7 @@ endian = 'little'
 
 [properties]
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt', '-fshort-enums']
-c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v6-m/nofp/', '-Wl,-z,noexecstack']
+c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.3.1/thumb/v6-m/nofp/', '-Wl,-z,noexecstack']
 skip_sanity_check = true
 default_flash_addr = '0x00000000'
 default_flash_size = '0x00400000'

--- a/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
@@ -20,7 +20,7 @@ endian = 'little'
 
 [properties]
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt', '-fshort-enums']
-c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7e-m+fp/hard/', '-Wl,-z,noexecstack']
+c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.3.1/thumb/v7e-m+fp/hard/', '-Wl,-z,noexecstack']
 skip_sanity_check = true
 default_flash_addr = '0x00000000'
 default_flash_size = '0x00400000'

--- a/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['clang', '-m32', '-target', 'thumbv7e-none-eabi', '-mcpu=cortex-m7', '-mfloat-abi=hard', '-nostdlib']
+c = ['ccache', 'clang', '-m32', '-target', 'thumbv7e-none-eabi', '-mcpu=cortex-m7', '-mfloat-abi=hard', '-nostdlib']
 c_ld = '/usr/bin/arm-none-eabi-ld'
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eab-as'

--- a/scripts/cross-clang-thumbv7m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7m-none-eabi.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['clang', '-m32', '-target', 'thumbv7m-none-eabi', '-mfloat-abi=soft', '-nostdlib']
+c = ['ccache', 'clang', '-m32', '-target', 'thumbv7m-none-eabi', '-mfloat-abi=soft', '-nostdlib']
 c_ld = '/usr/bin/arm-none-eabi-ld'
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eab-as'

--- a/scripts/cross-clang-thumbv7m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7m-none-eabi.txt
@@ -20,7 +20,7 @@ endian = 'little'
 
 [properties]
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt', '-fshort-enums']
-c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7-m/nofp/', '-Wl,-z,noexecstack']
+c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.3.1/thumb/v7-m/nofp/', '-Wl,-z,noexecstack']
 skip_sanity_check = true
 default_flash_addr = '0x00000000'
 default_flash_size = '0x00400000'

--- a/scripts/cross-cortex-a9-none-eabi.txt
+++ b/scripts/cross-cortex-a9-none-eabi.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['arm-none-eabi-gcc', '-mcpu=cortex-a9', '-nostdlib']
+c = ['ccache', 'arm-none-eabi-gcc', '-mcpu=cortex-a9', '-nostdlib']
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eabi-as'
 nm = 'arm-none-eabi-nm'

--- a/scripts/cross-i686-linux-gnu.txt
+++ b/scripts/cross-i686-linux-gnu.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['i686-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
+c = ['ccache', 'i686-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
 ar = 'i686-linux-gnu-ar'
 as = 'i686-linux-gnu-as'
 nm = 'i686-linux-gnu-nm'

--- a/scripts/cross-m68k-linux-gnu.txt
+++ b/scripts/cross-m68k-linux-gnu.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = ['m68k-linux-gnu-gcc', '-march=68020', '-static', '-nostdlib']
+c = ['ccache', 'm68k-linux-gnu-gcc', '-march=68020', '-static', '-nostdlib']
 ar = 'm68k-linux-gnu-ar'
 as = 'm68k-linux-gnu-as'
 ld = 'm68k-linux-gnu-ld'

--- a/scripts/cross-m68k-unknown-elf.txt
+++ b/scripts/cross-m68k-unknown-elf.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = ['m68k-unknown-elf-gcc', '-static', '-nostdlib', '-fno-builtin-isinfl']
+c = ['ccache', 'm68k-unknown-elf-gcc', '-static', '-nostdlib', '-fno-builtin-isinfl']
 ar = 'm68k-unknown-elf-ar'
 as = 'm68k-unknown-elf-as'
 ld = 'm68k-unknown-elf-ld'

--- a/scripts/cross-microblazeel-zephyr-elf.txt
+++ b/scripts/cross-microblazeel-zephyr-elf.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['microblazeel-zephyr-elf-gcc', '-nostdlib']
+c = ['ccache', 'microblazeel-zephyr-elf-gcc', '-nostdlib']
 ar = 'microblazeel-zephyr-elf-ar'
 as = 'microblazeel-zephyr-elf-as'
 ld = 'microblazeel-zephyr-elf-ld'

--- a/scripts/cross-mips-linux-gnu.txt
+++ b/scripts/cross-mips-linux-gnu.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['mips-linux-gnu-gcc', '-nostdlib']
+c = ['ccache', 'mips-linux-gnu-gcc', '-nostdlib']
 ar = 'mips-linux-gnu-ar'
 as = 'mips-linux-gnu-as'
 ld = 'mips-linux-gnu-ld'

--- a/scripts/cross-mips-zephyr-elf.txt
+++ b/scripts/cross-mips-zephyr-elf.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['mips-zephyr-elf-gcc', '-nostdlib', '-mips32', '-G0']
+c = ['ccache', 'mips-zephyr-elf-gcc', '-nostdlib', '-mips32', '-G0']
 ar = 'mips-zephyr-elf-ar'
 as = 'mips-zephyr-elf-as'
 nm = 'mips-zephyr-elf-nm'

--- a/scripts/cross-mipsel-linux-gnu.txt
+++ b/scripts/cross-mipsel-linux-gnu.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['mipsel-linux-gnu-gcc', '-nostdlib']
+c = ['ccache', 'mipsel-linux-gnu-gcc', '-nostdlib']
 ar = 'mipsel-linux-gnu-ar'
 as = 'mipsel-linux-gnu-as'
 ld = 'mipsel-linux-gnu-ld'

--- a/scripts/cross-msp430.txt
+++ b/scripts/cross-msp430.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['msp430-elf-gcc', '-nostdlib']
+c = ['ccache', 'msp430-elf-gcc', '-nostdlib']
 ar = 'msp430-elf-ar'
 as = 'msp430-elf-as'
 nm = 'msp430-elf-nm'

--- a/scripts/cross-nios2-zephyr-elf.txt
+++ b/scripts/cross-nios2-zephyr-elf.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['nios2-zephyr-elf-gcc', '-nostdlib', '-fno-pic', '-fno-pie', '--param=min-pagesize=0', '-mgpopt=global']
+c = ['ccache', 'nios2-zephyr-elf-gcc', '-nostdlib', '-fno-pic', '-fno-pie', '--param=min-pagesize=0', '-mgpopt=global']
 ar = 'nios2-zephyr-elf-ar'
 as = 'nios2-zephyr-elf-as'
 nm = 'nios2-zephyr-elf-nm'

--- a/scripts/cross-power9-fp128.txt
+++ b/scripts/cross-power9-fp128.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = ['powerpc64-linux-gnu-gcc', '-fno-pic', '-fno-pie', '-static', '-mabi=ieeelongdouble', '-mlong-double-128', '-mfloat128-hardware', '-mvsx', '-mfloat128', '-mpower9-vector', '-mcpu=power9', '-Wno-psabi']
+c = ['ccache', 'powerpc64-linux-gnu-gcc', '-fno-pic', '-fno-pie', '-static', '-mabi=ieeelongdouble', '-mlong-double-128', '-mfloat128-hardware', '-mvsx', '-mfloat128', '-mpower9-vector', '-mcpu=power9', '-Wno-psabi']
 ar = 'powerpc64-linux-gnu-ar'
 nm = 'powerpc64-linux-gnu-nm'
 strip = 'powerpc64-linux-gnu-strip'

--- a/scripts/cross-power9.txt
+++ b/scripts/cross-power9.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = ['powerpc64-linux-gnu-gcc', '-fno-pic', '-fno-pie', '-static', '-mfloat128-hardware', '-mvsx', '-mpower9-vector', '-mcpu=power9', '-Wno-psabi']
+c = ['ccache', 'powerpc64-linux-gnu-gcc', '-fno-pic', '-fno-pie', '-static', '-mfloat128-hardware', '-mvsx', '-mpower9-vector', '-mcpu=power9', '-Wno-psabi']
 ar = 'powerpc64-linux-gnu-ar'
 nm = 'powerpc64-linux-gnu-nm'
 strip = 'powerpc64-linux-gnu-strip'

--- a/scripts/cross-powerpc64-linux-gnu.txt
+++ b/scripts/cross-powerpc64-linux-gnu.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = ['powerpc64-linux-gnu-gcc', '-fno-pic', '-static']
+c = ['ccache', 'powerpc64-linux-gnu-gcc', '-fno-pic', '-static']
 ar = 'powerpc64-linux-gnu-ar'
 nm = 'powerpc64-linux-gnu-nm'
 strip = 'powerpc64-linux-gnu-strip'

--- a/scripts/cross-powerpc64le-linux-gnu.txt
+++ b/scripts/cross-powerpc64le-linux-gnu.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = ['powerpc64le-linux-gnu-gcc', '-fno-pic', '-static']
+c = ['ccache', 'powerpc64le-linux-gnu-gcc', '-fno-pic', '-static']
 ar = 'powerpc64le-linux-gnu-ar'
 as = 'powerpc64le-linux-gnu-as'
 nm = 'powerpc64le-linux-gnu-nm'

--- a/scripts/cross-riscv64-unknown-elf.txt
+++ b/scripts/cross-riscv64-unknown-elf.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['riscv64-unknown-elf-gcc', '-nostdlib']
+c = ['ccache', 'riscv64-unknown-elf-gcc', '-nostdlib']
 ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'
 strip = 'riscv64-unknown-elf-strip'

--- a/scripts/cross-riscv64-zephyr-elf.txt
+++ b/scripts/cross-riscv64-zephyr-elf.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['riscv64-zephyr-elf-gcc', '-nostdlib']
+c = ['ccache', 'riscv64-zephyr-elf-gcc', '-nostdlib']
 ar = 'riscv64-zephyr-elf-ar'
 as = 'riscv64-zephyr-elf-as'
 nm = 'riscv64-zephyr-elf-nm'

--- a/scripts/cross-rv32imac.txt
+++ b/scripts/cross-rv32imac.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = ['riscv64-unknown-elf-gcc', '-nostdlib']
+c = ['ccache', 'riscv64-unknown-elf-gcc', '-nostdlib']
 ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'
 nm = 'riscv64-unknown-elf-nm'

--- a/scripts/cross-rv32imac_zicsr.txt
+++ b/scripts/cross-rv32imac_zicsr.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = ['riscv64-unknown-elf-gcc', '-nostdlib']
+c = ['ccache', 'riscv64-unknown-elf-gcc', '-nostdlib']
 ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'
 nm = 'riscv64-unknown-elf-nm'

--- a/scripts/cross-sparc64-linux-gnu.txt
+++ b/scripts/cross-sparc64-linux-gnu.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['sparc64-linux-gnu-gcc', '-nostdlib']
+c = ['ccache', 'sparc64-linux-gnu-gcc', '-nostdlib']
 ar = 'sparc64-linux-gnu-ar'
 as = 'sparc64-linux-gnu-as'
 ld = 'sparc64-linux-gnu-ld'

--- a/scripts/cross-thumbv8_1m-none-eabi.txt
+++ b/scripts/cross-thumbv8_1m-none-eabi.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['arm-none-eabi-gcc', '-nostdlib', '-mthumb', '-march=armv8.1-m.main+mve', '-mfloat-abi=hard']
+c = ['ccache', 'arm-none-eabi-gcc', '-nostdlib', '-mthumb', '-march=armv8.1-m.main+mve', '-mfloat-abi=hard']
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eabi-as'
 nm = 'arm-none-eabi-nm'

--- a/scripts/cross-thumbv8m_main_fp-none-eabi.txt
+++ b/scripts/cross-thumbv8m_main_fp-none-eabi.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['arm-none-eabi-gcc', '-nostdlib', '-mthumb', '-march=armv8-m.main+fp', '-mfloat-abi=hard']
+c = ['ccache', 'arm-none-eabi-gcc', '-nostdlib', '-mthumb', '-march=armv8-m.main+fp', '-mfloat-abi=hard']
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eabi-as'
 nm = 'arm-none-eabi-nm'

--- a/scripts/cross-x86-linux-gnu.txt
+++ b/scripts/cross-x86-linux-gnu.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['x86_64-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
+c = ['ccache', 'x86_64-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
 ar = 'x86_64-linux-gnu-ar'
 as = 'x86_64-linux-gnu-as'
 nm = 'x86_64-linux-gnu-nm'

--- a/scripts/cross-x86_64-linux-gnu.txt
+++ b/scripts/cross-x86_64-linux-gnu.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['x86_64-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
+c = ['ccache', 'x86_64-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
 ar = 'x86_64-linux-gnu-ar'
 as = 'x86_64-linux-gnu-as'
 nm = 'x86_64-linux-gnu-nm'

--- a/scripts/cross-x86_64-zephyr-elf.txt
+++ b/scripts/cross-x86_64-zephyr-elf.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['x86_64-zephyr-elf-gcc', '-m32', '-msoft-float', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
+c = ['ccache', 'x86_64-zephyr-elf-gcc', '-m32', '-msoft-float', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
 ar = 'x86_64-zephyr-elf-ar'
 as = 'x86_64-zephyr-elf-as'
 nm = 'x86_64-zephyr-elf-nm'

--- a/scripts/cross-xtensa-esp32-elf.txt
+++ b/scripts/cross-xtensa-esp32-elf.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = 'xtensa-esp32-elf-gcc'
+c = ['ccache', 'xtensa-esp32-elf-gcc']
 ar = 'xtensa-esp32-elf-ar'
 as = 'xtensa-esp32-elf-as'
 nm = 'xtensa-esp32-elf-nm'

--- a/scripts/cross-xtensa-espressif_esp32_zephyr-elf.txt
+++ b/scripts/cross-xtensa-espressif_esp32_zephyr-elf.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['xtensa-espressif_esp32_zephyr-elf-gcc', '-nostdlib']
+c = ['ccache', 'xtensa-espressif_esp32_zephyr-elf-gcc', '-nostdlib']
 ar = 'xtensa-espressif_esp32_zephyr-elf-ar'
 as = 'xtensa-espressif_esp32_zephyr-elf-as'
 nm = 'xtensa-espressif_esp32_zephyr-elf-nm'

--- a/scripts/cross-xtensa-espressif_esp32s2_zephyr-elf.txt
+++ b/scripts/cross-xtensa-espressif_esp32s2_zephyr-elf.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['xtensa-espressif_esp32s2_zephyr-elf-gcc', '-nostdlib']
+c = ['ccache', 'xtensa-espressif_esp32s2_zephyr-elf-gcc', '-nostdlib']
 ar = 'xtensa-espressif_esp32s2_zephyr-elf-ar'
 as = 'xtensa-espressif_esp32s2_zephyr-elf-as'
 nm = 'xtensa-espressif_esp32s2_zephyr-elf-nm'

--- a/scripts/cross-xtensa-intel_apl_adsp_zephyr-elf.txt
+++ b/scripts/cross-xtensa-intel_apl_adsp_zephyr-elf.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['xtensa-intel_apl_adsp_zephyr-elf-gcc', '-nostdlib']
+c = ['ccache', 'xtensa-intel_apl_adsp_zephyr-elf-gcc', '-nostdlib']
 ar = 'xtensa-intel_apl_adsp_zephyr-elf-ar'
 as = 'xtensa-intel_apl_adsp_zephyr-elf-as'
 nm = 'xtensa-intel_apl_adsp_zephyr-elf-nm'

--- a/scripts/cross-xtensa-intel_s1000_zephyr-elf.txt
+++ b/scripts/cross-xtensa-intel_s1000_zephyr-elf.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['xtensa-intel_s1000_zephyr-elf-gcc', '-nostdlib']
+c = ['ccache', 'xtensa-intel_s1000_zephyr-elf-gcc', '-nostdlib']
 ar = 'xtensa-intel_s1000_zephyr-elf-ar'
 as = 'xtensa-intel_s1000_zephyr-elf-as'
 nm = 'xtensa-intel_s1000_zephyr-elf-nm'

--- a/scripts/cross-xtensa-lx106-elf.txt
+++ b/scripts/cross-xtensa-lx106-elf.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = 'xtensa-lx106-elf-gcc'
+c = ['ccache', 'xtensa-lx106-elf-gcc']
 ar = 'xtensa-lx106-elf-ar'
 as = 'xtensa-lx106-elf-as'
 nm = 'xtensa-lx106-elf-nm'

--- a/scripts/cross-xtensa-nxp_imx8m_adsp_zephyr-elf.txt
+++ b/scripts/cross-xtensa-nxp_imx8m_adsp_zephyr-elf.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['xtensa-nxp_imx8m_adsp_zephyr-elf-gcc', '-nostdlib']
+c = ['ccache', 'xtensa-nxp_imx8m_adsp_zephyr-elf-gcc', '-nostdlib']
 ar = 'xtensa-nxp_imx8m_adsp_zephyr-elf-ar'
 as = 'xtensa-nxp_imx8m_adsp_zephyr-elf-as'
 nm = 'xtensa-nxp_imx8m_adsp_zephyr-elf-nm'

--- a/scripts/cross-xtensa-nxp_imx_adsp_zephyr-elf.txt
+++ b/scripts/cross-xtensa-nxp_imx_adsp_zephyr-elf.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['xtensa-nxp_imx_adsp_zephyr-elf-gcc', '-nostdlib']
+c = ['ccache', 'xtensa-nxp_imx_adsp_zephyr-elf-gcc', '-nostdlib']
 ar = 'xtensa-nxp_imx_adsp_zephyr-elf-ar'
 as = 'xtensa-nxp_imx_adsp_zephyr-elf-as'
 nm = 'xtensa-nxp_imx_adsp_zephyr-elf-nm'

--- a/scripts/cross-xtensa-sample_controller_zephyr-elf.txt
+++ b/scripts/cross-xtensa-sample_controller_zephyr-elf.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['xtensa-sample_controller_zephyr-elf-gcc', '-nostdlib']
+c = ['ccache', 'xtensa-sample_controller_zephyr-elf-gcc', '-nostdlib']
 ar = 'xtensa-sample_controller_zephyr-elf-ar'
 as = 'xtensa-sample_controller_zephyr-elf-as'
 nm = 'xtensa-sample_controller_zephyr-elf-nm'


### PR DESCRIPTION
This reduces the build variations from 30 to 10, which should make CI runs go a lot faster. It also makes meson builds ready to use ccache when that's enabled.