### PR TITLE
tinystdio: Support nan/inf values in float scanf

### DIFF
--- a/newlib/libc/tinystdio/conv_flt.c
+++ b/newlib/libc/tinystdio/conv_flt.c
@@ -239,10 +239,10 @@ conv_flt (FLT_STREAM *stream, FLT_CONTEXT *context, width_t width, void *addr, u
                             continue;
                         scanf_ungetc (i, stream, context);
                     }
-		    if (p == pstr_nfinity + 3)
-			break;
-		    return 0;
-		}
+                }
+                if (p == pstr_nfinity + 3)
+                    break;
+                return 0;
 	    }
         }
 	break;

--- a/newlib/libc/tinystdio/conv_flt.c
+++ b/newlib/libc/tinystdio/conv_flt.c
@@ -559,6 +559,30 @@ conv_flt (FLT_STREAM *stream, FLT_CONTEXT *context, width_t width, void *addr, u
 	break;
     } /* switch */
 
+#if defined(__riscv) || defined(__ARC64__) || defined(__mips)
+    /*
+     * Some processors don't preserve the sign of NAN across
+     * conversions, so we have to negate after the cast
+     */
+    if (addr) {
+	if (CHECK_LONG_LONG()) {
+            long double ld = (long double) flt;
+            if (flags & FL_MINUS)
+                ld = -ld;
+            *((long double *) addr) = ld;
+	} else if (CHECK_LONG()) {
+            double d = (double) flt;
+            if (flags & FL_MINUS)
+                d = -d;
+	    *((double *) addr) = d;
+        } else {
+            float f = (float) flt;
+            if (flags & FL_MINUS)
+                f = -f;
+	    *((float *) addr) = f;
+        }
+    }
+#else
     if (flags & FL_MINUS)
 	flt = -flt;
     if (addr) {
@@ -569,6 +593,7 @@ conv_flt (FLT_STREAM *stream, FLT_CONTEXT *context, width_t width, void *addr, u
         else
 	    *((float *) addr) = (float) flt;
     }
+#endif
     return 1;
 }
 

--- a/newlib/libc/tinystdio/ldtox_engine.c
+++ b/newlib/libc/tinystdio/ldtox_engine.c
@@ -124,8 +124,24 @@ __ldtox_engine(long double x, struct dtoa *dtoa, int prec, unsigned char case_co
         _u128   mask = _u128_not(_u128_minus_64(_u128_lshift(half, 1), 1));
 
         /* round even */
-        if (_u128_gt(_u128_and(s, _u128_not(mask)), half) || _u128_and_64(_u128_rshift(s, bits), 1) != 0)
+        if (_u128_gt(_u128_and(s, _u128_not(mask)), half) || _u128_and_64(_u128_rshift(s, bits), 1) != 0) {
             s = _u128_plus(s, half);
+
+#if !defined(LSIG_MSB) && (__LDBL_MANT_DIG__ & 3) == 0
+            /*
+             * Formats without an implicit '1' for the MSB and which
+             * fill all four bits of the top digit might actually
+             * overflow when rounding. Check for that and shift right.
+             * We can do this without loss of accuracy because we just
+             * carried all the way from 'half' to the top digit of the
+             * value
+             */
+            if (_u128_ge(s, _u128_lshift(to_u128(1), __LDBL_MANT_DIG__))) {
+                s = _u128_rshift(s, 4);
+                exp += 4;
+            }
+#endif
+        }
 
         s = _u128_and(s, mask);
     }

--- a/newlib/libc/tinystdio/ldtox_engine.c
+++ b/newlib/libc/tinystdio/ldtox_engine.c
@@ -95,7 +95,10 @@ __ldtox_engine(long double x, struct dtoa *dtoa, int prec, unsigned char case_co
     _u128 fi, s;
     int exp;
 
+    dtoa->flags = 0;
     fi = asuintld(x);
+    if (_u128_and_64(_u128_rshift(fi, LSIGN_SHIFT), 1))
+        dtoa->flags = DTOA_MINUS;
 
     exp = _u128_and_64(_u128_rshift(fi, LEXP_SHIFT), LEXP_MASK);
     s = fi = _u128_lshift(_u128_and(fi, LSIG_MASK), LSIG_SHIFT);
@@ -110,9 +113,6 @@ __ldtox_engine(long double x, struct dtoa *dtoa, int prec, unsigned char case_co
         }
         exp -= LEXP_BIAS;
     }
-    dtoa->flags = 0;
-    if (_u128_and_64(_u128_rshift(fi, LSIGN_SHIFT), 1))
-        dtoa->flags = DTOA_MINUS;
 
     if (prec < 0)
         prec = 0;

--- a/newlib/libm/ld/common/e_lgammal.c
+++ b/newlib/libm/ld/common/e_lgammal.c
@@ -14,7 +14,7 @@
 long double
 lgammal(long double x)
 {
-	return (lgammal_r(x, &signgam));
+	return (lgammal_r(x, &__signgam));
 }
 
 #  ifdef _HAVE_ALIAS_ATTRIBUTE

--- a/scripts/run-riscv
+++ b/scripts/run-riscv
@@ -97,7 +97,7 @@ if $qemu --version | grep -q 'version [89]'; then
 fi
 
 if $qemu --version | grep -q 'version \(8.[1-9]\|9\)'; then
-    all_options="Zfa $all_options"
+    all_options="zfa $all_options"
 fi
 
 for o in $all_options; do

