### PR TITLE
tinystdio: fgets returns NULL only when EOF is reached

### DIFF
--- a/newlib/libc/tinystdio/fgets.c
+++ b/newlib/libc/tinystdio/fgets.c
@@ -42,8 +42,12 @@ fgets(char *str, int size, FILE *stream)
 
 	size--;
 	for (c = 0, cp = str; c != '\n' && size > 0; size--, cp++) {
-		if ((c = getc(stream)) == EOF)
-			return NULL;
+		if ((c = getc(stream)) == EOF) {
+			if(cp == str)
+				return NULL;
+			else
+				break;
+		}
 		*cp = (char)c;
 	}
 	*cp = '\0';

--- a/test/meson.build
+++ b/test/meson.build
@@ -533,7 +533,14 @@ foreach target : targets
 
     # legacy stdio doesn't work on semihosting, so just skip it
     if tinystdio
-      plain_tests += ['test-fopen', 'test-mktemp', 'test-tmpnam', 'test-fread-fwrite', 'test-ungetc-ftell', 'test-fgetc']
+      plain_tests += ['test-fopen',
+                      'test-mktemp',
+                      'test-tmpnam',
+                      'test-fread-fwrite',
+                      'test-ungetc-ftell',
+                      'test-fgetc',
+                      'test-fgets-eof',
+                     ]
     endif
   endif
 

--- a/test/test-fgets-eof.c
+++ b/test/test-fgets-eof.c
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2024, Synopsys Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+const char *string = "123456789";
+
+int main(void)
+{
+    char *pchar;
+    char line[12];
+    int compare_result;
+    FILE *file;
+    int ret = 0;
+
+    file = fopen("testfile.dat", "w");
+    if(file == NULL) return 1;
+    fputs(string, file);
+    fclose(file);
+
+    file = fopen( "testfile.dat", "r" );
+    if(file == NULL) return 1;
+
+    /*Calling fgets to reach EOF and check on the returned value*/
+    pchar = fgets( line, 12, file);
+    if(pchar == line)
+        printf("fgets return is correct\n");
+    else {
+        printf("fgets return is wrong!!\n");
+        ret = 1;
+    }
+
+    compare_result = strcmp( line, string );
+    if(compare_result == 0)
+        printf("compare results passed\n");
+    else {
+        printf("compare results failed!!\n");
+        ret = 1;
+    }
+
+    fclose( file );
+
+    return ret;
+}


### PR DESCRIPTION
According to the ISO/IEC_9899_1999, section:7.19.7.2 It is mentioned that when EOF is encountered and no characters were read into the array a null pointer is returned. In the fgets function in picolibc,
it always returned NULL when it reaches EOF even if characters were read and that the file is not empty.

Accordingly a flag was added that checks if the file is empty or not, there is an added "if" condition that checks on this flag, if EOF was encountered for whether NULL or the pointer to the array that was read will be returned. The case where it returns NULL occurs when EOF and no characters were read. This change checks and handles that fgets returns the pointer to the array correctly when it reaches EOF.

This is a simple testcase that shows the effect of this change:

```c
#include <stdio.h>
#include <string.h>

const char *string = "123456789";    

int main(){

    char *pchar;
    char line[12];
    int compare_result;
    FILE *file;

    file = fopen("testfile.dat", "w");
    if(file == NULL) return 1;
    fputs(string, file);
    fclose(file);

    file = fopen( "testfile.dat", "r" );
    if(file == NULL) return 1;
    
    /*Calling fgets to reach EOF and check on the returned value*/
    pchar = fgets( line, 12, file);
    if(pchar == line)
        printf("\nfgets return is correct\n");
    else
        printf("\nfgets return is wrong!!\n");

    compare_result = strcmp( line, string );
    if(compare_result == 0)
        printf("\ncompare results passed\n");
    else
        printf("\ncompare results failed!!\n");
  
    fclose( file );

    return 0;
}
```