### PR TITLE
libc/tinystdio: Replace %/ with fancy non-div using code on some targets

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -117,7 +117,7 @@ jobs:
           "",
 
           # Tinystdio and math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
-          "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",
+          "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false -Dprintf-small-ultoa=true",
           "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false -Dnewlib-obsolete-math=true -Dwant-math-errno=true",
 
           # Original stdio, one with multithread disabled
@@ -177,7 +177,7 @@ jobs:
           "",
 
           # Tinystdio and math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
-          "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",
+          "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false -Dprintf-small-ultoa=true",
           "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false -Dnewlib-obsolete-math=true -Dwant-math-errno=true",
 
           # Original stdio, one with multithread disabled

--- a/.github/workflows/variants
+++ b/.github/workflows/variants
@@ -6,7 +6,7 @@
           "",
 
           # Tinystdio and math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
-          "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",
+          "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false -Dprintf-small-ultoa=true",
           "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false -Dnewlib-obsolete-math=true -Dwant-math-errno=true",
 
           # Original stdio, one with multithread disabled

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -64,7 +64,7 @@ jobs:
           "",
 
           # Tinystdio and math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
-          "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",
+          "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false -Dprintf-small-ultoa=true",
           "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false -Dnewlib-obsolete-math=true -Dwant-math-errno=true",
 
           # Original stdio, one with multithread disabled
@@ -124,7 +124,7 @@ jobs:
           "",
 
           # Tinystdio and math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
-          "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false",
+          "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false -Dprintf-small-ultoa=true",
           "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false -Dnewlib-obsolete-math=true -Dwant-math-errno=true",
 
           # Original stdio, one with multithread disabled

--- a/meson.build
+++ b/meson.build
@@ -311,6 +311,7 @@ format_default = get_option('format-default')
 printf_aliases = get_option('printf-aliases')
 io_percent_b = tinystdio and get_option('io-percent-b')
 io_long_double = get_option('io-long-double') or get_option('newlib-io-long-double')
+printf_small_ultoa = tinystdio and get_option('printf-small-ultoa')
 
 if printf_aliases
   double_printf_compile_args=['-DPICOLIBC_DOUBLE_PRINTF_SCANF']
@@ -1231,6 +1232,7 @@ conf_data.set('NEWLIB_TLS', thread_local_storage, description: 'use thread local
 conf_data.set('PICOLIBC_TLS', thread_local_storage, description: 'use thread local storage')
 conf_data.set('_HAVE_PICOLIBC_TLS_API', thread_local_storage and have_picolibc_tls_api, description: '_set_tls and _init_tls functions available')
 conf_data.set('POSIX_IO', posix_io, description: 'Use open/close/read/write in tinystdio')
+conf_data.set('_PRINTF_SMALL_ULTOA', printf_small_ultoa, description: 'avoid software division in decimal conversion')
 conf_data.set('ATOMIC_UNGETC', atomic_ungetc, description: 'Use atomics for fgetc/ungetc for re-entrancy')
 conf_data.set('_PICOLIBC_ATOMIC_SIGNAL', get_option('atomic-signal'), description: 'Use atomics for signal/raise for re-entrancy')
 conf_data.set('_HAVE_BITFIELDS_IN_PACKED_STRUCTS', have_bitfields_in_packed_structs, description: 'Use bitfields in packed structs')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -159,6 +159,8 @@ option('format-default', type: 'combo', choices: ['double', 'float', 'integer'],
        description: 'which printf/scanf versions should be the default')
 option('printf-aliases', type: 'boolean', value: true,
        description: 'Allow link-time printf aliases')
+option('printf-small-ultoa', type: 'boolean', value: false,
+       description: 'Avoid softare division in decimal conversions')
 
 #
 # Options applying to only legacy stdio

--- a/newlib/libc/stdio/findfp.c
+++ b/newlib/libc/stdio/findfp.c
@@ -128,24 +128,30 @@ stderr_init(FILE *ptr)
   std (ptr, __SRW | __SNBF, 2);
 }
 
