### PR TITLE
tinystdio: Check the *address* of weak stdin/stdout

### DIFF
--- a/newlib/libc/tinystdio/bufio.c
+++ b/newlib/libc/tinystdio/bufio.c
@@ -168,8 +168,15 @@ again:
 
 	if (bf->off >= bf->len) {
 
-		/* Flush stdout if reading from stdin */
-		if (f == stdin && !flushed && stdout != NULL) {
+		/*
+                 * Flush stdout if reading from stdin.
+                 *
+                 * The odd-looking NULL address checks along with the
+                 * weak attributes for stdin and stdout above avoids
+                 * pulling in stdin/stdout definitions just for this
+                 * check.
+                 */
+		if (&stdin != NULL && &stdout != NULL && f == stdin && !flushed) {
                         flushed = true;
 			__bufio_unlock(f);
 			fflush(stdout);


### PR DESCRIPTION
__bufio_get wants to flush stdout when reading from stdin, but only if both stdin and stdout are actually being used by the application. The hack for this is to declare them as 'weak' symbols; if not used elsewhere in the application, they'll end up with address zero.

We detect that case by comparing the *address* of the symbols against NULL, not the value.

Replace the value check for stdout with a check of the address and add an address check for stdin before fetching that.