### PR TITLE
make boot_flash customizable from .ld file again

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1015,7 +1015,9 @@ foreach target : ['default-target'] + targets
     endif
 
     init_memory_template = '''
-        @0@ (rx!w) : ORIGIN = @1@, LENGTH = @2@
+	@0@ (rx!w) :
+		ORIGIN = DEFINED(__@0@) ? __@0@ : @1@,
+		LENGTH = DEFINED(__@0@_size) ? __@0@_size : @2@
 '''
     init_section_template = '''
         .@0@ : {

--- a/scripts/cross-msp430-unknown-elf.txt
+++ b/scripts/cross-msp430-unknown-elf.txt
@@ -26,10 +26,10 @@ default_ram_addr    = '0x00001c00'
 default_ram_size    = '0x00004000'
 default_stack_size  = '0x00000400'
 additional_sections = ['init', 'vector']
-default_init_addr = 'DEFINED(__init) ? __init : 0x00005c00'
-default_init_size = 'DEFINED(__init_size) ? __init_size : 0x0000a3c0'
+default_init_addr = '0x00005c00'
+default_init_size = '0x0000a3c0'
 default_init_contents = ['KEEP (*(.text.init.enter))', 'KEEP (*(.data.init.enter))', 'KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))']
 
-default_vector_addr = 'DEFINED(__vector) ? __vector : 0x0000ffc0'
-default_vector_size = 'DEFINED(__vector_size) ? __vector_size : 0x00000040'
+default_vector_addr = '0x0000ffc0'
+default_vector_size = '0x00000040'
 default_vector_contents = ['KEEP (*(.rodata.vector*))']


### PR DESCRIPTION
Make the generated link script honor the __boot_flash and __boot_flash_size variables as it does for e.g. __flash and __flash_size.