### PR TITLE
tests: add target link flags

### DIFF
--- a/newlib/libm/test/meson.build
+++ b/newlib/libm/test/meson.build
@@ -151,7 +151,7 @@ foreach target : targets
   endif
 
   _c_args = value[1] + get_variable('test_c_args_' + target, test_c_args)
-  _link_args = value[1] + get_variable('test_link_args_' + target, test_link_args)
+  _link_args = ['-lmul_none', '-lgcc'] + value[1] + get_variable('test_link_args_' + target, test_link_args)
   _link_depends = get_variable('test_link_depends_' + target, test_link_depends)
 
   _c_args = double_printf_compile_args + _c_args

--- a/newlib/testsuite/newlib.iconv/meson.build
+++ b/newlib/testsuite/newlib.iconv/meson.build
@@ -60,7 +60,7 @@ foreach target : targets
   endif
   
   _c_args = value[1] + get_variable('test_c_args_' + target, test_c_args)
-  _link_args = value[1] + get_variable('test_link_args_' + target, test_link_args)
+  _link_args = ['-lmul_none', '-lgcc'] + value[1] + get_variable('test_link_args_' + target, test_link_args)
   _link_depends = get_variable('test_link_depends_' + target, test_link_depends)
 
   _c_args += ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE'] + iconv_test_c_args

--- a/newlib/testsuite/newlib.locale/meson.build
+++ b/newlib/testsuite/newlib.locale/meson.build
@@ -55,7 +55,7 @@ foreach target : targets
   endif
   
   _c_args = value[1] + get_variable('test_c_args_' + target, test_c_args)
-  _link_args = value[1] + get_variable('test_link_args_' + target, test_link_args)
+  _link_args = ['-lmul_none', '-lgcc'] + value[1] + get_variable('test_link_args_' + target, test_link_args)
   _link_depends = get_variable('test_link_depends_' + target, test_link_depends)
 
   _c_args += ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE']

--- a/newlib/testsuite/newlib.search/meson.build
+++ b/newlib/testsuite/newlib.search/meson.build
@@ -49,7 +49,7 @@ foreach target : targets
   endif
   
   _c_args = value[1] + get_variable('test_c_args_' + target, test_c_args)
-  _link_args = value[1] + get_variable('test_link_args_' + target, test_link_args)
+  _link_args = ['-lmul_none', '-lgcc'] + value[1] + get_variable('test_link_args_' + target, test_link_args)
   _link_depends = get_variable('test_link_depends_' + target, test_link_depends)
 
   _c_args += ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE']

--- a/newlib/testsuite/newlib.stdio/meson.build
+++ b/newlib/testsuite/newlib.stdio/meson.build
@@ -53,7 +53,7 @@ foreach target : targets
   endif
   
   _c_args = value[1] + get_variable('test_c_args_' + target, test_c_args)
-  _link_args = value[1] + get_variable('test_link_args_' + target, test_link_args)
+  _link_args = ['-lmul_none', '-lgcc'] + value[1] + get_variable('test_link_args_' + target, test_link_args)
   _link_depends = get_variable('test_link_depends_' + target, test_link_depends)
 
   _c_args += ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE']

--- a/newlib/testsuite/newlib.stdlib/meson.build
+++ b/newlib/testsuite/newlib.stdlib/meson.build
@@ -49,7 +49,7 @@ foreach target : targets
   endif
   
   _c_args = value[1] + get_variable('test_c_args_' + target, test_c_args)
-  _link_args = value[1] + get_variable('test_link_args_' + target, test_link_args)
+  _link_args = ['-lmul_none', '-lgcc'] + value[1] + get_variable('test_link_args_' + target, test_link_args)
   _link_depends = get_variable('test_link_depends_' + target, test_link_depends)
 
   _c_args += ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE']

--- a/newlib/testsuite/newlib.string/meson.build
+++ b/newlib/testsuite/newlib.string/meson.build
@@ -49,7 +49,7 @@ foreach target : targets
   endif
   
   _c_args = value[1] + get_variable('test_c_args_' + target, test_c_args)
-  _link_args = value[1] + get_variable('test_link_args_' + target, test_link_args)
+  _link_args = ['-lmul_none', '-lgcc'] + value[1] + get_variable('test_link_args_' + target, test_link_args)
   _link_depends = get_variable('test_link_depends_' + target, test_link_depends)
 
   _c_args += ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE']

--- a/newlib/testsuite/newlib.time/meson.build
+++ b/newlib/testsuite/newlib.time/meson.build
@@ -49,7 +49,7 @@ foreach target : targets
   endif
   
   _c_args = value[1] + get_variable('test_c_args_' + target, test_c_args)
-  _link_args = value[1] + get_variable('test_link_args_' + target, test_link_args)
+  _link_args = ['-lmul_none', '-lgcc'] + value[1] + get_variable('test_link_args_' + target, test_link_args)
   _link_depends = get_variable('test_link_depends_' + target, test_link_depends)
 
   _c_args += ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE']

--- a/newlib/testsuite/newlib.wctype/meson.build
+++ b/newlib/testsuite/newlib.wctype/meson.build
@@ -51,7 +51,7 @@ foreach target : targets
   endif
   
   _c_args = value[1] + get_variable('test_c_args_' + target, test_c_args)
-  _link_args = value[1] + get_variable('test_link_args_' + target, test_link_args)
+  _link_args = ['-lmul_none', '-lgcc'] + value[1] + get_variable('test_link_args_' + target, test_link_args)
   _link_depends = get_variable('test_link_depends_' + target, test_link_depends)
 
   _c_args += ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE']

--- a/test/libc-testsuite/meson.build
+++ b/test/libc-testsuite/meson.build
@@ -47,7 +47,7 @@ foreach target : targets
   endif
 
   _c_args = value[1] + get_variable('test_c_args_' + target, test_c_args)
-  _link_args = value[1] + get_variable('test_link_args_' + target, test_link_args)
+  _link_args = ['-lmul_none', '-lgcc'] + value[1] + get_variable('test_link_args_' + target, test_link_args)
   _link_depends = get_variable('test_link_depends_' + target, test_link_depends)
 
   libc_tests = [

--- a/test/meson.build
+++ b/test/meson.build
@@ -49,7 +49,7 @@ foreach target : targets
   endif
 
   _c_args = value[1] + get_variable('test_c_args_' + target, test_c_args)
-  _link_args = value[1] + get_variable('test_link_args_' + target, test_link_args)
+  _link_args = ['-lmul_none', '-lgcc'] + value[1] + get_variable('test_link_args_' + target, test_link_args)
   _link_depends = get_variable('test_link_depends_' + target, test_link_depends)
 
   t1 = 'printf_scanf'

--- a/test/semihost/meson.build
+++ b/test/semihost/meson.build
@@ -90,7 +90,7 @@ foreach target : targets
   endif
   
   _c_args = value[1] + get_variable('test_c_args_' + target, test_c_args)
-  _link_args = value[1] + get_variable('test_link_args_' + target, test_link_args)
+  _link_args = ['-lmul_none', '-lgcc'] + value[1] + get_variable('test_link_args_' + target, test_link_args)
   _link_depends = get_variable('test_link_depends_' + target, test_link_depends)
 
   _c_args += ['-DCOMMAND_LINE="' + command_line + '"']


### PR DESCRIPTION
This fixes the link errors from
missing __mspabi_mpyd and various
other helper functions on MSP430
for the tests.