### PR TITLE
sys/features.h: Check _POSIX_C_SOURCE before defining _ZEPHYR_SOURCE

### DIFF
--- a/newlib/libc/include/sys/features.h
+++ b/newlib/libc/include/sys/features.h
@@ -133,11 +133,11 @@ extern "C" {
 
 /* When building for Zephyr, set _ZEPHYR_SOURCE unless some other API
  * indicator is set by the application. Don't check __STRICT_ANSI__ as that
- * is set by the compiler for -std=cxx, or _POSIX_C_SOURCE as Zephyr defines
- * that for picolibc currently.
+ * is set by the compiler for -std=cxx.
  */
 
 #if defined(__ZEPHYR__) && !defined(_ZEPHYR_SOURCE) &&                  \
+    !defined(_POSIX_C_SOURCE) &&                                        \
     !defined(_GNU_SOURCE)&&                                             \
     !defined(_BSD_SOURCE) &&                                            \
     !defined(_SVID_SOURCE) &&                                           \


### PR DESCRIPTION
Add the missing check for _POSIX_C_SOURCE prior to defining _ZEPHYR_SOURCE.

This may have been missed in 1c80a6706.