### PR TITLE
math: Add back a few missing fenv functions

### DIFF
--- a/newlib/libc/include/machine/fenv-softfloat.h
+++ b/newlib/libc/include/machine/fenv-softfloat.h
@@ -78,9 +78,13 @@ fesetexceptflag(const fexcept_t *flagp, int excepts)
 __declare_fenv_inline(int)
 feraiseexcept(int excepts)
 {
-
 	return( excepts != 0 );
+}
 
+__declare_fenv_inline(int)
+fesetexcept(int excepts)
+{
+        return( excepts != 0 );
 }
 
 __declare_fenv_inline(int)

--- a/newlib/libc/machine/aarch64/machine/fenv-fp.h
+++ b/newlib/libc/machine/aarch64/machine/fenv-fp.h
@@ -72,6 +72,12 @@ feraiseexcept(int __excepts)
 }
 
 __declare_fenv_inline(int)
+fesetexcept(int excepts)
+{
+        return feraiseexcept(excepts);
+}
+
+__declare_fenv_inline(int)
 fetestexcept(int __excepts)
 {
 	fexcept_t __r;

--- a/newlib/libc/machine/arm/machine/fenv-fp.h
+++ b/newlib/libc/machine/arm/machine/fenv-fp.h
@@ -116,7 +116,6 @@ __declare_fenv_inline(int) feholdexcept(fenv_t *envp)
 
 __declare_fenv_inline(int) fesetenv(const fenv_t *envp)
 {
-
 	_vmsr_fpscr(*envp);
 	return (0);
 }
@@ -136,8 +135,12 @@ __declare_fenv_inline(int) feraiseexcept(int excepts)
 {
 	fexcept_t __ex = excepts;
 
-	fesetexceptflag(&__ex, excepts);
-	return (0);
+	return fesetexceptflag(&__ex, excepts);
+}
+
+__declare_fenv_inline(int) fesetexcept(int excepts)
+{
+        return feraiseexcept(excepts);
 }
 
 __declare_fenv_inline(int) fesetround(int round)

--- a/newlib/libc/machine/m68k/machine/fenv-fp.h
+++ b/newlib/libc/machine/m68k/machine/fenv-fp.h
@@ -140,6 +140,11 @@ __declare_fenv_inline(int) feraiseexcept(int excepts)
     return 0;
 }
 
+__declare_fenv_inline(int) fesetexcept(int excepts)
+{
+    return feraiseexcept(excepts);
+}
+
 __declare_fenv_inline(int) fesetenv(const fenv_t *envp)
 {
     fenv_t env = *envp;

--- a/newlib/libc/machine/powerpc/machine/fenv-fp.h
+++ b/newlib/libc/machine/powerpc/machine/fenv-fp.h
@@ -80,6 +80,12 @@ feraiseexcept(int excepts)
 }
 
 __declare_fenv_inline(int)
+fesetexcept(int excepts)
+{
+        return feraiseexcept(excepts);
+}
+
+__declare_fenv_inline(int)
 fetestexcept(int excepts)
 {
 	union __fpscr __r;

--- a/newlib/libc/machine/riscv/machine/fenv-fp.h
+++ b/newlib/libc/machine/riscv/machine/fenv-fp.h
@@ -259,6 +259,11 @@ __declare_fenv_inline(int) feraiseexcept(int excepts)
   return 0;
 }
 
+__declare_fenv_inline(int) fesetexcept(int excepts)
+{
+    return feraiseexcept(excepts);
+}
+
 /* This implementation is intended to comply with the following
  * specification:
  *

--- a/newlib/libc/machine/sh/machine/fenv-fp.h
+++ b/newlib/libc/machine/sh/machine/fenv-fp.h
@@ -139,6 +139,11 @@ __declare_fenv_inline(int) feraiseexcept(int excepts)
 	return (0);
 }
 
+__declare_fenv_inline(int) fesetexcept(int excepts)
+{
+        return feraiseexcept(excepts);
+}
+
 __declare_fenv_inline(int) fesetround(int round)
 {
 	fenv_t fpscr;

--- a/newlib/libc/machine/sparc/machine/fenv-fp.h
+++ b/newlib/libc/machine/sparc/machine/fenv-fp.h
@@ -95,6 +95,14 @@ fesetexceptflag(const fexcept_t *flagp, int excepts)
 	return 0;
 }
 
+__declare_fenv_inline(int)
+fesetexcept(int excepts)
+{
+	fexcept_t __ex = excepts;
+
+	return fesetexceptflag(&__ex, excepts);
+}
+
 /*
  * The feraiseexcept() function raises the supported floating-point exceptions
  * represented by the argument `excepts'.

--- a/newlib/libc/machine/xtensa/machine/fenv-fp.h
+++ b/newlib/libc/machine/xtensa/machine/fenv-fp.h
@@ -119,6 +119,11 @@ __declare_fenv_inline(int) feraiseexcept(int excepts)
   return 0;
 }
 
+__declare_fenv_inline(int) fesetexcept(int excepts)
+{
+  return feraiseexcept(excepts);
+}
+
 __declare_fenv_inline(int) fesetenv(const fenv_t * env_ptr)
 {
   __asm__ volatile ("wur.fsr %0" : : "a"(*env_ptr));

--- a/newlib/libm/fenv/CMakeLists.txt
+++ b/newlib/libm/fenv/CMakeLists.txt
@@ -36,4 +36,6 @@
 picolibc_sources(
   fe_dfl_env.c
   fenv.c
+  fegetmode.c
+  fesetmode.c
   )

--- a/newlib/libm/fenv/fegetmode.c
+++ b/newlib/libm/fenv/fegetmode.c
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2022 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define __STDC_WANT_IEC_60559_BFP_EXT__
+#include <fenv.h>
+
+/* By default, the only state we carry is the rounding mode */
+
+int fegetmode(femode_t *modep)
+{
+    modep->round = fegetround();
+    modep->except = fegetexcept();
+    return 0;
+}

--- a/newlib/libm/fenv/fesetmode.c
+++ b/newlib/libm/fenv/fesetmode.c
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2022 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define __STDC_WANT_IEC_60559_BFP_EXT__
+#include <fenv.h>
+
+/* By default, the only state we carry is the rounding mode */
+
+int fesetmode(femode_t *modep)
+{
+    int round = FE_TONEAREST, except = 0;
+    if (modep) {
+        round = modep->round;
+        except = modep->except;
+    }
+    /* assume any failure indicates that there isn't hw support,
+     * so we wouldn't be affecting anything
+     */
+    (void) fesetround(round);
+    (void) fedisableexcept(FE_ALL_EXCEPT & ~except);
+    (void) feenableexcept(except);
+    return 0;
+}

--- a/newlib/libm/fenv/meson.build
+++ b/newlib/libm/fenv/meson.build
@@ -34,6 +34,8 @@
 #
 srcs_fenv = [
   'fenv.c',
+  'fegetmode.c',
+  'fesetmode.c',
   'fe_dfl_env.c',
 ]
 


### PR DESCRIPTION
There were two functions which were generic and should be included in libm/fenv: fegetmode and fesetmode.

Then there was a machine-dependent function, fesetexcept, which none of the targets provided and which was getting replaced by the (incorrect) generic version.