### PR TITLE
Adjust RISC-V crt0 _trap to enable GDB backtraces

### DIFF
--- a/picocrt/machine/riscv/crt0.c
+++ b/picocrt/machine/riscv/crt0.c
@@ -161,7 +161,7 @@ _trap(void)
                 "csrw	mstatus, t0\n"
                 "csrwi	fcsr, 0");
 #endif
-        __asm__("j      _ctrap");
+        __asm__("jal    _ctrap");
 }
 #endif
 

--- a/picocrt/machine/riscv/crt0.c
+++ b/picocrt/machine/riscv/crt0.c
@@ -104,7 +104,7 @@ _trap(void)
 	__asm__(".option	push\n"
                 ".option	norelax\n"
                 "csrrw  sp, mscratch, sp\n"
-                "la	sp, __stack\n"
+                "la	sp, __heap_end\n"
                 ".option	pop");
 
         /* Make space for saved registers */


### PR DESCRIPTION
I was debugging a misaligned load error and noticed that setting a breakpoint in _ctrap (using the QEMU gdb stub) did not work as expected due to missing/incorrect unwind info. This pull request updates the _trap function such that setting a breakpoint in _ctrap prints a backtrace that points to the actual bad instruction.

To test this I added `__builtin_trap()` to fclose() and ran the test-fopen test.

```
$ gdb -q test/test-fopen '-ex=b _ctrap' '-ex=target remote :1234' -ex=c -ex=bt
Reading symbols from test/test-fopen...
Breakpoint 1 at 0x80000058: file ../../picolibc/picocrt/machine/riscv/crt0.c, line 84.
Remote debugging using :1234
0x0000000000001000 in ?? ()
Continuing.

Breakpoint 1, _ctrap (fault=0x805feee8) at ../../picolibc/picocrt/machine/riscv/crt0.c:84
84              printf("RISCV fault\n");
#0  _ctrap (fault=0x805feee8) at ../../picolibc/picocrt/machine/riscv/crt0.c:84
#1  0x00000000800001c4 in _trap () at ../../picolibc/picocrt/machine/riscv/crt0.c:168
#2  0x00000000800013d0 in fclose (f=0x804008c0) at ../../picolibc/newlib/libc/tinystdio/fclose.c:39
#3  0x0000000080000680 in main () at ../../picolibc/test/test-fopen.c:85
(gdb)
```