### PR TITLE
scripts: Enable test-stdin on m68k and nios2

### DIFF
--- a/scripts/do-m68k-configure
+++ b/scripts/do-m68k-configure
@@ -33,4 +33,4 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-exec "$(dirname "$0")"/do-configure m68k-linux-gnu -Dtests=true -Dposix-console=true -Dmultilib=false "$@"
+exec "$(dirname "$0")"/do-configure m68k-linux-gnu -Dtests=true -Dposix-console=true -Dmultilib=false -Dtest-stdin=true "$@"

--- a/scripts/do-m68k-unknown-elf-configure
+++ b/scripts/do-m68k-unknown-elf-configure
@@ -33,4 +33,4 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-exec "$(dirname "$0")"/do-configure m68k-unknown-elf -Dtests=true -Dposix-console=true "$@"
+exec "$(dirname "$0")"/do-configure m68k-unknown-elf -Dtests=true -Dposix-console=true -Dtest-stdin=true "$@"

--- a/scripts/do-nios2-configure
+++ b/scripts/do-nios2-configure
@@ -34,4 +34,4 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 multilib_list='.,nomul,mulx'
-exec "$(dirname "$0")"/do-configure nios2-zephyr-elf -Dposix-console=true -Dtests=true -Dmultilib-list="$multilib_list" "$@"
+exec "$(dirname "$0")"/do-configure nios2-zephyr-elf -Dposix-console=true -Dtests=true -Dmultilib-list="$multilib_list" -Dtest-stdin=true "$@"

--- a/scripts/run-arm
+++ b/scripts/run-arm
@@ -249,8 +249,11 @@ serial=none
 
 export QEMU_AUDIO_DRV=none
 
-# shellcheck disable=SC2086
-echo "$input" | "$qemu" $memory \
+input_file=`mktemp`
+trap 'rm "$input_file"' 0
+echo "$input" > "$input_file"
+
+"$qemu" $memory \
       -chardev "$chardev" \
       -semihosting-config "$semi" \
       -monitor "$mon" \
@@ -259,7 +262,7 @@ echo "$input" | "$qemu" $memory \
       -cpu "$cpu" \
       -device loader,file="$elf",cpu-num=0 \
       -nographic \
-      "$@"
+      "$@" < $input_file 
 
 result=$?
 

--- a/scripts/run-m68k
+++ b/scripts/run-m68k
@@ -44,24 +44,35 @@ qemu="qemu-system-m68k"
 
 # Point the semihosting driver at our new chardev
 
-semi=enable=on,chardev=stdio0
-
+cmdline="program-name"
 input=""
+done=0
 
-case "$1" in
-    --)
-	semi="$semi",arg="$2"
-	shift
-	shift
-	;;
-    -*|"")
-	;;
-    *)
-	semi="$semi",arg="$1"
-	input="$1"
-	shift
-	;;
-esac
+while [ "$done" != "1" ]; do
+    case "$1" in
+        --)
+            shift
+            done=1
+            ;;
+        -s|"")
+            done=1
+            ;;
+        *)
+            cmdline="$cmdline $1"
+            case "$input" in
+                "")
+                    input="$1"
+                    ;;
+                *)
+                    input="$input $1"
+                    ;;
+            esac
+            shift
+            ;;
+    esac
+done
+
+semi=enable=on,chardev=stdio0,arg="$cmdline"
 
 case "$elf" in
     *_softfp)

--- a/scripts/run-nios2
+++ b/scripts/run-nios2
@@ -44,24 +44,35 @@ qemu="qemu-system-nios2"
 
 # Point the semihosting driver at our new chardev
 
-semi=enable=on,chardev=stdio0
-
+cmdline="program-name"
 input=""
+done=0
 
-case "$1" in
-    --)
-	semi="$semi",arg="$2"
-	shift
-	shift
-	;;
-    -*|"")
-	;;
-    *)
-	semi="$semi",arg="$1"
-	input="$1"
-	shift
-	;;
-esac
+while [ "$done" != "1" ]; do
+    case "$1" in
+        --)
+            shift
+            done=1
+            ;;
+        -s|"")
+            done=1
+            ;;
+        *)
+            cmdline="$cmdline $1"
+            case "$input" in
+                "")
+                    input="$1"
+                    ;;
+                *)
+                    input="$input $1"
+                    ;;
+            esac
+            shift
+            ;;
+    esac
+done
+
+semi=enable=on,chardev=stdio0,arg="$cmdline"
 
 # Disable monitor
 

--- a/semihost/machine/m68k/m68k_read.c
+++ b/semihost/machine/m68k/m68k_read.c
@@ -44,5 +44,13 @@
 ssize_t
 read(int fd, void *buf, size_t count)
 {
-    return m68k_semihost3(HOSTED_READ, fd, (uintptr_t) buf, count);
+    ssize_t ret;
+
+    /* stdin is nonblocking and returns 0 if nothing is available.
+     * spin waiting for input.
+     */
+    do {
+        ret = m68k_semihost3(HOSTED_READ, fd, (uintptr_t) buf, count);
+    } while (fd == 0 && ret == 0);
+    return ret;
 }

--- a/semihost/machine/nios2/nios2_read.c
+++ b/semihost/machine/nios2/nios2_read.c
@@ -44,5 +44,13 @@
 ssize_t
 read(int fd, void *buf, size_t count)
 {
-    return nios2_semihost3(HOSTED_READ, fd, (uintptr_t) buf, count);
+    ssize_t ret;
+
+    /* stdin is nonblocking and returns 0 if nothing is available.
+     * spin waiting for input.
+     */
+    do {
+        ret = nios2_semihost3(HOSTED_READ, fd, (uintptr_t) buf, count);
+    } while (fd == 0 && ret == 0);
+    return ret;
 }


### PR DESCRIPTION
The semihosting support for both of these can support stdio testing.