### PR TITLE
libc/time: Perform result bounds checking in asctime_r

### DIFF
--- a/newlib/libc/include/time.h
+++ b/newlib/libc/include/time.h
@@ -120,9 +120,11 @@ extern size_t strftime_l (char *__restrict _s, size_t _maxsize,
 			  const struct tm *__restrict _t, locale_t _l);
 #endif
 
+#define __ASCTIME_SIZE 26
+
 char	  *asctime_r 	(const struct tm *__restrict,
-				 char *__restrict);
-char	  *ctime_r 	(const time_t *, char *);
+				 char [__restrict static __ASCTIME_SIZE]);
+char	  *ctime_r 	(const time_t *, char [__restrict static __ASCTIME_SIZE]);
 struct tm *gmtime_r 	(const time_t *__restrict,
 				 struct tm *__restrict);
 struct tm *localtime_r 	(const time_t *__restrict,

--- a/newlib/libc/time/asctime.c
+++ b/newlib/libc/time/asctime.c
@@ -62,14 +62,12 @@ ANSI C requires <<asctime>>.
 
 #ifndef _REENT_ONLY
 
-#define _ASCTIME_SIZE 26
-
-static NEWLIB_THREAD_LOCAL char _asctime_buf[_ASCTIME_SIZE];
+static NEWLIB_THREAD_LOCAL char _asctime_buf[__ASCTIME_SIZE];
 
 char *
 asctime (const struct tm *tim_p)
 {
-  return asctime_r (tim_p, (char * __restrict) &_asctime_buf);
+  return asctime_r (tim_p, _asctime_buf);
 }
 
 #endif

--- a/newlib/libc/time/asctime_r.c
+++ b/newlib/libc/time/asctime_r.c
@@ -20,10 +20,11 @@ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 
 #include <stdio.h>
 #include <time.h>
+#include <errno.h>
 
 char *
 asctime_r (const struct tm *__restrict tim_p,
-	char *__restrict result)
+           char result[__restrict static __ASCTIME_SIZE])
 {
   static const char day_name[7][3] = {
 	"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
@@ -33,10 +34,23 @@ asctime_r (const struct tm *__restrict tim_p,
 	"Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
   };
 
-  sprintf (result, "%.3s %.3s%3d %.2d:%.2d:%.2d %d\n",
-	    day_name[tim_p->tm_wday], 
-	    mon_name[tim_p->tm_mon],
-	    tim_p->tm_mday, tim_p->tm_hour, tim_p->tm_min,
-	    tim_p->tm_sec, 1900 + tim_p->tm_year);
+  int n;
+
+  n = snprintf (result, __ASCTIME_SIZE, "%.3s %.3s%3d %.2d:%.2d:%.2d %d\n",
+                day_name[tim_p->tm_wday], 
+                mon_name[tim_p->tm_mon],
+                tim_p->tm_mday, tim_p->tm_hour, tim_p->tm_min,
+                tim_p->tm_sec, 1900 + tim_p->tm_year);
+
+  if (n < 0)
+      return NULL;
+
+  if (n >= __ASCTIME_SIZE)
+      goto eoverflow;
+
   return result;
+
+eoverflow:
+  errno = EOVERFLOW;
+  return NULL;
 }

--- a/newlib/libc/time/ctime_r.c
+++ b/newlib/libc/time/ctime_r.c
@@ -22,7 +22,7 @@ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 
 char *
 ctime_r (const time_t * tim_p,
-        char * result)
+        char result[__restrict static __ASCTIME_SIZE])
 
 {
   struct tm tm;

--- a/newlib/testsuite/newlib.time/asctime.c
+++ b/newlib/testsuite/newlib.time/asctime.c
@@ -1,0 +1,137 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2023 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <time.h>
+#include <stdio.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <string.h>
+
+static struct {
+    struct tm   tm;
+    char        *result;
+    int         _errno;
+} tests[] = {
+    {
+        .tm = {
+            .tm_sec = 0,
+            .tm_min = 0,
+            .tm_hour = 0,
+            .tm_mday = 0,
+            .tm_mon = 0,
+            .tm_year = 0,
+            .tm_wday = 0,
+            .tm_yday = 0,
+            .tm_isdst = 0,
+        },
+        .result = "Sun Jan  0 00:00:00 1900\n",
+        ._errno = 0,
+    },
+    {
+        .tm = {
+            .tm_sec = 0,
+            .tm_min = 0,
+            .tm_hour = 0,
+            .tm_mday = 0,
+            .tm_mon = 0,
+            .tm_year = 8100,
+            .tm_wday = 0,
+            .tm_yday = 0,
+            .tm_isdst = 0,
+        },
+        .result = NULL,
+        ._errno = EOVERFLOW,
+    },
+    {
+	/* winter time is March, 21st 2022 at 8:15pm and 20 seconds */
+        .tm = {
+            .tm_sec     = 20,
+            .tm_min     = 15,
+            .tm_hour    = 20,
+            .tm_mday    = 21,
+            .tm_mon     = 3 - 1,
+            .tm_year    = 2022 - 1900,
+            .tm_isdst   = 0
+        },
+        .result = "Sun Mar 21 20:15:20 2022\n",
+        ._errno = 0,
+    },
+    {
+        /* summer time is July, 15th 2022 at 10:50am and 40 seconds */
+        .tm = {
+            .tm_sec     = 40,
+            .tm_min     = 50,
+            .tm_hour    = 10,
+            .tm_mday    = 15,
+            .tm_mon     = 7 - 1,
+            .tm_year    = 2022 - 1900,
+            .tm_isdst   = 1
+        },
+        .result = "Sun Jul 15 10:50:40 2022\n",
+        ._errno = 0,
+    },
+};
+
+static int mylen(const char *s)
+{
+    if (s == NULL)
+        return -1;
+    return strlen(s);
+}
+
+int main(void)
+{
+    unsigned n;
+    int err = 0;
+    char buf[26];
+
+    (void) tests;
+    for (n = 0; n < sizeof(tests)/sizeof(tests[0]); n++)
+    {
+        const char *result = asctime_r(&tests[n].tm, buf);
+
+        if (tests[n].result == NULL && result == NULL)
+            continue;
+
+        if (tests[n].result != NULL && result != NULL &&
+            strcmp(tests[n].result, result) == 0)
+        {
+            continue;
+        }
+        printf("expect \"%s\"(%d) result \"%s\"(%d)\n", tests[n].result, mylen(tests[n].result), result, mylen(result));
+        err = 1;
+    }
+    return err;
+}

--- a/newlib/testsuite/newlib.time/meson.build
+++ b/newlib/testsuite/newlib.time/meson.build
@@ -52,7 +52,8 @@ foreach target : targets
   _link_args = value[1] + get_variable('test_link_args_' + target, test_link_args)
   _link_depends = get_variable('test_link_depends_' + target, test_link_depends)
 
-  _c_args += ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE']
+  _c_args_extra = ['-D_XOPEN_SOURCE=700', '-D_GNU_SOURCE']
+  _c_args += _c_args_extra
 
   foreach test : tests
     if target == ''
@@ -73,5 +74,11 @@ foreach target : targets
 		    include_directories: test_inc),
          depends: bios_bin,
 	 env: test_env)