--- a/test/libc-testsuite/sscanf.c
+++ b/test/libc-testsuite/sscanf.c
@@ -26,6 +26,7 @@
 #include <limits.h>
 #include <locale.h>
 #include <wchar.h>
+#include <math.h>
 
 #define TEST(r, f, x, m) ( \
 ((r) = (f)) == (x) || \
@@ -41,6 +42,10 @@
 
 #define TEST_F(x) ( \
 TEST(i, sscanf(# x, "%lf", &d), 1, "got %d fields, expected %d"), \
+TEST(t, d, (double)x, "%a != %a") )
+
+#define TEST_FV(x,v) (\
+TEST(i, sscanf(v, "%lf", &d), 1, "got %d fields, expected %d"), \
 TEST(t, d, (double)x, "%a != %a") )
 
 #pragma GCC diagnostic ignored "-Wpragmas"
@@ -267,6 +272,22 @@ static int test_sscanf(void)
 	TEST_F(0.1e-10);
 	TEST_F(0x1234p56);
         TEST_F(3752432815e-39);
+        TEST(i, sscanf("nan", "%lg", &d), 1, "got %d fields, expected %d");
+        TEST(i, isnan(d), 1, "isnan %d expected %d");
+        TEST(i, !!signbit(d), 0, "signbit %d expected %d");
+        TEST(i, sscanf("-nan", "%lg", &d), 1, "got %d fields, expected %d");
+        TEST(i, isnan(d), 1, "isnan %d expected %d");
+        TEST(i, !!signbit(d), 1, "signbit %d expected %d");
+        TEST_FV(INFINITY, "inf");
+        TEST_FV(-INFINITY, "-inf");
+
+        d = 1.0;
+        TEST(i, sscanf("-inf", "%3lg", &d), 0, "got %d fields, expected %d");
+        TEST(i, d, 1.0, "%g expected %g");
+
+        TEST(i, sscanf("-inf", "%4lg", &d), 1, "got %d fields, expected %d");
+        TEST(i, isinf(d), 1, "isinf %d expected %d");
+        TEST(i, !!signbit(d), 1, "signbit %d expected %d");
 
 #ifndef __PICOLIBC__
         /* both tinystdio and legacy stdio fail this test */

--- a/test/printf-tests.c
+++ b/test/printf-tests.c
@@ -14,7 +14,7 @@
 #include <locale.h>
 
 #ifndef TINY_STDIO
-#define printf_float(x) x
+#define printf_float(x) ((double) (x))
 #ifdef _NANO_FORMATTED_IO
 #ifndef NO_FLOATING_POINT
 extern int _printf_float();
