### PR TITLE
picolib: Add (optional) rp2040 support to ARM TLS code

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1290,6 +1290,8 @@ conf_data.set('_HAVE_INIT_FINI', get_option('newlib-initfini'), description: 'Su
 conf_data.set('NEWLIB_TLS', thread_local_storage, description: 'use thread local storage')
 conf_data.set('PICOLIBC_TLS', thread_local_storage, description: 'use thread local storage')
 conf_data.set('_HAVE_PICOLIBC_TLS_API', thread_local_storage and have_picolibc_tls_api, description: '_set_tls and _init_tls functions available')
+conf_data.set('_HAVE_PICOLIBC_TLS_RP2040', get_option('tls-rp2040'),
+              description: 'Use Raspberry Pi RP2040 CPUID register to index thread local storage value')
 conf_data.set('POSIX_IO', posix_io, description: 'Use open/close/read/write in tinystdio')
 conf_data.set('_PRINTF_SMALL_ULTOA', printf_small_ultoa, description: 'avoid software division in decimal conversion')
 conf_data.set('ATOMIC_UNGETC', atomic_ungetc, description: 'Use atomics for fgetc/ungetc for re-entrancy')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -273,6 +273,8 @@ option('newlib-global-errno', type: 'boolean', value: false,
 option('errno-function', type: 'string',
        value: 'false',
        description: 'Use this function to compute errno address (default false, auto means autodetect, zephyr means use z_errno_wrap if !tls)')
+option('tls-rp2040', type: 'boolean', value: false,
+       description: 'Use Raspberry Pi RP2040 CPUID register to index thread local storage value')
 
 #
 # Math options

--- a/newlib/libc/picolib/machine/arm/arm_tls.h
+++ b/newlib/libc/picolib/machine/arm/arm_tls.h
@@ -36,3 +36,14 @@
 #if ((__ARM_FEATURE_COPROC & 1) || __ARM_ARCH >= 8) && __ARM_ARCH_PROFILE != 'M' && __ARM_ARCH >= 6
 #define ARM_TLS_CP15
 #endif
+
+/* Switch cortex-m0 to use RP2040 CPUID register if requested */
+#if __ARM_ARCH == 6 && __ARM_ARCH_PROFILE == 'M' && defined(_HAVE_PICOLIBC_TLS_RP2040)
+#define ARM_RP2040
+#endif
+
+#ifdef ARM_RP2040
+#define RP2040_SIO_BASE        0xd0000000
+#define RP2040_CPUID           (RP2040_SIO_BASE + 0)
+#define RP2040_NCORE            2
+#endif

--- a/newlib/libc/picolib/machine/arm/read_tp.S
+++ b/newlib/libc/picolib/machine/arm/read_tp.S
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Copyright © 2020 Keith Packard
+ * Copyright © 2024 Stephen Street
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -50,29 +51,51 @@
 __aeabi_read_tp:
 	.cfi_sections .debug_frame
 	.cfi_startproc
+
 #ifdef ARM_TLS_CP15
 	mrc p15, 0, r0, c13, c0, 3
-#else
-	/* Load the address of __tls */
-	ldr r0,1f
-	/* Dereference to get the value of __tls */
-	ldr r0,[r0]
-#endif
-	/* All done, return to caller */
 	bx lr
-	.cfi_endproc
-	
-	/* Holds the address of __tls */
-	.align 2
-#ifndef ARM_TLS_CP15
-1: .word __tls
+#else
 
+#ifdef ARM_RP2040
+
+	/*
+	 * Code for RP2040 processor. This is a dual-core cortex-m0
+	 * design. We use the CPUID register, stored at offset zero of
+	 * the Single-cycle IO block at 0xd0000000
+	 */
+
+#define TLS_SIZE	(4 * RP2040_NCORE)
+
+	push {r1,lr}		/* Save R1 (and LR) */
+	ldr r1,=0xd0000000	/* Address of SIO->CPUID */
+	ldr r1,[r1]	   	/* Fetch active core */
+	lsls r1,r1,#2	   	/* Multiply by 4 */
+	ldr r0,=__tls		/* Address of __tls array */
+	ldr r0,[r0,r1]		/* Fetch __tls[CPUID] */
+	pop {r1,pc}		/* Restore R1 and return  */
+
+#else
+
+#define TLS_SIZE	4
+
+	ldr r0,=__tls		/* Load the address of __tls */
+	ldr r0,[r0]		/* Dereference to get the value of __tls */
+	bx lr			/* All done, return to caller */
+
+#endif
+
+#endif
+
+	.cfi_endproc
+
+#ifndef ARM_TLS_CP15
 	.global __tls
 	.bss
 	.align 4
 	.type __tls, %object
-	.size __tls, 4
+	.size __tls, TLS_SIZE
 __tls:
-	.space 4
+	.space TLS_SIZE
 
 #endif

--- a/newlib/libc/picolib/machine/arm/tls.c
+++ b/newlib/libc/picolib/machine/arm/tls.c
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Copyright © 2019 Keith Packard
+ * Copyright © 2024 Stephen Street
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,7 +43,7 @@
  * refer to it in an asm statement
  */
 #ifndef ARM_TLS_CP15
-extern void *__tls;
+extern void *__tls[];
 #endif
 
 /* The size of the thread control block.
@@ -59,9 +60,15 @@ extern char __arm32_tls_tcb_offset;
 void
 _set_tls(void *tls)
 {
+        tls = (uint8_t *) tls - TP_OFFSET;
 #ifdef ARM_TLS_CP15
-	__asm__("mcr p15, 0, %0, cr13, cr0, 3" : : "r" (tls - TP_OFFSET));
+	__asm__("mcr p15, 0, %0, cr13, cr0, 3" : : "r" (tls));
 #else
-	__tls = (uint8_t *) tls - TP_OFFSET;
+#ifdef ARM_RP2040
+        uint32_t cpuid = *(uint32_t *)0xd0000000;
+        __tls[cpuid] = tls;
+#else
+	__tls[0] = tls;
+#endif
 #endif
 }


### PR DESCRIPTION
The RP2040 has two cortex-m0 cores. Allocate an array of TLS base pointers in __tls and then use the CPUID register to index into that.

Closes: #695 