### PR TITLE
semihost: Always perform fd remapping for semihost console

### DIFF
--- a/semihost/CMakeLists.txt
+++ b/semihost/CMakeLists.txt
@@ -52,6 +52,7 @@ target_sources(semihost PRIVATE
   kill.c
   lseek.c
   lseek64.c
+  mapstdio.c
   open.c
   read.c
   unlink.c

--- a/semihost/close.c
+++ b/semihost/close.c
@@ -42,5 +42,7 @@
 int
 close(int fd)
 {
+        if (fd <= 2)
+                return 0;
 	return (int) sys_semihost_close(fd);
 }

--- a/semihost/fstat.c
+++ b/semihost/fstat.c
@@ -47,7 +47,14 @@ struct timeval __semihost_write_time, __semihost_creat_time;
 int
 fstat (int fd, struct stat *sbuf )
 {
-	int size = sys_semihost_flen(fd);
+        fd = _map_stdio(fd);
+
+	int size;
+
+        if (fd > 0)
+                size = sys_semihost_flen(fd);
+        else
+                size = -1;
 
 	if (size > 0) {
 		sbuf->st_size = size;

--- a/semihost/isatty.c
+++ b/semihost/isatty.c
@@ -44,6 +44,11 @@
 int
 isatty (int fd)
 {
+        fd = _map_stdio(fd);
+
+        if (fd < 0)
+                return 1;
+
 	int size = sys_semihost_flen(fd);
 
 	return size <= 0;

--- a/semihost/lseek.c
+++ b/semihost/lseek.c
@@ -53,7 +53,9 @@ off_t lseek(int fd, off_t offset, int whence)
 		}
 	}
 
-	if (whence != SEEK_SET) {
+        fd = _map_stdio(fd);
+
+	if (whence != SEEK_SET || fd < 0) {
 		errno = EINVAL;
 		return (off_t) -1;
 	}

--- a/semihost/mapstdio.c
+++ b/semihost/mapstdio.c
@@ -54,6 +54,8 @@ _map_stdio(int fd)
 		fd_stderr = sys_semihost_open(":tt", 8);
 	}
 	switch (fd) {
+        case 0:
+                return -1;
 	case 1:
 		return fd_stdout;
 	case 2:

--- a/semihost/meson.build
+++ b/semihost/meson.build
@@ -57,6 +57,7 @@ if src_semihost != []
     'kill.c',
     'lseek.c',
     'lseek64.c',
+    'mapstdio.c',
     'open.c',
     'read.c',
     'sysconf.c',
@@ -92,8 +93,6 @@ if src_semihost != []
 
   if tinystdio
     src_semihost += 'iob.c'
-  else
-    src_semihost += 'mapstdio.c'
   endif
 
   install_headers('semihost.h',

--- a/semihost/open.c
+++ b/semihost/open.c
@@ -74,15 +74,13 @@ open(const char *pathname, int flags, ...)
 		break;
 	}
 
+        /* Make sure any stdout/stderr fds are allocated first */
+        (void) _map_stdio(0);
 	int ret;
 	do {
 		ret = sys_semihost_open(pathname, semiflags);
 	}
-#ifdef TINY_STDIO
-	while(0);
-#else
 	while (0 <= ret && ret <= 2);
-#endif
 	if (ret == -1)
 		errno = sys_semihost_errno();
         else if (&__semihost_creat_time && gettimeofday)

--- a/semihost/read.c
+++ b/semihost/read.c
@@ -44,14 +44,12 @@
 ssize_t
 read(int fd, void *buf, size_t count)
 {
-#ifndef TINY_STDIO
         if (fd == 0) {
                 int ch = sys_semihost_getc((FILE *) 0);
                 *(char *) buf = ch;
                 return 1;
         }
 	fd = _map_stdio(fd);
-#endif
 	uintptr_t ret = sys_semihost_read(fd, buf, count);
 
 	ssize_t got = count - (ssize_t) ret;

--- a/semihost/semihost-private.h
+++ b/semihost/semihost-private.h
@@ -77,7 +77,5 @@ typedef uintptr_t sh_param_t;
 uintptr_t
 sys_semihost(uintptr_t op, uintptr_t param);
 
-#ifndef TINY_STDIO
 int
 _map_stdio(int fd);
-#endif

--- a/semihost/write.c
+++ b/semihost/write.c
@@ -47,9 +47,7 @@ int gettimeofday(struct timeval *restrict tv, void *restrict tz) _ATTRIBUTE((__w
 ssize_t
 write(int fd, const void *buf, size_t count)
 {
-#ifndef TINY_STDIO
 	fd = _map_stdio(fd);
-#endif
 	uintptr_t ret = sys_semihost_write(fd, buf, count);
 
         if (&__semihost_write_time && gettimeofday)


### PR DESCRIPTION
Reserve fds 0-2 for stdin/stdout/stderr, remapping 1 and 2 to the relevant semihosting console files and simulating the relevant operations on fd 0 (semihosting doesn't support console stdin with the fd-based APIs).

This allows use of the posix-console option without requiring any special code in the semihost library.

Closes: #624 