### PR TITLE
newlib: libc: setenv should consider empty string invalid

### DIFF
--- a/newlib/libc/stdlib/setenv.c
+++ b/newlib/libc/stdlib/setenv.c
@@ -47,9 +47,10 @@ setenv (const char *name,
   size_t l_value;
   int offset;
 
-  if (strchr(name, '='))
+  /* Name cannot be NULL, empty, or contain an equal sign.  */ 
+  if (name == NULL || name[0] == '\0' || strchr(name, '='))
     {
-	    __errno_r(ptr) = EINVAL;
+      errno = EINVAL;
       return -1;
     }
 


### PR DESCRIPTION
According to POSIX, an empty string should be considered as an invalid name for environment variables, and the implementations should return -1 and set errno to EINVAL.

https://pubs.opengroup.org/onlinepubs/9699919799/functions/setenv.html

However, both picolibc and newlib support this currently in setenv. Perhaps it is underspecified in the ISO C standard. Otherwise it is not really clear to me if this is a feature or a bug.

Recycling the existing pattern from unsetenv(), this should work appropriately

Closes: #648 