### PR TITLE
mallocr.c: add an implementation of posix_memalign().

### DIFF
--- a/newlib/libc/stdlib/malloc-posix_memalign.c
+++ b/newlib/libc/stdlib/malloc-posix_memalign.c
@@ -1,0 +1,34 @@
+/*
+Copyright © 2019 Keith Packard
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided
+with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived
+from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#define DEFINE_POSIX_MEMALIGN
+#include "mallocr.c"

--- a/newlib/libc/stdlib/mallocr.c
+++ b/newlib/libc/stdlib/mallocr.c
@@ -963,6 +963,7 @@ extern Void_t*     sbrk();
 #define pvALLOc		__libc_pvalloc
 #define mALLINFo	__libc_mallinfo
 #define mALLOPt		__libc_mallopt
+#define pOSIx_mEMALIGn	__libc_posix_memalign
 
 #pragma weak calloc = __libc_calloc
 #pragma weak free = __libc_free
@@ -974,6 +975,7 @@ extern Void_t*     sbrk();
 #pragma weak pvalloc = __libc_pvalloc
 #pragma weak mallinfo = __libc_mallinfo
 #pragma weak mallopt = __libc_mallopt
+#pragma weak posix_memalign = __libc_posix_memalign
 
 #else
 
@@ -986,6 +988,7 @@ extern Void_t*     sbrk();
 #define pvALLOc		pvalloc
 #define mALLINFo	mallinfo
 #define mALLOPt		mallopt
+#define pOSIx_mEMALIGn	posix_memalign
 
 #ifdef _LIBC
 
@@ -1023,6 +1026,7 @@ size_t  malloc_usable_size(Void_t*);
 void    malloc_stats(void);
 int     mALLOPt(int, int);
 struct mallinfo mALLINFo(void);
+int     pOSIx_mEMALIGn(Void_t **, size_t, size_t);
 #else
 Void_t* mALLOc();
 void    fREe();
@@ -1037,6 +1041,7 @@ size_t  malloc_usable_size();
 void    malloc_stats();
 int     mALLOPt();
 struct mallinfo mALLINFo();
+int     pOSIx_mEMALIGn()
 #endif
 
 /* Work around compiler optimizing away stores to 'size' field before
@@ -3596,6 +3601,27 @@ int mALLOPt(param_number, value) RDECL int param_number; int value;
 }
 
 #endif /* DEFINE_MALLOPT */
+
+#ifdef DEFINE_POSIX_MEMALIGN
+#if __STD_C
+int pOSIx_mEMALIGn(Void_t **memptr, size_t align, size_t size)
+#else
+int pOSIx_mEMALIGn(memptr, align, size) RDECL Void_t **memptr; size_t align, size;
+#endif
+{
+    /* Return EINVAL if align isn't power of 2 or not a multiple of a pointer size */
+    if ((align & (align-1)) != 0 || align % sizeof(Void_t *) != 0 || align == 0)
+        return EINVAL;
+
+    Void_t *mem = mEMALIGn(align, size);
+
+    if (!mem)
+        return ENOMEM;
+
+    *memptr = mem;
+    return 0;
+}
+#endif
 
 /*
 

--- a/newlib/libc/stdlib/meson.build
+++ b/newlib/libc/stdlib/meson.build
@@ -59,6 +59,7 @@ std_malloc_srcs_stdlib = [
   'malloc-malloc_usable_size.c',
   'malloc-mallopt.c',
   'malloc-memalign.c',
+  'malloc-posix_memalign.c',
   'malloc-pvalloc.c',
   'malloc-realloc.c',
   'malloc-valloc.c',

--- a/test/malloc.c
+++ b/test/malloc.c
@@ -52,7 +52,7 @@ main(void)
 {
         void *r, *q;
 	int result = 0;
-	int pow;
+	int err, pow;
 
 	errno = 0;
 	r = malloc(0);
@@ -68,6 +68,42 @@ main(void)
 	if ((uintptr_t) r & 127) {
 		printf("memalign(128, 237) unaligned (%p)\n", r);
 		result++;
+	}
+	free(r);
+
+	r = NULL;
+	err = posix_memalign(&r, 128, 237);
+	printf("posix_memalign(128, 237): %p, err=%d\n", r, err);
+	if ((uintptr_t) r & 127) {
+		printf("posix_memalign(128, 237) unaligned (%p)\n", r);
+		err++;
+	}
+	free(r);
+
+	r = NULL;
+	err = posix_memalign(&r, 0, 237);
+	printf("posix_memalign(0, 237): %p, err=%d\n", r, err);
+	if (err != EINVAL) {
+		printf("posix_memalign(0, 237) should return EINVAL\n");
+		err++;
+	}
+	free(r);
+
+	r = NULL;
+	err = posix_memalign(&r, 129, 237);
+	printf("posix_memalign(129, 237): %p, err=%d\n", r, err);
+	if (err != EINVAL) {
+		printf("posix_memalign(129, 237) should return EINVAL\n");
+		err++;
+	}
+	free(r);
+
+	r = NULL;
+	err = posix_memalign(&r, 128, PTRDIFF_MAX);
+	printf("posix_memalign(128, PTRDIFF_MAX): %p, err=%d\n", r, err);
+	if (err != ENOMEM) {
+		printf("posix_memalign(128, PTRDIFF_MAX) should return ENOMEM\n");
+		err++;
 	}
 	free(r);
 


### PR DESCRIPTION
The two allocators mallocr.c and nano-mallocr.c mostly support the same set of functions, but posix_memalign is an exception: nano-mallocr has an implementation of it, but mallocr doesn't. This means the available API changes depending on whether you asked for a fast or a small memory allocator.

mallocr does support aligned memory allocation, via other APIs. So posix_memalign can be implemented as a wrapper on the existing API, just as it is in nano-mallocr.