### PR TITLE
tinystdio: Remove ctype.h includes

### DIFF
--- a/newlib/libc/tinystdio/atod_ryu.c
+++ b/newlib/libc/tinystdio/atod_ryu.c
@@ -19,7 +19,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <ctype.h>
 
 #ifdef RYU_DEBUG
 #include <inttypes.h>

--- a/newlib/libc/tinystdio/strtod.c
+++ b/newlib/libc/tinystdio/strtod.c
@@ -31,7 +31,6 @@
 /* $Id: strtod.c 2191 2010-11-05 13:45:57Z arcanum $ */
 
 
-#include <ctype.h>
 #include <errno.h>
 #include <limits.h>
 #include <math.h>		/* INFINITY, NAN		*/

--- a/newlib/libc/tinystdio/strtof.c
+++ b/newlib/libc/tinystdio/strtof.c
@@ -30,7 +30,6 @@
 
 /* $Id: strtof.c 2191 2010-11-05 13:45:57Z arcanum $ */
 
-#include <ctype.h>
 #include <errno.h>
 #include <limits.h>
 #include <math.h>		/* INFINITY, NAN		*/

--- a/newlib/libc/tinystdio/strtoi.h
+++ b/newlib/libc/tinystdio/strtoi.h
@@ -30,7 +30,6 @@
   POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <ctype.h>
 #include <limits.h>
 #include <math.h>
 #include <stdarg.h>

--- a/newlib/libc/tinystdio/strtold.c
+++ b/newlib/libc/tinystdio/strtold.c
@@ -31,7 +31,6 @@
 /* $Id: strtod.c 2191 2010-11-05 13:45:57Z arcanum $ */
 
 
-#include <ctype.h>
 #include <errno.h>
 #include <limits.h>
 #include <math.h>		/* INFINITY, NAN		*/

--- a/newlib/libc/tinystdio/vfscanf.c
+++ b/newlib/libc/tinystdio/vfscanf.c
@@ -32,7 +32,6 @@
 
 /* $Id: vfscanf.c 2191 2010-11-05 13:45:57Z arcanum $ */
 
-#include <ctype.h>
 #include <limits.h>
 #include <math.h>
 #include <stdarg.h>


### PR DESCRIPTION
None of the tinystdio code actually uses ctype, so remove the includes.