### PR TITLE
cdefs.h: Create __define_extern_inline to unify uses of gnu_inline

### DIFF
--- a/newlib/libc/ctype/isblank.c
+++ b/newlib/libc/ctype/isblank.c
@@ -36,7 +36,6 @@ PORTABILITY
 No supporting OS subroutines are required.
 */
 
-#define _DEFINING_ISBLANK
 #include <_ansi.h>
 #include <ctype.h>
 

--- a/newlib/libc/include/ctype.h
+++ b/newlib/libc/include/ctype.h
@@ -58,11 +58,10 @@ int isxdigit (int __c);
 int tolower (int __c);
 int toupper (int __c);
 
-#if  __ISO_C_VISIBLE >= 1999
-#ifdef _DEFINING_ISBLANK
-int isblank(int c);
-#else
-static __inline int isblank(int c) {
+#if __ISO_C_VISIBLE >= 1999
+int isblank (int __c);
+#ifdef __declare_extern_inline
+__declare_extern_inline(int) isblank(int c) {
 	return c == ' ' || c == '\t';
 }
 #endif

--- a/newlib/libc/include/ssp/ssp.h
+++ b/newlib/libc/include/ssp/ssp.h
@@ -41,8 +41,6 @@
 #endif
 #define __ssp_real(fun)		__ssp_real_(fun)
 
-#define __ssp_inline extern __inline__ __attribute__((__always_inline__, __gnu_inline__))
-
 #define __ssp_bos(ptr) __builtin_object_size(ptr, __SSP_FORTIFY_LEVEL > 1)
 #define __ssp_bos0(ptr) __builtin_object_size(ptr, 0)
 
@@ -51,7 +49,7 @@
 		__chk_fail()
 #define __ssp_decl(rtype, fun, args) \
 rtype __ssp_real_(fun) args __asm__(__ASMNAME(#fun)); \
-__ssp_inline rtype fun args
+__declare_extern_inline(rtype) fun args
 #define __ssp_redirect_raw(rtype, fun, args, call, cond, bos) \
 __ssp_decl(rtype, fun, args) \
 { \

--- a/newlib/libc/include/ssp/string.h
+++ b/newlib/libc/include/ssp/string.h
@@ -59,22 +59,22 @@ __END_DECLS
     __ ## fun ## _ichk(dst, src))
 
 #define __ssp_bos_icheck3_restrict(fun, type1, type2) \
-__ssp_inline type1 __ ## fun ## _ichk(type1 __restrict, type2 __restrict, size_t); \
-__ssp_inline type1 \
+__declare_extern_inline(type1) __ ## fun ## _ichk(type1 __restrict, type2 __restrict, size_t); \
+__declare_extern_inline(type1) \
 __ ## fun ## _ichk(type1 __restrict dst, type2 __restrict src, size_t len) { \
 	return __builtin___ ## fun ## _chk(dst, src, len, __ssp_bos0(dst)); \
 }
 
 #define __ssp_bos_icheck3(fun, type1, type2) \
-__ssp_inline type1 __ ## fun ## _ichk(type1, type2, size_t); \
-__ssp_inline type1 \
+__declare_extern_inline(type1) __ ## fun ## _ichk(type1, type2, size_t); \
+__declare_extern_inline(type1) \
 __ ## fun ## _ichk(type1 dst, type2 src, size_t len) { \
 	return __builtin___ ## fun ## _chk(dst, src, len, __ssp_bos0(dst)); \
 }
 
 #define __ssp_bos_icheck2_restrict(fun, type1, type2) \
-__ssp_inline type1 __ ## fun ## _ichk(type1, type2); \
-__ssp_inline type1 \
+__declare_extern_inline(type1) __ ## fun ## _ichk(type1, type2); \
+__declare_extern_inline(type1) \
 __ ## fun ## _ichk(type1 __restrict dst, type2 __restrict src) { \
 	return __builtin___ ## fun ## _chk(dst, src, __ssp_bos0(dst)); \
 }

--- a/newlib/libc/include/sys/cdefs.h
+++ b/newlib/libc/include/sys/cdefs.h
@@ -390,6 +390,13 @@
 #endif
 #endif
 
+#if defined(_HAVE_ATTRIBUTE_ALWAYS_INLINE) && defined(_HAVE_ATTRIBUTE_GNU_INLINE)
+/*
+ * When this macro is defined, use it to declare inline versions of extern functions.
+ */
+#define __declare_extern_inline(type) extern __inline type __attribute((gnu_inline, always_inline))
+#endif
+
 #if defined(__clang__) && defined(__nonnull)
 /* Clang has a builtin macro __nonnull for the _Nonnull qualifier */
 #undef __nonnull

--- a/newlib/libc/machine/aarch64/machine/math.h
+++ b/newlib/libc/machine/aarch64/machine/math.h
@@ -39,14 +39,13 @@
 #define _HAVE_FAST_FMA 1
 #define _HAVE_FAST_FMAF 1
 
-#if defined(_HAVE_ATTRIBUTE_ALWAYS_INLINE) && defined(_HAVE_ATTRIBUTE_GNU_INLINE)
-#define __declare_aarch64_macro(type) extern __inline type __attribute((gnu_inline, always_inline))
+#ifdef __declare_extern_inline
 
 #ifdef _WANT_MATH_ERRNO
 #include <errno.h>
 #endif
 
-__declare_aarch64_macro(double)
+__declare_extern_inline(double)
 sqrt (double x)
 {
     double result;
@@ -58,7 +57,7 @@ sqrt (double x)
     return result;
 }
 
-__declare_aarch64_macro(float)
+__declare_extern_inline(float)
 sqrtf (float x)
 {
     float result;
@@ -70,7 +69,7 @@ sqrtf (float x)
     return result;
 }
 
-__declare_aarch64_macro(double)
+__declare_extern_inline(double)
 fma (double x, double y, double z)
 {
     double result;
@@ -78,7 +77,7 @@ fma (double x, double y, double z)
     return result;
 }
 
-__declare_aarch64_macro(float)
+__declare_extern_inline(float)
 fmaf (float x, float y, float z)
 {
     float result;

--- a/newlib/libc/machine/arm/machine/math.h
+++ b/newlib/libc/machine/arm/machine/math.h
@@ -46,8 +46,7 @@
 #define _HAVE_FAST_FMAF 1
 #endif
 
-#if defined(_HAVE_ATTRIBUTE_ALWAYS_INLINE) && defined(_HAVE_ATTRIBUTE_GNU_INLINE)
-#define __declare_arm_macro(type) extern __inline type __attribute((gnu_inline, always_inline))
+#ifdef __declare_extern_inline
 
 #ifdef _WANT_MATH_ERRNO
 #include <errno.h>
@@ -59,7 +58,7 @@
  * Double precision routines
  */
 
-__declare_arm_macro(double)
+__declare_extern_inline(double)
 sqrt(double x)
 {
 	double result;
@@ -76,7 +75,7 @@ sqrt(double x)
 	return result;
 }
 
-__declare_arm_macro(double)
+__declare_extern_inline(double)
 fabs(double x)
 {
     double result;
@@ -85,7 +84,7 @@ fabs(double x)
 }
 
 #if __ARM_ARCH >= 8
-__declare_arm_macro(double)
+__declare_extern_inline(double)
 ceil (double x)
 {
   double result;
@@ -93,7 +92,7 @@ ceil (double x)
   return result;
 }
 
-__declare_arm_macro(double)
+__declare_extern_inline(double)
 floor (double x)
 {
   double result;
@@ -101,7 +100,7 @@ floor (double x)
   return result;
 }
 
-__declare_arm_macro(double)
+__declare_extern_inline(double)
 nearbyint (double x)
 {
     if (isnan(x)) return x + x;
@@ -116,7 +115,7 @@ nearbyint (double x)
     return x;
 }
 
-__declare_arm_macro(double)
+__declare_extern_inline(double)
 rint (double x)
 {
   double result;
@@ -124,7 +123,7 @@ rint (double x)
   return result;
 }
 
-__declare_arm_macro(double)
+__declare_extern_inline(double)
 round (double x)
 {
   double result;
@@ -132,7 +131,7 @@ round (double x)
   return result;
 }
 
-__declare_arm_macro(double)
+__declare_extern_inline(double)
 trunc (double x)
 {
   double result;
@@ -143,7 +142,7 @@ trunc (double x)
 
 #if _HAVE_FAST_FMA
 
-__declare_arm_macro(double)
+__declare_extern_inline(double)
 fma (double x, double y, double z)
 {
   __asm__ volatile ("vfma.f64 %P0, %P1, %P2" : "+w" (z) : "w" (x), "w" (y));
@@ -160,7 +159,7 @@ fma (double x, double y, double z)
  * Single precision functions
  */
 
-__declare_arm_macro(float)
+__declare_extern_inline(float)
 sqrtf(float x)
 {
 	float result;
@@ -177,7 +176,7 @@ sqrtf(float x)
 	return result;
 }
 
-__declare_arm_macro(float)
+__declare_extern_inline(float)
 fabsf(float x)
 {
     float result;
@@ -186,7 +185,7 @@ fabsf(float x)
 }
 
 #if __ARM_ARCH >= 8
-__declare_arm_macro(float)
+__declare_extern_inline(float)
 ceilf (float x)
 {
   float result;
@@ -194,7 +193,7 @@ ceilf (float x)
   return result;
 }
 
-__declare_arm_macro(float)
+__declare_extern_inline(float)
 floorf (float x)
 {
   float result;
@@ -202,7 +201,7 @@ floorf (float x)
   return result;
 }
 
-__declare_arm_macro(float)
+__declare_extern_inline(float)
 nearbyintf (float x)
 {
     if (isnan(x)) return x + x;
@@ -217,7 +216,7 @@ nearbyintf (float x)
     return x;
 }
 
-__declare_arm_macro(float)
+__declare_extern_inline(float)
 rintf (float x)
 {
   float result;
@@ -225,7 +224,7 @@ rintf (float x)
   return result;
 }
 
-__declare_arm_macro(float)
+__declare_extern_inline(float)
 roundf (float x)
 {
   float result;
@@ -233,7 +232,7 @@ roundf (float x)
   return result;
 }
 
-__declare_arm_macro(float)
+__declare_extern_inline(float)
 truncf (float x)
 {
   float result;
@@ -244,7 +243,7 @@ truncf (float x)
 
 #if _HAVE_FAST_FMAF
 
-__declare_arm_macro(float)
+__declare_extern_inline(float)
 fmaf (float x, float y, float z)
 {
   __asm__ volatile ("vfma.f32 %0, %1, %2" : "+t" (z) : "t" (x), "t" (y));
@@ -254,8 +253,6 @@ fmaf (float x, float y, float z)
 #endif
 
 #endif /* (__ARM_FP & 0x4) && !defined(__SOFTFP__) */
-
-#undef __declare_arm_macro
 
 #endif /* have attributes */
 

--- a/newlib/libc/machine/riscv/machine/math.h
+++ b/newlib/libc/machine/riscv/machine/math.h
@@ -98,18 +98,12 @@
 #endif
 
 
-/**
- * Not available for all compilers.
- * In case of absence, fall back to normal function calls
- */
-#if defined(__GNUC_GNU_INLINE__) || defined(__GNUC_STDC_INLINE__)
-
-# define __declare_riscv_macro(type) extern __inline type __attribute((gnu_inline, always_inline))
+#ifdef __declare_extern_inline
 
 #if __RISCV_HARD_FLOAT >= 64
 
 /* Double-precision functions */
-__declare_riscv_macro(double)
+__declare_extern_inline(double)
 copysign(double x, double y)
 {
 	double result;
@@ -117,7 +111,7 @@ copysign(double x, double y)
 	return result;
 }
 
-__declare_riscv_macro(double)
+__declare_extern_inline(double)
 fabs(double x)
 {
 	double result;
@@ -125,7 +119,7 @@ fabs(double x)
 	return result;
 }
 
-__declare_riscv_macro(double)
+__declare_extern_inline(double)
 fmax (double x, double y)
 {
 	double result;
@@ -136,7 +130,7 @@ fmax (double x, double y)
 	return result;
 }
 
-__declare_riscv_macro(double)
+__declare_extern_inline(double)
 fmin (double x, double y)
 {
 	double result;
@@ -147,20 +141,20 @@ fmin (double x, double y)
 	return result;
 }
 
-__declare_riscv_macro(int)
+__declare_extern_inline(int)
 __finite(double x)
 {
 	long fclass = _fclass_d (x);
 	return (fclass & (FCLASS_INF|FCLASS_NAN)) == 0;
 }
 
-__declare_riscv_macro(int)
+__declare_extern_inline(int)
 finite(double x)
 {
         return __finite(x);
 }
 
-__declare_riscv_macro(int)
+__declare_extern_inline(int)
 __fpclassifyd (double x)
 {
   long fclass = _fclass_d (x);
@@ -177,7 +171,7 @@ __fpclassifyd (double x)
     return FP_NAN;
 }
 
-__declare_riscv_macro(double)
+__declare_extern_inline(double)
 sqrt (double x)
 {
 	double result;
@@ -189,7 +183,7 @@ sqrt (double x)
 	return result;
 }
 
-__declare_riscv_macro(double)
+__declare_extern_inline(double)
 fma (double x, double y, double z)
 {
 	double result;
@@ -202,7 +196,7 @@ fma (double x, double y, double z)
 #if __RISCV_HARD_FLOAT >= 32
 
 /* Single-precision functions */
-__declare_riscv_macro(float)
+__declare_extern_inline(float)
 copysignf(float x, float y)
 {
 	float result;
@@ -210,7 +204,7 @@ copysignf(float x, float y)
 	return result;
 }
 
-__declare_riscv_macro(float)
+__declare_extern_inline(float)
 fabsf (float x)
 {
 	float result;
@@ -218,7 +212,7 @@ fabsf (float x)
 	return result;
 }
 
-__declare_riscv_macro(float)
+__declare_extern_inline(float)
 fmaxf (float x, float y)
 {
 	float result;
@@ -229,7 +223,7 @@ fmaxf (float x, float y)
 	return result;
 }
 
-__declare_riscv_macro(float)
+__declare_extern_inline(float)
 fminf (float x, float y)
 {
 	float result;
@@ -240,20 +234,20 @@ fminf (float x, float y)
 	return result;
 }
 
-__declare_riscv_macro(int)
+__declare_extern_inline(int)
 __finitef(float x)
 {
 	long fclass = _fclass_f (x);
 	return (fclass & (FCLASS_INF|FCLASS_NAN)) == 0;
 }
 
-__declare_riscv_macro(int)
+__declare_extern_inline(int)
 finitef(float x)
 {
         return __finitef(x);
 }
 
-__declare_riscv_macro(int)
+__declare_extern_inline(int)
 __fpclassifyf (float x)
 {
   long fclass = _fclass_f (x);
@@ -270,7 +264,7 @@ __fpclassifyf (float x)
     return FP_NAN;
 }
 
-__declare_riscv_macro(float)
+__declare_extern_inline(float)
 sqrtf (float x)
 {
 	float result;
@@ -282,7 +276,7 @@ sqrtf (float x)
 	return result;
 }
 
-__declare_riscv_macro(float)
+__declare_extern_inline(float)
 fmaf (float x, float y, float z)
 {
 	float result;

--- a/scripts/cross-arm-zephyr-eabi.txt
+++ b/scripts/cross-arm-zephyr-eabi.txt
@@ -23,3 +23,28 @@ default_flash_addr = '0x00000000'
 default_flash_size = '0x00400000'
 default_ram_addr   = '0x20000000'
 default_ram_size   = '0x00200000'
+
+custom_mem_config_thumb_v8_1_m_main_mve_hard = 'mps3_an547'
+custom_mem_config_thumb_v8_m_main_dp_hard = 'mps3_an547'
+custom_mem_config_thumb_v8_m_main_dp_softfp = 'mps3_an547'
+
+separate_boot_flash_mps3_an547 = true
+default_boot_flash_addr_mps3_an547 = '0x00000000'
+default_boot_flash_size_mps3_an547 = '0x00080000'
+default_flash_addr_mps3_an547 = '0x01000000'
+default_flash_size_mps3_an547 = '0x00200000'
+default_ram_addr_mps3_an547 = '0x60000000'
+default_ram_size_mps3_an547 = '0x01000000'
+
+custom_mem_config_thumb_v8_m_base_nofp = 'mps2_an505'
+custom_mem_config_thumb_v8_m_main_nofp = 'mps2_an505'
+custom_mem_config_thumb_v8_m_main_fp_hard = 'mps2_an505'
+custom_mem_config_thumb_v8_m_main_fp_softfp = 'mps2_an505'
+
+separate_boot_flash_mps2_an505 = true
+default_boot_flash_addr_mps2_an505 = '0x10000000'
+default_boot_flash_size_mps2_an505 = '0x10000400'
+default_flash_addr_mps2_an505 = '0x10000400'
+default_flash_size_mps2_an505 = '0x103ffc00'
+default_ram_addr_mps2_an505 = '0x80000000'
+default_ram_size_mps2_an505 = '0x01000000'


### PR DESCRIPTION
gnu_inline is used to create inline versions of functions which are required to also be available as real functions. There were numerous places this was used with inconsistent checks gating them. Create a new __define_extern_inline macro in cdefs.h and use that everywhere.