### PR TITLE
tinystdio: Fix freopen to reset unget buffer

### DIFF
--- a/newlib/libc/tinystdio/freopen.c
+++ b/newlib/libc/tinystdio/freopen.c
@@ -59,6 +59,7 @@ freopen(const char *pathname, const char *mode, FILE *stream)
 
         __bufio_lock(stream);
         close((int)(intptr_t) (pf->ptr));
+        (void) __atomic_exchange_ungetc(&stream->unget, 0);
         stream->flags = (stream->flags & ~(__SRD|__SWR|__SERR|__SEOF)) | stdio_flags;
         pf->pos = 0;
         pf->ptr = (void *) (intptr_t) (fd);


### PR DESCRIPTION
`freopen` should reset the unget buffer to ensure subsequent input operations such as scanf work correctly. The unget buffer was not being reset, causing issues when tests are run consecutively.