### PR TITLE
ctype: Fix isblank for non-C locales

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1021,9 +1021,9 @@ foreach target : ['default-target'] + targets
       if host_cpu_family == 'riscv'
         # ld.lld before version 15 did not support linker relaxations, disable
         # them if we are using an older version.
-        # There is no `cc.get_linker_version()` function, so we detect ld.lld
-        # version 15 by checking for a newly added linker flag.
-        if not cc.has_link_argument('--package-metadata=1')
+        # There is no `cc.get_linker_version()` function, so we just 
+        # assume lld is the same version as clang
+        if not cc.version().version_compare('>=15')
           message('Linking for RISCV with ld.lld < 15, forcing -mno-relax')
           c_args += ['-mno-relax']
         endif

--- a/newlib/libc/ctype/isblank.c
+++ b/newlib/libc/ctype/isblank.c
@@ -38,8 +38,13 @@ No supporting OS subroutines are required.
 
 #include <ctype.h>
 
+#undef isblank
 int
 isblank (int c)
 {
+#if _PICOLIBC_CTYPE_SMALL
     return c == ' ' || c == '\t';
+#else
+    return(__CTYPE_PTR[c+1] & _B) || c == '\t';
+#endif
 }

--- a/newlib/libc/include/ctype.h
+++ b/newlib/libc/include/ctype.h
@@ -83,11 +83,6 @@ int toupper (int c);
 
 #if __ISO_C_VISIBLE >= 1999
 int isblank (int c);
-#ifdef __declare_extern_inline
-__declare_extern_inline(int) isblank(int c) {
-	return c == ' ' || c == '\t';
-}
-#endif
 #endif
 
 #if __MISC_VISIBLE || __XSI_VISIBLE
@@ -126,6 +121,11 @@ int toascii_l (int c, locale_t l);
 #if _PICOLIBC_CTYPE_SMALL
 
 #ifdef __declare_extern_inline
+
+__declare_extern_inline(int) isblank (int c)
+{
+    return c == ' ' || c == '\t';
+}
 
 __declare_extern_inline(int) iscntrl (int c)
 {
@@ -264,6 +264,14 @@ static __inline char __ctype_lookup(int c) { return (__CTYPE_PTR + 1)[c]; }
 #define isprint(__c)	(__ctype_lookup(__c)&(_P|_U|_L|_N|_B))
 #define	isgraph(__c)	(__ctype_lookup(__c)&(_P|_U|_L|_N))
 #define iscntrl(__c)	(__ctype_lookup(__c)&_C)
+
+#if __ISO_C_VISIBLE >= 1999
+#if defined(__GNUC__)
+#define isblank(__c)                                            \
+    __extension__ ({ __typeof__ (__c) __x = (__c);		\
+            (__ctype_lookup(__x)&_B) || (int) (__x) == '\t';})
+#endif
+#endif
 
 #if __POSIX_VISIBLE >= 200809
 #ifdef __HAVE_LOCALE_INFO__

--- a/newlib/libc/tinystdio/bufio.c
+++ b/newlib/libc/tinystdio/bufio.c
@@ -307,7 +307,7 @@ __bufio_close(FILE *f)
          * FILE structs defined for stdin/stdout/stderr.
          */
         if (bf->bflags & __BFALL) {
-                bufio_close(bf);
+                ret = bufio_close(bf);
                 free(f);
         }
 	return ret;

--- a/test/meson.build
+++ b/test/meson.build
@@ -41,6 +41,7 @@ plain_tests_common = ['regex', 'ungetc',
 	              'test-memset', 'test-put',
 	              'test-raise',
                       'test-sprintf-percent-n',
+                      'test-ctype',
 	      ]
 
 math_tests_common = [

--- a/test/test-ctype.c
+++ b/test/test-ctype.c
@@ -1,0 +1,89 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2024 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <ctype.h>
+#include <stdbool.h>
+
+/* Validate C locale ctype data */
+
+#define boolname(b)     ((b) ? "true" : "false")
+#define iscat(name)     is ## name
+#define TEST(name)   do {                                               \
+        if (!!iscat(name)(c) != !!name) {                               \
+            printf("character %#2x '%c' is%s is %s should be %s\n",     \
+                   c, c, #name, boolname(iscat(name)(c)), boolname(name)); \
+            error = 1;                                                  \
+        }                                                               \
+    } while(0)
+
+int main(void) {
+
+    int c;
+    int error = 0;
+
+    for (c = 0; c < 128; c++) {
+        /* Direct values */
+        bool blank = c == ' ' || c == '\t';
+        bool cntrl = c < ' ' || c >= 127;
+        bool digit = '0' <= c && c <= '9';
+        bool graph = ' ' < c && c < 127;
+        bool lower = 'a' <= c && c <= 'z';
+        bool print = ' ' <= c && c < 127;
+        bool space = c == ' ' || c == '\f' || c == '\n' || c == '\r' || c == '\t' || c == '\v';
+        bool upper = 'A' <= c && c <= 'Z';
+        bool xdigit = ('0' <= c && c <= '9') || ('a' <= c && c <= 'f') || ('A' <= c && c <= 'F');
+
+        /* Derived values */
+        bool alpha = upper || lower;
+        bool alnum = alpha || digit;
+
+        bool punct = print && !space && !alnum;
+
+        TEST(alnum);
+        TEST(alpha);
+        TEST(blank);
+        TEST(cntrl);
+        TEST(digit);
+        TEST(graph);
+        TEST(lower);
+        TEST(print);
+        TEST(punct);
+        TEST(space);
+        TEST(upper);
+        TEST(xdigit);
+    }
+    return error;
+}


### PR DESCRIPTION
In non-C locales, isblank is supposed to return true for locale-specific characters for which isspace is true and are used to separate words within a line of text. That's what the _B bit does in the ctype tables. That bit is also used by 'isprint', which should not include tab, so we need an explicit test for tab in isblank.

Closes: #778 