### PR TITLE
tinystdio: Mirror bufio stdin/stdout flush fix to fast fread

### DIFF
--- a/newlib/libc/tinystdio/bufio.c
+++ b/newlib/libc/tinystdio/bufio.c
@@ -176,11 +176,13 @@ again:
                  * pulling in stdin/stdout definitions just for this
                  * check.
                  */
-		if (&stdin != NULL && &stdout != NULL && f == stdin && !flushed) {
+                if (!flushed) {
                         flushed = true;
-			__bufio_unlock(f);
-			fflush(stdout);
-                        goto again;
+                        if (&stdin != NULL && &stdout != NULL && f == stdin) {
+                                __bufio_unlock(f);
+                                fflush(stdout);
+                                goto again;
+                        }
 		}
 
                 ret = __bufio_fill_locked(f);

--- a/newlib/libc/tinystdio/fread.c
+++ b/newlib/libc/tinystdio/fread.c
@@ -82,7 +82,7 @@ fread(void *ptr, size_t size, size_t nmemb, FILE *stream)
                                 /* Flush stdout if reading from stdin */
                                 if (!flushed) {
                                         flushed = true;
-                                        if (stream == stdin && stdout != NULL) {
+                                        if (&stdin != NULL && &stdout != NULL && stream == stdin) {
                                                 __bufio_unlock(stream);
                                                 fflush(stdout);
                                                 goto again;


### PR DESCRIPTION
The fast-bufio path in fread has the same stdin/stdout semantics as found in __bufio_get, so the fix applied there for weak stdin/stdout needs to be applied to fread as well. Take advantage of this to copy the slightly more efficient test from fread to __bufio_get.