### PR TITLE
Fix name collision between test-fgets-eof and test-ungetc-ftell

### DIFF
--- a/test/test-fgets-eof.c
+++ b/test/test-fgets-eof.c
@@ -36,6 +36,10 @@
 #include <stdio.h>
 #include <string.h>
 
+#ifndef TEST_FILE_NAME
+#define TEST_FILE_NAME "FGETSEOF.TXT"
+#endif
+
 const char *string = "123456789";
 
 int main(void)
@@ -46,12 +50,12 @@ int main(void)
     FILE *file;
     int ret = 0;
 
-    file = fopen("testfile.dat", "w");
+    file = fopen( TEST_FILE_NAME, "w" );
     if(file == NULL) return 1;
     fputs(string, file);
     fclose(file);
 
-    file = fopen( "testfile.dat", "r" );
+    file = fopen( TEST_FILE_NAME, "r" );
     if(file == NULL) return 1;
 
     /*Calling fgets to reach EOF and check on the returned value*/

--- a/test/test-ungetc-ftell.c
+++ b/test/test-ungetc-ftell.c
@@ -36,6 +36,10 @@
 #include <stdio.h>
 #include <string.h>
 
+#ifndef TEST_FILE_NAME
+#define TEST_FILE_NAME "UNGETCFTELL.DAT"
+#endif
+
 const char *str = "This is a string";
 
 int main(void) {
@@ -44,12 +48,12 @@ int main(void) {
     char first;
     long position, start;
 
-    file = fopen( "testfile.dat", "wb" );
+    file = fopen( TEST_FILE_NAME, "wb" );
     if( file == NULL ) return 1;
     fputs(str, file);
     fclose(file);
 
-    file = fopen( "testfile.dat", "rb" );
+    file = fopen( TEST_FILE_NAME, "rb" );
     if(file == NULL) return 1;
 
     first = fgetc(file);


### PR DESCRIPTION
These two newly introduced tests both make a file called "testfile.dat". So if they're run concurrently in the same directory, one can overwrite the other's test file and cause a spurious test failure.

Other tests in this directory avoid this problem by defining a macro TEST_FILE_NAME to something unique to the test, and then using that macro consistently. I've updated these two tests to do the same thing.