### PR TITLE
Fixes for GCC 13

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -147,6 +147,7 @@ have_long_double = cc.compiles(long_double_code, name : 'long double check', arg
 
 enable_multilib = get_option('multilib')
 multilib_list = get_option('multilib-list')
+multilib_exclude = get_option('multilib-exclude')
 enable_picolib = get_option('picolib')
 enable_picocrt = get_option('picocrt')
 enable_picocrt_lib = get_option('picocrt-lib')
@@ -876,6 +877,17 @@ if enable_multilib
   foreach target : target_list
     message('target ' + target)
     tmp = target.split(';')
+    matches_exclude = false
+    foreach exclude : multilib_exclude
+      if tmp[0].contains(exclude)
+        matches_exclude = true
+        message('skipping target ' + tmp[0])
+        break
+      endif
+    endforeach
+    if matches_exclude
+      continue
+    endif
     flags = []
 
     # Let the user specify a subset of the possible multilib

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -50,6 +50,9 @@ option('multilib', type: 'boolean', value: true,
 option('multilib-list', type: 'array', value: [],
        description: 'List of multilib configurations to build for')
 
+option('multilib-exclude', type: 'array', value: [],
+       description: 'Multilib configurations containing any of these strings will not be built')
+
 option('build-type-subdir', type: 'string',
        description: 'Build-type subdir. Also skips installing .specs file')
 

--- a/newlib/libc/posix/dirname.c
+++ b/newlib/libc/posix/dirname.c
@@ -1,5 +1,3 @@
-#ifndef _NO_DIRNAME
-
 /* Copyright 2005 Shaun Jackman
  * Permission to use, copy, modify, and distribute this software
  * is freely granted, provided that this notice is preserved.
@@ -8,12 +6,13 @@
 #include <libgen.h>
 #include <string.h>
 
-#if __GNUC__ == 12 && __GNUC_MINOR__ >= 2 && __OPTIMIZE_SIZE__
+#if defined(__GNUC__) && !defined(clang) && __OPTIMIZE_SIZE__
 /*
  * GCC 12.x has a bug in -Os mode on (at least) arm v8.1-m which
  * mis-compiles this function. Work around that by switching
  * optimization mode
  */
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC optimize("O2")
 #endif
 
@@ -38,5 +37,3 @@ dirname (char *path)
 		p == path ? "/" :
 		(*p = '\0', path);
 }
-
-#endif /* !_NO_DIRNAME  */

--- a/scripts/cross-clang-riscv64-unknown-elf.txt
+++ b/scripts/cross-clang-riscv64-unknown-elf.txt
@@ -20,7 +20,7 @@ endian = 'little'
 
 [properties]
 c_args = ['-Werror=double-promotion', '-fshort-enums']
-c_link_args = ['-L/usr/lib/gcc/riscv64-unknown-elf/12.2.0/rv64imac/lp64/', '-L/usr/lib/gcc/riscv64-unknown-elf/12.1.0/rv64imac/lp64/']
+c_link_args = ['-L/usr/lib/gcc/riscv64-unknown-elf/13.2.0/rv64imac/lp64/', '-L/usr/lib/gcc/riscv64-unknown-elf/12.2.0/rv64imac/lp64/', '-L/usr/lib/gcc/riscv64-unknown-elf/12.1.0/rv64imac/lp64/', '-Wno-unused-command-line-argument']
 skip_sanity_check = true
 has_link_defsym = true
 default_flash_addr = '0x80000000'

--- a/scripts/cross-clang-thumbv6m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv6m-none-eabi.txt
@@ -20,7 +20,7 @@ endian = 'little'
 
 [properties]
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt', '-fshort-enums']
-c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.3.1/thumb/v6-m/nofp/', '-Wl,-z,noexecstack']
+c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v6-m/nofp/', '-Wl,-z,noexecstack']
 skip_sanity_check = true
 default_flash_addr = '0x00000000'
 default_flash_size = '0x00400000'

--- a/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
@@ -20,7 +20,7 @@ endian = 'little'
 
 [properties]
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt', '-fshort-enums']
-c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.3.1/thumb/v7e-m+fp/hard/', '-Wl,-z,noexecstack']
+c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v7e-m+fp/hard/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
 skip_sanity_check = true
 default_flash_addr = '0x00000000'
 default_flash_size = '0x00400000'

--- a/scripts/cross-clang-thumbv7m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7m-none-eabi.txt
@@ -20,7 +20,7 @@ endian = 'little'
 
 [properties]
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt', '-fshort-enums']
-c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.3.1/thumb/v7-m/nofp/', '-Wl,-z,noexecstack']
+c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v7-m/nofp/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
 skip_sanity_check = true
 default_flash_addr = '0x00000000'
 default_flash_size = '0x00400000'

--- a/scripts/do-arm-configure
+++ b/scripts/do-arm-configure
@@ -33,4 +33,4 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-exec "$(dirname "$0")"/do-configure arm-none-eabi -Dtests=true "$@"
+exec "$(dirname "$0")"/do-configure arm-none-eabi -Dtests=true -Dmultilib-exclude=pacbti "$@"


### PR DESCRIPTION
Testing with GCC 13.2 found a few minor issues:
 
 * pacbti configurations are now enabled by default. We'll skip these for now.
 * dirname still gets mis-compiled with -Os. Use -O2 forever.