### PR TITLE
CI: increase Docker compression level

### DIFF
--- a/.github/workflows/head
+++ b/.github/workflows/head
@@ -52,5 +52,5 @@ jobs:
           platforms: linux/amd64
           file: .github/Dockerfile
           tags: ${{ env.IMAGE }}:latest
-          outputs: type=docker,force-compression=true,compression=zstd,compression-level=20,dest=${{ env.IMAGE_FILE }}
+          outputs: type=docker,force-compression=true,compression=zstd,compression-level=22,dest=${{ env.IMAGE_FILE }}
 

--- a/.github/workflows/head-zephyr
+++ b/.github/workflows/head-zephyr
@@ -53,5 +53,5 @@ jobs:
           platforms: linux/amd64
           file: .github/Dockerfile-zephyr
           tags: ${{ env.IMAGE }}:latest
-          outputs: type=docker,force-compression=true,compression=zstd,compression-level=20,dest=${{ env.IMAGE_FILE }}
+          outputs: type=docker,force-compression=true,compression=zstd,compression-level=22,dest=${{ env.IMAGE_FILE }}
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -52,7 +52,7 @@ jobs:
           platforms: linux/amd64
           file: .github/Dockerfile
           tags: ${{ env.IMAGE }}:latest
-          outputs: type=docker,force-compression=true,compression=zstd,compression-level=20,dest=${{ env.IMAGE_FILE }}
+          outputs: type=docker,force-compression=true,compression=zstd,compression-level=22,dest=${{ env.IMAGE_FILE }}
 
   cmake-linux:
     needs: cache-maker

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -53,7 +53,7 @@ jobs:
           platforms: linux/amd64
           file: .github/Dockerfile-zephyr
           tags: ${{ env.IMAGE }}:latest
-          outputs: type=docker,force-compression=true,compression=zstd,compression-level=20,dest=${{ env.IMAGE_FILE }}
+          outputs: type=docker,force-compression=true,compression=zstd,compression-level=22,dest=${{ env.IMAGE_FILE }}
 
   minsize-zephyr:
     needs: cache-maker


### PR DESCRIPTION
Increasing the compression level from 19
to 20 gives significant space savings
without increasing docker load times.
Increase the compression level to the max
since that will benefit every download
performed by the CI.

Compression level is documented, but it
does currently not have any effect
for the docker exporter. If level 22
turns out to take prohibitively long
when the parameter is no longer ignored,
this setting can be dialed back to 20.