### PR TITLE
math/riscv: Providing definitions of exceptions flags for softfloat

### DIFF
--- a/newlib/libc/machine/riscv/sys/fenv.h
+++ b/newlib/libc/machine/riscv/sys/fenv.h
@@ -20,27 +20,6 @@
  * Version 2.1", Section 8.2, "Floating-Point Control and Status
  * Register":
  *
- * Flag Mnemonic Flag Meaning
- * ------------- -----------------
- * NV            Invalid Operation
- * DZ            Divide by Zero
- * OF            Overflow
- * UF            Underflow
- * NX            Inexact
- */
-
-#define FE_INVALID   0x00000010
-#define FE_DIVBYZERO 0x00000008
-#define FE_OVERFLOW  0x00000004
-#define FE_UNDERFLOW 0x00000002
-#define FE_INEXACT   0x00000001
-
-#define FE_ALL_EXCEPT (FE_INVALID|FE_DIVBYZERO|FE_OVERFLOW|FE_UNDERFLOW|FE_INEXACT)
-
-/* Per "The RISC-V Instruction Set Manual: Volume I: User-Level ISA:
- * Version 2.1", Section 8.2, "Floating-Point Control and Status
- * Register":
- *
  * Rounding Mode  Mnemonic Meaning  Meaning
  * -------------  ----------------  -------
  * 000            RNE               Round to Nearest, ties to Even
@@ -62,6 +41,27 @@
 
 #define FE_RMODE_MASK   0x7
 #endif
+
+/* Per "The RISC-V Instruction Set Manual: Volume I: User-Level ISA:
+ * Version 2.1", Section 8.2, "Floating-Point Control and Status
+ * Register":
+ *
+ * Flag Mnemonic Flag Meaning
+ * ------------- -----------------
+ * NV            Invalid Operation
+ * DZ            Divide by Zero
+ * OF            Overflow
+ * UF            Underflow
+ * NX            Inexact
+ */
+
+#define FE_INVALID   0x00000010
+#define FE_DIVBYZERO 0x00000008
+#define FE_OVERFLOW  0x00000004
+#define FE_UNDERFLOW 0x00000002
+#define FE_INEXACT   0x00000001
+
+#define FE_ALL_EXCEPT (FE_INVALID|FE_DIVBYZERO|FE_OVERFLOW|FE_UNDERFLOW|FE_INEXACT)
 
 /* Per "The RISC-V Instruction Set Manual: Volume I: User-Level ISA:
  * Version 2.1":


### PR DESCRIPTION
Part 7.6 point 5 of ISO/IEC 9899:1999 standard requires the modified macros to exist as long as functions in 7.6.2 are provided (these functions are provided also in fenv-softfloat.h not only fenv-fp.h). Current Picolibc only defines the macros when extensions ("f", "Zfinx", "Zdinx") are provided. So we need to adjust these macros to be defined whenever 7.6.2 functions are provided.

