### PR TITLE
CI: cancel jobs when updating PRs

### DIFF
--- a/.github/workflows/head
+++ b/.github/workflows/head
@@ -8,6 +8,12 @@ on:
     branches:
       - main
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   DOCKERFILE: picolibc/.github/Dockerfile
   IMAGE_FILE: dockerimg-linux.tar.zst

--- a/.github/workflows/head-zephyr
+++ b/.github/workflows/head-zephyr
@@ -8,6 +8,12 @@ on:
     branches:
       - main
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   DOCKERFILE: picolibc/.github/Dockerfile-zephyr
   IMAGE_FILE: dockerimg-zephyr.tar.zst

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,6 +8,12 @@ on:
     branches:
       - main
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   DOCKERFILE: picolibc/.github/Dockerfile
   IMAGE_FILE: dockerimg-linux.tar.zst

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,6 +8,12 @@ on:
     branches:
       - main
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   # 20M measured cache size (August 2023).
   CCACHE_SIZE: "25M"

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -8,6 +8,12 @@ on:
     branches:
       - main
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   DOCKERFILE: picolibc/.github/Dockerfile-zephyr
   IMAGE_FILE: dockerimg-zephyr.tar.zst


### PR DESCRIPTION
When a PR gets updated, cancel any CI jobs
from the previous run. Let merge jobs complete
their runs, even if more PRs are merged after.