### PR TITLE
newlib/libm: Protect math vector generator from fopen failure

### DIFF
--- a/newlib/libm/test/test.h
+++ b/newlib/libm/test/test.h
@@ -23,6 +23,7 @@
 //#include <ieeefp.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 #ifdef INCLUDE_GENERATE
 #define TEST_CONST
@@ -215,6 +216,7 @@ int fmag_of_error (float, float);
   char buffer[100];\
    sprintf(buffer,"%s_vec.c",x);\
     f = fopen(buffer,"w");\
+    if (!f) { perror(buffer); exit(1); } \
      fprintf(f,"#include \"test.h\"\n");\
       fprintf(f," one_line_type %s_vec[] = {\n", x);\
 }

--- a/test/libc-testsuite/string.c
+++ b/test/libc-testsuite/string.c
@@ -54,26 +54,27 @@
 
 int test_string(void)
 {
-	char b[32];
-	char *s;
+        char b[32] = {0};
+        char c[32] = {0};
+	char *s = NULL;
 	int i;
 	int err=0;
 
-	b[16]='a'; b[17]='b'; b[18]='c'; b[19]=0;
-	TEST(s, strcpy(b, b+16), b, "wrong return %p != %p");
+	c[0]='a'; c[1]='b'; c[2]='c'; c[3]=0;
+	TEST(s, strcpy(b, c), b, "wrong return %p != %p");
 	TEST_S(s, "abc", "strcpy gave incorrect string");
-	TEST(s, strcpy(b+1, b+16), b+1, "wrong return %p != %p");
+	TEST(s, strcpy(b+1, c), b+1, "wrong return %p != %p");
 	TEST_S(s, "abc", "strcpy gave incorrect string");
-	TEST(s, strcpy(b+2, b+16), b+2, "wrong return %p != %p");
+	TEST(s, strcpy(b+2, c), b+2, "wrong return %p != %p");
 	TEST_S(s, "abc", "strcpy gave incorrect string");
-	TEST(s, strcpy(b+3, b+16), b+3, "wrong return %p != %p");
+	TEST(s, strcpy(b+3, c), b+3, "wrong return %p != %p");
 	TEST_S(s, "abc", "strcpy gave incorrect string");
 
-	TEST(s, strcpy(b+1, b+17), b+1, "wrong return %p != %p");
+	TEST(s, strcpy(b+1, c+1), b+1, "wrong return %p != %p");
 	TEST_S(s, "bc", "strcpy gave incorrect string");
-	TEST(s, strcpy(b+2, b+18), b+2, "wrong return %p != %p");
+	TEST(s, strcpy(b+2, c+2), b+2, "wrong return %p != %p");
 	TEST_S(s, "c", "strcpy gave incorrect string");
-	TEST(s, strcpy(b+3, b+19), b+3, "wrong return %p != %p");
+	TEST(s, strcpy(b+3, c+3), b+3, "wrong return %p != %p");
 	TEST_S(s, "", "strcpy gave incorrect string");
 
 	TEST(s, memset(b, 'x', sizeof b), b, "wrong return %p != %p");


### PR DESCRIPTION
Bail if the test vector output file creation fails. This is not used during testing, only to re-generate the test vectors using a "known good" math library.

This fixes a warning generated by the compiler from the matching fclose call as without the check, that could be called with a NULL FILE pointer.