### PR TITLE
Control sys/cdefs checking with new tests-cdefs option

### DIFF
--- a/.github/do-build
+++ b/.github/do-build
@@ -10,6 +10,9 @@ done
 
 ANALYZER="-Danalyzer=true"
 
+CDEFS="-Dtests-cdefs=true"
+TEST="test"
+
 # Disable analyzer on m68k because the compiler gets very confused
 # about complex values
 
@@ -32,9 +35,9 @@ mkdir "$DIR"
 trap 'rm -rf "$DIR"' 0 1 15
 (cd "$DIR" || exit 1
  echo '##################################################'
- echo '##########' ../scripts/"$CONFIGURE" -Dwerror=true $ANALYZER "$@"
+ echo '##########' ../scripts/"$CONFIGURE" -Dwerror=true $ANALYZER $CDEFS "$@"
  echo '##################################################'
- ../scripts/"$CONFIGURE" -Dwerror=true $ANALYZER "$@"
+ ../scripts/"$CONFIGURE" -Dwerror=true $ANALYZER $CDEFS "$@"
  case $? in
      0)
 	 echo 'Configuration succeeded'
@@ -50,4 +53,4 @@ trap 'rm -rf "$DIR"' 0 1 15
 	 ;;
  esac
  cat meson-logs/*
- ninja || exit 1) || exit 1
+ ninja $TEST || exit 1) || exit 1

--- a/meson.build
+++ b/meson.build
@@ -155,6 +155,11 @@ enable_picocrt = get_option('picocrt')
 enable_picocrt_lib = get_option('picocrt-lib')
 enable_semihost = get_option('semihost')
 enable_tests = get_option('tests')
+if get_option('tests-cdefs') == 'auto'
+  enable_cdefs_tests = enable_tests
+else
+  enable_cdefs_tests = get_option('tests-cdefs') == 'true'
+endif
 enable_native_tests = get_option('native-tests')
 enable_native_math_tests = enable_native_tests and get_option('native-math-tests')
 tests_enable_stack_protector = get_option('tests-enable-stack-protector')
@@ -260,7 +265,7 @@ if nm.found()
   duplicate_names = find_program('scripts/duplicate-names', required : true)
 endif
 
-if enable_tests
+if enable_cdefs_tests
   validate_cdefs = find_program ('scripts/validate-cdefs', required : true)
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -113,6 +113,8 @@ option('native-math-tests', type: 'boolean', value: true,
        description: 'Run math tests against native libm when native-tests is enable')
 option('tests', type: 'boolean', value: false,
        description: 'Enable tests')
+option('tests-cdefs', type: 'combo', choices: ['true', 'false', 'auto'], value: 'auto',
+       description: 'Enable test of sys/cdefs.h. If set to auto, enable when tests are enabled')
 option('tests-enable-stack-protector', type: 'boolean', value: true,
        description: 'tests enable stack protector')
 option('tests-enable-full-malloc-stress', type: 'boolean', value: false,

--- a/newlib/libc/include/arpa/meson.build
+++ b/newlib/libc/include/arpa/meson.build
@@ -40,7 +40,7 @@ inc_arpa_headers = [
 install_headers(inc_arpa_headers,
 		install_dir: include_dir / 'arpa')
 
-if enable_tests
+if enable_cdefs_tests
   ignore_headers = []
   foreach header : inc_arpa_headers
     if not (header in ignore_headers) and not (header.startswith('_'))

--- a/newlib/libc/include/meson.build
+++ b/newlib/libc/include/meson.build
@@ -112,7 +112,7 @@ install_headers(inc_headers,
 install_headers(['bits/types/mbstate_t.h'],
 		install_dir: include_dir / 'bits/types')
 
-if enable_tests
+if enable_cdefs_tests
 
   ignore_headers = ['cpio.h', 'paths.h', 'termios.h', 'newlib.h', 'regdef.h', 'tar.h', 'utmp.h']
   foreach header : inc_headers

--- a/newlib/libc/include/rpc/meson.build
+++ b/newlib/libc/include/rpc/meson.build
@@ -41,7 +41,7 @@ inc_rpc_headers = [
 install_headers(inc_rpc_headers,
 		install_dir: include_dir / 'rpc')
 
-if enable_tests
+if enable_cdefs_tests
   ignore_headers = []
   foreach header : inc_rpc_headers
     if not (header in ignore_headers) and not (header.startswith('_'))

--- a/newlib/libc/include/sys/meson.build
+++ b/newlib/libc/include/sys/meson.build
@@ -89,7 +89,7 @@ endforeach
 install_headers(inc_sys_headers,
 		install_dir: include_dir / 'sys')
 
-if enable_tests
+if enable_cdefs_tests
   ignore_headers = ['config.h', 'features.h', 'string.h', 'custom_file.h', 'dirent.h']
   foreach header : inc_sys_headers
     if not (header in ignore_headers) and not (header.startswith('_'))

--- a/newlib/libc/machine/aarch64/sys/meson.build
+++ b/newlib/libc/machine/aarch64/sys/meson.build
@@ -39,7 +39,7 @@ inc_sys_headers_machine = [
 install_headers(inc_sys_headers_machine,
 		install_dir: include_dir / 'sys')
 
-if enable_tests
+if enable_cdefs_tests
   ignore_headers = []
   foreach header : inc_sys_headers_machine
     if not (header in ignore_headers) and not (header.startswith('_'))

--- a/newlib/libc/machine/arm/sys/meson.build
+++ b/newlib/libc/machine/arm/sys/meson.build
@@ -39,7 +39,7 @@ inc_sys_headers_machine = [
 install_headers(inc_sys_headers_machine,
 		install_dir: include_dir / 'sys')
 
-if enable_tests
+if enable_cdefs_tests
   ignore_headers = []
   foreach header : inc_sys_headers_machine
     if not (header in ignore_headers) and not (header.startswith('_'))

--- a/newlib/libc/machine/m68k/sys/meson.build
+++ b/newlib/libc/machine/m68k/sys/meson.build
@@ -39,7 +39,7 @@ inc_sys_headers_machine = [
 install_headers(inc_sys_headers_machine,
 		install_dir: include_dir / 'sys')
 
-if enable_tests
+if enable_cdefs_tests
   ignore_headers = []
   foreach header : inc_sys_headers_machine
     if not (header in ignore_headers) and not (header.startswith('_'))

--- a/newlib/libc/machine/mips/sys/meson.build
+++ b/newlib/libc/machine/mips/sys/meson.build
@@ -39,7 +39,7 @@ inc_sys_headers_machine = [
 install_headers(inc_sys_headers_machine,
 		install_dir: include_dir / 'sys')
 
-if enable_tests
+if enable_cdefs_tests
   ignore_headers = []
   foreach header : inc_sys_headers_machine
     if not (header in ignore_headers) and not (header.startswith('_'))

--- a/newlib/libc/machine/powerpc/sys/meson.build
+++ b/newlib/libc/machine/powerpc/sys/meson.build
@@ -39,7 +39,7 @@ inc_sys_headers_machine = [
 install_headers(inc_sys_headers_machine,
 		install_dir: include_dir / 'sys')
 
-if enable_tests
+if enable_cdefs_tests
   ignore_headers = []
   foreach header : inc_sys_headers_machine
     if not (header in ignore_headers) and not (header.startswith('_'))

--- a/newlib/libc/machine/riscv/sys/meson.build
+++ b/newlib/libc/machine/riscv/sys/meson.build
@@ -39,7 +39,7 @@ inc_sys_headers_machine = [
 install_headers(inc_sys_headers_machine,
 		install_dir: include_dir / 'sys')
 
-if enable_tests
+if enable_cdefs_tests
   ignore_headers = []
   foreach header : inc_sys_headers_machine
     if not (header in ignore_headers) and not (header.startswith('_'))

--- a/newlib/libc/machine/sh/sys/meson.build
+++ b/newlib/libc/machine/sh/sys/meson.build
@@ -39,7 +39,7 @@ inc_sys_headers_machine = [
 install_headers(inc_sys_headers_machine,
 		install_dir: include_dir / 'sys')
 
-if enable_tests
+if enable_cdefs_tests
   ignore_headers = []
   foreach header : inc_sys_headers_machine
     if not (header in ignore_headers) and not (header.startswith('_'))

--- a/newlib/libc/machine/sparc/sys/meson.build
+++ b/newlib/libc/machine/sparc/sys/meson.build
@@ -39,7 +39,7 @@ inc_sys_headers_machine = [
 install_headers(inc_sys_headers_machine,
 		install_dir: include_dir / 'sys')
 
-if enable_tests
+if enable_cdefs_tests
   ignore_headers = []
   foreach header : inc_sys_headers_machine
     if not (header in ignore_headers) and not (header.startswith('_'))

--- a/newlib/libc/machine/x86/sys/meson.build
+++ b/newlib/libc/machine/x86/sys/meson.build
@@ -39,7 +39,7 @@ inc_sys_headers_machine = [
 install_headers(inc_sys_headers_machine,
 		install_dir: include_dir / 'sys')
 
-if enable_tests
+if enable_cdefs_tests
   ignore_headers = []
   foreach header : inc_sys_headers_machine
     if not (header in ignore_headers) and not (header.startswith('_'))

--- a/newlib/libc/machine/xtensa/sys/meson.build
+++ b/newlib/libc/machine/xtensa/sys/meson.build
@@ -39,7 +39,7 @@ inc_sys_headers_machine = [
 install_headers(inc_sys_headers_machine,
 		install_dir: include_dir / 'sys')
 
-if enable_tests
+if enable_cdefs_tests
   ignore_headers = []
   foreach header : inc_sys_headers_machine
     if not (header in ignore_headers) and not (header.startswith('_'))

--- a/newlib/libc/stdio/meson.build
+++ b/newlib/libc/stdio/meson.build
@@ -300,7 +300,7 @@ endforeach
 
 src_stdio = files(srcs_stdio_use)
 
-if enable_tests
+if enable_cdefs_tests
   foreach header : inc_headers
     test_name = 'check-cdef-' + header
     test(test_name,

--- a/newlib/libc/stdio/sys/meson.build
+++ b/newlib/libc/stdio/sys/meson.build
@@ -49,7 +49,7 @@ endforeach
 install_headers(inc_stdio_sys_headers,
 		install_dir: include_dir / 'sys')
 
-if enable_tests
+if enable_cdefs_tests
   foreach header : inc_stdio_sys_headers
     test_name = 'check-cdef-sys-' + header
     test(test_name,

--- a/newlib/libc/tinystdio/meson.build
+++ b/newlib/libc/tinystdio/meson.build
@@ -250,7 +250,7 @@ endforeach
 
 src_tinystdio = files(srcs_tinystdio_use)
 
-if enable_tests
+if enable_cdefs_tests
   foreach header : inc_headers
     test_name = 'check-cdef-' + header
     test(test_name,

--- a/semihost/meson.build
+++ b/semihost/meson.build
@@ -130,7 +130,7 @@ if src_semihost != []
     
   endforeach
 
-  if enable_tests
+  if enable_cdefs_tests
     ignore_headers = []
     foreach header : inc_headers
 


### PR DESCRIPTION
This is a three/way (true/false/auto) option which selects whether to validate the include files for correctly including sys/cdefs.h. When set to 'auto', then these tests are enabled if the regular library tests are enabled.