### PR TITLE
Add weak attribute to TLS functions and sbrk

### DIFF
--- a/newlib/libc/picolib/inittls.c
+++ b/newlib/libc/picolib/inittls.c
@@ -61,7 +61,7 @@ extern char __tbss_size[];	/* Size of TLS zero-filled data */
 extern char __tbss_offset[];    /* Offset from tdata to tbss */
 #endif
 
-void
+__attribute__((weak)) void
 _init_tls(void *__tls)
 {
 	char *tls = __tls;

--- a/newlib/libc/picolib/machine/aarch64/tls.c
+++ b/newlib/libc/picolib/machine/aarch64/tls.c
@@ -54,7 +54,7 @@ extern char __arm64_tls_tcb_offset;
 #endif
 
 
-void
+__attribute__((weak)) void
 _set_tls(void *tls)
 {
 	__asm__ volatile("msr tpidr_el0, %0" : : "r" (tls - TP_OFFSET));

--- a/newlib/libc/picolib/machine/arc/tls.c
+++ b/newlib/libc/picolib/machine/arc/tls.c
@@ -48,7 +48,7 @@
 #define _REG(n) "r" # n
 #define REG(n) _REG(n)
 
-void
+__attribute__((weak)) void
 _set_tls(void *tls)
 {
     __asm__("mov " REG(TLS_REGNO) ", %0" : : "r" (tls));

--- a/newlib/libc/picolib/machine/arm/read_tp.S
+++ b/newlib/libc/picolib/machine/arm/read_tp.S
@@ -41,7 +41,7 @@
 	.text
 	.align 4
 	.p2align 4,,15
-	.global __aeabi_read_tp
+	.weak __aeabi_read_tp
 	.type __aeabi_read_tp,%function
 #ifdef __thumb__
 	.thumb

--- a/newlib/libc/picolib/machine/arm/tls.c
+++ b/newlib/libc/picolib/machine/arm/tls.c
@@ -56,7 +56,7 @@ void *__tls;
 extern char __arm32_tls_tcb_offset;
 #define TP_OFFSET ((size_t)&__arm32_tls_tcb_offset)
 
-void
+__attribute__((weak)) void
 _set_tls(void *tls)
 {
 #ifdef ARM_TLS_CP15

--- a/newlib/libc/picolib/machine/mips/tls.c
+++ b/newlib/libc/picolib/machine/mips/tls.c
@@ -37,7 +37,7 @@
 #include <string.h>
 #include <stdint.h>
 
-void
+__attribute__((weak)) void
 _set_tls(void *tls)
 {
     __asm__(".set push\n"

--- a/newlib/libc/picolib/machine/riscv/tls.c
+++ b/newlib/libc/picolib/machine/riscv/tls.c
@@ -38,7 +38,7 @@
 #include <stdint.h>
 
 /* This code is duplicated in picocrt/machine/riscv/crt0.c */
-void
+__attribute__((weak)) void
 _set_tls(void *tls)
 {
 	__asm__("mv tp, %0" : : "r" (tls));

--- a/newlib/libc/picolib/machine/sparc/tls.c
+++ b/newlib/libc/picolib/machine/sparc/tls.c
@@ -38,7 +38,7 @@
 
 extern char __tls_size_align[];
 
-void
+__attribute__((weak)) void
 _set_tls(void *tls)
 {
         char *ctls = tls;

--- a/newlib/libc/picolib/machine/xtensa/tls.c
+++ b/newlib/libc/picolib/machine/xtensa/tls.c
@@ -40,7 +40,7 @@
 #define _REG(n) # n
 #define REG(n) _REG(n)
 
-void
+__attribute__((weak)) void
 _set_tls(void *tls)
 {
     __asm__("wur %0," REG(THREADPTR) : : "r" (tls));

--- a/newlib/libc/picolib/picosbrk.c
+++ b/newlib/libc/picolib/picosbrk.c
@@ -41,7 +41,7 @@ extern char __heap_end[];
 
 static char *brk = __heap_start;
 
-void *sbrk(ptrdiff_t incr)
+__attribute((weak)) void *sbrk(ptrdiff_t incr)
 {
 	if (incr < 0) {
                 if ((size_t) (brk - __heap_start) < (size_t) (-incr)) {


### PR DESCRIPTION
I have recently been hacking up (public release momentarily) a tiny RTOS targeting the [Raspberry RP2040](https://www.raspberrypi.com/documentation/microcontrollers/rp2040.html) which supports a symmetric dual core cortex-m0+ design.  To correctly implement multi-core TLS support I need to override the `_init_tls`, `_set_tls` and `__aeabi_read_tp` implementations to allow a per-core `__tls` initialization and usage.  This PR marks the TLS support functions as **weak** to allow easy overrides.

I have also added **weak** to the `sbrk` implementation because additional care will be required to share a common heap in an SMP configuration.

I believe these changes have no/limited impact if unused and should be easy to include.