### PR TITLE
Add MIPS64 CPU family support.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -95,6 +95,8 @@ cpu_family_aliases = {
 		       'm88110' : 'm88k',
 		       # Microblaze
 		       'microblazeel' : 'microblaze',
+		       # mips
+		       'mips64' : 'mips',
 		       # or1k
 		       'or1knd': 'or1k',
 		       # powerpc


### PR DESCRIPTION
It appears that the `mips` machine subdirectory includes code for handling 64-bit MIPS architectures, but picolibc was missing [the relevant CPU family alias](https://mesonbuild.com/Reference-tables.html#cpu-families).