### PR TITLE
give isblank external linkage

### DIFF
--- a/newlib/libc/ctype/isblank.c
+++ b/newlib/libc/ctype/isblank.c
@@ -36,7 +36,6 @@ PORTABILITY
 No supporting OS subroutines are required.
 */
 
-#define _DEFINING_ISBLANK
 #include <_ansi.h>
 #include <ctype.h>
 

--- a/newlib/libc/include/ctype.h
+++ b/newlib/libc/include/ctype.h
@@ -58,14 +58,8 @@ int isxdigit (int __c);
 int tolower (int __c);
 int toupper (int __c);
 
-#if  __ISO_C_VISIBLE >= 1999
-#ifdef _DEFINING_ISBLANK
+#if __ISO_C_VISIBLE >= 1999
 int isblank(int c);
-#else
-static __inline int isblank(int c) {
-	return c == ' ' || c == '\t';
-}
-#endif
 #endif
 
 #if __MISC_VISIBLE || __XSI_VISIBLE


### PR DESCRIPTION
External linkage is required by C11. Not conforming to this results in issues in implementation of C++ modules. [1]

[1] https://github.com/llvm/llvm-project/issues/76980