### PR TITLE
clang: Adjust lld version detection method

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1021,9 +1021,9 @@ foreach target : ['default-target'] + targets
       if host_cpu_family == 'riscv'
         # ld.lld before version 15 did not support linker relaxations, disable
         # them if we are using an older version.
-        # There is no `cc.get_linker_version()` function, so we detect ld.lld
-        # version 15 by checking for a newly added linker flag.
-        if not cc.has_link_argument('--package-metadata=1')
+        # There is no `cc.get_linker_version()` function, so we just 
+        # assume lld is the same version as clang
+        if not cc.version().version_compare('>=15')
           message('Linking for RISCV with ld.lld < 15, forcing -mno-relax')
           c_args += ['-mno-relax']
         endif

--- a/newlib/libc/tinystdio/bufio.c
+++ b/newlib/libc/tinystdio/bufio.c
@@ -307,7 +307,7 @@ __bufio_close(FILE *f)
          * FILE structs defined for stdin/stdout/stderr.
          */
         if (bf->bflags & __BFALL) {
-                bufio_close(bf);
+                ret = bufio_close(bf);
                 free(f);
         }
 	return ret;


### PR DESCRIPTION
Instead of attempting to detect the lld version by checking for a specific compiler flag, just assume the clang version is the same as the lld version.

Closes: #773 