### PR TITLE
picolibc.ld.in: use separate sections for .rodata and .data.rel.ro

### DIFF
--- a/picolibc.ld.in
+++ b/picolibc.ld.in
@@ -75,7 +75,9 @@ SECTIONS
 		PROVIDE (__etext = __text_end);
 		PROVIDE (_etext = __text_end);
 		PROVIDE (etext = __text_end);
+	} >flash AT>flash :text
 
+	.rodata : {
 		/* read-only data */
 		*(.rdata)
 		*(.rodata .rodata.*)
@@ -86,6 +88,9 @@ SECTIONS
 		*(.srodata.cst4)
 		*(.srodata.cst2)
 		*(.srodata .srodata.*)
+	} >flash AT>flash :text
+
+	.data.rel.ro : {
 		*(.data.rel.ro .data.rel.ro.*)
 
 		/* Need to pre-align so that the symbols come after padding */


### PR DESCRIPTION
Having these be separate makes it easier to look at binary and see which sections contribute to total binary size. Additionally, it would allow for a correct PT_GNU_RELRO if picolibc.ld were to grow PIC support in the future.

This should not have any effect on the final binary layout, it only adds two more ELF section headers.