### PR TITLE
nano-malloc: Ensure that MALLOC_MINSIZE is a power of two

### DIFF
--- a/newlib/libc/stdlib/nano-mallocr.c
+++ b/newlib/libc/stdlib/nano-mallocr.c
@@ -106,8 +106,11 @@ typedef struct malloc_chunk {
 #define MALLOC_PAGE_ALIGN 	(0x1000)
 
 /* Minimum allocation size */
-#define MALLOC_MINSIZE		__align_up(MALLOC_HEAD + sizeof(chunk_t), MALLOC_HEAD_ALIGN)
-
+#define MALLOC_MINSIZE                                                         \
+    __align_up(MALLOC_HEAD + sizeof(chunk_t),                                  \
+               MAX(MALLOC_HEAD_ALIGN, MALLOC_CHUNK_ALIGN))
+_Static_assert((MALLOC_MINSIZE & (MALLOC_MINSIZE - 1)) == 0,
+               "must be a power of two");
 /* Maximum allocation size */
 #define MALLOC_MAXSIZE 		(SIZE_MAX - (MALLOC_HEAD + 2*MALLOC_CHUNK_ALIGN))
 


### PR DESCRIPTION
In the current implementation this does not hold e.g. for systems such as 64-bit CHERI-RISC-V or Morello, where we end up with a value of 18 for MALLOC_MINSIZE. This breaks `align = MAX(align, MALLOC_MINSIZE)` inside memalign where we expect align to be a power of two. No functional change for non-CHERI architectures.