### PR TITLE
meson.build: get -mhwmult selection from GCC

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -565,12 +565,21 @@ endif
 # Let targets add more support libraries 
 additional_libs_list = meson.get_cross_property('additional_libs', [])
 
-if cc.get_id() == 'ccomp'
+compiler_id = cc.get_id()
+if compiler_id == 'ccomp'
   # When passing the specs file to CompCert, the libcompcert needs to be included there as well
   additional_libs_list += '-lcompcert'
 endif
 
 additional_libs = ' '.join(additional_libs_list)
+
+if compiler_id == 'gcc' and target_machine.cpu_family() == 'msp430'
+  # Extract -mhwmult-selection-snippet from GCC.
+  dumped_specs = run_command(cc.cmd_array() + '-dumpspecs').stdout()
+  hwmult_start = dumped_specs.split('%{mhwmult=auto')[1]
+  hwmult_snippet = '%{mhwmult=auto' + hwmult_start.split('-lc')[0]
+  additional_libs += hwmult_snippet
+endif
 
 specs_extra = ''
 specs_extra_list = meson.get_cross_property('specs_extra', [])

--- a/newlib/libc/picolib/machine/arm/read_tp.S
+++ b/newlib/libc/picolib/machine/arm/read_tp.S
@@ -51,7 +51,7 @@ __aeabi_read_tp:
 	.cfi_sections .debug_frame
 	.cfi_startproc
 #ifdef ARM_TLS_CP15
-	mrc 15, 0, r0, c13, c0, 3
+	mrc p15, 0, r0, c13, c0, 3
 #else
 	/* Load the address of __tls */
 	ldr r0,1f

--- a/newlib/libc/picolib/machine/arm/tls.c
+++ b/newlib/libc/picolib/machine/arm/tls.c
@@ -60,7 +60,7 @@ void
 _set_tls(void *tls)
 {
 #ifdef ARM_TLS_CP15
-	__asm__("mcr 15, 0, %0, cr13, cr0, 3" : : "r" (tls - TP_OFFSET));
+	__asm__("mcr p15, 0, %0, cr13, cr0, 3" : : "r" (tls - TP_OFFSET));
 #else
 	__tls = (uint8_t *) tls - TP_OFFSET;
 #endif

--- a/scripts/cross-msp430-unknown-elf.txt
+++ b/scripts/cross-msp430-unknown-elf.txt
@@ -18,7 +18,7 @@ endian = 'little'
 
 [properties]
 skip_sanity_check = true
-additional_libs = ['-lmul_none']
+libgcc = ['-lmul_none', '-lgcc']
 default_alignment = 2
 default_flash_addr  = '0x00010000'
 default_flash_size  = '0x000e0000'

--- a/scripts/cross-msp430.txt
+++ b/scripts/cross-msp430.txt
@@ -17,5 +17,5 @@ endian = 'little'
 
 [properties]
 skip_sanity_check = true
-additional_libs = ['-lmul_none']
+libgcc = ['-lmul_none', '-lgcc']
 default_alignment = 2


### PR DESCRIPTION
Query GCC for the snippet that selects the library corresponding to the -mhwmult parameter, and
splice that into picolibc.specs.

This makes the tests not link on msp430 since
they are linked with -nostartfiles, so add -lmul_none in the libgcc config option in scripts since that
is not propagated outside picolibc.