### PR TITLE
CI: compress docker images

### DIFF
--- a/.github/workflows/head
+++ b/.github/workflows/head
@@ -10,7 +10,7 @@ on:
 
 env:
   DOCKERFILE: picolibc/.github/Dockerfile
-  IMAGE_FILE: dockerimg-linux.tar.xz
+  IMAGE_FILE: dockerimg-linux.tar.zst
   IMAGE: picolibc-linux
   PACKAGES_FILE: picolibc/.github/linux-packages.txt
   EXTRA_FILE: picolibc/.github/linux-files.txt
@@ -43,5 +43,5 @@ jobs:
           platforms: linux/amd64
           file: .github/Dockerfile
           tags: ${{ env.IMAGE }}:latest
-          outputs: type=docker,dest=${{ env.IMAGE_FILE }}
+          outputs: type=docker,force-compression=true,compression=zstd,compression-level=20,dest=${{ env.IMAGE_FILE }}
 

--- a/.github/workflows/head-zephyr
+++ b/.github/workflows/head-zephyr
@@ -10,7 +10,7 @@ on:
 
 env:
   DOCKERFILE: picolibc/.github/Dockerfile-zephyr
-  IMAGE_FILE: dockerimg-zephyr.tar.xz
+  IMAGE_FILE: dockerimg-zephyr.tar.zst
   IMAGE: picolibc
   PACKAGES_FILE: picolibc/.github/zephyr-packages.txt
   EXTRA_FILE: picolibc/.github/zephyr-files.txt
@@ -43,5 +43,5 @@ jobs:
           platforms: linux/amd64
           file: .github/Dockerfile-zephyr
           tags: ${{ env.IMAGE }}:latest
-          outputs: type=docker,dest=${{ env.IMAGE_FILE }}
+          outputs: type=docker,force-compression=true,compression=zstd,compression-level=20,dest=${{ env.IMAGE_FILE }}
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   DOCKERFILE: picolibc/.github/Dockerfile
-  IMAGE_FILE: dockerimg-linux.tar.xz
+  IMAGE_FILE: dockerimg-linux.tar.zst
   IMAGE: picolibc-linux
   PACKAGES_FILE: picolibc/.github/linux-packages.txt
   EXTRA_FILE: picolibc/.github/linux-files.txt
@@ -43,7 +43,7 @@ jobs:
           platforms: linux/amd64
           file: .github/Dockerfile
           tags: ${{ env.IMAGE }}:latest
-          outputs: type=docker,dest=${{ env.IMAGE_FILE }}
+          outputs: type=docker,force-compression=true,compression=zstd,compression-level=20,dest=${{ env.IMAGE_FILE }}
 
   cmake-linux:
     needs: cache-maker

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   DOCKERFILE: picolibc/.github/Dockerfile-zephyr
-  IMAGE_FILE: dockerimg-zephyr.tar.xz
+  IMAGE_FILE: dockerimg-zephyr.tar.zst
   IMAGE: picolibc
   PACKAGES_FILE: picolibc/.github/zephyr-packages.txt
   EXTRA_FILE: picolibc/.github/zephyr-files.txt
@@ -43,7 +43,7 @@ jobs:
           platforms: linux/amd64
           file: .github/Dockerfile-zephyr
           tags: ${{ env.IMAGE }}:latest
-          outputs: type=docker,dest=${{ env.IMAGE_FILE }}
+          outputs: type=docker,force-compression=true,compression=zstd,compression-level=20,dest=${{ env.IMAGE_FILE }}
 
   minsize-zephyr:
     needs: cache-maker


### PR DESCRIPTION
Add compression options to the exporter.

Pick zstd as format since that can
run multiple threads to compress, and
use level 20 since that gives a significant
space improvement over 19.