### PR TITLE
scripts: Give up on test-stdin

### DIFF
--- a/scripts/do-arc-configure
+++ b/scripts/do-arc-configure
@@ -34,4 +34,4 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 multilib_list="arcem,archs,em"
-exec "$(dirname "$0")"/do-configure arc-zephyr-elf -Dtest-stdin=true -Dposix-console=true -Dtests=true -Dthread-local-storage=false -Dmultilib-list="$multilib_list" "$@"
+exec "$(dirname "$0")"/do-configure arc-zephyr-elf -Dposix-console=true -Dtests=true -Dthread-local-storage=false -Dmultilib-list="$multilib_list" "$@"

--- a/scripts/do-arc64-configure
+++ b/scripts/do-arc64-configure
@@ -37,6 +37,5 @@ multilib_list="fpus,hs58,hs5x,m128"
 exec "$(dirname "$0")"/do-configure arc64-zephyr-elf \
     -Dposix-console=true \
     -Dtests=true \
-    -Dtest-stdin=true \
     -Dthread-local-storage=false \
     -Dmultilib-list="$multilib_list" "$@"

--- a/scripts/do-arm-configure
+++ b/scripts/do-arm-configure
@@ -33,4 +33,4 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-exec "$(dirname "$0")"/do-configure arm-none-eabi -Dtests=true -Dtest-stdin=true "$@"
+exec "$(dirname "$0")"/do-configure arm-none-eabi -Dtests=true "$@"

--- a/scripts/do-m68k-configure
+++ b/scripts/do-m68k-configure
@@ -33,4 +33,4 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-exec "$(dirname "$0")"/do-configure m68k-linux-gnu -Dtests=true -Dposix-console=true -Dmultilib=false -Dtest-stdin=true "$@"
+exec "$(dirname "$0")"/do-configure m68k-linux-gnu -Dtests=true -Dposix-console=true -Dmultilib=false "$@"

--- a/scripts/do-m68k-unknown-elf-configure
+++ b/scripts/do-m68k-unknown-elf-configure
@@ -33,4 +33,4 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-exec "$(dirname "$0")"/do-configure m68k-unknown-elf -Dtests=true -Dposix-console=true -Dtest-stdin=true "$@"
+exec "$(dirname "$0")"/do-configure m68k-unknown-elf -Dtests=true -Dposix-console=true "$@"

--- a/scripts/do-nios2-configure
+++ b/scripts/do-nios2-configure
@@ -34,4 +34,4 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 multilib_list='.,nomul,mulx'
-exec "$(dirname "$0")"/do-configure nios2-zephyr-elf -Dposix-console=true -Dtests=true -Dmultilib-list="$multilib_list" -Dtest-stdin=true "$@"
+exec "$(dirname "$0")"/do-configure nios2-zephyr-elf -Dposix-console=true -Dtests=true -Dmultilib-list="$multilib_list" "$@"

--- a/scripts/do-riscv-configure
+++ b/scripts/do-riscv-configure
@@ -33,4 +33,4 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-exec "$(dirname "$0")"/do-configure riscv64-unknown-elf -Dtests=true -Dtest-stdin=true "$@"
+exec "$(dirname "$0")"/do-configure riscv64-unknown-elf -Dtests=true "$@"


### PR DESCRIPTION
This is causing too many random failures in CI because qemu has bugs in stdin handling.