### PR TITLE
CI: increase ccache size for Zephyr jobs

### DIFF
--- a/.github/workflows/head-zephyr
+++ b/.github/workflows/head-zephyr
@@ -15,9 +15,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # .github/do-zephyr -Dtinystdio=false -Dfortify-source=2 --buildtype release
-  # is the largest cache, 376.5M (August 2023).
-  CCACHE_SIZE: "400M"
+  # .github/do-zephyr -Dfortify-source=2 --buildtype release
+  # is the largest cache, 429.5M (September 2023).
+  CCACHE_SIZE: "450M"
   CCACHE_CMD: ccache
   DOCKERFILE: picolibc/.github/Dockerfile-zephyr
   IMAGE_FILE: dockerimg-zephyr.tar.zst

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -15,9 +15,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # .github/do-zephyr -Dtinystdio=false -Dfortify-source=2 --buildtype release
-  # is the largest cache, 376.5M (August 2023).
-  CCACHE_SIZE: "400M"
+  # .github/do-zephyr -Dfortify-source=2 --buildtype release
+  # is the largest cache, 429.5M (September 2023).
+  CCACHE_SIZE: "450M"
   CCACHE_CMD: ccache
   DOCKERFILE: picolibc/.github/Dockerfile-zephyr
   IMAGE_FILE: dockerimg-zephyr.tar.zst


### PR DESCRIPTION
The documented largest cache is wrong, so
fix that and increase the cache size
accordingly.