### PR TITLE
strcmp optimization for riscv

### DIFF
--- a/COPYING.picolibc
+++ b/COPYING.picolibc
@@ -2845,7 +2845,7 @@ Files: .clang-format
  scripts/cross-riscv64-unknown-elf.txt
  scripts/cross-riscv64-zephyr-elf.txt
  scripts/cross-rv32imac.txt
- scripts/cross-rv32imac_zicsr.txt
+ scripts/cross-rv32imac_zicsr_zbb.txt
  scripts/cross-sh-unknown-elf.txt
  scripts/cross-sparc-zephyr-elf.txt
  scripts/cross-sparc64-linux-gnu.txt

--- a/newlib/libc/machine/riscv/strcmp.S
+++ b/newlib/libc/machine/riscv/strcmp.S
@@ -37,21 +37,25 @@ strcmp:
   and   a4, a4, SZREG-1
   bnez  a4, .Lmisaligned
 
+#ifndef __riscv_zbb
 #if SZREG == 4
   li a5, 0x7f7f7f7f
 #else
   ld a5, mask
 #endif
+#endif
 
   .macro check_one_word i n
     REG_L a2, \i*SZREG(a0)
     REG_L a3, \i*SZREG(a1)
-
+#ifdef __riscv_zbb
+    orc.b t0, a2
+#else
     and   t0, a2, a5
     or    t1, a2, a5
     add   t0, t0, a5
     or    t0, t0, t1
-
+#endif
     bne   t0, t2, .Lnull\i
     .if \i+1-\n
       bne   a2, a3, .Lmismatch
@@ -189,7 +193,7 @@ strcmp:
 #endif
 .size	strcmp, .-strcmp
 
-#if SZREG == 8
+#if SZREG == 8 && !defined(__riscv_zbb)
 .section .srodata.cst8,"aM",@progbits,8
 .align 3
 mask:

--- a/scripts/cross-rv32imac_zicsr_zbb.txt
+++ b/scripts/cross-rv32imac_zicsr_zbb.txt
@@ -14,8 +14,8 @@ cpu = 'riscv32'
 endian = 'little'
 
 [properties]
-c_args = ['-msave-restore', '-fshort-enums', '-march=rv32imac_zicsr', '-mabi=ilp32']
-c_link_args = ['-msave-restore', '-fshort-enums', '-march=rv32imac', '-mabi=ilp32']
+c_args = ['-msave-restore', '-fshort-enums', '-march=rv32imac_zicsr_zbb', '-mabi=ilp32']
+c_link_args = ['-msave-restore', '-fshort-enums', '-march=rv32imac_zicsr_zbb', '-mabi=ilp32']
 skip_sanity_check = true
 default_flash_addr = '0x80000000'
 default_flash_size = '0x00200000'

--- a/scripts/do-rv32imac-configure
+++ b/scripts/do-rv32imac-configure
@@ -40,7 +40,7 @@ case "$version" in
 	arch=rv32imac
 	;;
     *)
-	arch=rv32imac_zicsr
+	arch=rv32imac_zicsr_zbb
 	;;
 esac
 exec "$(dirname "$0")"/do-configure "$arch" \


### PR DESCRIPTION
Optimize strcmp by calling orc.b (OR-Combine) instruction when Zbb extension is supported instead of 4 instructions to detect if zero byte is exist in word