### PR TITLE
libc/stdio: Fix some legacy stdio build options

### DIFF
--- a/newlib/libc/include/sys/_types.h
+++ b/newlib/libc/include/sys/_types.h
@@ -64,6 +64,7 @@ typedef __WINT_TYPE__ wint_t;
 
 #ifndef __machine_blkcnt_t_defined
 typedef long __blkcnt_t;
+typedef __int64_t __blkcnt64_t;
 #endif
 
 #ifndef __machine_blksize_t_defined
@@ -122,6 +123,7 @@ typedef unsigned long __ino_t;
 #else
 typedef unsigned short __ino_t;
 #endif
+typedef __uint64_t      __ino64_t;
 #endif
 
 #ifndef __machine_mode_t_defined
@@ -148,6 +150,7 @@ __extension__ typedef long long _off64_t;
 typedef _off64_t __off_t;
 #else
 typedef _off_t __off_t;
+typedef __uint64_t __off64_t;
 #endif
 
 typedef _off64_t __loff_t;

--- a/newlib/libc/include/sys/stat.h
+++ b/newlib/libc/include/sys/stat.h
@@ -107,6 +107,57 @@ struct	stat
 #endif
 };
 
+struct stat64
+{
+  __dev_t st_dev;		/* Device.  */
+#  ifdef __x86_64__
+  __ino64_t st_ino;		/* File serial number.  */
+  __nlink_t st_nlink;		/* Link count.  */
+  __mode_t st_mode;		/* File mode.  */
+#  else
+  unsigned int __pad1;
+  __ino_t __st_ino;			/* 32bit file serial number.	*/
+  __mode_t st_mode;			/* File mode.  */
+  __nlink_t st_nlink;			/* Link count.  */
+#  endif
+  __uid_t st_uid;		/* User ID of the file's owner.	*/
+  __gid_t st_gid;		/* Group ID of the file's group.*/
+#  ifdef __x86_64__
+  int __pad0;
+  __dev_t st_rdev;		/* Device number, if device.  */
+  __off_t st_size;		/* Size of file, in bytes.  */
+#  else
+  __dev_t st_rdev;			/* Device number, if device.  */
+  unsigned int __pad2;
+  __off64_t st_size;			/* Size of file, in bytes.  */
+#  endif
+  __blksize_t st_blksize;	/* Optimal block size for I/O.  */
+  __blkcnt64_t st_blocks;	/* Nr. 512-byte blocks allocated.  */
+#if defined(__svr4__) && !defined(__PPC__) && !defined(__sun__)
+  __time_t st_atime;			/* Time of last access.  */
+  __syscall_ulong_t st_atimensec;	/* Nscecs of last access.  */
+  __time_t st_mtime;			/* Time of last modification.  */
+  __syscall_ulong_t st_mtimensec;	/* Nsecs of last modification.  */
+  __time_t st_ctime;			/* Time of last status change.  */
+  __syscall_ulong_t st_ctimensec;	/* Nsecs of last status change.  */
+#else
+  /* Nanosecond resolution timestamps are stored in a format
+     equivalent to 'struct timespec'.  This is the type used
+     whenever possible but the Unix namespace rules do not allow the
+     identifier 'timespec' to appear in the <sys/stat.h> header.
+     Therefore we have to handle the use of this header in strictly
+     standard-compliant sources special.  */
+  struct timespec st_atim;		/* Time of last access.  */
+  struct timespec st_mtim;		/* Time of last modification.  */
+  struct timespec st_ctim;		/* Time of last status change.  */
+#  endif
+#  ifdef __x86_64__
+  __int64_t __glibc_reserved[3];
+#  else
+  __ino64_t st_ino;			/* File serial number.		*/
+#  endif
+};
+
 #if !(defined(__svr4__) && !defined(__PPC__) && !defined(__sun__))
 #define st_atime st_atim.tv_sec
 #define st_ctime st_ctim.tv_sec

