### PR TITLE
fix specs file in case picocrt disabled

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -729,6 +729,10 @@ endif
 specs_startfile = specs_option_format.format(crt0_prefix, crt0_buildtype, crt0_gen)
 endif
 
+if not enable_picocrt
+  specs_startfile = ''
+endif
+
 specs_data = configuration_data()
 specs_data.set('SPECS_ISYSTEM', specs_isystem)
 specs_data.set('SPECS_LIBPATH', specs_libpath)


### PR DESCRIPTION
In case picocrt is disabled I observe a linking error:

```
......./picolibc/xtensa-esp-elf/lib/esp32/no-rtti/crt0.o: No such file or directory
```