### PR TITLE
doc: Document the syscall requirements for abort

### DIFF
--- a/cmake/TC-clang-thumbv6m.cmake
+++ b/cmake/TC-clang-thumbv6m.cmake
@@ -22,8 +22,9 @@ set(_HAVE_PICOLIBC_TLS_API TRUE)
 
 set(PICOLIBC_LINK_FLAGS
   --ld-path=/usr/bin/arm-none-eabi-ld
-  -L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7-m/nofp/
+  -L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v7-m/nofp/
   -L/usr/lib/gcc/arm-none-eabi/12.3.1/thumb/v7-m/nofp/
+  -L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7-m/nofp/
   -Wl,-z,noexecstack
   -Wl,-no-enum-size-warning
   -T ${CMAKE_CURRENT_SOURCE_DIR}/cmake/TC-arm-none-eabi.ld

--- a/cmake/TC-clang-thumbv7m.cmake
+++ b/cmake/TC-clang-thumbv7m.cmake
@@ -22,8 +22,9 @@ set(_HAVE_PICOLIBC_TLS_API TRUE)
 
 set(PICOLIBC_LINK_FLAGS
   --ld-path=/usr/bin/arm-none-eabi-ld
-  -L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7-m/nofp/
+  -L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v7-m/nofp/
   -L/usr/lib/gcc/arm-none-eabi/12.3.1/thumb/v7-m/nofp/
+  -L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7-m/nofp/
   -Wl,-z,noexecstack
   -Wl,-no-enum-size-warning
   -T ${CMAKE_CURRENT_SOURCE_DIR}/cmake/TC-arm-none-eabi.ld

--- a/doc/os.md
+++ b/doc/os.md
@@ -120,6 +120,17 @@ The sample linker script provided with picolibc defines these two
 symbols to enclose all RAM which is not otherwise used by the
 application.
 
+## abort
+
+Posix says that `abort` sends `SIGABRT` to the calling process as if
+the process called `raise(SIGABRT)`. It also says `abort` shall not
+return. The picolibc implementation of `abort` calls `raise`; if that
+returns, it then calls `_exit`. The picolibc version of `raise` also
+calls `_exit` for uncaught and un-ignored signals.
+
+This means that an application needs to provide an implementation of
+`_exit` to support `abort`.
+
 ## Linking with System Library
 
 To get Picolibc to use a system library, that library needs to be

--- a/scripts/cross-clang-rv32imafdc-unknown-elf.txt
+++ b/scripts/cross-clang-rv32imafdc-unknown-elf.txt
@@ -20,7 +20,7 @@ endian = 'little'
 
 [properties]
 c_args = ['-Werror=double-promotion']
-c_link_args = ['-Wl,-melf32lriscv', '-L/usr/lib/gcc/riscv64-unknown-elf/12.2.0/rv32imafdc/ilp32d', '-L/usr/lib/gcc/riscv64-unknown-elf/12.1.0/rv32imafdc/ilp32d']
+c_link_args = ['-Wl,-melf32lriscv', '-L/usr/lib/gcc/riscv64-unknown-elf/13.2.0/rv32imafdc/ilp32d', '-L/usr/lib/gcc/riscv64-unknown-elf/12.2.0/rv32imafdc/ilp32d', '-L/usr/lib/gcc/riscv64-unknown-elf/12.1.0/rv32imafdc/ilp32d']
 skip_sanity_check = true
 has_link_defsym = true
 default_flash_addr = '0x80000000'


### PR DESCRIPTION
To use the picolibc implementation of `abort`, applications need to provide an implementation of `_exit`. Document how the implementation of `abort` and `raise` lead to this.

Closes: #683 