### PR TITLE
posix: Change "INFINITY" constant in regex code to REGEX_INFINITY

### DIFF
--- a/newlib/libc/posix/regcomp.c
+++ b/newlib/libc/posix/regcomp.c
@@ -460,7 +460,7 @@ p_ere_exp(struct parse *p)
 				count2 = p_count(p);
 				(void)REQUIRE(count <= count2, REG_BADBR);
 			} else		/* single number with comma */
-				count2 = INFINITY;
+				count2 = REGEX_INFINITY;
 		} else		/* just a single number */
 			count2 = count;
 		repeat(p, pos, count, count2);
@@ -635,7 +635,7 @@ p_simp_re(struct parse *p,
 				count2 = p_count(p);
 				(void)REQUIRE(count <= count2, REG_BADBR);
 			} else		/* single number with comma */
-				count2 = INFINITY;
+				count2 = REGEX_INFINITY;
 		} else		/* just a single number */
 			count2 = count;
 		repeat(p, pos, count, count2);
@@ -1075,13 +1075,13 @@ static void
 repeat(struct parse *p,
        sopno start,		/* operand from here to end of strip */
        int from,		/* repeated from this number */
-       int to)		        /* to this number of times (maybe INFINITY) */
+       int to)		        /* to this number of times (maybe REGEX_INFINITY) */
 {
 	sopno finish = HERE();
 #	define	N	2
 #	define	INF	3
 #	define	REP(f, t)	((f)*8 + (t))
-#	define	MAP(n)	(((n) <= 1) ? (n) : ((n) == INFINITY) ? INF : N)
+#	define	MAP(n)	(((n) <= 1) ? (n) : ((n) == REGEX_INFINITY) ? INF : N)
 	sopno copy;
 
 	if (p->error != 0)	/* head off possible runaway recursion */

--- a/newlib/libc/posix/utils.h
+++ b/newlib/libc/posix/utils.h
@@ -36,7 +36,7 @@
 
 /* utility definitions */
 #define	DUPMAX		_POSIX2_RE_DUP_MAX	/* xxx is this right? */
-#define	INFINITY	(DUPMAX + 1)
+#define	REGEX_INFINITY	(DUPMAX + 1)
 #define	NC		(CHAR_MAX - CHAR_MIN + 1)
 typedef unsigned char uch;
 

--- a/zephyr/zephyr.cmake
+++ b/zephyr/zephyr.cmake
@@ -93,8 +93,6 @@ if(CONFIG_PICOLIBC_USE_MODULE)
 
   # Enable POSIX APIs
 
-  zephyr_compile_options(-D_POSIX_C_SOURCE=200809)
-
   # Link to C library and libgcc (on non-armclang toolchains)
 
   if(${ZEPHYR_TOOLCHAIN_VARIANT} STREQUAL "armclang")


### PR DESCRIPTION
Avoid using the math symbol in case that has gotten included somehow.

Closes: #647 