### PR TITLE
libc: Don't try to be clever when declaring __bsd_qsort_r and __xpg_strerror_r

### DIFF
--- a/newlib/libc/search/qsort.c
+++ b/newlib/libc/search/qsort.c
@@ -164,9 +164,13 @@ __unused
 #define PARAMETER_STACK_LEVELS 8u
 
 #if defined(I_AM_QSORT_R)
-# ifdef __GNUC__
-__typeof(qsort_r) __bsd_qsort_r;
-#endif
+void
+__bsd_qsort_r (void *a,
+	size_t n,
+	size_t es,
+	void *thunk,
+        cmp_t *cmp);
+
 void
 __bsd_qsort_r (void *a,
 	size_t n,

--- a/newlib/libc/string/xpg_strerror_r.c
+++ b/newlib/libc/string/xpg_strerror_r.c
@@ -4,7 +4,10 @@
 #include <errno.h>
 #include <string.h>
 
-__typeof(strerror_r) __xpg_strerror_r;
+int
+__xpg_strerror_r (int errnum,
+	char *buffer,
+        size_t n);
 
 int
 __xpg_strerror_r (int errnum,


### PR DESCRIPTION
Don't try to use typeof to match the definitions as those won't actually match if the library is built with -D_GNU_SOURCE=1.

Closes: #758 