### PR TITLE
Fix compile failure when <time.h> is compiled as C++.

### DIFF
--- a/newlib/libc/include/time.h
+++ b/newlib/libc/include/time.h
@@ -123,8 +123,19 @@ extern size_t strftime_l (char *__restrict _s, size_t _maxsize,
 #define __ASCTIME_SIZE 26
 
 char	  *asctime_r 	(const struct tm *__restrict,
-				 char [__restrict static __ASCTIME_SIZE]);
-char	  *ctime_r 	(const time_t *, char [__restrict static __ASCTIME_SIZE]);
+#ifndef __cplusplus
+                         char [__restrict static __ASCTIME_SIZE]
+#else
+                         char *__restrict
+#endif
+                        );
+char	  *ctime_r 	(const time_t *,
+#ifndef __cplusplus
+                         char [__restrict static __ASCTIME_SIZE]
+#else
+                         char *__restrict
+#endif
+                        );
 struct tm *gmtime_r 	(const time_t *__restrict,
 				 struct tm *__restrict);
 struct tm *localtime_r 	(const time_t *__restrict,


### PR DESCRIPTION
Commit a88bd2fe8a23f2d replaced the `char *` arguments of asctime_r and ctime_r with `char[__restrict static __ASCTIME_SIZE]`. This isn't legal C++ syntax (either the `static SIZE` clause, or putting `restrict` inside the square brackets), and causes a compile error.

An easy fix is to guard the new syntax with `#ifdef __cplusplus`, otherwise falling back to plain `char *__restrict`.