### PR TITLE
tinystdio: Don't limit %a precision

### DIFF
--- a/newlib/libc/tinystdio/dtox_engine.c
+++ b/newlib/libc/tinystdio/dtox_engine.c
@@ -61,7 +61,7 @@
 #define SIG_MSB         0x10000000000000LL
 #define EXP_BIAS        1023
 #define ASUINT(x)       asuint64(x)
-#define DTOX_NDIGS 14
+#define DTOX_NDIGS      14
 
 #define _NEED_IO_FLOAT64
 

--- a/newlib/libc/tinystdio/freopen.c
+++ b/newlib/libc/tinystdio/freopen.c
@@ -59,6 +59,7 @@ freopen(const char *pathname, const char *mode, FILE *stream)
 
         __bufio_lock(stream);
         close((int)(intptr_t) (pf->ptr));
+        (void) __atomic_exchange_ungetc(&stream->unget, 0);
         stream->flags = (stream->flags & ~(__SRD|__SWR|__SERR|__SEOF)) | stdio_flags;
         pf->pos = 0;
         pf->ptr = (void *) (intptr_t) (fd);

--- a/newlib/libc/tinystdio/vfprintf.c
+++ b/newlib/libc/tinystdio/vfprintf.c
@@ -694,8 +694,9 @@ int vfprintf (FILE * stream, const CHAR *fmt, va_list ap_orig)
                     if (!(flags & FL_PREC))
                         prec = -1;
 
-                    prec = __float_x_engine(fval, &dtoa, prec, case_convert);
-                    ndigs = prec + 1;
+                    ndigs = 1 + __float_x_engine(fval, &dtoa, prec, case_convert);
+                    if (prec <= ndigs)
+                        prec = ndigs - 1;
                     exp = dtoa.exp;
                     ndigs_exp = 1;
                 } else

--- a/test/testcases.c
+++ b/test/testcases.c
@@ -718,6 +718,7 @@
     result |= test(__LINE__, "0X1.FFFFFFFFFFFFFP+1022", "%A", 0x1.fffffffffffffp+1022);
     result |= test(__LINE__, "0X1.23456789ABCDEP-1022", "%A", 0x1.23456789abcdep-1022);
     result |= test(__LINE__, "0X1.23456789ABCDFP-1022", "%A", 0x1.23456789abcdfp-1022);
+    result |= test(__LINE__, "0X1.D749096BB98C800P+8", "%.15A", 0x1.D749096BB98C8p+8);
 #endif
 #endif
     /* test %ls for wchar_t string */


### PR DESCRIPTION
The conversion returns the number of fraction digits generated (ndig - 1); we need to remember the number of fraction digits desired in case that is larger so we can pad with zeros.

Closes: #775 

Reported-by: Ahmed Shehab <shehab@synopsys.com>