### PR TITLE
Add missing include of <sys/cdefs.h> from <assert.h>.

### DIFF
--- a/newlib/libc/include/assert.h
+++ b/newlib/libc/include/assert.h
@@ -36,6 +36,7 @@ SUCH DAMAGE.
 */
 
 #include "_ansi.h"
+#include <sys/cdefs.h>
 
 _BEGIN_STD_C
 


### PR DESCRIPTION
As of commit 5e4d0c80f49b4ef, Internal functions like `__assert` and `__assert_no_args` are declared using the C `_Noreturn` keyword. In C++ mode, <sys/cdefs.h> redefines that keyword to the C++-style `[[noreturn]]` attribute. But <assert.h> doesn't include <sys/cdefs.h>, so you don't reliably get the intended one of those two.

This can cause a compile failure, if you compile a C++ source file that includes <assert.h>, then <limits.h>, then <assert.h> again (perhaps without noticing, because they're transitively included from other files in that sequence). The first include of <assert.h> defines those functions with the compiler's built-in `_Noreturn`, and the second one defines them with `[[noreturn]]`, because in between, <limits.h> included <sys/cdefs.h>, which redefined `_Noreturn`. And those don't count as the same attribute, so clang gives an error.

Including <sys/cdefs.h> directly from <assert.h> means it will always use the redefined `_Noreturn`, so its definitions will be consistent every time it's included.