### PR TITLE
tinystdio: Add a fix for rounding in case of 0 decimal places for fmode

### DIFF
--- a/newlib/libc/tinystdio/dtoa_ryu.c
+++ b/newlib/libc/tinystdio/dtoa_ryu.c
@@ -283,7 +283,7 @@ d2d(const uint64_t ieeeMantissa, const uint32_t ieeeExponent, int max_digits, bo
 
 	// We need to take vr + 1 if vr is outside bounds or we need to round up.
 	// I don't know if the 'truncate_max' case is entirely correct; need some tests
-	uint8_t carry = ((!truncate_max && vr == vm && (!acceptBounds || !vmIsTrailingZeros)) || lastRemovedDigit >= 5);
+	uint8_t carry = (((!truncate_max && vr == vm && (!acceptBounds || !vmIsTrailingZeros)) || lastRemovedDigit >= 5) && !(fmode && max_decimals == 0));
 	output += carry;
 
 	int len = decimalLength17(output);

--- a/test/testcases.c
+++ b/test/testcases.c
@@ -296,6 +296,7 @@
     result |= test(__LINE__, "8.6000", "%2.4f", 8.6);
     result |= test(__LINE__, "0.600000", "%0f", 0.6);
     result |= test(__LINE__, "1", "%.0f", 0.6);
+    result |= test(__LINE__, "0", "%.0f", 0.45);
     result |= test(__LINE__, "8.6000e+00", "%2.4e", 8.6);
     result |= test(__LINE__, " 8.6000e+00", "% 2.4e", 8.6);
     result |= test(__LINE__, "-8.6000e+00", "% 2.4e", -8.6);


### PR DESCRIPTION
before this change, in case of rouding to 0 decimal places with fmode for 0 < x < 1
some numbers get printed incorrectly such as 0,45 gets rounded to 1 instead of 0

it's because rounding happens in dtoa_ryu.c d2d function then another rounding
happens in vfprintf function itself, because that cascading rounding results in
incorrect results incase of rounding to 0 decimal places, this change prevents
the extra rounding that happens in dtoa_ryu.c and rely on vfprintf rounding for
this case.