### PR TITLE
Lld fixes

### DIFF
--- a/.github/do-linux
+++ b/.github/do-linux
@@ -4,6 +4,7 @@ HERE=`dirname "$0"`
 "$HERE"/do-test arm "$@"
 "$HERE"/do-test cortex-a9 "$@"
 "$HERE"/do-test clang-thumbv7e+fp "$@"
+"$HERE"/do-test clang-thumbv7e+dp "$@"
 "$HERE"/do-test clang-thumbv7m "$@"
 "$HERE"/do-test clang-thumbv6m "$@"
 "$HERE"/do-build mips "$@"

--- a/meson.build
+++ b/meson.build
@@ -978,6 +978,8 @@ foreach target : ['default-target'] + targets
       picolibc_linker_type_data.set('BFD_END', '*/')
       picolibc_linker_type_data.set('LLD_START', '')
       picolibc_linker_type_data.set('LLD_END', '')
+      picolibc_linker_type_data.set('TLS_PHDRS', 'tls PT_TLS;')
+      picolibc_linker_type_data.set('TLS_INIT_SEG', 'tls')
       if host_cpu_family == 'riscv'
         # ld.lld before version 15 did not support linker relaxations, disable
         # them if we are using an older version.
@@ -993,6 +995,9 @@ foreach target : ['default-target'] + targets
       picolibc_linker_type_data.set('BFD_END', '')
       picolibc_linker_type_data.set('LLD_START', '/* For ld.lld: ')
       picolibc_linker_type_data.set('LLD_END', '*/')
+      picolibc_linker_type_data.set('TLS_PHDRS', '''tls_init PT_TLS;
+        tls PT_TLS;''')
+      picolibc_linker_type_data.set('TLS_INIT_SEG', 'tls_init')
     endif
 
     init_memory_template = '''

--- a/picolibc.ld.in
+++ b/picolibc.ld.in
@@ -55,8 +55,7 @@ PHDRS
 	text PT_LOAD;
 	ram_init PT_LOAD;
 	ram PT_LOAD;
-	tls_init PT_TLS;
-	tls PT_TLS;
+	@TLS_PHDRS@
 }
 
 SECTIONS
@@ -200,7 +199,7 @@ SECTIONS
 		*(.tdata .tdata.* .gnu.linkonce.td.*)
 		PROVIDE(@PREFIX@__data_end = .);
 		PROVIDE(@PREFIX@__tdata_end = .);
-	} >ram AT>flash :tls_init :ram_init
+	} >ram AT>flash :@TLS_INIT_SEG@ :ram_init
 	PROVIDE( @PREFIX@__tls_base = ADDR(.tdata));
 	PROVIDE( @PREFIX@__tdata_start = ADDR(.tdata));
 	PROVIDE( @PREFIX@__tdata_source = LOADADDR(.tdata) );

--- a/scripts/cross-clang-thumbv6m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv6m-none-eabi.txt
@@ -4,7 +4,6 @@
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
 c = ['ccache', 'clang', '-m32', '--target=thumbv6m-none-eabi', '-nostdlib']
-c_ld = '/usr/bin/arm-none-eabi-ld'
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eab-as'
 nm = 'arm-none-eab-nm'

--- a/scripts/cross-clang-thumbv7e+dp-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7e+dp-none-eabi.txt
@@ -1,0 +1,27 @@
+[binaries]
+# Meson 0.53.2 doesn't use any cflags when doing basic compiler tests,
+# so we have to add -nostdlib to the compiler configuration itself or
+# early compiler tests will fail. This can be removed when picolibc
+# requires at least version 0.54.2 of meson.
+c = ['ccache', 'clang', '-m32', '-target', 'arm-none-eabihf', '-march=armv7em', '-mfloat-abi=hard', '-nostdlib']
+ar = 'arm-none-eabi-ar'
+as = 'arm-none-eab-as'
+nm = 'arm-none-eab-nm'
+strip = 'arm-none-eabi-strip'
+# only needed to run tests
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-arm "$@"', 'run-arm']
+
+[host_machine]
+system = 'none'
+cpu_family = 'arm'
+cpu = 'arm'
+endian = 'little'
+
+[properties]
+c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt', '-fshort-enums']
+c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v7e-m+dp/hard/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
+skip_sanity_check = true
+default_flash_addr = '0x00000000'
+default_flash_size = '0x00400000'
+default_ram_addr   = '0x20000000'
+default_ram_size   = '0x00200000'

--- a/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
@@ -4,7 +4,6 @@
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
 c = ['ccache', 'clang', '-m32', '-target', 'thumbv7e-none-eabi', '-mcpu=cortex-m7', '-mfloat-abi=hard', '-nostdlib']
-c_ld = '/usr/bin/arm-none-eabi-ld'
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eab-as'
 nm = 'arm-none-eab-nm'

--- a/scripts/cross-clang-thumbv7m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7m-none-eabi.txt
@@ -4,7 +4,6 @@
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
 c = ['ccache', 'clang', '-m32', '-target', 'thumbv7m-none-eabi', '-mfloat-abi=soft', '-nostdlib']
-c_ld = '/usr/bin/arm-none-eabi-ld'
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eab-as'
 nm = 'arm-none-eab-nm'

--- a/scripts/do-clang-thumbv7e+dp-configure
+++ b/scripts/do-clang-thumbv7e+dp-configure
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2019 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+exec "$(dirname "$0")"/do-configure clang-thumbv7e+dp-none-eabi -Dtests=true -Dtests-enable-full-malloc-stress=false -Dmultilib=false "$@"

--- a/scripts/run-arm
+++ b/scripts/run-arm
@@ -93,6 +93,9 @@ case "$cpu_arch"/"$cpu_profile" in
                         ;;
                 esac
                 ;;
+            VFPv4-D16)
+                cpu=cortex-m7
+                ;;
             *)
                 cpu=cortex-m4
                 ;;


### PR DESCRIPTION
Fix the linker script to use a single TLS segment when using lld as that linker doesn't support more than one.
Switch the sample ARM clang configurations to use lld.
Add a sample clang config for thumbv7e+dp.

Closes: #705 