### PR TITLE
tinystdio: Set the file stream to wide orientation in fputwc/fgetwc functions

### DIFF
--- a/newlib/libc/tinystdio/fgetwc.c
+++ b/newlib/libc/tinystdio/fgetwc.c
@@ -39,6 +39,8 @@ fgetwc(FILE *stream)
         unsigned i;
         int sc;
         __ungetc_t unget;
+        
+        stream->flags |= __SWIDE;
 
 	if ((stream->flags & __SRD) == 0)
 		return WEOF;

--- a/newlib/libc/tinystdio/fputwc.c
+++ b/newlib/libc/tinystdio/fputwc.c
@@ -37,19 +37,16 @@ fputwc(wchar_t c, FILE *stream)
                 char c[sizeof(wchar_t)];
         } u;
         unsigned i;
+        
+        stream->flags |= __SWIDE;
 
 	if ((stream->flags & __SWR) == 0)
 		return WEOF;
 
-        if (stream->flags & __SWIDE) {
-                u.wc = c;
-                for (i = 0; i < sizeof(wchar_t); i++)
-                        if (stream->put(u.c[i], stream) < 0)
-                                return WEOF;
-        } else {
-                if (stream->put((int)(char)c, stream) < 0)
+        u.wc = c;
+        for (i = 0; i < sizeof(wchar_t); i++)
+                if (stream->put(u.c[i], stream) < 0)
                         return WEOF;
-        }
 
 	return (wint_t) c;
 }

--- a/test/meson.build
+++ b/test/meson.build
@@ -544,6 +544,7 @@ foreach target : targets
                       'test-ungetc-ftell',
                       'test-fgetc',
                       'test-fgets-eof',
+                      'test-wchar',
                      ]
     endif
   endif
@@ -643,6 +644,12 @@ if enable_native_tests
 		    c_args: native_c_args,
 		    link_args: native_c_args,
 		    dependencies: native_lib_m))
+    test('test-wchar_native',
+    executable('test-wchar_native',
+        'test-wchar.c',
+        c_args: native_c_args,
+        link_args: native_c_args,
+        dependencies: native_lib_m))
 
     test('fenv-native',
          executable('fenv-native',

--- a/test/test-wchar.c
+++ b/test/test-wchar.c
@@ -1,0 +1,77 @@
+/*
+* SPDX-License-Identifier: BSD-3-Clause
+* 
+* Copyright © 2024, Synopsys Inc.
+* Copyright © 2024, Solid Sands B.V.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+*
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above
+*    copyright notice, this list of conditions and the following
+*    disclaimer in the documentation and/or other materials provided
+*    with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its
+*    contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+* STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+* OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <stdio.h>
+#include <wchar.h>
+
+
+const wchar_t *string = L"Hello\n";
+
+int main (void)
+{
+    FILE *file;
+    const wchar_t *ref;
+	wint_t res;
+
+    /* Create testfile.dat in write mode */
+    file = fopen("testfile.dat", "w");
+    if (file == NULL) return 1;
+    
+    /* Write wide characters to the file */
+    fputws(string, file);
+	fclose(file);
+    
+    /* Open testfile.dat in read mode */
+    file = fopen("testfile.dat", "r");
+
+	for (ref = string; *ref != L'\0'; ref++) {
+        
+        /* Read wide-char by wide-char from the file */
+		res = fgetwc(file);
+        if((wchar_t) res != *ref) {
+            printf("Test Failed: Failed to read wide character from file\n");
+            return 1;
+        }
+	}
+
+    if(fgetwc(file) != WEOF) {
+        printf("Test Failed: Failed to check if end-of-file reached\n");
+        return 1;    
+    }
+    
+    printf("Test Passed: Wide characters were written & read successfuly\n");
+    return 0;
+}


### PR DESCRIPTION
According to ISO/IEC 9899/1999 section 7.19.2: Streams

wide character input/output functions when applied to a stream should change the file orientation to be wide-oriented

Before this change wide character input/output functions were applied to
byte-oriented stream resulting in erroneous results handling wide characters
input/output to/from files.

Issue found by running [SuperTest by SolidSands](https://solidsands.com/products/supertest).