### PR TITLE
picocrt: Add an option to enable caches

### DIFF
--- a/.github/do-arm
+++ b/.github/do-arm
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
 HERE=`dirname "$0"`
-"$HERE"/do-test native -Dnative-tests=false -Dtests-enable-posix-io=false
+"$HERE"/do-test native -Dnative-tests=false -Dtests-enable-posix-io=false -Dpicocrt-enable-caches=true
 "$HERE"/do-test native -Dnative-tests=false -Dtests-enable-posix-io=false -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false
 "$HERE"/do-test native -Dnative-tests=false -Dtests-enable-posix-io=false -Dformat-default=integer -Dposix-io=false -Dnewlib-obsolete-math=true -Dwant-math-errno=true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,9 @@ set(_HAVE_INITFINI_ARRAY 1)
 # Support _init() and _fini() functions
 set(_HAVE_INIT_FINI 1)
 
+# Enable CPU caches in pico crt startup
+set(PICOCRT_ENABLE_CACHES 0)
+
 # Compiler has long double type
 picolibc_flag(_HAVE_LONG_DOUBLE)
 

--- a/meson.build
+++ b/meson.build
@@ -1635,6 +1635,9 @@ endif
 # make sure to include semihost BEFORE picocrt!
 if enable_picocrt
   subdir('picocrt')
+  picocrt_enable_caches = get_option('picocrt-enable-caches')
+  conf_data.set('PICOCRT_ENABLE_CACHES', picocrt_enable_caches,
+                description: 'Turn on caches in picocrt startup code')
 endif
 subdir('newlib')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -62,6 +62,9 @@ option('picolib', type: 'boolean', value: true,
 option('picocrt', type: 'boolean', value: true,
        description: 'Include pico crt bits')
 
+option('picocrt-enable-caches', type: 'boolean', value: false,
+       description: 'Enable CPU caches in pico crt startup')
+
 option('picocrt-lib', type: 'boolean', value: true,
        description: 'Include pico crt bits in lib form')
 

--- a/picolibc.h.in
+++ b/picolibc.h.in
@@ -23,6 +23,9 @@
 /* use thread local storage */
 #cmakedefine NEWLIB_TLS
 
+/* Turn on caches in picocrt startup code */
+#cmakedefine PICOCRT_ENABLE_CACHES
+
 /* use thread local storage */
 #cmakedefine PICOLIBC_TLS
 


### PR DESCRIPTION
This is currently only implemented for Arm32 where the CPU starts off
with caches disabled. In order to turn on caches on Arm32 we also need
to turn on the MMU first, so this requires 16KB of page table memory and
is therefore gated by a default-off option.