### PR TITLE
picocrt/mips: Use 'dla' instead of 'la' on 64-bit targets

### DIFF
--- a/picocrt/machine/mips/crt0.c
+++ b/picocrt/machine/mips/crt0.c
@@ -43,11 +43,18 @@ _cstart(void)
 
 extern char __stack[];
 
+#if __mips == 32
+#define LA  "la"
+#endif
+#if __mips ==64
+#define LA  "dla"
+#endif
+
 void __section(".init") __attribute__((used))
 _start(void)
 {
 	/* Initialize stack pointer */
-	__asm__("la $sp,%0" : : "i" (__stack));
+	__asm__(LA " $sp,%0" : : "i" (__stack));
 
 #ifndef __mips_soft_float
         /* Enable FPU */


### PR DESCRIPTION
dla is needed to load 64-bit addresses as la only handles 32-bit values.