### PR TITLE
Fix stderr fileno and stdout/stdin linking

### DIFF
--- a/newlib/libc/tinystdio/posixiob_stderr.c
+++ b/newlib/libc/tinystdio/posixiob_stderr.c
@@ -41,7 +41,7 @@
 
 static char write_buf[__PICOLIBC_STDERR_BUFSIZ];
 
-static struct __file_bufio __stderr = FDEV_SETUP_POSIX(1, write_buf, __PICOLIBC_STDERR_BUFSIZ, __SWR, __BLBF);
+static struct __file_bufio __stderr = FDEV_SETUP_POSIX(2, write_buf, __PICOLIBC_STDERR_BUFSIZ, __SWR, __BLBF);
 
 FILE *const __posix_stderr = &__stderr.xfile.cfile.file;
 


### PR DESCRIPTION
It looks like I used the wrong fd for `stderr` (it should be 2, not 1) in a previous PR, sorry about that. I also noticed that the `extern` definitions of `stdout` can cause problems with linking, where the `stdout` variable does not get properly included in the final binary if it is not used by user code, even if it is used by `__bufio_get`. This causes its use by `__bufio_get` to perform unintended accesses of other data.

Thanks!