@@ -60,8 +60,16 @@ static int test(int serial, char *expect, char *fmt, ...) {
     va_copy(aap, ap);
 #endif
 #ifndef NO_FLOATING_POINT
+# ifdef _HAS_IO_FLOAT
+    uint32_t dv;
+# else
     double dv;
+# endif
+#ifndef NO_LONG_DOUBLE
+    long double ldv;
+#endif
     char *star;
+    char *long_double;
 #endif
     switch (fmt[strlen(fmt)-1]) {
     case 'e':
@@ -76,29 +84,63 @@ static int test(int serial, char *expect, char *fmt, ...) {
 	    return 0;
 #else
 	    star = strchr(fmt, '*');
+            long_double = strchr(fmt, 'L');
 	    if (star) {
 		    if (strchr(star+1, '*')) {
 			    int iv1 = va_arg(ap, int);
 			    int iv2 = va_arg(ap, int);
-			    dv = va_arg(ap, double);
-			    n = snprintf(buf, PRINTF_BUF_SIZE, fmt, iv1, iv2, printf_float(dv));
+#ifndef NO_LONG_DOUBLE
+                            if (long_double) {
+                                    ldv = va_arg(ap, long double);
+                                    n = snprintf(buf, PRINTF_BUF_SIZE, fmt, iv1, iv2, ldv);
 #ifdef TEST_ASPRINTF
-			    an = asprintf(&abuf, fmt, iv1, iv2, printf_float(dv));
+                                    an = asprintf(&abuf, fmt, iv1, iv2, ldv);
 #endif
+                            } else
+#endif
+                            {
+                                    dv = va_arg(ap, __typeof(dv));
+                                    n = snprintf(buf, PRINTF_BUF_SIZE, fmt, iv1, iv2, dv);
+#ifdef TEST_ASPRINTF
+                                    an = asprintf(&abuf, fmt, iv1, iv2, dv);
+#endif
+                            }
 		    } else  {
 			    int iv = va_arg(ap, int);
-			    dv = va_arg(ap, double);
-			    n = snprintf(buf, PRINTF_BUF_SIZE, fmt, iv, printf_float(dv));
+#ifndef NO_LONG_DOUBLE
+                            if (long_double) {
+                                    ldv = va_arg(ap, long double);
+                                    n = snprintf(buf, PRINTF_BUF_SIZE, fmt, iv, ldv);
 #ifdef TEST_ASPRINTF
-			    an = asprintf(&abuf, fmt, iv, printf_float(dv));
+                                    an = asprintf(&abuf, fmt, iv, ldv);
 #endif
+                            } else
+#endif
+                            {
+                                    dv = va_arg(ap, __typeof(dv));
+                                    n = snprintf(buf, PRINTF_BUF_SIZE, fmt, iv, dv);
+#ifdef TEST_ASPRINTF
+                                    an = asprintf(&abuf, fmt, iv, dv);
+#endif
+                            }
 		    }
 	    } else {
-		    dv = va_arg(ap, double);
-		    n = snprintf(buf, PRINTF_BUF_SIZE, fmt, printf_float(dv));
+#ifndef NO_LONG_DOUBLE
+                    if (long_double) {
+                            ldv = va_arg(ap, long double);
+                            n = snprintf(buf, PRINTF_BUF_SIZE, fmt, ldv);
 #ifdef TEST_ASPRINTF
-		    an = asprintf(&abuf, fmt, printf_float(dv));
+                            an = asprintf(&abuf, fmt, ldv);
 #endif
+                    } else
+#endif
+                    {
+                            dv = va_arg(ap, __typeof(dv));
+                            n = snprintf(buf, PRINTF_BUF_SIZE, fmt, dv);
+#ifdef TEST_ASPRINTF
+                            an = asprintf(&abuf, fmt, dv);
+#endif
+                    }
 	    }
 	    break;
 #endif
@@ -169,7 +211,11 @@ static int testw(int serial, wchar_t *expect, wchar_t *fmt, ...) {
     va_copy(aap, ap);
 #endif
 #ifndef NO_FLOATING_POINT
+# ifdef _HAS_IO_FLOAT
+    uint32_t dv;
+# else
     double dv;
+# endif
     wchar_t *star;
 #endif
     switch (fmt[wcslen(fmt)-1]) {
@@ -189,16 +235,16 @@ static int testw(int serial, wchar_t *expect, wchar_t *fmt, ...) {
 		    if (wcschr(star+1, '*')) {
 			    int iv1 = va_arg(ap, int);
 			    int iv2 = va_arg(ap, int);
-			    dv = va_arg(ap, double);
-			    n = swprintf(wbuf, PRINTF_BUF_SIZE, fmt, iv1, iv2, printf_float(dv));
+			    dv = va_arg(ap, __typeof(dv));
+			    n = swprintf(wbuf, PRINTF_BUF_SIZE, fmt, iv1, iv2, dv);
 		    } else  {
 			    int iv = va_arg(ap, int);
-			    dv = va_arg(ap, double);
-			    n = swprintf(wbuf, PRINTF_BUF_SIZE, fmt, iv, printf_float(dv));
+			    dv = va_arg(ap, __typeof(dv));
+			    n = swprintf(wbuf, PRINTF_BUF_SIZE, fmt, iv, dv);
 		    }
 	    } else {
-		    dv = va_arg(ap, double);
-		    n = swprintf(wbuf, PRINTF_BUF_SIZE, fmt, printf_float(dv));
+		    dv = va_arg(ap, __typeof(dv));
+		    n = swprintf(wbuf, PRINTF_BUF_SIZE, fmt, dv);
 	    }
 	    break;
 #endif

--- a/test/testcases.c
+++ b/test/testcases.c
@@ -31,8 +31,12 @@
 #  endif
 # elif defined(_HAS_IO_FLOAT)
 #  define LOW_FLOAT
+#  define FLOAT float
 # else
 #  define NO_FLOAT
+# endif
+# ifndef _HAS_IO_LONG_DOUBLE
+#  define NO_LONGDOUBLE
 # endif
 # ifndef _HAS_IO_LONG_LONG
 #  define NO_LONGLONG
@@ -70,6 +74,9 @@
 # define NORMALIZED_A
 #endif
 
+#ifndef FLOAT
+#define FLOAT double
+#endif
 
 #if __SIZEOF_INT__ < 4
 #define I(a,b) (b)
@@ -82,8 +89,8 @@
    from ../../printf-tests.txt . You probably do not want to
    manually edit this file. */
 #ifndef NO_FLOAT
-    result |= test(__LINE__, "0", "%.7g", 0.0);
-    result |= test(__LINE__, "0.33", "%.*f", 2, 0.33333333);
+    result |= test(__LINE__, "0", "%.7g", printf_float(0.0));
+    result |= test(__LINE__, "0.33", "%.*f", 2, printf_float(0.33333333));
 #endif
 #ifndef NO_WIDTH_PREC
     result |= test(__LINE__, "foo", "%.3s", "foobar");
@@ -136,20 +143,20 @@
     result |= test(__LINE__, "-42            ", "%0-15d", -42);
 #endif
 #ifndef NO_FLOAT
-    result |= test(__LINE__, "42.90", "%.2f", 42.8952);
-    result |= test(__LINE__, "42.90", "%.2F", 42.8952);
+    result |= test(__LINE__, "42.90", "%.2f", printf_float(42.8952));
+    result |= test(__LINE__, "42.90", "%.2F", printf_float(42.8952));
 #ifdef LOW_FLOAT
-    result |= test(__LINE__, "42.89520", "%.5f", 42.8952);
+    result |= test(__LINE__, "42.89520", "%.5f", printf_float(42.8952));
 #else
-    result |= test(__LINE__, "42.8952000000", "%.10f", 42.8952);
+    result |= test(__LINE__, "42.8952000000", "%.10f", printf_float(42.8952));
 #endif
-    result |= test(__LINE__, "42.90", "%1.2f", 42.8952);
-    result |= test(__LINE__, " 42.90", "%6.2f", 42.8952);
-    result |= test(__LINE__, "+42.90", "%+6.2f", 42.8952);
+    result |= test(__LINE__, "42.90", "%1.2f", printf_float(42.8952));
+    result |= test(__LINE__, " 42.90", "%6.2f", printf_float(42.8952));
+    result |= test(__LINE__, "+42.90", "%+6.2f", printf_float(42.8952));
 #ifdef LOW_FLOAT
-    result |= test(__LINE__, "42.89520", "%5.5f", 42.8952);
+    result |= test(__LINE__, "42.89520", "%5.5f", printf_float(42.8952));
 #else
-    result |= test(__LINE__, "42.8952000000", "%5.10f", 42.8952);
+    result |= test(__LINE__, "42.8952000000", "%5.10f", printf_float(42.8952));
 #endif
 #endif /* NO_FLOAT */
     /* 51: anti-test */
@@ -182,8 +189,8 @@
     result |= test(__LINE__, " foo", "%*s", 4, "foo");
 #endif
 #ifndef NO_FLOAT
-    result |= test(__LINE__, "      3.14", "%*.*f", 10, 2, 3.14159265);
-    result |= test(__LINE__, "3.14      ", "%-*.*f", 10, 2, 3.14159265);
+    result |= test(__LINE__, "      3.14", "%*.*f", 10, 2, printf_float(3.14159265));
+    result |= test(__LINE__, "3.14      ", "%-*.*f", 10, 2, printf_float(3.14159265));
 # if !(defined(TINY_STDIO) && !defined(_IO_FLOAT_EXACT))
 #  ifndef LOW_FLOAT
 #   ifdef TINY_STDIO
@@ -191,7 +198,7 @@
 #   else
 #    define SQRT2_60 "1414213562373095053224405813183213153460812619236586568024064.000"
 #   endif
-    result |= test(__LINE__, SQRT2_60, "%.3f", 1.4142135623730950e60);
+    result |= test(__LINE__, SQRT2_60, "%.3f", printf_float(1.4142135623730950e60));
 #  endif
 # endif
 #endif
@@ -213,15 +220,15 @@
     /* 75: excluded for C */
 #ifndef NO_FLOAT
 #ifdef LOW_FLOAT
-    result |= test(__LINE__, "         +7.894561e+08", "%+#22.6e", 7.89456123e8);
-    result |= test(__LINE__, "7.894561e+08          ", "%-#22.6e", 7.89456123e8);
-    result |= test(__LINE__, "          7.894561e+08", "%#22.6e", 7.89456123e8);
+    result |= test(__LINE__, "         +7.894561e+08", "%+#22.6e", printf_float(7.89456123e8));
+    result |= test(__LINE__, "7.894561e+08          ", "%-#22.6e", printf_float(7.89456123e8));
+    result |= test(__LINE__, "          7.894561e+08", "%#22.6e", printf_float(7.89456123e8));
 #else
-    result |= test(__LINE__, "+7.894561230000000e+08", "%+#22.15e", 7.89456123e8);
-    result |= test(__LINE__, "7.894561230000000e+08 ", "%-#22.15e", 7.89456123e8);
-    result |= test(__LINE__, " 7.894561230000000e+08", "%#22.15e", 7.89456123e8);
+    result |= test(__LINE__, "+7.894561230000000e+08", "%+#22.15e", printf_float(7.89456123e8));
+    result |= test(__LINE__, "7.894561230000000e+08 ", "%-#22.15e", printf_float(7.89456123e8));
+    result |= test(__LINE__, " 7.894561230000000e+08", "%#22.15e", printf_float(7.89456123e8));
 #endif
-    result |= test(__LINE__, "8.e+08", "%#1.1g", 7.89456123e8);
+    result |= test(__LINE__, "8.e+08", "%#1.1g", printf_float(7.89456123e8));
 #endif
 #ifndef NO_LONGLONG
 #ifndef NO_WIDTH_PREC
@@ -303,15 +310,15 @@
     /* 150: excluded for C */
     result |= test(__LINE__, "2", "%-1d", 2);
 #ifndef NO_FLOAT
-    result |= test(__LINE__, "8.6000", "%2.4f", 8.6);
-    result |= test(__LINE__, "0.600000", "%0f", 0.6);
-    result |= test(__LINE__, "1", "%.0f", 0.6);
-    result |= test(__LINE__, "0", "%.0f", 0.45);
-    result |= test(__LINE__, "8.6000e+00", "%2.4e", 8.6);
-    result |= test(__LINE__, " 8.6000e+00", "% 2.4e", 8.6);
-    result |= test(__LINE__, "-8.6000e+00", "% 2.4e", -8.6);
-    result |= test(__LINE__, "+8.6000e+00", "%+2.4e", 8.6);
-    result |= test(__LINE__, "8.6", "%2.4g", 8.6);
+    result |= test(__LINE__, "8.6000", "%2.4f", printf_float(8.6));
+    result |= test(__LINE__, "0.600000", "%0f", printf_float(0.6));
+    result |= test(__LINE__, "1", "%.0f", printf_float(0.6));
+    result |= test(__LINE__, "0", "%.0f", printf_float(0.45));
+    result |= test(__LINE__, "8.6000e+00", "%2.4e", printf_float(8.6));
+    result |= test(__LINE__, " 8.6000e+00", "% 2.4e", printf_float(8.6));
+    result |= test(__LINE__, "-8.6000e+00", "% 2.4e", printf_float(-8.6));
+    result |= test(__LINE__, "+8.6000e+00", "%+2.4e", printf_float(8.6));
+    result |= test(__LINE__, "8.6", "%2.4g", printf_float(8.6));
 #endif
     result |= test(__LINE__, "-1", "%-i", -1);
     result |= test(__LINE__, "1", "%-i", 1);
@@ -609,9 +616,9 @@
     result |= test(__LINE__, "hi x", "%*sx", -3, "hi");
 #endif
 #ifndef NO_FLOAT
-    result |= test(__LINE__, "1.000e-38", "%.3e", 1e-38);
+    result |= test(__LINE__, "1.000e-38", "%.3e", printf_float(1e-38));
 #ifndef LOW_FLOAT
-    result |= test(__LINE__, "1.000e-308", "%.3e", 1e-308);
+    result |= test(__LINE__, "1.000e-308", "%.3e", printf_float(1e-308));
 #endif
 #endif
 #ifndef _NANO_FORMATTED_IO
@@ -620,26 +627,26 @@
 #endif
 #endif
 #ifndef NO_FLOAT
-    result |= test(__LINE__, "1e-09", "%g", 0.000000001);
-    result |= test(__LINE__, "1e-08", "%g", 0.00000001);
-    result |= test(__LINE__, "1e-07", "%g", 0.0000001);
-    result |= test(__LINE__, "1e-06", "%g", 0.000001);
-    result |= test(__LINE__, "0.0001", "%g", 0.0001);
-    result |= test(__LINE__, "0.001", "%g", 0.001);
-    result |= test(__LINE__, "0.01", "%g", 0.01);
-    result |= test(__LINE__, "0.1", "%g", 0.1);
-    result |= test(__LINE__, "1", "%g", 1.0);
-    result |= test(__LINE__, "10", "%g", 10.0);
-    result |= test(__LINE__, "100", "%g", 100.0);
-    result |= test(__LINE__, "1000", "%g", 1000.0);
-    result |= test(__LINE__, "10000", "%g", 10000.0);
-    result |= test(__LINE__, "100000", "%g", 100000.0);
-    result |= test(__LINE__, "1e+06", "%g", 1000000.0);
-    result |= test(__LINE__, "1e+07", "%g", 10000000.0);
-    result |= test(__LINE__, "1e+08", "%g", 100000000.0);
-    result |= test(__LINE__, "10.0000", "%#.6g", 10.0);
-    result |= test(__LINE__, "10", "%.6g", 10.0);
-    result |= test(__LINE__, "10.00000000000000000000", "%#.22g", 10.0);
+    result |= test(__LINE__, "1e-09", "%g", printf_float(0.000000001));
+    result |= test(__LINE__, "1e-08", "%g", printf_float(0.00000001));
+    result |= test(__LINE__, "1e-07", "%g", printf_float(0.0000001));
+    result |= test(__LINE__, "1e-06", "%g", printf_float(0.000001));
+    result |= test(__LINE__, "0.0001", "%g", printf_float(0.0001));
+    result |= test(__LINE__, "0.001", "%g", printf_float(0.001));
+    result |= test(__LINE__, "0.01", "%g", printf_float(0.01));
+    result |= test(__LINE__, "0.1", "%g", printf_float(0.1));
+    result |= test(__LINE__, "1", "%g", printf_float(1.0));
+    result |= test(__LINE__, "10", "%g", printf_float(10.0));
+    result |= test(__LINE__, "100", "%g", printf_float(100.0));
+    result |= test(__LINE__, "1000", "%g", printf_float(1000.0));
+    result |= test(__LINE__, "10000", "%g", printf_float(10000.0));
+    result |= test(__LINE__, "100000", "%g", printf_float(100000.0));
+    result |= test(__LINE__, "1e+06", "%g", printf_float(1000000.0));
+    result |= test(__LINE__, "1e+07", "%g", printf_float(10000000.0));
+    result |= test(__LINE__, "1e+08", "%g", printf_float(100000000.0));
+    result |= test(__LINE__, "10.0000", "%#.6g", printf_float(10.0));
+    result |= test(__LINE__, "10", "%.6g", printf_float(10.0));
+    result |= test(__LINE__, "10.00000000000000000000", "%#.22g", printf_float(10.0));
 #endif
 
     // Regression test for wrong behavior with negative precision in tinystdio
@@ -654,9 +661,9 @@
     result |= test(__LINE__,       "42", "%.*d", -6, 42);
 #endif
 #ifndef NO_FLOAT
-    result |= test(__LINE__,        "0", "%.*f",  0, 0.123);
-    result |= test(__LINE__,      "0.1", "%.*f",  1, 0.123);
-    result |= test(__LINE__, "0.123000", "%.*f", -1, 0.123);
+    result |= test(__LINE__,        "0", "%.*f",  0, printf_float(0.123));
+    result |= test(__LINE__,      "0.1", "%.*f",  1, printf_float(0.123));
+    result |= test(__LINE__, "0.123000", "%.*f", -1, printf_float(0.123));
 #endif
 #ifdef _WANT_IO_C99_FORMATS
 {
@@ -674,61 +681,128 @@
     (void) c;
 #endif
 #ifndef NO_FLOAT
-    result |= test(__LINE__, "0x1p+0", "%a", 0x1p+0);
-    result |= test(__LINE__, "0x0p+0", "%a", 0.0);
-    result |= test(__LINE__, "-0x0p+0", "%a", -0.0);
-    result |= test(__LINE__, "0x1.9p+4", "%.1a", 0x1.89p+4);
-    result |= test(__LINE__, "0x1.8p+4", "%.1a", 0x1.88p+4);
-    result |= test(__LINE__, "0x1.8p+4", "%.1a", 0x1.78p+4);
-    result |= test(__LINE__, "0x1.7p+4", "%.1a", 0x1.77p+4);
-    result |= test(__LINE__, "0x1.fffffep+126", "%a", (double) 0x1.fffffep+126f);
-    result |= test(__LINE__, "0x1.234564p-126", "%a", (double) 0x1.234564p-126f);
-    result |= test(__LINE__, "0x1.234566p-126", "%a", (double) 0x1.234566p-126f);
-    result |= test(__LINE__, "0X1.FFFFFEP+126", "%A", (double) 0x1.fffffep+126f);
-    result |= test(__LINE__, "0X1.234564P-126", "%A", (double) 0x1.234564p-126f);
-    result |= test(__LINE__, "0X1.234566P-126", "%A", (double) 0x1.234566p-126f);
-    result |= test(__LINE__, "0x1.6p+1", "%.1a", (double) 0x1.6789ap+1f);
-    result |= test(__LINE__, "0x1.68p+1", "%.2a", (double) 0x1.6789ap+1f);
-    result |= test(__LINE__, "0x1.679p+1", "%.3a", (double) 0x1.6789ap+1f);
-    result |= test(__LINE__, "0x1.678ap+1", "%.4a", (double) 0x1.6789ap+1f);
-    result |= test(__LINE__, "0x1.6789ap+1", "%.5a", (double) 0x1.6789ap+1f);
-    result |= test(__LINE__, "0x1.6789a0p+1", "%.6a", (double) 0x1.6789ap+1f);
-    result |= test(__LINE__, "0x1.ffp+1", "%.2a", (double) 0x1.ffp+1f);
-    result |= test(__LINE__, "0x2.0p+1", "%.1a", (double) 0x1.ffp+1f);
-    result |= test(__LINE__, "0x2p+4", "%.a", 24.0);
-    result |= test(__LINE__, "0X2P+4", "%.A", 24.0);
-    result |= test(__LINE__, "nan", "%a", (double) NAN);
-    result |= test(__LINE__, "inf", "%a", (double) INFINITY);
-    result |= test(__LINE__, "-inf", "%a", (double) -INFINITY);
-    result |= test(__LINE__, "NAN", "%A", (double) NAN);
-    result |= test(__LINE__, "INF", "%A", (double) INFINITY);
-    result |= test(__LINE__, "-INF", "%A", (double) -INFINITY);
+    result |= test(__LINE__, "0x1p+0", "%a", printf_float(0x1p+0));
+    result |= test(__LINE__, "0x0p+0", "%a", printf_float(0.0));
+    result |= test(__LINE__, "-0x0p+0", "%a", printf_float(-0.0));
+    result |= test(__LINE__, "0x1.9p+4", "%.1a", printf_float(0x1.89p+4));
+    result |= test(__LINE__, "0x1.8p+4", "%.1a", printf_float(0x1.88p+4));
+    result |= test(__LINE__, "0x1.8p+4", "%.1a", printf_float(0x1.78p+4));
+    result |= test(__LINE__, "0x1.7p+4", "%.1a", printf_float(0x1.77p+4));
+    result |= test(__LINE__, "0x1.fffffep+126", "%a", printf_float(0x1.fffffep+126f));
+    result |= test(__LINE__, "0x1.234564p-126", "%a", printf_float(0x1.234564p-126f));
+    result |= test(__LINE__, "0x1.234566p-126", "%a", printf_float(0x1.234566p-126f));
+    result |= test(__LINE__, "0X1.FFFFFEP+126", "%A", printf_float(0x1.fffffep+126f));
+    result |= test(__LINE__, "0X1.234564P-126", "%A", printf_float(0x1.234564p-126f));
+    result |= test(__LINE__, "0X1.234566P-126", "%A", printf_float(0x1.234566p-126f));
+    result |= test(__LINE__, "0x1.6p+1", "%.1a", printf_float(0x1.6789ap+1f));
+    result |= test(__LINE__, "0x1.68p+1", "%.2a", printf_float(0x1.6789ap+1f));
+    result |= test(__LINE__, "0x1.679p+1", "%.3a", printf_float(0x1.6789ap+1f));
+    result |= test(__LINE__, "0x1.678ap+1", "%.4a", printf_float(0x1.6789ap+1f));
+    result |= test(__LINE__, "0x1.6789ap+1", "%.5a", printf_float(0x1.6789ap+1f));
+    result |= test(__LINE__, "0x1.6789a0p+1", "%.6a", printf_float(0x1.6789ap+1f));
+    result |= test(__LINE__, "0x1.ffp+1", "%.2a", printf_float(0x1.ffp+1f));
+    result |= test(__LINE__, "0x2.0p+1", "%.1a", printf_float(0x1.ffp+1f));
+    result |= test(__LINE__, "0x2p+4", "%.a", printf_float(24.0));
+    result |= test(__LINE__, "0X2P+4", "%.A", printf_float(24.0));
+    result |= test(__LINE__, "nan", "%a", printf_float(NAN));
+    result |= test(__LINE__, "-nan", "%a", printf_float(-(FLOAT) NAN));
+    result |= test(__LINE__, "inf", "%a", printf_float(INFINITY));
+    result |= test(__LINE__, "-inf", "%a", printf_float(-INFINITY));
+    result |= test(__LINE__, "NAN", "%A", printf_float(NAN));
+    result |= test(__LINE__, "-NAN", "%A", printf_float(-(FLOAT) NAN));
+    result |= test(__LINE__, "INF", "%A", printf_float(INFINITY));
+    result |= test(__LINE__, "-INF", "%A", printf_float(-(FLOAT) INFINITY));
+
+#ifndef NO_LONGDOUBLE
+#if __LDBL_MANT_DIG__ == 64 && (!defined(__PICOLIBC__) || defined(TINY_STDIO))
+    /*
+     * x86 and m68k 80-bit format fill the top
+     * hex digit so they generate a different result than
+     * regular formats when using tinystdio or glibc.
+     */
+    result |= test(__LINE__, "0x8p-3", "%La", 0x1p+0l);
+    result |= test(__LINE__, "0x0p+0", "%La", 0x0p+0l);
+    result |= test(__LINE__, "-0x0p+0", "%La", -0x0p+0l);
+    result |= test(__LINE__, "0xc.4p+1", "%.1La", 0x1.89p+4l);
+    result |= test(__LINE__, "0xc.4p+1", "%.1La", 0x1.88p+4l);
+    result |= test(__LINE__, "0xb.cp+1", "%.1La", 0x1.78p+4l);
+    result |= test(__LINE__, "0xb.cp+1", "%.1La", 0x1.77p+4l);
+    result |= test(__LINE__, "0xf.fffffp+123", "%La", 0x1.fffffep+126l);
+    result |= test(__LINE__, "0x9.1a2b2p-129", "%La", 0x1.234564p-126l);
+    result |= test(__LINE__, "0x9.1a2b3p-129", "%La", 0x1.234566p-126l);
+    result |= test(__LINE__, "0XF.FFFFFP+123", "%LA", 0X1.FFFFFEP+126l);
+    result |= test(__LINE__, "0X9.1A2B2P-129", "%LA", 0X1.234564P-126l);
+    result |= test(__LINE__, "0X9.1A2B3P-129", "%LA", 0X1.234566P-126l);
+    result |= test(__LINE__, "0xb.4p-2", "%.1La", 0x1.6789ap+1l);
+    result |= test(__LINE__, "0xb.3cp-2", "%.2La", 0x1.6789ap+1l);
+    result |= test(__LINE__, "0xb.3c5p-2", "%.3La", 0x1.6789ap+1l);
+    result |= test(__LINE__, "0xb.3c4dp-2", "%.4La", 0x1.6789ap+1l);
+    result |= test(__LINE__, "0xb.3c4d0p-2", "%.5La", 0x1.6789ap+1l);
+    result |= test(__LINE__, "0xb.3c4d00p-2", "%.6La", 0x1.6789ap+1l);
+    result |= test(__LINE__, "0xf.f8p-2", "%.2La", 0x1.ffp+1l);
+    result |= test(__LINE__, "0x1.0p+2", "%.1La", 0x1.ffp+1l);
+    result |= test(__LINE__, "0xcp+1", "%.La", 24.0l);
+    result |= test(__LINE__, "0XCP+1", "%.LA", 24.0l);
+#else
+    result |= test(__LINE__, "0x1p+0", "%La", (long double) 0x1p+0l);
+    result |= test(__LINE__, "0x0p+0", "%La", 0.0L);
+    result |= test(__LINE__, "-0x0p+0", "%La", -0.0L);
+    result |= test(__LINE__, "0x1.9p+4", "%.1La", 0x1.89p+4L);
+    result |= test(__LINE__, "0x1.8p+4", "%.1La", 0x1.88p+4L);
+    result |= test(__LINE__, "0x1.8p+4", "%.1La", 0x1.78p+4L);
+    result |= test(__LINE__, "0x1.7p+4", "%.1La", 0x1.77p+4L);
+    result |= test(__LINE__, "0x1.fffffep+126", "%La", (long double) 0x1.fffffep+126);
+    result |= test(__LINE__, "0x1.234564p-126", "%La", (long double) 0x1.234564p-126);
+    result |= test(__LINE__, "0x1.234566p-126", "%La", (long double) 0x1.234566p-126);
+    result |= test(__LINE__, "0X1.FFFFFEP+126", "%LA", (long double) 0x1.fffffep+126);
+    result |= test(__LINE__, "0X1.234564P-126", "%LA", (long double) 0x1.234564p-126);
+    result |= test(__LINE__, "0X1.234566P-126", "%LA", (long double) 0x1.234566p-126);
+    result |= test(__LINE__, "0x1.6p+1", "%.1La", (long double) 0x1.6789ap+1);
+    result |= test(__LINE__, "0x1.68p+1", "%.2La", (long double) 0x1.6789ap+1);
+    result |= test(__LINE__, "0x1.679p+1", "%.3La", (long double) 0x1.6789ap+1);
+    result |= test(__LINE__, "0x1.678ap+1", "%.4La", (long double) 0x1.6789ap+1);
+    result |= test(__LINE__, "0x1.6789ap+1", "%.5La", (long double) 0x1.6789ap+1);
+    result |= test(__LINE__, "0x1.6789a0p+1", "%.6La", (long double) 0x1.6789ap+1);
+    result |= test(__LINE__, "0x1.ffp+1", "%.2La", (long double) 0x1.ffp+1);
+    result |= test(__LINE__, "0x2.0p+1", "%.1La", (long double) 0x1.ffp+1);
+    result |= test(__LINE__, "0x2p+4", "%.La", 24.0L);
+    result |= test(__LINE__, "0X2P+4", "%.LA", 24.0L);
+#endif
+    result |= test(__LINE__, "nan", "%La", (long double) NAN);
+    result |= test(__LINE__, "-nan", "%La", (long double) -NAN);
+    result |= test(__LINE__, "inf", "%La", (long double) INFINITY);
+    result |= test(__LINE__, "-inf", "%La", (long double) -INFINITY);
+    result |= test(__LINE__, "NAN", "%LA", (long double) NAN);
+    result |= test(__LINE__, "-NAN", "%LA", (long double) -NAN);
+    result |= test(__LINE__, "INF", "%LA", (long double) INFINITY);
+    result |= test(__LINE__, "-INF", "%LA", (long double) -INFINITY);
+#endif
 #ifdef LOW_FLOAT
 #ifdef NORMALIZED_A
-    result |= test(__LINE__, "0x1p-149", "%a", 0x1p-149);
-    result |= test(__LINE__, "0x1p-127", "%.a", 0x1p-127);
+    result |= test(__LINE__, "0x1p-149", "%a", printf_float(0x1p-149));
+    result |= test(__LINE__, "0x1p-127", "%.a", printf_float(0x1p-127));
 #else
-    result |= test(__LINE__, "0x0.000002p-126", "%a", 0x1p-149);
-    result |= test(__LINE__, "0x0p-126", "%.a", 0x1p-127);
+    result |= test(__LINE__, "0x0.000002p-126", "%a", printf_float(0x1p-149));
+    result |= test(__LINE__, "0x0p-126", "%.a", printf_float(0x1p-127));
 #endif
 #else
-    result |= test(__LINE__, "0x1.306efbp-98", "%a", 3752432815e-39);
+    result |= test(__LINE__, "0x1.306efbp-98", "%a", printf_float(3752432815e-39));
 #ifdef NORMALIZED_A
     /* newlib legacy stdio normalizes %a format */
-    result |= test(__LINE__, "0x1p-1074", "%a", 0x1p-1074);
-    result |= test(__LINE__, "0x1p-1023", "%.a", 0x1p-1023);
+    result |= test(__LINE__, "0x1p-1074", "%a", printf_float(0x1p-1074));
+    result |= test(__LINE__, "0x1p-1023", "%.a", printf_float(0x1p-1023));
 #else
     /* glibc and picolibc show denorms like this */
-    result |= test(__LINE__, "0x0.0000000000001p-1022", "%a", 0x1p-1074);
-    result |= test(__LINE__, "0x0p-1022", "%.a", 0x1p-1023);
+    result |= test(__LINE__, "0x0.0000000000001p-1022", "%a", printf_float(0x1p-1074));
+    result |= test(__LINE__, "0x0p-1022", "%.a", printf_float(0x1p-1023));
 #endif
-    result |= test(__LINE__, "0x1.fffffffffffffp+1022", "%a", 0x1.fffffffffffffp+1022);
-    result |= test(__LINE__, "0x1.23456789abcdep-1022", "%a", 0x1.23456789abcdep-1022);
-    result |= test(__LINE__, "0x1.23456789abcdfp-1022", "%a", 0x1.23456789abcdfp-1022);
-    result |= test(__LINE__, "0X1.FFFFFFFFFFFFFP+1022", "%A", 0x1.fffffffffffffp+1022);
-    result |= test(__LINE__, "0X1.23456789ABCDEP-1022", "%A", 0x1.23456789abcdep-1022);
-    result |= test(__LINE__, "0X1.23456789ABCDFP-1022", "%A", 0x1.23456789abcdfp-1022);
-    result |= test(__LINE__, "0X1.D749096BB98C800P+8", "%.15A", 0x1.D749096BB98C8p+8);
+    result |= test(__LINE__, "0x1.fffffffffffffp+1022", "%a", printf_float(0x1.fffffffffffffp+1022));
+    result |= test(__LINE__, "0x1.23456789abcdep-1022", "%a", printf_float(0x1.23456789abcdep-1022));
+    result |= test(__LINE__, "0x1.23456789abcdfp-1022", "%a", printf_float(0x1.23456789abcdfp-1022));
+    result |= test(__LINE__, "0X1.FFFFFFFFFFFFFP+1022", "%A", printf_float(0x1.fffffffffffffp+1022));
+    result |= test(__LINE__, "0X1.23456789ABCDEP-1022", "%A", printf_float(0x1.23456789abcdep-1022));
+    result |= test(__LINE__, "0X1.23456789ABCDFP-1022", "%A", printf_float(0x1.23456789abcdfp-1022));
+    result |= test(__LINE__, "0X1.D749096BB98C800P+8", "%.15A", printf_float(0x1.D749096BB98C8p+8));
 #endif
 #endif
     /* test %ls for wchar_t string */


### PR DESCRIPTION
Handle limited input width in the format spec when looking for nan and inf(inity) values.

Add tests for both of these values in both signs.