### PR TITLE
time: Bounds check tm_wday and tm_mon in asctime_r

### DIFF
--- a/newlib/libc/time/asctime_r.c
+++ b/newlib/libc/time/asctime_r.c
@@ -22,6 +22,9 @@ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 #include <time.h>
 #include <errno.h>
 
+#define oob(x,a) ((unsigned)(x) >= sizeof(a)/sizeof(a[0]))
+#define valid(x,a)   (oob(x,a) ? "???" : a[x])
+
 char *
 asctime_r (const struct tm *__restrict tim_p,
            char result[__restrict static __ASCTIME_SIZE])
@@ -30,15 +33,15 @@ asctime_r (const struct tm *__restrict tim_p,
 	"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
   };
   static const char mon_name[12][3] = {
-	"Jan", "Feb", "Mar", "Apr", "May", "Jun", 
+	"Jan", "Feb", "Mar", "Apr", "May", "Jun",
 	"Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
   };
 
   int n;
 
   n = snprintf (result, __ASCTIME_SIZE, "%.3s %.3s%3d %.2d:%.2d:%.2d %d\n",
-                day_name[tim_p->tm_wday], 
-                mon_name[tim_p->tm_mon],
+                valid(tim_p->tm_wday, day_name),
+                valid(tim_p->tm_mon, mon_name),
                 tim_p->tm_mday, tim_p->tm_hour, tim_p->tm_min,
                 tim_p->tm_sec, 1900 + tim_p->tm_year);
 

--- a/newlib/testsuite/newlib.time/asctime.c
+++ b/newlib/testsuite/newlib.time/asctime.c
@@ -83,6 +83,7 @@ static struct {
             .tm_mday    = 21,
             .tm_mon     = 3 - 1,
             .tm_year    = 2022 - 1900,
+            .tm_wday = 0,
             .tm_isdst   = 0
         },
         .result = "Sun Mar 21 20:15:20 2022\n",
@@ -97,11 +98,44 @@ static struct {
             .tm_mday    = 15,
             .tm_mon     = 7 - 1,
             .tm_year    = 2022 - 1900,
+            .tm_wday = 0,
             .tm_isdst   = 1
         },
         .result = "Sun Jul 15 10:50:40 2022\n",
         ._errno = 0,
     },
+#if defined(__GLIBC__) || defined(__PICOLIBC__)
+    {
+        /* Invalid wday */
+        .tm = {
+            .tm_sec     = 40,
+            .tm_min     = 50,
+            .tm_hour    = 10,
+            .tm_mday    = 15,
+            .tm_mon     = 7 - 1,
+            .tm_year    = 2022 - 1900,
+            .tm_wday    = -1,
+            .tm_isdst   = 1
+        },
+        .result = "??? Jul 15 10:50:40 2022\n",
+        ._errno = 0,
+    },
+    {
+        /* Invalid mon */
+        .tm = {
+            .tm_sec     = 40,
+            .tm_min     = 50,
+            .tm_hour    = 10,
+            .tm_mday    = 15,
+            .tm_mon     = 12,
+            .tm_year    = 2022 - 1900,
+            .tm_wday    = 1,
+            .tm_isdst   = 1
+        },
+        .result = "Mon ??? 15 10:50:40 2022\n",
+        ._errno = 0,
+    },
+#endif
 };
 
 static int mylen(const char *s)


### PR DESCRIPTION
Check these values before using the local array to avoid out-of-bounds accesses. Mimic glibc's behavior of using ??? for out-of-bounds values.

Add a test for glibc and picolibc checking this result.