### PR TITLE
newlib/testsuite: only test iconv when enabled

### DIFF
--- a/newlib/testsuite/meson.build
+++ b/newlib/testsuite/meson.build
@@ -33,8 +33,13 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-dirs = [
-	'newlib.iconv',
+if newlib_iconv_encodings == []
+  dirs = []
+else
+  dirs = ['newlib.iconv']
+endif
+
+dirs += [
 	'newlib.locale',
 	'newlib.search',
 	'newlib.stdio',


### PR DESCRIPTION
The compiler gives warnings when building
with -Dnewlib-iconv-encodings=none because
the iconv tests read outside array bounds
when the arrays are empty.

Only build iconv tests when there are some
encodings to actually test.

Fixes #545