### PR TITLE
riscv: Fix fesetround() behavior in case of wrong input

### DIFF
--- a/newlib/libc/machine/riscv/machine/fenv-fp.h
+++ b/newlib/libc/machine/riscv/machine/fenv-fp.h
@@ -373,9 +373,6 @@ int status = 1;
       /* Intentional fall-through */
 
     case FE_TONEAREST:
-      /* Mask round to be sure only valid rounding bits are set */
-      round &= FE_RMODE_MASK;
-
       /* Set the rounding mode */
       __asm__ volatile("fsrm %0" : : "r"(round));
 

--- a/newlib/libc/machine/riscv/machine/fenv-fp.h
+++ b/newlib/libc/machine/riscv/machine/fenv-fp.h
@@ -356,14 +356,36 @@ __declare_fenv_inline(int) fesetexceptflag(const fexcept_t *flagp, int excepts)
 
 __declare_fenv_inline(int) fesetround(int round)
 {
+int status = 1;
 
-  /* Mask round to be sure only valid rounding bits are set */
+  switch (round)
+  {
+    case FE_TONEAREST_MM:
+      /* Intentional fall-through */
 
-  round &= FE_RMODE_MASK;
+    case FE_UPWARD:
+      /* Intentional fall-through */
 
-  /* Set the rounding mode */
+    case FE_DOWNWARD:
+      /* Intentional fall-through */
 
-  __asm__ volatile("fsrm %0" : : "r"(round));
+    case FE_TOWARDZERO:
+      /* Intentional fall-through */
+
+    case FE_TONEAREST:
+      /* Mask round to be sure only valid rounding bits are set */
+      round &= FE_RMODE_MASK;
+
+      /* Set the rounding mode */
+      __asm__ volatile("fsrm %0" : : "r"(round));
+
+      /* status 0 to indicate successful processing of rounding mode */
+      status = 0;
+      break;
+
+    default:
+      break;
+  }
 
   /* Per 'fesetround.html:
    *
@@ -371,7 +393,7 @@ __declare_fenv_inline(int) fesetround(int round)
    * if the requested rounding direction was established."
    */
 
-  return 0;
+  return status;
 }
 
 /* This implementation is intended to comply with the following


### PR DESCRIPTION
Part 7.6.3.2 of ISO/IEC 9899:1999 standard requires in case of wrong input to function `fesetround()` that the rounding direction is not changed and it returns a non-zero value.
