### PR TITLE
tinystdio: Use weak symbols for stdin/stdout read/flush test

### DIFF
--- a/newlib/libc/tinystdio/bufio.c
+++ b/newlib/libc/tinystdio/bufio.c
@@ -149,6 +149,8 @@ bail:
 	return ret;
 }
 
+extern FILE *const stdin _ATTRIBUTE((__weak__));
+extern FILE *const stdout _ATTRIBUTE((__weak__));
 
 int
 __bufio_get(FILE *f)
@@ -167,7 +169,7 @@ again:
 	if (bf->off >= bf->len) {
 
 		/* Flush stdout if reading from stdin */
-		if (f == stdin && !flushed) {
+		if (f == stdin && !flushed && stdout != NULL) {
                         flushed = true;
 			__bufio_unlock(f);
 			fflush(stdout);

--- a/newlib/libc/tinystdio/fread.c
+++ b/newlib/libc/tinystdio/fread.c
@@ -35,6 +35,9 @@
 #include "../stdlib/mul_overflow.h"
 #endif
 
+extern FILE *const stdin _ATTRIBUTE((__weak__));
+extern FILE *const stdout _ATTRIBUTE((__weak__));
+
 size_t
 fread(void *ptr, size_t size, size_t nmemb, FILE *stream)
 {
@@ -79,7 +82,7 @@ fread(void *ptr, size_t size, size_t nmemb, FILE *stream)
                                 /* Flush stdout if reading from stdin */
                                 if (!flushed) {
                                         flushed = true;
-                                        if (stream == stdin) {
+                                        if (stream == stdin && stdout != NULL) {
                                                 __bufio_unlock(stream);
                                                 fflush(stdout);
                                                 goto again;


### PR DESCRIPTION
Reading from stdin needs to flush stdout before blocking, and that requires comparing the FILE points with those global variables. To prevent that from pulling in an otherwise-unused FILE during linking, use weak versions of stdin/stdout for those operations. That means checking for NULL stdout, which does take additional instructions.