### PR TITLE
tinystdio: fclose issue if called more than once

### DIFF
--- a/newlib/libc/tinystdio/bufio.c
+++ b/newlib/libc/tinystdio/bufio.c
@@ -307,7 +307,7 @@ __bufio_close(FILE *f)
          * FILE structs defined for stdin/stdout/stderr.
          */
         if (bf->bflags & __BFALL) {
-                bufio_close(bf);
+                ret = bufio_close(bf);
                 free(f);
         }
 	return ret;


### PR DESCRIPTION
The __bufio_close() function used to discard the return value of the semihost, so this return value is now saved in a variable to be returned. It Will return -1 if the file has been closed before.