### PR TITLE
Enable MMU on arm V7/V7A targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,6 +229,9 @@ set(_HAVE_INITFINI_ARRAY 1)
 # Support _init() and _fini() functions
 set(_HAVE_INIT_FINI 1)
 
+# Enable MMU in pico crt startup
+set(_PICOCRT_ENABLE_MMU 1)
+
 # Compiler has long double type
 picolibc_flag(_HAVE_LONG_DOUBLE)
 

--- a/meson.build
+++ b/meson.build
@@ -1693,6 +1693,9 @@ endif
 # make sure to include semihost BEFORE picocrt!
 if enable_picocrt
   subdir('picocrt')
+  picocrt_enable_mmu = get_option('picocrt-enable-mmu')
+  conf_data.set('_PICOCRT_ENABLE_MMU', picocrt_enable_mmu,
+                description: 'Turn on mmu in picocrt startup code')
 endif
 subdir('newlib')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -62,6 +62,9 @@ option('picolib', type: 'boolean', value: true,
 option('picocrt', type: 'boolean', value: true,
        description: 'Include pico crt bits')
 
+option('picocrt-enable-mmu', type: 'boolean', value: true,
+       description: 'Enable memory management unit in picocrt startup')
+
 option('picocrt-lib', type: 'boolean', value: true,
        description: 'Include pico crt bits in lib form')
 

--- a/newlib/libc/picolib/machine/arm/interrupt.c
+++ b/newlib/libc/picolib/machine/arm/interrupt.c
@@ -135,29 +135,29 @@ __weak_vector_table(void)
 	 * Exception vector that lives at the
 	 * start of program text (usually 0x0)
 	 */
-#if __thumb2__
+#if __thumb2__ && __ARM_ARCH_PROFILE != 'A'
 	/* Thumb 2 processors start in thumb mode */
-	__asm__(".thumb");
-	__asm__(".syntax unified");
-	__asm__("b.w _start");
-	__asm__("b.w arm_undef_vector");
-	__asm__("b.w arm_svc_vector");
-	__asm__("b.w arm_prefetch_abort_vector");
-	__asm__("b.w arm_data_abort_vector");
-	__asm__("b.w arm_not_used_vector");
-	__asm__("b.w arm_irq_vector");
-	__asm__("b.w arm_fiq_vector");
+	__asm__(".thumb\n"
+                ".syntax unified\n"
+                "b.w _start\n"
+                "b.w arm_undef_vector\n"
+                "b.w arm_svc_vector\n"
+                "b.w arm_prefetch_abort_vector\n"
+                "b.w arm_data_abort_vector\n"
+                "b.w arm_not_used_vector\n"
+                "b.w arm_irq_vector\n"
+                "b.w arm_fiq_vector");
 #else
 	/* Thumb 1 and arm processors start in arm mode */
-	__asm__(".arm");
-	__asm__("b _start");
-	__asm__("b arm_undef_vector");
-	__asm__("b arm_svc_vector");
-	__asm__("b arm_prefetch_abort_vector");
-	__asm__("b arm_data_abort_vector");
-	__asm__("b arm_not_used_vector");
-	__asm__("b arm_irq_vector");
-	__asm__("b arm_fiq_vector");
+        __asm__(".arm\n"
+                "b _start\n"
+                "b arm_undef_vector\n"
+                "b arm_svc_vector\n"
+                "b arm_prefetch_abort_vector\n"
+                "b arm_data_abort_vector\n"
+                "b arm_not_used_vector\n"
+                "b arm_irq_vector\n"
+                "b arm_fiq_vector");
 #endif
 }
 

--- a/picolibc.h.in
+++ b/picolibc.h.in
@@ -23,6 +23,9 @@
 /* use thread local storage */
 #cmakedefine NEWLIB_TLS
 
+/* Turn on mmu in picocrt startup code */
+#cmakedefine _PICOCRT_ENABLE_MMU
+
 /* use thread local storage */
 #cmakedefine PICOLIBC_TLS
 

--- a/scripts/run-arm
+++ b/scripts/run-arm
@@ -64,7 +64,7 @@ case "$cpu_arch"/"$cpu_profile" in
     v6S-M/Microcontroller)
         cpu=cortex-m0
         ;;
-    v7/Application|v7/)
+    v7/Application)
         case "$fp_arch" in
             VFPv3)
                 cpu=cortex-a9
@@ -72,11 +72,27 @@ case "$cpu_arch"/"$cpu_profile" in
             VFPv3-D16)
                 cpu=cortex-a8
                 ;;
+            VFPv4)
+                cpu=cortex-a7
+                ;;
             *)
                 cpu=cortex-a7
                 ;;
         esac
-        ;;        
+        ;;
+    v7/)
+        case "$fp_arch" in
+            VFPv3)
+                cpu=cortex-r5
+                ;;
+            VFPv3-D16)
+                cpu=cortex-r5f
+                ;;
+            *)
+                cpu=cortex-r5
+                ;;
+        esac
+        ;;
     v7/Microcontroller)
         cpu=cortex-m3
         ;;


### PR DESCRIPTION
This adapts pr #740 so that it only applies to V7 and V7A targets, and then auto-detects whether the MMU is present at runtime so that it can run on targets that only have an MPU (or nothing). I've adjusted the range of memory affected to only go from 0x0 through 0x7fffffff as the upper 2GB is "usually" reserved for devices and other non-memory objects for which caching should not be enabled.

This is needed for CI to work as QEMU has started enforcing memory type on MMU-enabled systems; when the MMU is disabled, the memory type is set to Device, which doesn't allow unaligned references and hence the default compiler setting for these targets doesn't work. Enabling the MMU lets us specify the memory type along with enabling caching. Because of this, I've actually enabled the option by default. You can turn it off for specific targets once you know they don't have an MMU. It's only in picocrt after all, so this won't affect downstream users like Zephyr which provide their own startup code.

I also discovered that the non-M exception handling stuff was quite broken; we need to set up the various shadow SPs at startup so that exception entry will have a stack ready to go. For now, I'm just using the same stack for everyone as that's sufficient to catch exceptions and generate at least a PC value. Obviously, anyone using these processors in a real application would need to allocate separate stacks for each class of exception.

Closes: #740 