### PR TITLE
CI: make qemu-system-nios2 run again

### DIFF
--- a/.github/zephyr-packages.txt
+++ b/.github/zephyr-packages.txt
@@ -4,6 +4,7 @@ file
 libgtk-3-0
 libjack0
 libpulse0
+libsndio7.0
 librados2
 librbd1
 libvte-2.91-0


### PR DESCRIPTION
Add the libsndio7.0 package so qemu-system-nios2 in the Zephyr tests can run.
