### PR TITLE
tinystdio: fgetc fix when reading from a non readable stream

### DIFF
--- a/newlib/libc/tinystdio/atomic_load.c
+++ b/newlib/libc/tinystdio/atomic_load.c
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2024 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "stdio_private.h"
+
+#if defined(ATOMIC_UNGETC) && !defined(PICOLIBC_HAVE_SYNC_COMPARE_AND_SWAP)
+
+__ungetc_t
+__picolibc_non_atomic_load_ungetc(const volatile __ungetc_t *p)
+{
+	return __non_atomic_load_ungetc(p);
+}
+
+__weak_reference(__picolibc_non_atomic_load_ungetc, __atomic_load_ungetc);
+
+#endif

--- a/newlib/libc/tinystdio/fgetc.c
+++ b/newlib/libc/tinystdio/fgetc.c
@@ -37,8 +37,10 @@ fgetc(FILE *stream)
 	int rv;
 	__ungetc_t unget;
 
-	if ((stream->flags & __SRD) == 0)
+	if ((stream->flags & __SRD) == 0) {
+		stream->flags |= __SERR;
 		return EOF;
+	}
 
 	if ((unget = __atomic_exchange_ungetc(&stream->unget, 0)) != 0)
                 return (unsigned char) (unget - 1);

--- a/newlib/libc/tinystdio/ftell.c
+++ b/newlib/libc/tinystdio/ftell.c
@@ -43,8 +43,12 @@ FSEEK_TYPE
 ftell(FILE *stream)
 {
         struct __file_ext *xf = (struct __file_ext *) stream;
-        if ((stream->flags & __SEXT) && xf->seek)
-                return (FSEEK_TYPE) (xf->seek) (stream, 0, SEEK_CUR);
+        if ((stream->flags & __SEXT) && xf->seek) {
+                FSEEK_TYPE ret = (FSEEK_TYPE) (xf->seek) (stream, 0, SEEK_CUR);
+                if (__atomic_load_ungetc(&stream->unget) != 0)
+                    ret--;
+                return ret;
+        }
         errno = ESPIPE;
 	return -1;
 }

--- a/newlib/libc/tinystdio/meson.build
+++ b/newlib/libc/tinystdio/meson.build
@@ -34,6 +34,7 @@
 #
 srcs_tinystdio = [
   'asprintf.c',
+  'atomic_load.c',
   'atold_engine.c',
   'bufio.c',
   'clearerr.c',

--- a/newlib/libc/tinystdio/stdio_private.h
+++ b/newlib/libc/tinystdio/stdio_private.h
@@ -580,6 +580,12 @@ __non_atomic_compare_exchange_ungetc(__ungetc_t *p, __ungetc_t d, __ungetc_t v)
 	return true;
 }
 
+static inline uint16_t
+__non_atomic_load_ungetc(const volatile __ungetc_t *p)
+{
+        return *p;
+}
+
 #ifdef ATOMIC_UNGETC
 
 #if __PICOLIBC_UNGETC_SIZE == 4 && defined (__GCC_HAVE_SYNC_COMPARE_AND_SWAP_4)
@@ -608,6 +614,12 @@ __atomic_exchange_ungetc(__ungetc_t *p, __ungetc_t v)
 	return atomic_exchange_explicit(pa, v, memory_order_relaxed);
 }
 
+static inline __ungetc_t
+__atomic_load_ungetc(const volatile __ungetc_t *p)
+{
+	_Atomic __ungetc_t *pa = (_Atomic __ungetc_t *) p;
+        return atomic_load(pa);
+}
 #else
 
 bool
@@ -616,6 +628,9 @@ __atomic_compare_exchange_ungetc(__ungetc_t *p, __ungetc_t d, __ungetc_t v);
 __ungetc_t
 __atomic_exchange_ungetc(__ungetc_t *p, __ungetc_t v);
 
+__ungetc_t
+__atomic_load_ungetc(const volatile __ungetc_t *p);
+
 #endif /* PICOLIBC_HAVE_SYNC_COMPARE_AND_SWAP */
 
 #else
