### PR TITLE
scripts: Silence warning about .got table when linking on aarch64

### DIFF
--- a/scripts/cross-aarch64-linux-gnu.txt
+++ b/scripts/cross-aarch64-linux-gnu.txt
@@ -20,7 +20,7 @@ endian = 'little'
 
 [properties]
 skip_sanity_check = true
-link_spec = '--build-id=none'
+link_spec = '--build-id=none --no-warn-rwx-segments'
 specs_extra = ['*libgcc:', '-lgcc']
 default_flash_addr = '0x40000000'
 default_flash_size = '0x00400000'


### PR DESCRIPTION
The .got table gets marked as writable but doesn't need to be. We want to stick it in read-only memory along with executable bits so the linker ends up warning about the unified segment being marked RWX. Silence the linker warning as I can't figure out how to fix it for real.