### PR TITLE
include: Restore missing members of struct sigevent

### DIFF
--- a/newlib/libc/include/sys/signal.h
+++ b/newlib/libc/include/sys/signal.h
@@ -77,7 +77,11 @@ struct sigevent {
   int              sigev_notify;               /* Notification type */
   int              sigev_signo;                /* Signal number */
   union sigval     sigev_value;                /* Signal value */
-
+#if defined(_POSIX_THREADS)
+  void           (*sigev_notify_function)( union sigval );
+                                               /* Notification function */
+  pthread_attr_t  *sigev_notify_attributes;    /* Notification Attributes */
+#endif
 };
 
 /* Signal Actions, P1003.1b-1993, p. 64 */


### PR DESCRIPTION
When removing some pthread API definitions, I unintentionally removed elements of 'struct sigevent' which are required by POSIX.

Closes: #754 