-struct glue_with_file {
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#pragma GCC diagnostic ignored "-Wanalyzer-malloc-leak"
+#endif
+
+struct glue_with_files {
   struct _glue glue;
-  FILE file;
+  FILE file[];
 };
 
 static struct _glue *
 sfmoreglue (int n)
 {
-  struct glue_with_file *g;
+  struct glue_with_files *g;
 
-  g = (struct glue_with_file *)
-    malloc (sizeof (*g) + (n - 1) * sizeof (FILE));
+  g = (struct glue_with_files *)
+    malloc (sizeof (*g) + n * sizeof (FILE));
   if (g == NULL)
     return NULL;
   g->glue._next = NULL;
   g->glue._niobs = n;
-  g->glue._iobs = &g->file;
-  memset (&g->file, 0, n * sizeof (FILE));
+  g->glue._iobs = g->file;
+  memset (g->file, 0, n * sizeof (FILE));
   return &g->glue;
 }
 

--- a/newlib/libc/tinystdio/ultoa_invert.c
+++ b/newlib/libc/tinystdio/ultoa_invert.c
@@ -28,6 +28,121 @@
 
 #include "xtoa_fast.h"
 
+#if PRINTF_LEVEL < PRINTF_FLT && defined(_PRINTF_SMALL_ULTOA)
+
+#ifdef __arm__
+
+# define FANCY_DIVMOD_8
+# ifndef __ARM_FEATURE_IDIV__
+#  define FANCY_DIVMOD_4
+# endif
+
+#elif defined(__riscv)
+
+# if __riscv_xlen <= 32
+#  define FANCY_DIVMOD_8
+#  ifndef __riscv_m
+#   define FANCY_DIVMOD_4
+#  endif
+# elif __riscv_xlen >= 64
+#  ifndef __riscv_m
+#   define FANCY_DIVMOD_8
+#   define FANCY_DIVMOD_4
+#  endif
+# endif
+
+#elif defined(__arc__)
+
+#if __SIZEOF_LONG__ <= 4
+# define FANCY_DIVMOD_8
+# ifndef __ARC_DIVREM__
+#  define FANCY_DIVMOD_4
+# endif
+#else
+# ifndef __ARC_DIVREM__
+#  define FANCY_DIVMOD_8
+#  define FANCY_DIVMOD_4
+# endif
+#endif
+
+#else
+# if __SIZEOF_LONG__ < 8
+#  define FANCY_DIVMOD_8
+# endif
+#endif
+
+#if SIZEOF_ULTOA == 8 && defined(FANCY_DIVMOD_8)
+
+#define FANCY_DIVMOD
+
+static inline uint64_t udivmod10(uint64_t n, char *rp) {
+        uint64_t q;
+        char r;
+
+	q = (n >> 1) + (n >> 2);
+	q = q + (q >> 4);
+	q = q + (q >> 8);
+	q = q + (q >> 16);
+        q = q + (q >> 32);
+	q = q >> 3;
+	r = (char) (n - (((q << 2) + q) << 1));
+        if (r > 9) {
+            q++;
+            r -= 10;
+        }
+        *rp = r;
+	return q;
+}
+
+#elif SIZEOF_ULTOA == 4 && defined(FANCY_DIVMOD_4)
+
+#define FANCY_DIVMOD
+
+static inline uint32_t udivmod10(uint32_t n, char *rp) {
+	uint32_t q;
+        char r;
+
+	q = (n >> 1) + (n >> 2);
+	q = q + (q >> 4);
+	q = q + (q >> 8);
+	q = q + (q >> 16);
+	q = q >> 3;
+	r = (char) (n - (((q << 2) + q) << 1));
+        if (r > 9) {
+            q++;
+            r -= 10;
+        }
+        *rp = r;
+	return q;
+}
+
+#endif
+
+#endif
+
+#ifdef FANCY_DIVMOD
+
+static inline ultoa_unsigned_t
+udivmod(ultoa_unsigned_t val, int base, char *dig)
+{
+    switch(base) {
+#ifdef _WANT_IO_PERCENT_B
+    case 2:
+        *dig = val & 1;
+        return val >> 1;
+#endif
+    case 8:
+        *dig = val & 7;
+        return val >> 3;
+    case 16:
+        *dig = val & 15;
+        return val >> 4;
+    }
+    return udivmod10(val, dig);
+}
+
+#endif
+
 static __noinline char *
 __ultoa_invert(ultoa_unsigned_t val, char *str, int base)
 {
@@ -40,9 +155,12 @@ __ultoa_invert(ultoa_unsigned_t val, char *str, int base)
 	do {
 		char	v;
 
+#ifdef FANCY_DIVMOD
+                val = udivmod(val, base, &v);
+#else
                 v = val % base;
                 val /= base;
-
+#endif
 		if (v > 9)
                         v += hex;
                 v += '0';

--- a/test/meson.build
+++ b/test/meson.build
@@ -91,6 +91,23 @@ foreach target : targets
        depends: bios_bin,
        env: test_env)
 
+  t1 = 'printfi_scanfi'
+  if target == ''
+    t1_name = t1
+  else
+    t1_name = t1 + '_' + target
+  endif
+
+  test(t1_name,
+       executable(t1_name, ['printf_scanf.c', 'lock-valid.c'],
+		  c_args: int_printf_compile_args + _c_args,
+		  link_args: int_printf_link_args + _lib_files + _link_args,
+		  objects: _objs,
+		  link_depends:  _link_depends + _libs,
+		  include_directories: inc),
+       depends: bios_bin,
+       env: test_env)
+
   t1 = 'printf-tests'
   if target == ''
     t1_name = t1

--- a/test/meson.build
+++ b/test/meson.build
@@ -40,6 +40,11 @@ foreach target : targets
     _libs += [get_variable('lib_semihost' + target)]
   endif
 
+  _lib_files=[]
+  foreach _lib : _libs
+    _lib_files += _lib.full_path()
+  endforeach
+
   if is_variable('crt0_semihost' + target)
     _objs = [get_variable('crt0_semihost'+ target)]
   elif is_variable('crt0_hosted' + target)
@@ -62,10 +67,9 @@ foreach target : targets
   test(t1_name,
        executable(t1_name, ['printf_scanf.c', 'lock-valid.c'],
 		  c_args: double_printf_compile_args + _c_args,
-		  link_args: double_printf_link_args + _link_args,
+		  link_args: double_printf_link_args + _lib_files + _link_args,
 		  objects: _objs,
-		  link_with: _libs,
-		  link_depends:  _link_depends,
+		  link_depends:  _link_depends + _libs,
 		  include_directories: inc),
        depends: bios_bin,
        env: test_env)
@@ -80,10 +84,9 @@ foreach target : targets
   test(t1_name,
        executable(t1_name, ['printf_scanf.c', 'lock-valid.c'],
 		  c_args: float_printf_compile_args + _c_args,
-		  link_args: float_printf_link_args + _link_args,
+		  link_args: float_printf_link_args + _lib_files + _link_args,
 		  objects: _objs,
-		  link_with: _libs,
-		  link_depends:  _link_depends,
+		  link_depends:  _link_depends + _libs,
 		  include_directories: inc),
        depends: bios_bin,
        env: test_env)
@@ -98,9 +101,9 @@ foreach target : targets
   test(t1_name,
        executable(t1_name, ['printf-tests.c', 'lock-valid.c'],
 		  c_args: double_printf_compile_args + _c_args,
-		  link_args: double_printf_link_args + _link_args,
+		  link_args: double_printf_link_args + _lib_files + _link_args,
 		  objects: _objs,
-		  link_with: _libs,
+		  link_depends: _libs,
 		  include_directories: inc),
        depends: bios_bin,
        env: test_env)
@@ -115,9 +118,9 @@ foreach target : targets
   test(t1_name,
        executable(t1_name, ['printf-tests.c', 'lock-valid.c'],
 		  c_args: float_printf_compile_args + _c_args,
-		  link_args: float_printf_link_args + _link_args,
+		  link_args: float_printf_link_args + _lib_files + _link_args,
 		  objects: _objs,
-		  link_with: _libs,
+		  link_depends: _libs,
 		  include_directories: inc),
        depends: bios_bin,
        env: test_env)
@@ -132,9 +135,9 @@ foreach target : targets
   test(t1_name,
        executable(t1_name, ['printf-tests.c', 'lock-valid.c'],
 		  c_args: int_printf_compile_args + _c_args,
-		  link_args: int_printf_link_args + _link_args,
+		  link_args: int_printf_link_args + _lib_files + _link_args,
 		  objects: _objs,
-		  link_with: _libs,
+		  link_depends: _libs,
 		  include_directories: inc),
        depends: bios_bin,
        env: test_env)
@@ -156,9 +159,9 @@ foreach target : targets
   test(t1_name,
        executable(t1_name, ['time-sprintf.c', 'lock-valid.c'],
 		  c_args: int_printf_compile_args + _c_args + ['-fno-builtin'],
-		  link_args: int_printf_link_args + _link_args,
+		  link_args: int_printf_link_args + _lib_files + _link_args,
 		  objects: _objs,
-		  link_with: _libs,
+		  link_depends: _libs,
 		  include_directories: inc),
        depends: bios_bin,
        env: test_env)

--- a/test/printf_scanf.c
+++ b/test/printf_scanf.c
@@ -53,8 +53,12 @@
 # define printf_float(x) ((double) (x))
 #elif defined(TINY_STDIO)
 # ifdef PICOLIBC_INTEGER_PRINTF_SCANF
+#  define NO_FLOATING_POINT
 #  ifndef _WANT_IO_POS_ARGS
 #   define NO_POS_ARGS
+#  endif
+#  ifndef _WANT_IO_LONG_LONG
+#   define NO_LONG_LONG
 #  endif
 # endif
 # ifdef _WANT_IO_PERCENT_B
@@ -79,7 +83,7 @@ int (*_reference_scanf_float)() = _scanf_float;
 #endif
 #endif
 
-#if defined(TINY_STDIO) || !defined(NO_FLOATING_POINT)
+#if !defined(NO_FLOATING_POINT)
 static const double test_vals[] = { 1.234567, 1.1, M_PI };
 #endif
 
@@ -178,7 +182,7 @@ main(void)
         }
         wprintf(L"hello world %g\n", 1.0);
 
-#if defined(TINY_STDIO) || !defined(NO_FLOATING_POINT)
+#if !defined(NO_FLOATING_POINT)
 	sprintf(buf, "%g", printf_float(0.0f));
 	if (strcmp(buf, "0") != 0) {
 		printf("0: wanted \"0\" got \"%s\"\n", buf);
@@ -280,11 +284,11 @@ main(void)
 	CHECK_RT(unsigned short, "h");
         CHECK_RT(unsigned int, "");
         CHECK_RT(unsigned long, "l");
-#if defined(_WANT_IO_LONG_LONG) || defined(TINY_STDIO)
+#if defined(_WANT_IO_LONG_LONG)
         CHECK_RT(unsigned long long, "ll");
 #endif
 #ifndef _NANO_FORMATTED_IO
-#if !defined(_WANT_IO_LONG_LONG) && !defined(TINY_STDIO)
+#if !defined(_WANT_IO_LONG_LONG)
 	if (sizeof(intmax_t) <= sizeof(long))
 #endif
 	{
@@ -300,7 +304,7 @@ main(void)
             void *r = (void *) -1;
             VERIFY("", "p");
         }
-#if defined(TINY_STDIO) || !defined(NO_FLOATING_POINT)
+#if !defined(NO_FLOATING_POINT)
 #ifdef PICOLIBC_FLOAT_PRINTF_SCANF
 #define float_type float
 #define pow(a,b) powf((float) a, (float) b)


### PR DESCRIPTION
Provides custom divide+modulus code for use by printf on targets without hardware dividers. This custom code avoids requiring soft divide code, which can be useful if applications aren't otherwise using division of the relevant size.

For instance, arm targets do not have 64-bit division needed for decimal output when io-long-long is enabled.

The custom code uses the multiplication-by-reciprocal technique to approximate the division and then adjusts to provide an exact quotient and remainder.

This needs to be configured per-target but there isn't any convenient general-purpose tests available during the build. For now, there are examples which use architecture-specific preprocessor symbols on Arc, ARM and Risc-V to use the custom code on targets known to lack hardware division. For other architectures, the custom code will be enabled for 64-bit conversions on targets with sizeof(long) < 8.