+    if enable_native_tests
+      test(test_name + '-native',
+           executable(test_name + '-native', [src],
+                      c_args: native_c_args + _c_args_extra,
+                      link_args: native_c_args))
+    endif
   endforeach
 endforeach

--- a/newlib/testsuite/newlib.time/meson.build
+++ b/newlib/testsuite/newlib.time/meson.build
@@ -33,7 +33,7 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-tests = ['tzset']
+tests = ['tzset', 'asctime']
 
 foreach target : targets
   value = get_variable('target_' + target)

--- a/newlib/testsuite/newlib.time/tzset.c
+++ b/newlib/testsuite/newlib.time/tzset.c
@@ -113,6 +113,8 @@ const struct tz_test test_timezones[] = {
 
     /// test parsing errors
     // 1. names are too long
+#ifdef __PICOLIBC__
+    /* glibc is more lenient about name lengths, don't check on that */
     {"JUSTEXCEEDI1:11:11",                                      0,   NO_TIME},
     {"AVERYLONGNAMEWHICHEXCEEDSTZNAMEMAX2:22:22",               0,   NO_TIME},
     {"FIRSTVERYLONGNAME3:33:33SECONDVERYLONGNAME4:44:44",       0,   0},
@@ -125,7 +127,8 @@ const struct tz_test test_timezones[] = {
     {"HE6:34:47LO3:34:47",      0,   0},
     {"<AB>2:34:47",             0,   NO_TIME},
     {"<AB>2:34:47<CD>3:34:47",  0,   0},
-    
+#endif
+
     // 3. names contain invalid chars
     {"N?ME2:10:56",     0,   NO_TIME},
     {"N!ME2:10:56",     0,   NO_TIME},


### PR DESCRIPTION
And update `time.h` to include the required array sizes so that we get compile-time checking. Also test to make sure asctime_r actually does bounds checking now.