@@ -623,6 +638,8 @@ __atomic_exchange_ungetc(__ungetc_t *p, __ungetc_t v);
 #define __atomic_compare_exchange_ungetc(p,d,v) __non_atomic_compare_exchange_ungetc(p,d,v)
 
 #define __atomic_exchange_ungetc(p,v) __non_atomic_exchange_ungetc(p,v)
+
+#define __atomic_load_ungetc(p) (*(p))
 
 #endif /* ATOMIC_UNGETC */
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -533,7 +533,7 @@ foreach target : targets
 
     # legacy stdio doesn't work on semihosting, so just skip it
     if tinystdio
-      plain_tests += ['test-fopen', 'test-mktemp', 'test-tmpnam', 'test-fread-fwrite', 'test-ungetc-ftell']
+      plain_tests += ['test-fopen', 'test-mktemp', 'test-tmpnam', 'test-fread-fwrite', 'test-ungetc-ftell', 'test-fgetc']
     endif
   endif
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -533,7 +533,7 @@ foreach target : targets
 
     # legacy stdio doesn't work on semihosting, so just skip it
     if tinystdio
-      plain_tests += ['test-fopen', 'test-mktemp', 'test-tmpnam', 'test-fread-fwrite']
+      plain_tests += ['test-fopen', 'test-mktemp', 'test-tmpnam', 'test-fread-fwrite', 'test-ungetc-ftell']
     endif
   endif
 

--- a/test/test-fgetc.c
+++ b/test/test-fgetc.c
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2022 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#define _DEFAULT_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifndef TEST_FILE_NAME
+#define TEST_FILE_NAME "FGETC.TXT"
+#endif
+
+#define check(condition, message) do {                  \
+        if (!(condition)) {                             \
+            printf("%s: %s\n", message, #condition);    \
+            if (f)                                      \
+                fclose(f);                              \
+            (void) remove(TEST_FILE_NAME);              \
+            exit(1);                                    \
+        }                                               \
+    } while(0)
+
+
+int
+main(void)
+{
+    FILE *f;
+    int ch;
+
+    /* Make sure we can create a file */
+    f = fopen(TEST_FILE_NAME, "w");
+    check(f != NULL, "Error opening file");
+
+    // Get error indicator before reading
+    check(ferror(f) == 0, "Error occured before reading");
+
+    // Attempt to read from the file
+    ch = fgetc(f);
+    check(ch == EOF, "fgetc returns non EOF");
+
+    // Get error indicator after reading
+    check(ferror(f) != 0, "After reading from non readable stream, the error flag of straem f is not set");
+
+    // Close the file
+    fclose(f);
+
+    (void) remove(TEST_FILE_NAME);
+
+    exit(0);
+}

--- a/test/test-ungetc-ftell.c
+++ b/test/test-ungetc-ftell.c
@@ -1,0 +1,75 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2024 Hana Ashour
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+const char *str = "This is a string";
+
+int main(void) {
+
+    FILE *file;
+    char first;
+    long position, start;
+
+    file = fopen( "testfile.dat", "wb" );
+    if( file == NULL ) return 1;
+    fputs(str, file);
+    fclose(file);
+
+    file = fopen( "testfile.dat", "rb" );
+    if(file == NULL) return 1;
+
+    first = fgetc(file);
+    printf("First character read: %c\n", first);
+
+    start = ftell(file);
+    printf("Position before ungetc: %ld\n", start);
+
+    ungetc(first, file);  // Use ungetc to put the character back
+
+    position = ftell(file);  // Check ftell position (should be 0 after ungetc if first character was read)
+    printf("Position after ungetc: %ld\n", position);
+
+    fclose(file);
+
+    if (position == 0) {
+        printf("Test passed: ungetc and ftell working as expected.\n");
+        return 0;
+    } else {
+        printf("Test failed: Incorrect position after ungetc.\n");
+        return 1;
+    }
+}


### PR DESCRIPTION
Following with ISO/IEC 9899:1999 section 7.19.7.1, standard C library is expected to set the error flag when attempting to read from a stream opened in a non read mode, and return EOF.

This is a copy of #721 using a branch inside the picolibc repo.