### PR TITLE
meson: Add missing -Wl, prefix to cc.has_link_argument() call

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1025,7 +1025,8 @@ foreach target : ['default-target'] + targets
         # them if we are using an older version.
         # There is no `cc.get_linker_version()` function, so we detect ld.lld
         # version 15 by checking for a newly added linker flag.
-        if not cc.has_link_argument('--package-metadata=1')
+        # Note: --version still checks for valid arguments so this works.
+        if not cc.has_link_argument('-Wl,--package-metadata=1,--version')
           message('Linking for RISCV with ld.lld < 15, forcing -mno-relax')
           c_args += ['-mno-relax']
         endif

--- a/meson.build
+++ b/meson.build
@@ -1023,9 +1023,9 @@ foreach target : ['default-target'] + targets
       if host_cpu_family == 'riscv'
         # ld.lld before version 15 did not support linker relaxations, disable
         # them if we are using an older version.
-        # There is no `cc.get_linker_version()` function, so we just 
-        # assume lld is the same version as clang
-        if not cc.version().version_compare('>=15')
+        # There is no `cc.get_linker_version()` function, so we detect ld.lld
+        # version 15 by checking for a newly added linker flag.
+        if not cc.has_link_argument('--package-metadata=1')
           message('Linking for RISCV with ld.lld < 15, forcing -mno-relax')
           c_args += ['-mno-relax']
         endif


### PR DESCRIPTION
This fixes the detection of ld.lld 15 which previously failed
unconditionally since the argument was being passed to the compiler and
not forwarded to the linker.
However, even with -Wl, this check fails since we are linking with
-nostartfiles and thus ld.lld complains about missing _start. We can work
around this problem by also passing --version, which ensures that we get an
error for unknown arguments and a zero exit code if all arguments exist.

Fixes https://github.com/picolibc/picolibc/issues/773