### PR TITLE
libc/stdlib: Rework nano malloc to avoid padding in chunk struct

### DIFF
--- a/newlib/libc/stdlib/nano-mallocr.c
+++ b/newlib/libc/stdlib/nano-mallocr.c
@@ -56,18 +56,14 @@
 #define assert(x) ((void)0)
 #endif
 
-typedef struct {
-    char c;
-    union {
-	void *p;
-	double d;
-	long long ll;
-	size_t s;
-    } u;
+typedef union {
+    void *p;
+    double d;
+    long long ll;
+    size_t s;
 } align_chunk_t;
 
 typedef struct {
-    char c;
     size_t s;
 } align_head_t;
 
@@ -97,10 +93,10 @@ typedef struct malloc_chunk
 
 /* Alignment of allocated chunk. Compute the alignment required from a
  * range of types */
-#define MALLOC_CHUNK_ALIGN	(offsetof(align_chunk_t, u))
+#define MALLOC_CHUNK_ALIGN	_Alignof(align_chunk_t)
 
 /* Alignment of the header. Never larger than MALLOC_CHUNK_ALIGN */
-#define MALLOC_HEAD_ALIGN	(offsetof(align_head_t, s))
+#define MALLOC_HEAD_ALIGN	_Alignof(align_head_t)
 
 /* Size of malloc header. Keep it aligned. */
 #define MALLOC_HEAD 		__align_up(sizeof(size_t), MALLOC_HEAD_ALIGN)

--- a/newlib/libc/stdlib/nano-mallocr.c
+++ b/newlib/libc/stdlib/nano-mallocr.c
@@ -42,6 +42,7 @@
 #include <unistd.h>
 #include <sys/config.h>
 #include <sys/lock.h>
+#include <sys/param.h>
 #include <stdint.h>
 
 #if MALLOC_DEBUG
@@ -53,10 +54,6 @@
 #define MALLOC_UNLOCK __LIBC_UNLOCK()
 #undef assert
 #define assert(x) ((void)0)
-#endif
-
-#ifndef MAX
-#define MAX(a,b) ((a) >= (b) ? (a) : (b))
 #endif
 
 typedef struct {


### PR DESCRIPTION
When size_t and pointers have different sizes, the previous malloc_chunk struct would end up with unnecessary padding between them. Rework the code by removing the size field from malloc_chunk and then explicitly store the size before the malloc_chunk. This will save a bit of memory in every allocation by eliminating those padding bytes.

This patch also adopts changes from Alex Richardson's #686 that use cdefs.h macros that compute aligned sizes.
