### PR TITLE
picolib/arm: Fix mrc/mcr coproc operand syntax

### DIFF
--- a/newlib/libc/picolib/machine/arm/read_tp.S
+++ b/newlib/libc/picolib/machine/arm/read_tp.S
@@ -51,7 +51,7 @@ __aeabi_read_tp:
 	.cfi_sections .debug_frame
 	.cfi_startproc
 #ifdef ARM_TLS_CP15
-	mrc 15, 0, r0, c13, c0, 3
+	mrc p15, 0, r0, c13, c0, 3
 #else
 	/* Load the address of __tls */
 	ldr r0,1f

--- a/newlib/libc/picolib/machine/arm/tls.c
+++ b/newlib/libc/picolib/machine/arm/tls.c
@@ -60,7 +60,7 @@ void
 _set_tls(void *tls)
 {
 #ifdef ARM_TLS_CP15
-	__asm__("mcr 15, 0, %0, cr13, cr0, 3" : : "r" (tls - TP_OFFSET));
+	__asm__("mcr p15, 0, %0, cr13, cr0, 3" : : "r" (tls - TP_OFFSET));
 #else
 	__tls = (uint8_t *) tls - TP_OFFSET;
 #endif


### PR DESCRIPTION
Hi,

Clang does not like the `mrc 15, ...` syntax - it allows only `mrc p15, ...`. GCC seems fine with it.

When compiling https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm for armv8r it errors with:
```
../../../../_deps/picolibc-src/newlib/libc/picolib/machine/arm/tls.c:63:10: error: invalid operand for instruction
   63 |         __asm__("mcr 15, 0, %0, cr13, cr0, 3" : : "r" (tls - TP_OFFSET));
      |                 ^
<inline asm>:1:6: note: instantiated into assembly here
    1 |         mcr 15, 0, r0, cr13, cr0, 3
      |             ^
```
and
```
../../../../_deps/picolibc-src/newlib/libc/picolib/machine/arm/read_tp.S:54:6: error: invalid operand for instruction
 mrc 15, 0, r0, c13, c0, 3
     ^
```

So I changed the operand to p15. I hope it's correct.