### PR TITLE
CI: use ccache on macOS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: "daily"
+  target-branch: "main"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -158,7 +158,7 @@ jobs:
           docker load -i $IMAGE_FILE
           docker images -a $IMAGE
 
-      - name: Fortity source test
+      - name: Fortify source test
         run: |
           docker run -v $(readlink -f picolibc):/picolibc -w /picolibc $IMAGE ${{ matrix.test }} ${{ matrix.meson_flags }} -Dfortify-source=2 --buildtype release
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+env:
+  # 20M measured cache size (August 2023).
+  CCACHE_SIZE: "25M"
+
 jobs:
   macos:
     runs-on: macos-latest
@@ -22,6 +26,13 @@ jobs:
 
       - name: Install meson and ninja
         run: pip install meson ninja
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.10
+        with:
+          key: compilation-${{ runner.os }}-${{ github.job }}
+          append-timestamp: false
+          max-size: ${{ env.CCACHE_SIZE }}
 
       - name: MacOS tests
         run: ./.github/do-arm

--- a/.github/workflows/steps-fortify-source
+++ b/.github/workflows/steps-fortify-source
@@ -1,4 +1,4 @@
-      - name: Fortity source test
+      - name: Fortify source test
         run: |
           docker run -v $(readlink -f picolibc):/picolibc -w /picolibc $IMAGE ${{ matrix.test }} ${{ matrix.meson_flags }} -Dfortify-source=2 --buildtype release
 

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -123,7 +123,7 @@ jobs:
           docker load -i $IMAGE_FILE
           docker images -a $IMAGE
 
-      - name: Fortity source test
+      - name: Fortify source test
         run: |
           docker run -v $(readlink -f picolibc):/picolibc -w /picolibc $IMAGE ${{ matrix.test }} ${{ matrix.meson_flags }} -Dfortify-source=2 --buildtype release
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,12 @@ cmake_minimum_required(VERSION 3.20.0)
 
 project(Picolibc VERSION 1.8.3 LANGUAGES C ASM)
 
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+  message(STATUS "Using ccache: ${CCACHE_PROGRAM}")
+  set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+endif()
+
 if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "arm64")
   set(CMAKE_SYSTEM_PROCESSOR "aarch64")
 endif()


### PR DESCRIPTION
Add a dependabot configuration that automatically makes pull requests when Github actions have new versions available.

Add ccache support to CMakeLists.txt and the CI for macOS.