### PR TITLE
doc: List headers to be provided by the toolchain

### DIFF
--- a/doc/using.md
+++ b/doc/using.md
@@ -5,6 +5,29 @@ running either no operating system or a small RTOS. It is designed to
 be linked statically along with any operating system and application
 code.
 
+### Prerequisites
+
+It is expected that the toolchain used for compilation of applicatons
+against Picolibc provides the follwoing headers in its default search
+paths:
+
+ * float.h
+ * iso646.h
+ * stdalign.h
+ * stdarg.h
+ * stdbool.h
+ * stddef.h
+ * tgmath.h
+
+Vanilla GCC & Clang/LLVM toolchains take care of that so most of
+the users have everything in place. But some third-party toolchains
+may expect these headers to be provided by the C library. Unfortunately
+it is not possible as these headers have compiler-specific parts and
+so whatever version could be imported in the Picolibc, it won't work
+nicely with certain compilers. Moreover even different versions of the
+same compiler may not work well with the same version of one of the
+headers mentioned above.
+
 ## Compiling with Picolibc
 
 To compile source code to use Picolibc, you can use the GCC .specs


### PR DESCRIPTION
Some third-party toolchains may have an expectation that a C library will provide all the headers necessary for user application compilation. Which makes some sense, but in reality there're dependencies between certain headers (or rather their contents) and capabilities of the compiler used in the toolchain.

Thus, let's warn poor users for toolchains which have too high expectations from the C library.