### PR TITLE
tinystdio: Resolve issue with tmpnam function

### DIFF
--- a/newlib/libc/tinystdio/mktemp.c
+++ b/newlib/libc/tinystdio/mktemp.c
@@ -98,8 +98,10 @@ _gettemp (char *path,
           int *doopen,
           int flags)
 {
-  char *start, *trv;
+  char *trv;
   char *end;
+  static char inc = 0;
+  static char pos = 1;
 
   end = path + strlen(path) - suffixlen;
   trv = end;
@@ -115,10 +117,28 @@ _gettemp (char *path,
       return 0;
     }
 
-  start = trv + 1;
+  trv += pos;
 
   for (;;)
     {
+      /* Increment the string of letters to generate another name */
+      for(;;)
+      {
+        if (trv == end)
+          return 0;
+        
+        if ((*trv + inc - 1) == 'z') {
+          *trv++ = 'a';
+          pos++;
+          inc = 1;
+        }
+        else {
+          *trv += inc;
+          inc++;
+          break;
+        }
+      }
+
       /*
        * Use open to check if the file exists to avoid depending on
        * stat or access. Don't rely on O_EXCL working, although if it
@@ -145,22 +165,7 @@ _gettemp (char *path,
         }
       } else
         close(fd);
-
-      /* Increment the string of letters to generate another name */
-      trv = start;
-      for(;;)
-	{
-	  if (trv == end)
-	    return 0;
-	  if (*trv == 'z')
-	    *trv++ = 'a';
-	  else {
-            ++ * trv;
-            break;
-          }
-	}
     }
-  /*NOTREACHED*/
 }
 
 int


### PR DESCRIPTION
The `tmpname()` function should generate a different temporary file name each time it is called up. But, the original implementation of `tmpnam()` function generates identical file names on subsequent calls.

So, we need to fix this implementation to generate a different temporary file name upon each invocation.

This is a simple testcase:
- In case of the original implementation: prints `"FAILED!"` and returns `-1`.
- In case of the new implementation: prints `"PASSED!"` and returns `0`.
```c
#include <stdio.h>
#include <string.h>

int main() {
    char generate[2][L_tmpnam];
    
    // Generate two temporary files
    tmpnam(generate[0]);
    tmpnam(generate[1]);
    
    // Check if the two file names are the same
    if (strcmp(tmpnam(generate[0]), generate[1]) == 0)
    {
        // The same file name
        printf("FAILED!\n");
        return -1;
    }
    else
    {
        // Different file names
        printf("PASSED!\n");
        return 0;
    }
}
```