### PR TITLE
libc/stdlib: Split assert helpers into separate files

### DIFF
--- a/newlib/libc/stdlib/CMakeLists.txt
+++ b/newlib/libc/stdlib/CMakeLists.txt
@@ -40,6 +40,8 @@ picolibc_sources(
   arc4random.c
   arc4random_uniform.c
   assert.c
+  assert_func.c
+  assert_no_arg.c
   atof.c
   atoff.c
   atoi.c

--- a/newlib/libc/stdlib/assert_func.c
+++ b/newlib/libc/stdlib/assert_func.c
@@ -51,11 +51,19 @@ Supporting OS subroutines required (only if enabled): <<close>>, <<fstat>>,
 #include <stdlib.h>
 #include <stdio.h>
 
+#ifndef _HAVE_ASSERT_FUNC
+/* func can be NULL, in which case no function information is given.  */
 void
-__assert (const char *failedexpr,
-	const char *file,
-	int line)
+__assert_func (const char *file,
+	int line,
+	const char *func,
+	const char *failedexpr)
 {
-   __assert_func (file, line, NULL, failedexpr);
+  fprintf(stderr,
+	   "assertion \"%s\" failed: file \"%s\", line %d%s%s\n",
+	   failedexpr, file, line,
+	   func ? ", function: " : "", func ? func : "");
+  abort();
   /* NOTREACHED */
 }
+#endif /* _HAVE_ASSERT_FUNC */

--- a/newlib/libc/stdlib/assert_no_arg.c
+++ b/newlib/libc/stdlib/assert_no_arg.c
@@ -52,10 +52,8 @@ Supporting OS subroutines required (only if enabled): <<close>>, <<fstat>>,
 #include <stdio.h>
 
 void
-__assert (const char *failedexpr,
-	const char *file,
-	int line)
+__assert_no_args  (void)
 {
-   __assert_func (file, line, NULL, failedexpr);
-  /* NOTREACHED */
+    fprintf(stderr, "assertion failed\n");
+    abort();
 }

--- a/newlib/libc/stdlib/meson.build
+++ b/newlib/libc/stdlib/meson.build
@@ -90,6 +90,8 @@ srcs_stdlib = [
     'arc4random.c',
     'arc4random_uniform.c',
     'assert.c',
+    'assert_func.c',
+    'assert_no_arg.c',
     'atof.c',
     'atoff.c',
     'atoi.c',


### PR DESCRIPTION
This avoids linking conflicts when applications define one of the helpers while picolibc uses another.