### PR TITLE
Move more constants out of RAM

### DIFF
--- a/newlib/libc/misc/__dprintf.c
+++ b/newlib/libc/misc/__dprintf.c
@@ -34,6 +34,7 @@
 
 #include <_ansi.h>
 #include <unistd.h>
+#include <endian.h>
 #include "ctype.h"
 #include "string.h"
 #include "unctrl.h"
@@ -52,9 +53,6 @@ static long get_number (char *, long, int);
 static void print_number (int, int, long);
 static void write_char (char c);
 static void write_string (const char *s);
-
-/* Non-zero for big-endian systems.  */
-static int big_endian_p;
 
 /* For now hardcode 2 (stderr) as the console file descriptor.
    May wish to let the caller pass in a file descriptor or some such but
@@ -91,12 +89,6 @@ __dprintf (fmt, va_alist)
 #endif
 {
   va_list args;
-
-  /* Which endian are we?  */
-  {
-    short tmp = 1;
-    big_endian_p = *(char *) &tmp == 0;
-  }
 
 #ifdef __STDC__
   va_start (args, fmt);
@@ -220,7 +212,7 @@ get_number (char *s,
 	x = (x ^ 0x80) - 0x80;
       return x;
     case 2 :
-      if (big_endian_p)
+      if (_BYTE_ORDER == _BIG_ENDIAN)
 	x = (p[0] << 8) | p[1];
       else
 	x = (p[1] << 8) | p[0];
@@ -228,7 +220,7 @@ get_number (char *s,
 	x = (x ^ 0x8000) - 0x8000;
       return x;
     case 4 :
-      if (big_endian_p)
+      if (_BYTE_ORDER == _BIG_ENDIAN)
 	x = ((long)p[0] << 24) | ((long)p[1] << 16) | (p[2] << 8) | p[3];
       else
 	x = ((long)p[3] << 24) | ((long)p[2] << 16) | (p[1] << 8) | p[0];

--- a/newlib/libc/posix/regerror.c
+++ b/newlib/libc/posix/regerror.c
@@ -55,7 +55,7 @@ extern "C" {
 #endif
 
 /* === regerror.c === */
-static char *regatoi(const regex_t *preg, char *localbuf);
+static const char *regatoi(const regex_t *preg, char *localbuf);
 
 #ifdef __cplusplus
 }
@@ -81,10 +81,10 @@ static char *regatoi(const regex_t *preg, char *localbuf);
  = #define	REG_ATOI	255	// convert name to number (!)
  = #define	REG_ITOA	0400	// convert number to name (!)
  */
-static struct rerr {
+static const struct rerr {
 	int code;
-	char *name;
-	char *explain;
+	const char *name;
+	const char *explain;
 } rerrs[] = {
 	{REG_NOMATCH,	"REG_NOMATCH",	"regexec() failed to match"},
 	{REG_BADPAT,	"REG_BADPAT",	"invalid regular expression"},
@@ -117,10 +117,10 @@ regerror(int errcode,
          char *__restrict errbuf,
          size_t errbuf_size)
 {
-	struct rerr *r;
+	const struct rerr *r;
 	size_t len;
 	int target = errcode &~ REG_ITOA;
-	char *s;
+	const char *s;
 	char convbuf[50];
 
 	if (errcode == REG_ATOI)
@@ -158,16 +158,14 @@ regerror(int errcode,
  - regatoi - internal routine to implement REG_ATOI
  == static char *regatoi(const regex_t *preg, char *localbuf);
  */
-static char *
+static const char *
 regatoi(const regex_t *preg, char *localbuf)
 {
-	struct rerr *r;
+	const struct rerr *r;
 
 	for (r = rerrs; r->code != 0; r++)
 		if (strcmp(r->name, preg->re_endp) == 0)
 			break;
-	if (r->code == 0)
-		return("0");
 
 	sprintf(localbuf, "%d", r->code);
 	return(localbuf);

--- a/newlib/libc/search/hash_page.c
+++ b/newlib/libc/search/hash_page.c
@@ -852,11 +852,12 @@ static int
 open_temp(HTAB *hashp)
 {
 	sigset_t set, oset;
-	static char namestr[] = "_hashXXXXXX";
+	char namestr[sizeof("_hashXXXXXX")];
 
 	/* Block signals; make sure file goes away at process exit. */
 	(void)sigfillset(&set);
 	(void)sigprocmask(SIG_BLOCK, &set, &oset);
+        strcpy(namestr, "_hashXXXXXX");
 	if ((hashp->fp = mkstemp(namestr)) != -1) {
 		(void)unlink(namestr);
 #ifdef _HAVE_FCNTL

--- a/newlib/libc/time/gettzinfo.c
+++ b/newlib/libc/time/gettzinfo.c
@@ -3,11 +3,7 @@
 #include "local.h"
 
 /* Shared timezone information for libc/time functions.  */
-static __tzinfo_type tzinfo = {1, 0,
-    { {'J', 0, 0, 0, 0, (time_t)0, 0L },
-      {'J', 0, 0, 0, 0, (time_t)0, 0L } 
-    } 
-};
+static __tzinfo_type tzinfo;
 
 __tzinfo_type *
 __gettzinfo (void)

--- a/newlib/libm/common/math_config.h
+++ b/newlib/libm/common/math_config.h
@@ -270,27 +270,48 @@ issignaling_inline (double x)
   return 2 * (ix ^ 0x0008000000000000ULL) > 2 * 0x7ff8000000000000ULL;
 }
 
+/*
+ * gcc older than version 13 places 'const volatile' variables in
+ * .data while clang places them in .rodata. gcc never optimizes away
+ * math operations which might generate exceptions while clang will
+ * happily do so. Therefore, we don't need volatile with gcc, but we
+ * do need it for clang. And, we don't want volatile with gcc to avoid
+ * placing these constants in the .data section with older gcc versions
+ */
+
+#ifdef __clang__
+#define CONST_FORCE_FLOAT_MODIFIER    volatile
+#else
+#define CONST_FORCE_FLOAT_MODIFIER
+#endif
+
 #ifdef PICOLIBC_FLOAT_NOEXCEPT
 #define FORCE_FLOAT     float
+#define CONST_FORCE_FLOAT const float
 #define pick_float_except(expr,val)    (val)
 #else
 #define FORCE_FLOAT     volatile float
+#define CONST_FORCE_FLOAT       const CONST_FORCE_FLOAT_MODIFIER float
 #define pick_float_except(expr,val)    (expr)
 #endif
 
 #ifdef PICOLIBC_DOUBLE_NOEXCEPT
 #define FORCE_DOUBLE    double
+#define CONST_FORCE_DOUBLE      const double
 #define pick_double_except(expr,val)    (val)
 #else
 #define FORCE_DOUBLE    volatile double
+#define CONST_FORCE_DOUBLE      const CONST_FORCE_FLOAT_MODIFIER double
 #define pick_double_except(expr,val)    (expr)
 #endif
 
 #ifdef PICOLIBC_LONG_DOUBLE_NOEXCEPT
 #define FORCE_LONG_DOUBLE       long double
+#define CONST_FORCE_LONG_DOUBLE const long double
 #define pick_long_double_except(expr,val)       (val)
 #else
 #define FORCE_LONG_DOUBLE       volatile long double
+#define CONST_FORCE_LONG_DOUBLE const CONST_FORCE_FLOAT_MODIFIER long double
 #define pick_long_double_except(expr,val)       (expr)
 #endif
 
@@ -614,6 +635,7 @@ force_eval_long_double (long double x)
 #  define _NAME_64_SPECIAL(d,l) l
    typedef long double __float64;
 #  define FORCE_FLOAT64 FORCE_LONG_DOUBLE
+#  define CONST_FORCE_FLOAT64 CONST_FORCE_LONG_DOUBLE
 #  define pick_float64_except(a,b) pick_long_double_except(a,b)
 #  define _NEED_FLOAT64
 #  define __F_64(x)     x ## L
@@ -673,6 +695,7 @@ force_eval_long_double (long double x)
 # define _FLOAT64_MANT_DIG  __DBL_MANT_DIG__
 typedef double __float64;
 # define FORCE_FLOAT64 FORCE_DOUBLE
+# define CONST_FORCE_FLOAT64 CONST_FORCE_DOUBLE
 # define pick_float64_except(a,b) pick_double_except(a,b)
 # define force_eval_float64 force_eval_double
 # define opt_barrier_float64 opt_barrier_double

--- a/newlib/libm/common/math_denorm.c
+++ b/newlib/libm/common/math_denorm.c
@@ -33,7 +33,7 @@
 #ifndef __math_denorm
 
 #ifndef PICOLIBC_DOUBLE_NOEXCEPT
-static const FORCE_FLOAT64 VAL = _FLOAT64_MIN;
+static CONST_FORCE_FLOAT64 VAL = _FLOAT64_MIN;
 #endif
 
 HIDDEN __float64

--- a/newlib/libm/common/math_denormf.c
+++ b/newlib/libm/common/math_denormf.c
@@ -31,7 +31,7 @@
 #ifndef __math_denormf
 
 #ifndef PICOLIBC_FLOAT_NOEXCEPT
-static const FORCE_FLOAT VAL = __FLT_MIN__;
+static CONST_FORCE_FLOAT VAL = __FLT_MIN__;
 #endif
 
 HIDDEN float

--- a/newlib/libm/common/math_denorml.c
+++ b/newlib/libm/common/math_denorml.c
@@ -33,7 +33,7 @@
 #ifndef __math_denorml
 
 #ifndef PICOLIBC_LONG_DOUBLE_NOEXCEPT
-static const FORCE_LONG_DOUBLE VAL = __LDBL_MIN__;
+static CONST_FORCE_LONG_DOUBLE VAL = __LDBL_MIN__;
 #endif
 
 HIDDEN long double

--- a/newlib/libm/common/math_err_divzero.c
+++ b/newlib/libm/common/math_err_divzero.c
@@ -28,7 +28,7 @@
 
 #include "math_config.h"
 
-static const FORCE_FLOAT64 VAL = pick_float64_except(_F_64(0.0), (__float64) INFINITY);
+static CONST_FORCE_FLOAT64 VAL = pick_float64_except(_F_64(0.0), (__float64) INFINITY);
 
 HIDDEN __float64
 __math_divzero (uint32_t sign)

--- a/newlib/libm/common/math_err_invalid.c
+++ b/newlib/libm/common/math_err_invalid.c
@@ -28,7 +28,7 @@
 
 #include "math_config.h"
 
-static const FORCE_FLOAT64 VAL = pick_float64_except(_F_64(0.0), (__float64) NAN);
+static CONST_FORCE_FLOAT64 VAL = pick_float64_except(_F_64(0.0), (__float64) NAN);
 
 HIDDEN __float64
 __math_invalid (__float64 x)

--- a/newlib/libm/common/math_err_may_uflow.c
+++ b/newlib/libm/common/math_err_may_uflow.c
@@ -30,7 +30,7 @@
 
 #if WANT_ERRNO_UFLOW && defined(_NEED_FLOAT64)
 
-static const FORCE_FLOAT64 VAL = pick_float64_except(_F_64(0x1.8p-538), _F_64(0.0));
+static CONST_FORCE_FLOAT64 VAL = pick_float64_except(_F_64(0x1.8p-538), _F_64(0.0));
 
 /* Underflows to zero in some non-nearest rounding mode, setting errno
    is valid even if the result is non-zero, but in the subnormal range.  */

--- a/newlib/libm/common/math_err_oflow.c
+++ b/newlib/libm/common/math_err_oflow.c
@@ -28,7 +28,7 @@
 
 #include "math_config.h"
 
-static const FORCE_FLOAT64 VAL = pick_float64_except(_FLOAT64_MAX, (__float64) INFINITY);
+static CONST_FORCE_FLOAT64 VAL = pick_float64_except(_FLOAT64_MAX, (__float64) INFINITY);
 
 HIDDEN __float64
 __math_oflow (uint32_t sign)

--- a/newlib/libm/common/math_err_uflow.c
+++ b/newlib/libm/common/math_err_uflow.c
@@ -30,7 +30,7 @@
 
 #ifdef _NEED_FLOAT64
 
-static const FORCE_FLOAT64 VAL = pick_float64_except(_FLOAT64_MIN, _F_64(0.0));
+static CONST_FORCE_FLOAT64 VAL = pick_float64_except(_FLOAT64_MIN, _F_64(0.0));
 
 HIDDEN __float64
 __math_uflow (uint32_t sign)

--- a/newlib/libm/common/math_errf_divzerof.c
+++ b/newlib/libm/common/math_errf_divzerof.c
@@ -29,7 +29,7 @@
 #include "fdlibm.h"
 #include "math_config.h"
 
-static const FORCE_FLOAT VAL = pick_float_except(0.0f, (float) INFINITY);
+static CONST_FORCE_FLOAT VAL = pick_float_except(0.0f, (float) INFINITY);
 
 HIDDEN float
 __math_divzerof (uint32_t sign)

--- a/newlib/libm/common/math_errf_invalidf.c
+++ b/newlib/libm/common/math_errf_invalidf.c
@@ -29,7 +29,7 @@
 #include "fdlibm.h"
 #include "math_config.h"
 
-static const FORCE_FLOAT VAL = pick_float_except(0.0f, (float) NAN);
+static CONST_FORCE_FLOAT VAL = pick_float_except(0.0f, (float) NAN);
 
 HIDDEN float
 __math_invalidf (float x)

--- a/newlib/libm/common/math_errf_may_uflowf.c
+++ b/newlib/libm/common/math_errf_may_uflowf.c
@@ -31,7 +31,7 @@
 
 #if WANT_ERRNO_UFLOW
 
-static const FORCE_FLOAT VAL = pick_float_except(0x1.4p-75f, 0.0f);
+static CONST_FORCE_FLOAT VAL = pick_float_except(0x1.4p-75f, 0.0f);
 
 /* Underflows to zero in some non-nearest rounding mode, setting errno
    is valid even if the result is non-zero, but in the subnormal range.  */

--- a/newlib/libm/common/math_errf_oflowf.c
+++ b/newlib/libm/common/math_errf_oflowf.c
@@ -29,7 +29,7 @@
 #include "fdlibm.h"
 #include "math_config.h"
 
-static const FORCE_FLOAT VAL = pick_float_except(FLT_MAX, (float) INFINITY);
+static CONST_FORCE_FLOAT VAL = pick_float_except(FLT_MAX, (float) INFINITY);
 
 HIDDEN float
 __math_oflowf (uint32_t sign)

--- a/newlib/libm/common/math_errf_uflowf.c
+++ b/newlib/libm/common/math_errf_uflowf.c
@@ -29,7 +29,7 @@
 #include "fdlibm.h"
 #include "math_config.h"
 
-static const FORCE_FLOAT VAL = pick_float_except(FLT_MIN, 0.0f);
+static CONST_FORCE_FLOAT VAL = pick_float_except(FLT_MIN, 0.0f);
 
 HIDDEN float
 __math_uflowf (uint32_t sign)

--- a/newlib/libm/common/math_inexact.c
+++ b/newlib/libm/common/math_inexact.c
@@ -37,7 +37,7 @@
 
 #if FE_INEXACT && !defined(PICOLIBC_DOUBLE_NOEXECPT)
 
-static const FORCE_DOUBLE VAL = pick_double_except(DBL_MIN, 0.0);
+static CONST_FORCE_DOUBLE VAL = pick_double_except(DBL_MIN, 0.0);
 
 HIDDEN void
 __math_set_inexact(void)

--- a/newlib/libm/common/math_inexactf.c
+++ b/newlib/libm/common/math_inexactf.c
@@ -37,7 +37,7 @@
 
 #if FE_INEXACT && !defined(PICOLIBC_FLOAT_NOEXECPT)
 
-static const FORCE_FLOAT VAL = pick_float_except(FLT_MIN, 0.0f);
+static CONST_FORCE_FLOAT VAL = pick_float_except(FLT_MIN, 0.0f);
 
 HIDDEN void
 __math_set_inexactf(void)

--- a/newlib/libm/common/math_inexactl.c
+++ b/newlib/libm/common/math_inexactl.c
@@ -38,11 +38,11 @@
 #if defined(FE_INEXACT) && !defined(PICOLIBC_LONG_DOUBLE_NOEXECPT) && defined(_NEED_FLOAT_HUGE)
 
 #ifdef _DOUBLE_DOUBLE_FLOAT
-static const FORCE_LONG_DOUBLE VAL = pick_long_double_except(LDBL_MIN, 0.0L);
-static const FORCE_LONG_DOUBLE VAL1 = pick_long_double_except(LDBL_MAX, 0.0L);
+static CONST_FORCE_LONG_DOUBLE VAL = pick_long_double_except(LDBL_MIN, 0.0L);
+static CONST_FORCE_LONG_DOUBLE VAL1 = pick_long_double_except(LDBL_MAX, 0.0L);
 #define eqn (1.0L + VAL + VAL1)
 #else
-static const FORCE_LONG_DOUBLE VAL = pick_long_double_except(LDBL_MIN, 0.0L);
+static CONST_FORCE_LONG_DOUBLE VAL = pick_long_double_except(LDBL_MIN, 0.0L);
 #define eqn (1.0L + VAL)
 #endif
 

--- a/newlib/libm/ld/math_errl_divzerol.c
+++ b/newlib/libm/ld/math_errl_divzerol.c
@@ -28,7 +28,7 @@
 
 #include "math_ld.h"
 
-static const FORCE_LONG_DOUBLE VAL = pick_long_double_except(0.0L, (long double) INFINITY);
+static CONST_FORCE_LONG_DOUBLE VAL = pick_long_double_except(0.0L, (long double) INFINITY);
 
 HIDDEN long double
 __math_divzerol (uint32_t sign)

--- a/newlib/libm/ld/math_errl_invalidl.c
+++ b/newlib/libm/ld/math_errl_invalidl.c
@@ -30,7 +30,7 @@
 
 #ifdef _NEED_FLOAT_HUGE
 
-static const FORCE_LONG_DOUBLE VAL = pick_long_double_except((long double) 0.0, (long double) NAN);
+static CONST_FORCE_LONG_DOUBLE VAL = pick_long_double_except((long double) 0.0, (long double) NAN);
 
 HIDDEN long double
 __math_invalidl (long double x)

--- a/newlib/libm/ld/math_errl_oflowl.c
+++ b/newlib/libm/ld/math_errl_oflowl.c
@@ -30,7 +30,7 @@
 
 #ifdef _NEED_FLOAT_HUGE
 
-static const FORCE_LONG_DOUBLE VAL = pick_long_double_except(LDBL_MAX, (long double) INFINITY);
+static CONST_FORCE_LONG_DOUBLE VAL = pick_long_double_except(LDBL_MAX, (long double) INFINITY);
 
 HIDDEN long double
 __math_oflowl (uint32_t sign)

--- a/newlib/libm/ld/math_errl_uflowl.c
+++ b/newlib/libm/ld/math_errl_uflowl.c
@@ -30,7 +30,7 @@
 
 #ifdef _NEED_FLOAT_HUGE
 
-static const FORCE_LONG_DOUBLE VAL = pick_long_double_except(LDBL_MIN, 0.0l);
+static CONST_FORCE_LONG_DOUBLE VAL = pick_long_double_except(LDBL_MIN, 0.0l);
 
 HIDDEN long double
 __math_uflowl (uint32_t sign)

--- a/newlib/libm/test/test.c
+++ b/newlib/libm/test/test.c
@@ -177,7 +177,7 @@ mag_of_error (double is,
   __ieee_double_shape_type a,b;
   int i;
   int a_big;
-  unsigned  int mask;
+  uint32_t mask;
   unsigned long int __x;
   unsigned long int msw, lsw;						  
   a.value = is;
@@ -240,7 +240,7 @@ fmag_of_error (float is,
   __ieee_float_shape_type a,b;
   int i;
   int a_big;
-  unsigned  int mask;
+  uint32_t mask;
   uint32_t sw;
   a.value = is;
   

--- a/newlib/testsuite/newlib.time/tzset.c
+++ b/newlib/testsuite/newlib.time/tzset.c
@@ -20,7 +20,7 @@ extern const struct tm winter_tm;
 extern const struct tm summer_tm;
 extern const time_t winter_time;
 extern const time_t summer_time;
-extern struct tz_test test_timezones[];
+extern const struct tz_test test_timezones[];
 
 // winter time is March, 21st 2022 at 8:15pm and 20 seconds
 const struct tm winter_tm = {
@@ -48,7 +48,7 @@ const struct tm summer_tm = {
 const time_t winter_time = 1647893720;
 const time_t summer_time = 1657882240;
 
-struct tz_test test_timezones[] = {
+const struct tz_test test_timezones[] = {
     /*
      * creating test vectors based on the POSIX spec (https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html#tag_08_03)
      */

--- a/test/tls.c
+++ b/test/tls.c
@@ -33,6 +33,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <picotls.h>
 #include <stdlib.h>
@@ -49,16 +50,16 @@
 
 #define TLS_ALIGN      (OVERALIGN_DATA > OVERALIGN_BSS ? OVERALIGN_DATA : OVERALIGN_BSS)
 
-NEWLIB_THREAD_LOCAL volatile int data_var = DATA_VAL;
-NEWLIB_THREAD_LOCAL volatile int bss_var;
-_Alignas(OVERALIGN_DATA) NEWLIB_THREAD_LOCAL volatile int overaligned_data_var = DATA_VAL2;
-_Alignas(OVERALIGN_BSS) NEWLIB_THREAD_LOCAL volatile int overaligned_bss_var;
-_Alignas(OVERALIGN_NON_TLS_BSS) volatile int overaligned_non_tls_bss_var;
+NEWLIB_THREAD_LOCAL volatile int32_t data_var = DATA_VAL;
+NEWLIB_THREAD_LOCAL volatile int32_t bss_var;
+_Alignas(OVERALIGN_DATA) NEWLIB_THREAD_LOCAL volatile int32_t overaligned_data_var = DATA_VAL2;
+_Alignas(OVERALIGN_BSS) NEWLIB_THREAD_LOCAL volatile int32_t overaligned_bss_var;
+_Alignas(OVERALIGN_NON_TLS_BSS) volatile int32_t overaligned_non_tls_bss_var;
 
-volatile int *volatile data_addr;
-volatile int *volatile overaligned_data_addr;
-volatile int *volatile bss_addr;
-volatile int *volatile overaligned_bss_addr;
+volatile int32_t *volatile data_addr;
+volatile int32_t *volatile overaligned_data_addr;
+volatile int32_t *volatile bss_addr;
+volatile int32_t *volatile overaligned_bss_addr;
 
 #ifdef PICOLIBC_TLS
 extern char __tdata_start[], __tdata_end[];
@@ -123,61 +124,61 @@ check_tls(char *where, bool check_addr, void *tls_region)
                 result++;
         }
 	if (data_var != DATA_VAL) {
-		printf("%s: initialized thread var has wrong value (0x%x instead of 0x%x)\n",
-		       where, data_var, DATA_VAL);
+		printf("%s: initialized thread var has wrong value (0x%" PRIx32 " instead of 0x%" PRIx32 ")\n",
+		       where, data_var, (int32_t) DATA_VAL);
 		result++;
 	}
 	if (overaligned_data_var != DATA_VAL2) {
-		printf("%s: initialized overaligned thread var has wrong value (0x%x instead of 0x%x)\n",
-		       where, overaligned_data_var, DATA_VAL2);
+		printf("%s: initialized overaligned thread var has wrong value (0x%" PRIx32 " instead of 0x%" PRIx32 ")\n",
+		       where, overaligned_data_var, (int32_t) DATA_VAL2);
 		result++;
 	}
 
 	if (bss_var != 0) {
-		printf("%s: uninitialized thread var has wrong value (0x%x instead of 0x%x)\n",
-		       where, bss_var, 0);
+		printf("%s: uninitialized thread var has wrong value (0x%" PRIx32 " instead of 0x%" PRIx32 ")\n",
+		       where, bss_var, (int32_t) 0);
 		result++;
 	}
         if (overaligned_bss_var != 0) {
-		printf("%s: overaligned uninitialized thread var has wrong value (0x%x instead of 0x%x)\n",
-		       where, overaligned_bss_var, 0);
+		printf("%s: overaligned uninitialized thread var has wrong value (0x%" PRIx32 " instead of 0x%" PRIx32 ")\n",
+		       where, overaligned_bss_var, (int32_t) 0);
 		result++;
         }
 	if (overaligned_non_tls_bss_var != 0) {
-		printf("%s: overaligned uninitialized var has wrong value (0x%x instead of 0x%x)\n",
-		       where, overaligned_non_tls_bss_var, 0);
+		printf("%s: overaligned uninitialized var has wrong value (0x%" PRIx32 " instead of 0x%" PRIx32 ")\n",
+		       where, overaligned_non_tls_bss_var, (int32_t) 0);
 		result++;
         }
 
 	data_var = ~data_var;
 
 	if (data_var != ~DATA_VAL) {
-		printf("%s: initialized thread var set to wrong value (0x%x instead of 0x%x)\n",
-		       where, data_var, ~DATA_VAL);
+		printf("%s: initialized thread var set to wrong value (0x%" PRIx32 " instead of 0x%" PRIx32 ")\n",
+		       where, data_var, ~((int32_t) DATA_VAL));
 		result++;
 	}
 
 	overaligned_data_var = ~overaligned_data_var;
 
 	if (overaligned_data_var != ~DATA_VAL2) {
-		printf("%s: overaligned initialized thread var set to wrong value (0x%x instead of 0x%x)\n",
-		       where, overaligned_data_var, ~DATA_VAL2);
+		printf("%s: overaligned initialized thread var set to wrong value (0x%" PRIx32 " instead of 0x%" PRIx32 ")\n",
+		       where, overaligned_data_var, ~((int32_t) DATA_VAL2));
 		result++;
 	}
 
 	bss_var = ~bss_var;
 
 	if (bss_var != ~0) {
-		printf("%s: uninitialized thread var has wrong value (0x%x instead of 0x%x)\n",
-		       where, bss_var, ~0);
+		printf("%s: uninitialized thread var has wrong value (0x%" PRIx32 " instead of 0x%" PRIx32 ")\n",
+		       where, bss_var, ~((int32_t) 0));
 		result++;
 	}
 
 	overaligned_bss_var = ~overaligned_bss_var;
 
 	if (overaligned_bss_var != ~0) {
-		printf("%s: overaligned uninitialized thread var has wrong value (0x%x instead of 0x%x)\n",
-		       where, overaligned_bss_var, ~0);
+		printf("%s: overaligned uninitialized thread var has wrong value (0x%" PRIx32 " instead of 0x%" PRIx32 ")\n",
+		       where, overaligned_bss_var, ~((int32_t) 0));
 		result++;
 	}
 


### PR DESCRIPTION
Here's another series of small patches which adjust the location of constants to move them from RAM to flash.

With this series, there are no more read-only variables that land in initialized RAM.