### PR TITLE
tinystdio: Add funopen

### DIFF
--- a/newlib/libc/tinystdio/CMakeLists.txt
+++ b/newlib/libc/tinystdio/CMakeLists.txt
@@ -77,6 +77,7 @@ picolibc_sources(
   ftell.c
   ftello.c
   ftox_engine.c
+  funopen.c
   fwide.c
   fwprintf.c
   fwrite.c

--- a/newlib/libc/tinystdio/fread.c
+++ b/newlib/libc/tinystdio/fread.c
@@ -101,7 +101,7 @@ fread(void *ptr, size_t size, size_t nmemb, FILE *stream)
                                         bf->off = 0;
 
                                         /* Large reads go directly to the destination */
-                                        ssize_t len = (bf->read)(bf->fd, cp, bytes);
+                                        ssize_t len = bufio_read(bf, cp, bytes);
                                         if (len <= 0) {
                                                 stream->flags |= (len < 0) ? __SERR : __SEOF;
                                                 break;

--- a/newlib/libc/tinystdio/freopen.c
+++ b/newlib/libc/tinystdio/freopen.c
@@ -58,16 +58,16 @@ freopen(const char *pathname, const char *mode, FILE *stream)
         fflush(stream);
 
         __bufio_lock(stream);
-        close(pf->fd);
+        close((int)(intptr_t) (pf->ptr));
         stream->flags = (stream->flags & ~(__SRD|__SWR|__SERR|__SEOF)) | stdio_flags;
         pf->pos = 0;
-        pf->fd = fd;
+        pf->ptr = (void *) (intptr_t) (fd);
 
         /* Switch to POSIX backend */
-        pf->read = read;
-        pf->write = write;
-        pf->lseek = lseek;
-        pf->close = close;
+        pf->read_int = read;
+        pf->write_int = write;
+        pf->lseek_int = lseek;
+        pf->close_int = close;
 
         __bufio_unlock(stream);
 

--- a/newlib/libc/tinystdio/fwrite.c
+++ b/newlib/libc/tinystdio/fwrite.c
@@ -78,7 +78,7 @@ fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream)
                         /* Large writes go direct. */
                         if (__bufio_flush_locked(stream) >= 0) {
                                 while (bytes) {
-                                        ssize_t len = (bf->write)(bf->fd, cp, bytes);
+                                        ssize_t len = bufio_write(bf, cp, bytes);
                                         if (len <= 0) {
                                                 stream->flags |= _FDEV_ERR;
                                                 break;

--- a/newlib/libc/tinystdio/meson.build
+++ b/newlib/libc/tinystdio/meson.build
@@ -78,6 +78,7 @@ srcs_tinystdio = [
   'ftell.c',
   'ftello.c',
   'ftox_engine.c',
+  'funopen.c',
   'fwide.c',
   'fwprintf.c',
   'fwrite.c',

--- a/newlib/libc/tinystdio/stdio.h
+++ b/newlib/libc/tinystdio/stdio.h
@@ -324,6 +324,17 @@ char *tmpnam (char *s);
 ssize_t getline(char **__restrict lineptr, size_t *__restrict n, FILE *__restrict stream);
 ssize_t getdelim(char **__restrict lineptr, size_t *__restrict  n, int delim, FILE *__restrict stream);
 
+#if __BSD_VISIBLE
+FILE	*funopen (const void *cookie,
+		ssize_t (*readfn)(void *cookie, void *buf,
+				size_t n),
+		ssize_t (*writefn)(void *cookie, const void *buf,
+				 size_t n),
+		__off_t (*seekfn)(void *cookie, __off_t off, int whence),
+		int (*closefn)(void *cookie));
+# define	fropen(__cookie, __fn) funopen(__cookie, __fn, NULL, NULL, NULL)
+# define	fwopen(__cookie, __fn) funopen(__cookie, NULL, __fn, NULL, NULL)
+#endif /*__BSD_VISIBLE */
 /*
  * The format of tmpnam names is TXXXXXX, which works with mktemp
  */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,6 +51,7 @@ set(tests
   math-funcs
   timegm
   time-tests
+  test-funopen
   test-strtod
   test-strchr
   test-memset

--- a/test/meson.build
+++ b/test/meson.build
@@ -510,6 +510,7 @@ foreach target : targets
 		 'test-efcvt', 'test-atomic',
 		 'test-raise',
                  'test-fma',
+                 'test-funopen',
 		]
 
   if have_attr_ctor_dtor

--- a/test/test-funopen.c
+++ b/test/test-funopen.c
@@ -1,0 +1,134 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2024 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _DEFAULT_SOURCE
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#if defined(__PICOLIBC__) && !defined(TINY_STDIO)
+# define IO_T int
+# define BUF_T char
+# ifdef __LARGE64_FILES
+#  define SEEK_T _fpos64_t
+# else
+#  define SEEK_T fpos_t
+# endif
+#else
+# define IO_T ssize_t
+# define BUF_T void
+# define SEEK_T __off_t
+#endif
+
+static char test_buf[1024];
+static SEEK_T test_pos;
+static SEEK_T test_end;
+
+#define min(a, b)  ((SEEK_T) (a) < (SEEK_T) (b) ? (SEEK_T) (a) : (SEEK_T) (b))
+#define max(a, b)  ((SEEK_T) (a) > (SEEK_T) (b) ? (SEEK_T) (a) : (SEEK_T) (b))
+
+static IO_T
+test_read(void *cookie, BUF_T *buf, size_t n)
+{
+    (void) cookie;
+    n = min(n, test_end - test_pos);
+    memcpy(buf, test_buf + test_pos, n);
+    test_pos += n;
+    return n;
+}
+
+static IO_T
+test_write(void *cookie, const BUF_T *buf, size_t n)
+{
+    (void) cookie;
+    n = min(n, sizeof(test_buf) - test_pos);
+    memcpy(test_buf + test_pos, buf, n);
+    test_pos += n;
+    test_end = max(test_end, test_pos);
+    return n;
+}
+
+static SEEK_T
+test_seek(void *cookie, SEEK_T off, int whence)
+{
+    SEEK_T new_pos = test_pos;
+    (void) cookie;
+    switch (whence) {
+    case SEEK_CUR:
+        new_pos = test_pos + off;
+        break;
+    case SEEK_SET:
+        new_pos = off;
+        break;
+    case SEEK_END:
+        new_pos = test_pos + off;
+        break;
+    }
+    test_pos = min(test_end, new_pos);
+    return -1;
+}
+
+static int
+test_close(void *cookie)
+{
+    (void) cookie;
+    return 0;
+}
+
+#define check(condition, message) do {                  \
+        if (!(condition)) {                             \
+            printf("%s: %s\n", message, #condition);    \
+            exit(1);                                    \
+        }                                               \
+    } while(0)
+
+#define MESSAGE "hello, world"
+
+int main(void)
+{
+    FILE        *fp = funopen(NULL, test_read, test_write, test_seek, test_close);
+    char        buf[sizeof(MESSAGE)];
+    size_t      ret;
+
+    fprintf(fp, "%s", MESSAGE);
+    fflush(fp);
+    check(memcmp(test_buf, MESSAGE, strlen(MESSAGE)) == 0, "printf");
+    fseek(fp, 0L, SEEK_SET);
+    ret = fread(buf, 1, sizeof(buf), fp);
+    check(ret == strlen(MESSAGE), "fread size");
+    check(memcmp(buf, MESSAGE, strlen(MESSAGE)) == 0, "fread contents");
+    fclose(fp);
+    return 0;
+}


### PR DESCRIPTION
This is a lot like fdevopen, but with bulk APIs instead of simple get/put APIs. To make this work, the existing bufio layer needed to be extended to allow either an int or a pointer to be stored in the FILE for all of the callbacks.