--- a/newlib/libc/stdio/fseeko.c
+++ b/newlib/libc/stdio/fseeko.c
@@ -248,7 +248,7 @@ fseeko (
 	curoff = fp->_offset;
       else
 	{
-	  curoff = seekfn (ptr, fp->_cookie, 0L, SEEK_CUR);
+	  curoff = seekfn (fp->_cookie, 0L, SEEK_CUR);
 	  if (curoff == POS_ERR)
 	    goto dumb;
 	}
@@ -284,7 +284,7 @@ fseeko (
    * and return.
    */
 
-  if (target >= curoff && target < curoff + n)
+  if (target >= curoff && (size_t) target < (size_t) curoff + n)
     {
       register int o = target - curoff;
 
@@ -308,7 +308,7 @@ fseeko (
    */
 
   curoff = target & ~(fp->_blksize - 1);
-  if (seekfn (ptr, fp->_cookie, curoff, SEEK_SET) == POS_ERR)
+  if (seekfn (fp->_cookie, curoff, SEEK_SET) == POS_ERR)
     goto dumb;
   fp->_r = 0;
   fp->_p = fp->_bf._base;
@@ -318,7 +318,7 @@ fseeko (
   n = target - curoff;
   if (n)
     {
-      if (_srefill ( fp) || fp->_r < n)
+      if (_srefill ( fp) || fp->_r < (int) n)
 	goto dumb;
       fp->_p += n;
       fp->_r -= n;

--- a/newlib/libc/stdio64/fseeko64.c
+++ b/newlib/libc/stdio64/fseeko64.c
@@ -208,7 +208,7 @@ fseeko64 (
       struct stat64 st;
       if (seekfn != __sseek64
 	  || fp->_file < 0
-	  || _fstat64_r (ptr, fp->_file, &st)
+	  || _fstat64 (fp->_file, &st)
 	  || (st.st_mode & S_IFMT) != S_IFREG)
 	{
 	  fp->_flags |= __SNPT;
@@ -231,7 +231,8 @@ fseeko64 (
     target = offset;
   else
     {
-      if (_fstat64_r (ptr, fp->_file, &st))
+      struct stat64 st;
+      if (_fstat64 (fp->_file, &st))
 	goto dumb;
       target = st.st_size + offset;
     }
@@ -242,7 +243,7 @@ fseeko64 (
 	curoff = fp->_offset;
       else
 	{
-	  curoff = seekfn (ptr, fp->_cookie, (_fpos64_t)0, SEEK_CUR);
+	  curoff = seekfn (fp->_cookie, (_fpos64_t)0, SEEK_CUR);
 	  if (curoff == POS_ERR)
 	    goto dumb;
 	}
@@ -278,7 +279,7 @@ fseeko64 (
    * and return.
    */
 
-  if (target >= curoff && target < curoff + n)
+  if (target >= curoff && (size_t) target < (size_t) curoff + n)
     {
       register int o = target - curoff;
 
@@ -301,7 +302,7 @@ fseeko64 (
    */
 
   curoff = target & ~((_fpos64_t)(fp->_blksize - 1));
-  if (seekfn (ptr, fp->_cookie, curoff, SEEK_SET) == POS_ERR)
+  if (seekfn (fp->_cookie, curoff, SEEK_SET) == POS_ERR)
     goto dumb;
   fp->_r = 0;
   fp->_p = fp->_bf._base;
@@ -311,7 +312,7 @@ fseeko64 (
   n = target - curoff;
   if (n)
     {
-      if (__srefill_r (ptr, fp) || fp->_r < n)
+      if (_srefill (fp) || fp->_r < (int) n)
 	goto dumb;
       fp->_p += n;
       fp->_r -= n;


### PR DESCRIPTION
Building the legacy stdio code with fseek optimizations was broken on anything other than Cygwin because nothing else defined 'struct stat64'.

There were also numerous signed/unsigned conversion issues. This now builds and passes the tests I've managed to run.

Closes: #652