### PR TITLE
tinystdio: handling `"nan(n-sequence char)"` by `scanf()` family & `strtod()`

### DIFF
--- a/newlib/libc/tinystdio/conv_flt.c
+++ b/newlib/libc/tinystdio/conv_flt.c
@@ -244,29 +244,18 @@ conv_flt (FLT_STREAM *stream, FLT_CONTEXT *context, width_t width, void *addr, u
                     break;
                 return 0;
 	    }
-            if (flt != flt)
-            {
+            if (flt != flt) {
                 if (CHECK_WIDTH()) {
-                    if ((i = scanf_getc (stream, context)) == '(')
-                    {
-                        while(CHECK_WIDTH() && (i = scanf_getc (stream, context)) != ')')
-                        {
-                            if(isalnum(i) || i == '_' )
-                            {
+                    if ((i = scanf_getc (stream, context)) == '(') {
+                        while (CHECK_WIDTH() && (i = scanf_getc (stream, context)) != ')') {
+                            if (isalnum(i) || i == '_' )
                                 continue;
-                            }
                             else
-                            {
                                 break;
-                            }
                         }
-                        if(i != ')')
-                        {
+                        if (i != ')')
                             return 0;
-                        }
-                    }
-                    else
-                    {
+                    } else {
                         scanf_ungetc (i, stream, context);
                     }
                 }

--- a/newlib/libc/tinystdio/conv_flt.c
+++ b/newlib/libc/tinystdio/conv_flt.c
@@ -244,6 +244,33 @@ conv_flt (FLT_STREAM *stream, FLT_CONTEXT *context, width_t width, void *addr, u
                     break;
                 return 0;
 	    }
+            if (flt != flt)
+            {
+                if (CHECK_WIDTH()) {
+                    if ((i = scanf_getc (stream, context)) == '(')
+                    {
+                        while(CHECK_WIDTH() && (i = scanf_getc (stream, context)) != ')')
+                        {
+                            if(isalnum(i) || i == '_' )
+                            {
+                                continue;
+                            }
+                            else
+                            {
+                                break;
+                            }
+                        }
+                        if(i != ')')
+                        {
+                            return 0;
+                        }
+                    }
+                    else
+                    {
+                        scanf_ungetc (i, stream, context);
+                    }
+                }
+            }
         }
 	break;
 

--- a/test/libc-testsuite/sscanf.c
+++ b/test/libc-testsuite/sscanf.c
@@ -212,6 +212,53 @@ static int test_sscanf(void)
         /* legacy stdio fails this test */
 	TEST(i, sscanf("hello, world\n", "%8c%8c", a, b), 1, "%d fields, expected %d");
 	TEST_S(a, "hello, wX", "");
+
+    /* testing nan(n-seq-char) in the expected form */
+    a[0] = '#';
+    a[1] = '\0';
+    TEST(i, sscanf(" Nan(98b)", "%lf%c", &d, a), 1, "got %d fields, expected %d");
+    TEST(i, isnan(d), 1, "isnan %d expected %d");
+    TEST_S(a, "#", "");
+
+    /* testing nan(n-seq-char) missing closing paren */
+    a[0] = '#';
+    a[1] = '\0';
+    d = 1.0;
+    TEST(i, sscanf("NaN(abcdefg", "%lf%c", &d, a), -1, "got %d fields, expected %d");
+    TEST(i, d, 1.0, "%d expected %lf");
+    TEST_S(a, "#", "");
+
+    /* testing nan(n-seq-char) invalid character inside parens */
+    a[0] = '#';
+    a[1] = '\0';
+    d = 1.0;
+    TEST(i, sscanf("NaN(12:b)", "%lf%c", &d, a), 0, "got %d fields, expected %d");
+    TEST(i, d, 1.0, "%d expected %lf");
+    TEST_S(a, "#", "");
+    
+    /* testing nan(n-seq-char) overrunning a field width value */
+    a[0] = '#';
+    a[1] = '\0';
+    d = 1.0;
+    TEST(i, sscanf("Nan(12345)", "%9lf%c", &d, a), 0, "got %d fields, expected %d");
+    TEST(i, d, 1.0, "%d expected %lf");
+    TEST_S(a, "#", "");
+    
+    /* testing inf(n-seq-char) should 'inf' should be evaluated sperately */
+    a[0] = '#';
+    a[1] = '\0';
+    d = 1.0;
+    TEST(i, sscanf("inf(12b)", "%lf%c", &d, a), 2, "got %d fields, expected %d");
+    TEST(i, isinf(d), 1, "%d expected %d");
+    TEST_S(a, "(", "");
+
+    /* testing infinity(n-seq-char) should 'infinity' should be evaluated sperately */
+    a[0] = '#';
+    a[1] = '\0';
+    d = 1.0;
+    TEST(i, sscanf("infinity(abcd)", "%lf%c", &d, a), 2, "got %d fields, expected %d");
+    TEST(i, isinf(d), 1, "%d expected %d");
+    TEST_S(a, "(", "");
 #endif
 
 	TEST(i, sscanf("56789 0123 56a72", "%2d%d%*d %[0123456789]\n", &x, &y, a), 3, "only %d fields, expected %d");


### PR DESCRIPTION
Quoting from C standard part 7.19.6.2

> `a,e,f,g` Matches an optionally signed floating-point number, infinity, or NaN, whose format is the same as expected for the subject sequence of the `strtod` function. The corresponding argument shall be a pointer to floating.

Regarding `strtod`, quoting from C standard part 7.20.1.3

> A character sequence `NAN` or `NAN(n-char-sequence)`, is interpreted as a quiet NaN, if supported in the return type, else like a subject sequence part that does not have the expected form; the meaning of the n-char sequences is **implementation-defined**.
