### PR TITLE
fix specs_prefix_format to point to root toolchain's directory

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -535,20 +535,39 @@ if thread_local_storage
 endif
 
 if sysroot_install
+  # Get 'sysroot' or 'GCC_EXEC_PREFIX' from GCC output
   sysroot = run_command(cc.cmd_array() + ['-print-sysroot'], check : true).stdout().split('\n')[0]
   if sysroot != ''
-    specs_prefix_format = '%R/@0@'
+    specs_prefix_format_format = '%R/@0@'
+    specs_prefix_format_default = '%R/@0@'
   else
-    sysroot = cc_install_dir + '../../../..'
-    specs_prefix_format = '%:getenv(GCC_EXEC_PREFIX ../../@0@)'
-  endif
-  if not get_option('sysroot-install-skip-checks')
-    if sysroot == ''
+    if not get_option('sysroot-install-skip-checks')
       error('sysroot install requested, but compiler has no sysroot')
     endif
-    if not fs.is_samepath(sysroot, prefix)
-      error('sysroot install requires --prefix=' + sysroot)
+    sysroot = run_command(cc.cmd_array() + ['-print-search-dirs'], check : true).stdout().split('\n')[0].split(' ')[1]
+    specs_prefix_format_format = '%:getenv(GCC_EXEC_PREFIX @0@)'
+    specs_prefix_format_default = '%:getenv(GCC_EXEC_PREFIX ../../@0@)'
+  endif
+
+  # Try to calculate relative path from sysroot to prefix
+  specs_prefix_format = ''
+  if fs.exists(sysroot)
+    sysroot_to_prefix_correction = ''
+    foreach _ : sysroot.split('/')
+      if fs.is_samepath(sysroot + '/' + sysroot_to_prefix_correction, prefix)
+        specs_prefix_format = specs_prefix_format_format.format(sysroot_to_prefix_correction + '@0@')
+        break
+      endif
+      sysroot_to_prefix_correction += '../'
+    endforeach
+  endif
+
+  # Use default 'specs_prefix_format' if can not have relative sysroot path
+  if specs_prefix_format == ''
+    if not get_option('sysroot-install-skip-checks')
+      error('sysroot install requires sysroot(' + sysroot + ') to be a subdirectory of --prefix=<PATH>(' + prefix + ')')
     endif
+    specs_prefix_format = specs_prefix_format_default
   endif
 else
   specs_prefix_format = prefix + '/@0@'


### PR DESCRIPTION
I found that toolchains that have sysroot could not find picolibc includes or libs

In my case:

`%R` is `/home/alex/.espressif/tools/riscv32-esp-elf/esp-13.2.0_20240305.3-2cc49e8/riscv32-esp-elf/bin/../riscv32-esp-elf/`
but picolibc installed here: `/home/alex/.espressif/tools/riscv32-esp-elf/esp-13.2.0_20240305.3-2cc49e8/riscv32-esp-elf/picolibc`


In case `specs_prefix_format = '%:getenv(GCC_EXEC_PREFIX ../../@0@)'` all works fine. With this change `specs_prefix_format = '%:getenv(GCC_EXEC_PREFIX ../../@0@)'` and `specs_prefix_format = '%R/../@0@'` should point to the same directory... But I'm not sure that it's true for all GCC versions, I tested only with v14.1