### PR TITLE
DRAFT: make buffered stream operations atomic 

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -118,8 +118,9 @@ jobs:
           "",
 
           # Tinystdio and math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
+	  # one with integer default format, obsolete math, fast bufio and flockfile
           "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
-          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=false -Dfast-bufio=true",
+          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=false -Dfast-bufio=true -Dflockfile=true",
 
           # Original stdio, one with multithread disabled
           "-Dtinystdio=false",
@@ -178,8 +179,9 @@ jobs:
           "",
 
           # Tinystdio and math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
+	  # one with integer default format, obsolete math, fast bufio and flockfile
           "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
-          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=false -Dfast-bufio=true",
+          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=false -Dfast-bufio=true -Dflockfile=true",
 
           # Original stdio, one with multithread disabled
           "-Dtinystdio=false",

--- a/.github/workflows/variants
+++ b/.github/workflows/variants
@@ -6,8 +6,9 @@
           "",
 
           # Tinystdio and math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
+	  # one with integer default format, obsolete math, fast bufio and flockfile
           "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
-          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=false -Dfast-bufio=true",
+          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=false -Dfast-bufio=true -Dflockfile=true",
 
           # Original stdio, one with multithread disabled
           "-Dtinystdio=false",

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -64,8 +64,9 @@ jobs:
           "",
 
           # Tinystdio and math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
+	  # one with integer default format, obsolete math, fast bufio and flockfile
           "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
-          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=false -Dfast-bufio=true",
+          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=false -Dfast-bufio=true -Dflockfile=true",
 
           # Original stdio, one with multithread disabled
           "-Dtinystdio=false",
@@ -124,8 +125,9 @@ jobs:
           "",
 
           # Tinystdio and math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
+	  # one with integer default format, obsolete math, fast bufio and flockfile
           "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dnewlib-multithread=false -Dnewlib-retargetable-locking=false -Dnewlib-locale-info=true -Dnewlib-locale-info-extended=true -Dnewlib-mb=true -Dnewlib-iconv-external-ccs=true -Dnewlib-nano-malloc=false -Dpicoexit=false -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
-          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=false -Dfast-bufio=true",
+          "-Dformat-default=integer -Dfreestanding=true -Dposix-io=false -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=false -Dfast-bufio=true -Dflockfile=true",
 
           # Original stdio, one with multithread disabled
           "-Dtinystdio=false",

--- a/meson.build
+++ b/meson.build
@@ -354,22 +354,42 @@ if tinystdio and printf_aliases
     if format_default != 'double'
       double_printf_link_args += '-Wl,--defsym=' + vfprintf_symbol +  '=' + __d_vfprintf_symbol
       double_printf_link_args += '-Wl,--defsym=' + vfscanf_symbol + '=' + __d_vfscanf_symbol
+      if flockfile
+        double_printf_link_args += '-Wl,--defsym=' + vfprintf_symbol + '_unlocked' + '=' + __d_vfprintf_symbol + '_unlocked'
+        double_printf_link_args += '-Wl,--defsym=' + vfscanf_symbol + '_unlocked' +  '=' + __d_vfscanf_symbol + '_unlocked'
+      endif
     endif
     if format_default != 'float'
       float_printf_link_args += '-Wl,--defsym=' + vfprintf_symbol +  '=' + __f_vfprintf_symbol
       float_printf_link_args += '-Wl,--defsym=' + vfscanf_symbol + '=' + __f_vfscanf_symbol
+      if flockfile
+        float_printf_link_args += '-Wl,--defsym=' + vfscanf_symbol + '_unlocked' + '=' + __f_vfscanf_symbol + '_unlocked'
+        float_printf_link_args += '-Wl,--defsym=' + vfprintf_symbol + '_unlocked' +  '=' + __f_vfprintf_symbol + '_unlocked'
+      endif
     endif
     if format_default != 'long-long'
       llong_printf_link_args += '-Wl,--defsym=' + vfprintf_symbol +  '=' + __l_vfprintf_symbol
       llong_printf_link_args += '-Wl,--defsym=' + vfscanf_symbol + '=' + __l_vfscanf_symbol
+      if flockfile
+        llong_printf_link_args += '-Wl,--defsym=' + vfprintf_symbol + '_unlocked' + '=' + __l_vfprintf_symbol + '_unlocked'
+        llong_printf_link_args += '-Wl,--defsym=' + vfscanf_symbol + '_unlocked' +  '=' + __l_vfscanf_symbol + '_unlocked'
+      endif
     endif
     if format_default != 'integer'
       int_printf_link_args += '-Wl,--defsym=' + vfprintf_symbol +  '=' + __i_vfprintf_symbol
       int_printf_link_args += '-Wl,--defsym=' + vfscanf_symbol + '=' + __i_vfscanf_symbol
+      if flockfile
+        int_printf_link_args += '-Wl,--defsym=' + vfprintf_symbol + '_unlocked' + '=' + __i_vfprintf_symbol + '_unlocked'
+        int_printf_link_args += '-Wl,--defsym=' + vfscanf_symbol + '_unlocked' +  '=' + __i_vfscanf_symbol + '_unlocked'
+      endif
     endif
     if format_default != 'minimal'
       min_printf_link_args += '-Wl,--defsym=' + vfprintf_symbol +  '=' + __m_vfprintf_symbol
       min_printf_link_args += '-Wl,--defsym=' + vfscanf_symbol + '=' + __m_vfscanf_symbol
+      if flockfile
+        min_printf_link_args += '-Wl,--defsym=' + vfprintf_symbol + '_unlocked' + '=' + __m_vfprintf_symbol + '_unlocked'
+        min_printf_link_args += '-Wl,--defsym=' + vfscanf_symbol + '_unlocked' +  '=' + __m_vfscanf_symbol + '_unlocked'
+      endif
     endif
   elif has_link_alias
     if format_default == 'double'
@@ -381,6 +401,16 @@ if tinystdio and printf_aliases
       int_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + ',' + __d_vfscanf_symbol
       min_printf_link_args += '-Wl,-alias,' + vfprintf_symbol +  ',' + __d_vfprintf_symbol
       min_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + ',' + __d_vfscanf_symbol
+      if flockfile
+        float_printf_link_args += '-Wl,-alias,' + vfprintf_symbol + '_unlocked' +  ',' + __d_vfprintf_symbol + '_unlocked'
+        float_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + '_unlocked' + ',' + __d_vfscanf_symbol + '_unlocked'
+        llong_printf_link_args += '-Wl,-alias,' + vfprintf_symbol + '_unlocked' +  ',' + __d_vfprintf_symbol + '_unlocked'
+        llong_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + '_unlocked' + ',' + __d_vfscanf_symbol + '_unlocked'
+        int_printf_link_args += '-Wl,-alias,' + vfprintf_symbol + '_unlocked' +  ',' + __d_vfprintf_symbol + '_unlocked'
+        int_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + '_unlocked' + ',' + __d_vfscanf_symbol + '_unlocked'
+        min_printf_link_args += '-Wl,-alias,' + vfprintf_symbol + '_unlocked' +  ',' + __d_vfprintf_symbol + '_unlocked'
+        min_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + '_unlocked' + ',' + __d_vfscanf_symbol + '_unlocked'
+      endif
     endif
     if format_default == 'float'
       double_printf_link_args += '-Wl,-alias,' + vfprintf_symbol +  ',' + __f_vfprintf_symbol
@@ -391,6 +421,16 @@ if tinystdio and printf_aliases
       int_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + ',' + __f_vfscanf_symbol
       min_printf_link_args += '-Wl,-alias,' + vfprintf_symbol +  ',' + __f_vfprintf_symbol
       min_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + ',' + __f_vfscanf_symbol
+      if flockfile
+        double_printf_link_args += '-Wl,-alias,' + vfprintf_symbol + '_unlocked' +  ',' + __f_vfprintf_symbol + '_unlocked'
+        double_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + '_unlocked' + ',' + __f_vfscanf_symbol + '_unlocked'
+        llong_printf_link_args += '-Wl,-alias,' + vfprintf_symbol + '_unlocked' +  ',' + __f_vfprintf_symbol + '_unlocked'
+        llong_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + '_unlocked' + ',' + __f_vfscanf_symbol + '_unlocked'
+        int_printf_link_args += '-Wl,-alias,' + vfprintf_symbol + '_unlocked' +  ',' + __f_vfprintf_symbol + '_unlocked'
+        int_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + '_unlocked' + ',' + __f_vfscanf_symbol + '_unlocked'
+        min_printf_link_args += '-Wl,-alias,' + vfprintf_symbol + '_unlocked' +  ',' + __f_vfprintf_symbol + '_unlocked'
+        min_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + '_unlocked' + ',' + __f_vfscanf_symbol + '_unlocked'
+      endif
     endif
     if format_default == 'long-long'
       double_printf_link_args += '-Wl,-alias,' + vfprintf_symbol +  ',' + __l_vfprintf_symbol
@@ -401,6 +441,16 @@ if tinystdio and printf_aliases
       int_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + ',' + __l_vfscanf_symbol
       min_printf_link_args += '-Wl,-alias,' + vfprintf_symbol +  ',' + __l_vfprintf_symbol
       min_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + ',' + __l_vfscanf_symbol
+      if flockfile
+        double_printf_link_args += '-Wl,-alias,' + vfprintf_symbol + '_unlocked' +  ',' + __l_vfprintf_symbol + '_unlocked'
+        double_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + '_unlocked' + ',' + __l_vfscanf_symbol + '_unlocked'
+        float_printf_link_args += '-Wl,-alias,' + vfprintf_symbol + '_unlocked' +  ',' + __l_vfprintf_symbol + '_unlocked'
+        float_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + '_unlocked' + ',' + __l_vfscanf_symbol + '_unlocked'
+        int_printf_link_args += '-Wl,-alias,' + vfprintf_symbol + '_unlocked' +  ',' + __l_vfprintf_symbol + '_unlocked'
+        int_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + '_unlocked' + ',' + __l_vfscanf_symbol + '_unlocked'
+        min_printf_link_args += '-Wl,-alias,' + vfprintf_symbol + '_unlocked' +  ',' + __l_vfprintf_symbol + '_unlocked'
+        min_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + '_unlocked' + ',' + __l_vfscanf_symbol + '_unlocked'
+      endif
     endif
     if format_default == 'integer'
       double_printf_link_args += '-Wl,-alias,' + vfprintf_symbol +  ',' + __i_vfprintf_symbol
@@ -411,6 +461,16 @@ if tinystdio and printf_aliases
       llong_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + ',' + __i_vfscanf_symbol
       min_printf_link_args += '-Wl,-alias,' + vfprintf_symbol +  ',' + __i_vfprintf_symbol
       min_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + ',' + __i_vfscanf_symbol
+      if flockfile
+        double_printf_link_args += '-Wl,-alias,' + vfprintf_symbol + '_unlocked' +  ',' + __i_vfprintf_symbol + '_unlocked'
+        double_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + '_unlocked' + ',' + __i_vfscanf_symbol + '_unlocked'
+        float_printf_link_args += '-Wl,-alias,' + vfprintf_symbol + '_unlocked' +  ',' + __i_vfprintf_symbol + '_unlocked'
+        float_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + '_unlocked' + ',' + __i_vfscanf_symbol + '_unlocked'
+        llong_printf_link_args += '-Wl,-alias,' + vfprintf_symbol + '_unlocked' +  ',' + __i_vfprintf_symbol + '_unlocked'
+        llong_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + '_unlocked' + ',' + __i_vfscanf_symbol + '_unlocked'
+        min_printf_link_args += '-Wl,-alias,' + vfprintf_symbol + '_unlocked' +  ',' + __i_vfprintf_symbol + '_unlocked'
+        min_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + '_unlocked' + ',' + __i_vfscanf_symbol + '_unlocked'
+      endif
     endif
     if format_default == 'minimal'
       double_printf_link_args += '-Wl,-alias,' + vfprintf_symbol +  ',' + __m_vfprintf_symbol
@@ -421,26 +481,56 @@ if tinystdio and printf_aliases
       llong_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + ',' + __m_vfscanf_symbol
       int_printf_link_args += '-Wl,-alias,' + vfprintf_symbol +  ',' + __m_vfprintf_symbol
       int_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + ',' + __m_vfscanf_symbol
+      if flockfile
+        double_printf_link_args += '-Wl,-alias,' + vfprintf_symbol + '_unlocked' +  ',' + __m_vfprintf_symbol + '_unlocked'
+        double_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + '_unlocked' + ',' + __m_vfscanf_symbol + '_unlocked'
+        float_printf_link_args += '-Wl,-alias,' + vfprintf_symbol + '_unlocked' +  ',' + __m_vfprintf_symbol + '_unlocked'
+        float_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + '_unlocked' + ',' + __m_vfscanf_symbol + '_unlocked'
+        llong_printf_link_args += '-Wl,-alias,' + vfprintf_symbol + '_unlocked' +  ',' + __m_vfprintf_symbol + '_unlocked'
+        llong_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + '_unlocked' + ',' + __m_vfscanf_symbol + '_unlocked'
+        int_printf_link_args += '-Wl,-alias,' + vfprintf_symbol + '_unlocked' +  ',' + __m_vfprintf_symbol + '_unlocked'
+        int_printf_link_args += '-Wl,-alias,' + vfscanf_symbol + '_unlocked' + ',' + __m_vfscanf_symbol + '_unlocked'
+      endif
     endif
     if format_default != 'double'
       double_printf_link_args += '-Wl,-alias,' + __d_vfprintf_symbol +  ',' + vfprintf_symbol
       double_printf_link_args += '-Wl,-alias,' + __d_vfscanf_symbol + ',' + vfscanf_symbol
+      if flockfile
+        double_printf_link_args += '-Wl,-alias,' + __d_vfprintf_symbol + '_unlocked' +  ',' + vfprintf_symbol + '_unlocked'
+        double_printf_link_args += '-Wl,-alias,' + __d_vfscanf_symbol + '_unlocked' + ',' + vfscanf_symbol + '_unlocked'
+      endif
     endif
     if format_default != 'float'
-      float_printf_link_args += '-Wl,-alias,' + __f_vfprintf_symbol +  ',' + vfprintf_symbol
-      float_printf_link_args += '-Wl,-alias,' + __f_vfscanf_symbol + ',' + vfscanf_symbol
+      float_printf_link_args += '-Wl,-alias,' + __f_vfprintf_symbol + '_unlocked' +  ',' + vfprintf_symbol + '_unlocked'
+      float_printf_link_args += '-Wl,-alias,' + __f_vfscanf_symbol + '_unlocked' + ',' + vfscanf_symbol + '_unlocked'
+      if flockfile
+        float_printf_link_args += '-Wl,-alias,' + __f_vfprintf_symbol + '_unlocked' +  ',' + vfprintf_symbol + '_unlocked'
+        float_printf_link_args += '-Wl,-alias,' + __f_vfscanf_symbol + '_unlocked' + ',' + vfscanf_symbol + '_unlocked'
+      endif
     endif
     if format_default != 'long-long'
-      llong_printf_link_args += '-Wl,-alias,' + __l_vfprintf_symbol +  ',' + vfprintf_symbol
-      llong_printf_link_args += '-Wl,-alias,' + __l_vfscanf_symbol + ',' + vfscanf_symbol
+      llong_printf_link_args += '-Wl,-alias,' + __l_vfprintf_symbol + '_unlocked' +  ',' + vfprintf_symbol + '_unlocked'
+      llong_printf_link_args += '-Wl,-alias,' + __l_vfscanf_symbol + '_unlocked' + ',' + vfscanf_symbol + '_unlocked'
+      if flockfile
+        llong_printf_link_args += '-Wl,-alias,' + __l_vfprintf_symbol + '_unlocked' +  ',' + vfprintf_symbol + '_unlocked'
+        llong_printf_link_args += '-Wl,-alias,' + __l_vfscanf_symbol + '_unlocked' + ',' + vfscanf_symbol + '_unlocked'
+      endif
     endif
     if format_default != 'integer'
-      int_printf_link_args += '-Wl,-alias,' + __i_vfprintf_symbol +  ',' + vfprintf_symbol
-      int_printf_link_args += '-Wl,-alias,' + __i_vfscanf_symbol + ',' + vfscanf_symbol
+      int_printf_link_args += '-Wl,-alias,' + __i_vfprintf_symbol + '_unlocked' +  ',' + vfprintf_symbol + '_unlocked'
+      int_printf_link_args += '-Wl,-alias,' + __i_vfscanf_symbol + '_unlocked' + ',' + vfscanf_symbol + '_unlocked'
+      if flockfile
+        int_printf_link_args += '-Wl,-alias,' + __i_vfprintf_symbol + '_unlocked' +  ',' + vfprintf_symbol + '_unlocked'
+        int_printf_link_args += '-Wl,-alias,' + __i_vfscanf_symbol + '_unlocked' + ',' + vfscanf_symbol + '_unlocked'
+      endif
     endif
     if format_default != 'minimal'
-      min_printf_link_args += '-Wl,-alias,' + __m_vfprintf_symbol +  ',' + vfprintf_symbol
-      min_printf_link_args += '-Wl,-alias,' + __m_vfscanf_symbol + ',' + vfscanf_symbol
+      min_printf_link_args += '-Wl,-alias,' + __m_vfprintf_symbol + '_unlocked' +  ',' + vfprintf_symbol + '_unlocked'
+      min_printf_link_args += '-Wl,-alias,' + __m_vfscanf_symbol + '_unlocked' + ',' + vfscanf_symbol + '_unlocked'
+      if flockfile
+        min_printf_link_args += '-Wl,-alias,' + __m_vfprintf_symbol + '_unlocked' +  ',' + vfprintf_symbol + '_unlocked'
+        min_printf_link_args += '-Wl,-alias,' + __m_vfscanf_symbol + '_unlocked' + ',' + vfscanf_symbol + '_unlocked'
+      endif
     endif
   else
     if enable_tests
@@ -629,16 +719,29 @@ endif
 
 specs_printf = ''
 if tinystdio and printf_aliases
-  specs_printf=('%{DPICOLIBC_DOUBLE_PRINTF_SCANF:--defsym=vfprintf=' + __d_vfprintf_symbol + '}' +
-		' %{DPICOLIBC_DOUBLE_PRINTF_SCANF:--defsym=vfscanf=' + __d_vfscanf_symbol + '}' +
-                ' %{DPICOLIBC_FLOAT_PRINTF_SCANF:--defsym=vfprintf=' + __f_vfprintf_symbol + '}' +
-		' %{DPICOLIBC_FLOAT_PRINTF_SCANF:--defsym=vfscanf=' + __f_vfscanf_symbol + '}' +
-		' %{DPICOLIBC_LONG_LONG_PRINTF_SCANF:--defsym=vfprintf=' + __l_vfprintf_symbol + '}' +
-		' %{DPICOLIBC_LONG_LONG_PRINTF_SCANF:--defsym=vfscanf=' + __l_vfscanf_symbol + '}' +
-		' %{DPICOLIBC_INTEGER_PRINTF_SCANF:--defsym=vfprintf=' + __i_vfprintf_symbol + '}' +
-		' %{DPICOLIBC_INTEGER_PRINTF_SCANF:--defsym=vfscanf=' + __i_vfscanf_symbol + '}' +
-		' %{DPICOLIBC_MINIMAL_PRINTF_SCANF:--defsym=vfprintf=' + __m_vfprintf_symbol + '}' +
-		' %{DPICOLIBC_MINIMAL_PRINTF_SCANF:--defsym=vfscanf=' + __m_vfscanf_symbol + '}')
+  if flockfile
+    specs_printf=('%{DPICOLIBC_DOUBLE_PRINTF_SCANF:--defsym=vfprintf=' + __d_vfprintf_symbol + ' --defsym=vfprintf_unlocked=' + __d_vfprintf_symbol + '_unlocked}' +
+		  ' %{DPICOLIBC_DOUBLE_PRINTF_SCANF:--defsym=vfscanf=' + __d_vfscanf_symbol + ' --defsym=vfprintf_unlocked=' + __d_vfscanf_symbol + '_unlocked}' +
+                  ' %{DPICOLIBC_FLOAT_PRINTF_SCANF:--defsym=vfprintf=' + __f_vfprintf_symbol + ' --defsym=vfprintf_unlocked=' + __f_vfprintf_symbol + '_unlocked}' +
+		  ' %{DPICOLIBC_FLOAT_PRINTF_SCANF:--defsym=vfscanf=' + __f_vfscanf_symbol + ' --defsym=vfprintf_unlocked=' + __f_vfscanf_symbol + '_unlocked}' +
+		  ' %{DPICOLIBC_LONG_LONG_PRINTF_SCANF:--defsym=vfprintf=' + __l_vfprintf_symbol + ' --defsym=vfprintf_unlocked=' + __l_vfprintf_symbol + '_unlocked}' +
+		  ' %{DPICOLIBC_LONG_LONG_PRINTF_SCANF:--defsym=vfscanf=' + __l_vfscanf_symbol + ' --defsym=vfprintf_unlocked=' + __l_vfscanf_symbol + '_unlocked}' +
+		  ' %{DPICOLIBC_INTEGER_PRINTF_SCANF:--defsym=vfprintf=' + __i_vfprintf_symbol + ' --defsym=vfprintf_unlocked=' + __i_vfprintf_symbol + '_unlocked}' +
+		  ' %{DPICOLIBC_INTEGER_PRINTF_SCANF:--defsym=vfscanf=' + __i_vfscanf_symbol + ' --defsym=vfprintf_unlocked=' + __i_vfscanf_symbol + '_unlocked}' +
+		  ' %{DPICOLIBC_MINIMAL_PRINTF_SCANF:--defsym=vfprintf=' + __m_vfprintf_symbol + ' --defsym=vfprintf_unlocked=' + __m_vfprintf_symbol + '_unlocked}' +
+		  ' %{DPICOLIBC_MINIMAL_PRINTF_SCANF:--defsym=vfscanf=' + __m_vfscanf_symbol + ' --defsym=vfprintf_unlocked=' + __m_vfscanf_symbol + '_unlocked}')
+  else
+    specs_printf=('%{DPICOLIBC_DOUBLE_PRINTF_SCANF:--defsym=vfprintf=' + __d_vfprintf_symbol + '}' +
+		  ' %{DPICOLIBC_DOUBLE_PRINTF_SCANF:--defsym=vfscanf=' + __d_vfscanf_symbol + '}' +
+                  ' %{DPICOLIBC_FLOAT_PRINTF_SCANF:--defsym=vfprintf=' + __f_vfprintf_symbol + '}' +
+		  ' %{DPICOLIBC_FLOAT_PRINTF_SCANF:--defsym=vfscanf=' + __f_vfscanf_symbol + '}' +
+		  ' %{DPICOLIBC_LONG_LONG_PRINTF_SCANF:--defsym=vfprintf=' + __l_vfprintf_symbol + '}' +
+		  ' %{DPICOLIBC_LONG_LONG_PRINTF_SCANF:--defsym=vfscanf=' + __l_vfscanf_symbol + '}' +
+		  ' %{DPICOLIBC_INTEGER_PRINTF_SCANF:--defsym=vfprintf=' + __i_vfprintf_symbol + '}' +
+		  ' %{DPICOLIBC_INTEGER_PRINTF_SCANF:--defsym=vfscanf=' + __i_vfscanf_symbol + '}' +
+		  ' %{DPICOLIBC_MINIMAL_PRINTF_SCANF:--defsym=vfprintf=' + __m_vfprintf_symbol + '}' +
+		  ' %{DPICOLIBC_MINIMAL_PRINTF_SCANF:--defsym=vfscanf=' + __m_vfscanf_symbol + '}')
+  endif
 endif
 
 crt0_expr = '%{-crt0=*:crt0-%*%O%s; :crt0%O%s}'

--- a/meson.build
+++ b/meson.build
@@ -315,7 +315,7 @@ printf_percent_n = tinystdio and get_option('printf-percent-n')
 minimal_io_long_long = tinystdio and get_option('minimal-io-long-long')
 fast_bufio = tinystdio and get_option('fast-bufio')
 io_wchar = tinystdio and get_option('io-wchar')
-
+flockfile = posix_io and get_option('flockfile')
 
 if printf_aliases
   double_printf_compile_args=['-DPICOLIBC_DOUBLE_PRINTF_SCANF']
@@ -1322,6 +1322,10 @@ conf_data.set('_WANT_IO_PERCENT_B', io_percent_b)
 conf_data.set('_WANT_IO_LONG_DOUBLE', io_long_double)
 conf_data.set('_WANT_IO_WCHAR', io_wchar)
 conf_data.set('_ASSERT_VERBOSE', get_option('assert-verbose'))
+
+if tinystdio
+    conf_data.set('_WANT_FLOCKFILE', flockfile)
+endif
 
 if not tinystdio
   conf_data.set('NO_FLOATING_POINT', not newlib_io_float)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -184,7 +184,7 @@ option('fast-bufio', type: 'boolean', value: false,
 option('io-wchar', type: 'boolean', value: false,
        description: 'enable wide character support in printf/scanf even when newlib-mb is false')
 option('flockfile', type: 'boolean', value: false,
-       description: 'enable thread-safe mode for stream functions')
+       description: 'Use atomic i/o stream functions')
 
 #
 # Options applying to only legacy stdio

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -183,6 +183,8 @@ option('fast-bufio', type: 'boolean', value: false,
        description: 'enable some faster buffered i/o operations')
 option('io-wchar', type: 'boolean', value: false,
        description: 'enable wide character support in printf/scanf even when newlib-mb is false')
+option('flockfile', type: 'boolean', value: false,
+       description: 'enable thread-safe mode for stream functions')
 
 #
 # Options applying to only legacy stdio

--- a/newlib/libc/tinystdio/asprintf.c
+++ b/newlib/libc/tinystdio/asprintf.c
@@ -43,7 +43,7 @@ asprintf(char **strp, const char *fmt, ...)
 	int i;
 
 	va_start(ap, fmt);
-	i = vfprintf(&f.file, fmt, ap);
+	i = FILE_FN_UNLOCKED(vfprintf)(&f.file, fmt, ap);
 	va_end(ap);
 	if (i >= 0) {
                 char *buf = f.end - f.size;

--- a/newlib/libc/tinystdio/bufio.c
+++ b/newlib/libc/tinystdio/bufio.c
@@ -300,6 +300,7 @@ __bufio_close(FILE *f)
                 free(bf->buf);
 
 	__bufio_lock_close(f);
+	__flockfile_close(f);
 
         /*
          * Don't close the fd or free the FILE for things not

--- a/newlib/libc/tinystdio/clearerr.c
+++ b/newlib/libc/tinystdio/clearerr.c
@@ -39,7 +39,7 @@ FILE_FN_UNLOCKED(clearerr)(FILE *stream)
 	stream->flags &= ~(__SERR | __SEOF);
 }
 
-#if defined(_WANT_FLOCKFILE) && !defined(_FILE_INCLUDED)
+#if defined(_WANT_FLOCKFILE)
 void
 clearerr(FILE *stream)
 {

--- a/newlib/libc/tinystdio/clearerr.c
+++ b/newlib/libc/tinystdio/clearerr.c
@@ -33,7 +33,6 @@
 
 #undef clearerr
 
-FILE_FN_UNLOCKED_SPECIFIER
 void
 FILE_FN_UNLOCKED(clearerr)(FILE *stream)
 {

--- a/newlib/libc/tinystdio/clearerr.c
+++ b/newlib/libc/tinystdio/clearerr.c
@@ -33,9 +33,19 @@
 
 #undef clearerr
 
-void 
-clearerr(FILE *stream)
+FILE_FN_UNLOCKED_SPECIFIER
+void
+FILE_FN_UNLOCKED(clearerr)(FILE *stream)
 {
-
 	stream->flags &= ~(__SERR | __SEOF);
 }
+
+#if defined(_WANT_FLOCKFILE) && !defined(_FILE_INCLUDED)
+void
+clearerr(FILE *stream)
+{
+    __flockfile(stream);
+    FILE_FN_UNLOCKED(clearerr)(stream);
+    __funlockfile(stream);
+}
+#endif

--- a/newlib/libc/tinystdio/fclose.c
+++ b/newlib/libc/tinystdio/fclose.c
@@ -35,15 +35,12 @@ int
 fclose(FILE *f)
 {
         struct __file_close *cf = (struct __file_close *) f;
-#ifdef _WANT_FLOCKFILE
-        fflush(f);
-	__flockfile_close(f);
-#endif
         if ((f->flags & __SCLOSE) && cf->close) {
 		/*
 		 * File has 'close' function, call it
 		 */
 		return (*cf->close)(f);
 	}
+	__flockfile_close(f);
 	return 0;
 }

--- a/newlib/libc/tinystdio/fclose.c
+++ b/newlib/libc/tinystdio/fclose.c
@@ -34,8 +34,9 @@
 int
 fclose(FILE *f)
 {
-        struct __file_close *cf = (struct __file_close *) f;
-        if ((f->flags & __SCLOSE) && cf->close) {
+	__flockfile(f);
+	struct __file_close *cf = (struct __file_close *) f;
+	if ((f->flags & __SCLOSE) && cf->close) {
 		/*
 		 * File has 'close' function, call it
 		 */

--- a/newlib/libc/tinystdio/fclose.c
+++ b/newlib/libc/tinystdio/fclose.c
@@ -35,13 +35,11 @@ int
 fclose(FILE *f)
 {
 	int ret = 0;
+
 #ifdef _WANT_FLOCKFILE
-	FILE f_copy;
-	f_copy.lock = f->lock;
+        fflush(f);
+	__flockfile_close(f);
 #endif
-
-	__flockfile(f);
-
 	if (f->flags & __SCLOSE) {
 		/*
 		 * File has 'close' function, call it
@@ -51,10 +49,6 @@ fclose(FILE *f)
 			ret = (*cf->close)(f);
 	}
 
-#ifdef _WANT_FLOCKFILE
-    /* "f" could be already freed, so close copied lock */
-	__flockfile_close(&f_copy);
-#endif
 
 	return ret;
 }

--- a/newlib/libc/tinystdio/fclose.c
+++ b/newlib/libc/tinystdio/fclose.c
@@ -34,21 +34,16 @@
 int
 fclose(FILE *f)
 {
-	int ret = 0;
-
+        struct __file_close *cf = (struct __file_close *) f;
 #ifdef _WANT_FLOCKFILE
         fflush(f);
 	__flockfile_close(f);
 #endif
-	if (f->flags & __SCLOSE) {
+        if ((f->flags & __SCLOSE) && cf->close) {
 		/*
 		 * File has 'close' function, call it
 		 */
-		struct __file_close *cf = (struct __file_close *) f;
-		if (cf)
-			ret = (*cf->close)(f);
+		return (*cf->close)(f);
 	}
-
-
-	return ret;
+	return 0;
 }

--- a/newlib/libc/tinystdio/fdevopen.c
+++ b/newlib/libc/tinystdio/fdevopen.c
@@ -83,8 +83,12 @@ static int
 fdevclose(FILE *f)
 {
 	int ret = 0;
+
+	__flockfile(f);
 	if  (f->flush)
 		ret = (*f->flush)(f);
+	__flockfile_close(f);
+
 	free(f);
 	return ret;
 }
@@ -113,6 +117,8 @@ fdevopen(int (*put)(char, FILE *), int (*get)(FILE *), int (*flush)(FILE *))
 		cf->file.flush = flush;
 		cf->file.flags |= __SWR;
 	}
+
+    __flockfile_init(&(cf->file));
 
 	return (FILE *) cf;
 }

--- a/newlib/libc/tinystdio/fdopen.c
+++ b/newlib/libc/tinystdio/fdopen.c
@@ -59,6 +59,7 @@ fdopen(int fd, const char *mode)
         *bf = (struct __file_bufio)
                 FDEV_SETUP_POSIX(fd, buf, BUFSIZ, stdio_flags, __BFALL);
 
+        __flockfile_init(&(bf->xfile.cfile.file));
         __bufio_lock_init(&(bf->xfile.cfile.file));
 
 	if (open_flags & O_APPEND)

--- a/newlib/libc/tinystdio/feof.c
+++ b/newlib/libc/tinystdio/feof.c
@@ -33,9 +33,21 @@
 
 #undef feof
 
+FILE_FN_UNLOCKED_SPECIFIER
+int
+FILE_FN_UNLOCKED(feof)(FILE *stream)
+{
+	return stream->flags & __SEOF;
+}
+
+#ifdef _WANT_FLOCKFILE
 int
 feof(FILE *stream)
 {
-
-	return stream->flags & __SEOF;
+    int ret;
+    __flockfile(stream);
+    ret = FILE_FN_UNLOCKED(feof)(stream);
+    __funlockfile(stream);
+    return ret;
 }
+#endif

--- a/newlib/libc/tinystdio/ferror.c
+++ b/newlib/libc/tinystdio/ferror.c
@@ -33,9 +33,21 @@
 
 #undef ferror
 
+FILE_FN_UNLOCKED_SPECIFIER
+int
+FILE_FN_UNLOCKED(ferror)(FILE *stream)
+{
+	return stream->flags & __SERR;
+}
+
+#ifdef _WANT_FLOCKFILE
 int
 ferror(FILE *stream)
 {
-
-	return stream->flags & __SERR;
+    int ret;
+    __flockfile(stream);
+    ret = FILE_FN_UNLOCKED(ferror)(stream);
+    __funlockfile(stream);
+    return ret;
 }
+#endif

--- a/newlib/libc/tinystdio/fflush.c
+++ b/newlib/libc/tinystdio/fflush.c
@@ -44,7 +44,7 @@ FILE_FN_UNLOCKED(fflush)(FILE *stream)
 	return 0;
 }
 
-#if defined(_WANT_FLOCKFILE) && !defined(_FILE_INCLUDED)
+#if defined(_WANT_FLOCKFILE)
 int
 fflush(FILE *stream)
 {

--- a/newlib/libc/tinystdio/fflush.c
+++ b/newlib/libc/tinystdio/fflush.c
@@ -35,9 +35,23 @@
 
 #include "stdio_private.h"
 
-int fflush(FILE *stream)
+FILE_FN_UNLOCKED_SPECIFIER
+int
+FILE_FN_UNLOCKED(fflush)(FILE *stream)
 {
 	if (stream->flush)
 		return (stream->flush)(stream);
 	return 0;
 }
+
+#if defined(_WANT_FLOCKFILE) && !defined(_FILE_INCLUDED)
+int
+fflush(FILE *stream)
+{
+    int ret;
+    __flockfile(stream);
+    ret = FILE_FN_UNLOCKED(fflush)(stream);
+    __funlockfile(stream);
+    return ret;
+}
+#endif

--- a/newlib/libc/tinystdio/fgetc.c
+++ b/newlib/libc/tinystdio/fgetc.c
@@ -32,7 +32,7 @@
 #include "stdio_private.h"
 
 int
-fgetc(FILE *stream)
+FILE_FN_UNLOCKED(fgetc)(FILE *stream)
 {
 	int rv;
 	__ungetc_t unget;
@@ -55,8 +55,21 @@ fgetc(FILE *stream)
 	return (unsigned char)rv;
 }
 
+#ifdef _WANT_FLOCKFILE
+int
+fgetc(FILE *stream)
+{
+    int ret;
+    __flockfile(stream);
+    ret = FILE_FN_UNLOCKED(fgetc)(stream);
+    __funlockfile(stream);
+    return ret;
+}
+#else
 #undef getc
 #undef getc_unlocked
+#endif
+
 #ifdef _HAVE_ALIAS_ATTRIBUTE
 __strong_reference(fgetc, getc);
 __strong_reference(fgetc, getc_unlocked);

--- a/newlib/libc/tinystdio/fgetc.c
+++ b/newlib/libc/tinystdio/fgetc.c
@@ -66,14 +66,20 @@ fgetc(FILE *stream)
     return ret;
 }
 #else
+#ifdef _HAVE_ALIAS_ATTRIBUTE
+__strong_reference(fgetc, fgetc_unlocked);
+#else
+int fgetc_unlocked(FILE *stream) { return fgetc(stream); }
+#endif
+#endif
+
 #undef getc
 #undef getc_unlocked
-#endif
 
 #ifdef _HAVE_ALIAS_ATTRIBUTE
 __strong_reference(fgetc, getc);
-__strong_reference(fgetc, getc_unlocked);
+__strong_reference(FILE_FN_UNLOCKED(fgetc), getc_unlocked);
 #else
 int getc(FILE *stream) { return fgetc(stream); }
-int getc_unlocked(FILE *stream) { return fgetc(stream); }
+int getc_unlocked(FILE *stream) { return FILE_FN_UNLOCKED(fgetc)(stream); }
 #endif

--- a/newlib/libc/tinystdio/fgets.c
+++ b/newlib/libc/tinystdio/fgets.c
@@ -31,8 +31,9 @@
 
 #include "stdio_private.h"
 
+FILE_FN_UNLOCKED_SPECIFIER
 char *
-fgets(char *str, int size, FILE *stream)
+FILE_FN_UNLOCKED(fgets)(char *str, int size, FILE *stream)
 {
 	char *cp;
 	int c;
@@ -42,7 +43,7 @@ fgets(char *str, int size, FILE *stream)
 
 	size--;
 	for (c = 0, cp = str; c != '\n' && size > 0; size--, cp++) {
-		if ((c = getc(stream)) == EOF) {
+		if ((c = FILE_FN_UNLOCKED(fgetc)(stream)) == EOF) {
 			if(cp == str)
 				return NULL;
 			else
@@ -54,3 +55,15 @@ fgets(char *str, int size, FILE *stream)
 
 	return str;
 }
+
+#ifdef _WANT_FLOCKFILE
+char *
+fgets(char *str, int size, FILE *stream)
+{
+    char * ret;
+    __flockfile(stream);
+    ret = FILE_FN_UNLOCKED(fgets)(str, size, stream);
+    __funlockfile(stream);
+    return ret;
+}
+#endif

--- a/newlib/libc/tinystdio/fgetwc.c
+++ b/newlib/libc/tinystdio/fgetwc.c
@@ -39,7 +39,7 @@ FILE_FN_UNLOCKED(fgetwc)(FILE *stream)
         unsigned i;
         int sc;
         __ungetc_t unget;
-        
+
         stream->flags |= __SWIDE;
 
 	if ((stream->flags & __SRD) == 0)
@@ -58,7 +58,7 @@ FILE_FN_UNLOCKED(fgetwc)(FILE *stream)
 	return (wint_t) u.wc;
 }
 
-#if defined(_WANT_FLOCKFILE) && !defined(_FILE_INCLUDED)
+#ifdef _WANT_FLOCKFILE
 wint_t
 fgetwc(FILE *stream)
 {
@@ -68,10 +68,21 @@ fgetwc(FILE *stream)
     __funlockfile(stream);
     return ret;
 }
+#else
+#ifdef _HAVE_ALIAS_ATTRIBUTE
+__strong_reference(fgetwc, fgetwc_unlocked);
+#else
+wint_t fgetwc_unlocked(FILE *stream) { return fgetwc(stream); }
 #endif
+#endif
+
+#undef getwc
+#undef getwc_unlocked
 
 #ifdef _HAVE_ALIAS_ATTRIBUTE
 __strong_reference(fgetwc, getwc);
-#elif !defined(getwc)
+__strong_reference(FILE_FN_UNLOCKED(fgetwc), getwc_unlocked);
+#else
 wint_t getwc(FILE *stream) { return fgetwc(stream); }
+wint_t getwc_unlocked(FILE *stream) { return FILE_FN_UNLOCKED(fgetwc)(stream); }
 #endif

--- a/newlib/libc/tinystdio/fgetwc.c
+++ b/newlib/libc/tinystdio/fgetwc.c
@@ -30,7 +30,7 @@
 #include "stdio_private.h"
 
 wint_t
-fgetwc(FILE *stream)
+FILE_FN_UNLOCKED(fgetwc)(FILE *stream)
 {
         union {
                 wchar_t wc;
@@ -57,6 +57,18 @@ fgetwc(FILE *stream)
 
 	return (wint_t) u.wc;
 }
+
+#if defined(_WANT_FLOCKFILE) && !defined(_FILE_INCLUDED)
+wint_t
+fgetwc(FILE *stream)
+{
+    wint_t ret;
+    __flockfile(stream);
+    ret = FILE_FN_UNLOCKED(fgetwc)(stream);
+    __funlockfile(stream);
+    return ret;
+}
+#endif
 
 #ifdef _HAVE_ALIAS_ATTRIBUTE
 __strong_reference(fgetwc, getwc);

--- a/newlib/libc/tinystdio/fgetws.c
+++ b/newlib/libc/tinystdio/fgetws.c
@@ -29,7 +29,6 @@
 
 #include "stdio_private.h"
 
-FILE_FN_UNLOCKED_SPECIFIER
 wchar_t *
 FILE_FN_UNLOCKED(fgetws)(wchar_t *str, int size, FILE *stream)
 {

--- a/newlib/libc/tinystdio/fgetws.c
+++ b/newlib/libc/tinystdio/fgetws.c
@@ -30,7 +30,7 @@
 #include "stdio_private.h"
 
 wchar_t *
-fgetws(wchar_t *str, int size, FILE *stream)
+FILE_FN_UNLOCKED(fgetws)(wchar_t *str, int size, FILE *stream)
 {
 	wchar_t *cp;
 	wint_t c;
@@ -40,7 +40,7 @@ fgetws(wchar_t *str, int size, FILE *stream)
 
 	size--;
 	for (c = 0, cp = str; c != L'\n' && size > 0; size--, cp++) {
-		if ((c = getwc(stream)) == WEOF)
+		if ((c = FILE_FN_UNLOCKED(getwc)(stream)) == WEOF)
 			return NULL;
 		*cp = (wchar_t)c;
 	}
@@ -48,3 +48,15 @@ fgetws(wchar_t *str, int size, FILE *stream)
 
 	return str;
 }
+
+#if defined(_WANT_FLOCKFILE) && !defined(_FILE_INCLUDED)
+wchar_t *
+fgetws(wchar_t *str, int size, FILE *stream)
+{
+    wchar_t *ret;
+    __flockfile(stream);
+    ret = FILE_FN_UNLOCKED(fgetws)(str, size, stream);
+    __funlockfile(stream);
+    return ret;
+}
+#endif

--- a/newlib/libc/tinystdio/fgetws.c
+++ b/newlib/libc/tinystdio/fgetws.c
@@ -29,6 +29,7 @@
 
 #include "stdio_private.h"
 
+FILE_FN_UNLOCKED_SPECIFIER
 wchar_t *
 FILE_FN_UNLOCKED(fgetws)(wchar_t *str, int size, FILE *stream)
 {
@@ -49,7 +50,7 @@ FILE_FN_UNLOCKED(fgetws)(wchar_t *str, int size, FILE *stream)
 	return str;
 }
 
-#if defined(_WANT_FLOCKFILE) && !defined(_FILE_INCLUDED)
+#if defined(_WANT_FLOCKFILE)
 wchar_t *
 fgetws(wchar_t *str, int size, FILE *stream)
 {

--- a/newlib/libc/tinystdio/fileno.c
+++ b/newlib/libc/tinystdio/fileno.c
@@ -35,8 +35,9 @@
 
 #include "stdio_private.h"
 
+FILE_FN_UNLOCKED_SPECIFIER
 int
-fileno(FILE *file)
+FILE_FN_UNLOCKED(fileno)(FILE *file)
 {
         if (file->flags & __SBUF) {
                 struct __file_bufio *pf = (struct __file_bufio *) file;
@@ -44,3 +45,15 @@ fileno(FILE *file)
         }
 	return -1;
 }
+
+#ifdef _WANT_FLOCKFILE
+int
+fileno(FILE *file)
+{
+    int ret;
+    __flockfile(file);
+    ret = FILE_FN_UNLOCKED(fileno)(file);
+    __funlockfile(file);
+    return ret;
+}
+#endif

--- a/newlib/libc/tinystdio/flockfile.c
+++ b/newlib/libc/tinystdio/flockfile.c
@@ -35,14 +35,10 @@
 
 #include "stdio_private.h"
 
-/*
- * This only serializes with other threads also using flockfile,
- * but it's about as good as we can reasonably manage without
- * actually adding per-file locking to every API.
- */
-void
-flockfile (FILE *f)
-{
-    (void) f;
-    __LIBC_LOCK();
+#ifdef _WANT_FLOCKFILE
+
+void flockfile(FILE *f) {
+    __flockfile(f);
 }
+
+#endif // _WANT_FLOCKFILE

--- a/newlib/libc/tinystdio/flockfile.c
+++ b/newlib/libc/tinystdio/flockfile.c
@@ -35,10 +35,12 @@
 
 #include "stdio_private.h"
 
-#ifdef _WANT_FLOCKFILE
-
 void flockfile(FILE *f) {
+#ifdef _WANT_FLOCKFILE
     __flockfile(f);
+#else
+    (void) f;
+    __LIBC_LOCK();
+#endif
 }
 
-#endif // _WANT_FLOCKFILE

--- a/newlib/libc/tinystdio/flockfile.c
+++ b/newlib/libc/tinystdio/flockfile.c
@@ -35,7 +35,9 @@
 
 #include "stdio_private.h"
 
-void flockfile(FILE *f) {
+void
+flockfile (FILE *f)
+{
 #ifdef _WANT_FLOCKFILE
     __flockfile(f);
 #else
@@ -43,4 +45,3 @@ void flockfile(FILE *f) {
     __LIBC_LOCK();
 #endif
 }
-

--- a/newlib/libc/tinystdio/fmemopen.c
+++ b/newlib/libc/tinystdio/fmemopen.c
@@ -199,6 +199,7 @@ fmemopen(void *buf, size_t size, const char *mode)
         .pos = initial_pos,
         .mflags = mflags,
     };
+    __flockfile_init(&(mf->xfile.cfile.file));
 
     return (FILE *)mf;
 }

--- a/newlib/libc/tinystdio/fputc.c
+++ b/newlib/libc/tinystdio/fputc.c
@@ -31,7 +31,6 @@
 
 #include "stdio_private.h"
 
-FILE_FN_UNLOCKED_SPECIFIER
 int
 FILE_FN_UNLOCKED(fputc)(int c, FILE *stream)
 {
@@ -46,9 +45,6 @@ FILE_FN_UNLOCKED(fputc)(int c, FILE *stream)
 	return (unsigned char) c;
 }
 
-#undef putc
-#undef putc_unlocked
-
 #ifdef _WANT_FLOCKFILE
 int
 fputc(int c, FILE *stream)
@@ -59,12 +55,21 @@ fputc(int c, FILE *stream)
     __funlockfile(stream);
     return ret;
 }
+#else
+#ifdef _HAVE_ALIAS_ATTRIBUTE
+__strong_reference(fputc, fputc_unlocked);
+#else
+int fputc_unlocked(int c, FILE *stream) { return fputc(c, stream); }
 #endif
+#endif
+
+#undef putc
+#undef putc_unlocked
 
 #ifdef _HAVE_ALIAS_ATTRIBUTE
 __strong_reference(fputc, putc);
-__strong_reference(fputc, putc_unlocked);
+__strong_reference(FILE_FN_UNLOCKED(fputc), putc_unlocked);
 #else
 int putc(int c, FILE *stream) { return fputc(c, stream); }
-int putc_unlocked(int c, FILE *stream) { return fputc(c, stream); }
+int putc_unlocked(int c, FILE *stream) { return FILE_FN_UNLOCKED(fputc)(c, stream); }
 #endif

--- a/newlib/libc/tinystdio/fputc.c
+++ b/newlib/libc/tinystdio/fputc.c
@@ -31,8 +31,9 @@
 
 #include "stdio_private.h"
 
+FILE_FN_UNLOCKED_SPECIFIER
 int
-fputc(int c, FILE *stream)
+FILE_FN_UNLOCKED(fputc)(int c, FILE *stream)
 {
 	if ((stream->flags & __SWR) == 0)
 		return EOF;
@@ -47,6 +48,19 @@ fputc(int c, FILE *stream)
 
 #undef putc
 #undef putc_unlocked
+
+#ifdef _WANT_FLOCKFILE
+int
+fputc(int c, FILE *stream)
+{
+    int ret;
+    __flockfile(stream);
+    ret = FILE_FN_UNLOCKED(fputc)(c, stream);
+    __funlockfile(stream);
+    return ret;
+}
+#endif
+
 #ifdef _HAVE_ALIAS_ATTRIBUTE
 __strong_reference(fputc, putc);
 __strong_reference(fputc, putc_unlocked);

--- a/newlib/libc/tinystdio/fputs.c
+++ b/newlib/libc/tinystdio/fputs.c
@@ -36,17 +36,22 @@ fputs(const char *str, FILE *stream)
 {
         int (*put)(char, struct __file *);
 	char c;
+	int ret = EOF;
 
+	__flockfile(stream);
 	if ((stream->flags & __SWR) == 0)
-		return EOF;
+		goto fail;
 
         put = stream->put;
 
 	while ((c = *str++) != '\0')
                 if (put(c, stream) < 0) {
                         stream->flags |= __SERR;
-			return EOF;
+			goto fail;
                 }
 
-	return 0;
+	ret = 0;
+fail:
+	__funlockfile(stream);
+	return ret;
 }

--- a/newlib/libc/tinystdio/fputwc.c
+++ b/newlib/libc/tinystdio/fputwc.c
@@ -37,7 +37,7 @@ FILE_FN_UNLOCKED(fputwc)(wchar_t c, FILE *stream)
                 char c[sizeof(wchar_t)];
         } u;
         unsigned i;
-        
+
         stream->flags |= __SWIDE;
 
 	if ((stream->flags & __SWR) == 0)
@@ -51,8 +51,6 @@ FILE_FN_UNLOCKED(fputwc)(wchar_t c, FILE *stream)
 	return (wint_t) c;
 }
 
-#ifndef _FILE_INCLUDED
-
 #ifdef _WANT_FLOCKFILE
 wint_t
 fputwc(wchar_t c, FILE *stream)
@@ -63,12 +61,21 @@ fputwc(wchar_t c, FILE *stream)
     __funlockfile(stream);
     return ret;
 }
+#else
+#ifdef _HAVE_ALIAS_ATTRIBUTE
+__strong_reference(fputwc, fputwc_unlocked);
+#else
+wint_t fputwc_unlocked(wchar_t c, FILE *stream) { return fputwc(c, stream); }
 #endif
+#endif
+
+#undef putwc
+#undef putwc_unlocked
 
 #ifdef _HAVE_ALIAS_ATTRIBUTE
 __strong_reference(fputwc, putwc);
-#elif !defined(getwc)
+__strong_reference(FILE_FN_UNLOCKED(fputwc), putwc_unlocked);
+#else
 wint_t putwc(wchar_t c, FILE *stream) { return fputwc(c, stream); }
+wint_t putwc_unlocked(wchar_t c, FILE *stream) { return FILE_FN_UNLOCKED(fputw)(c, stream); }
 #endif
-
-#endif // _FILE_INCLUDED

--- a/newlib/libc/tinystdio/fputwc.c
+++ b/newlib/libc/tinystdio/fputwc.c
@@ -30,7 +30,7 @@
 #include "stdio_private.h"
 
 wint_t
-fputwc(wchar_t c, FILE *stream)
+FILE_FN_UNLOCKED(fputwc)(wchar_t c, FILE *stream)
 {
         union {
                 wchar_t wc;
@@ -51,8 +51,24 @@ fputwc(wchar_t c, FILE *stream)
 	return (wint_t) c;
 }
 
+#ifndef _FILE_INCLUDED
+
+#ifdef _WANT_FLOCKFILE
+wint_t
+fputwc(wchar_t c, FILE *stream)
+{
+    wint_t ret;
+    __flockfile(stream);
+    ret = FILE_FN_UNLOCKED(fputwc)(c, stream);
+    __funlockfile(stream);
+    return ret;
+}
+#endif
+
 #ifdef _HAVE_ALIAS_ATTRIBUTE
 __strong_reference(fputwc, putwc);
 #elif !defined(getwc)
 wint_t putwc(wchar_t c, FILE *stream) { return fputwc(c, stream); }
 #endif
+
+#endif // _FILE_INCLUDED

--- a/newlib/libc/tinystdio/fputws.c
+++ b/newlib/libc/tinystdio/fputws.c
@@ -32,7 +32,7 @@
 #include "stdio_private.h"
 
 int
-fputws(const wchar_t *str, FILE *stream)
+FILE_FN_UNLOCKED(fputws)(const wchar_t *str, FILE *stream)
 {
 	wchar_t c;
 	int rv = 0;
@@ -41,8 +41,20 @@ fputws(const wchar_t *str, FILE *stream)
 		return EOF;
 
 	while ((c = *str++) != L'\0')
-		if (fputwc(c, stream) == WEOF)
+		if (FILE_FN_UNLOCKED(fputwc)(c, stream) == WEOF)
                         rv = EOF;
 
 	return rv;
 }
+
+#ifdef _WANT_FLOCKFILE
+int
+fputws(const wchar_t *str, FILE *stream)
+{
+    int ret;
+    __flockfile(stream);
+    ret = FILE_FN_UNLOCKED(fputws)(str, stream);
+    __funlockfile(stream);
+    return ret;
+}
+#endif

--- a/newlib/libc/tinystdio/fread.c
+++ b/newlib/libc/tinystdio/fread.c
@@ -38,8 +38,9 @@
 extern FILE *const stdin _ATTRIBUTE((__weak__));
 extern FILE *const stdout _ATTRIBUTE((__weak__));
 
+FILE_FN_UNLOCKED_SPECIFIER
 size_t
-fread(void *ptr, size_t size, size_t nmemb, FILE *stream)
+FILE_FN_UNLOCKED(fread)(void *ptr, size_t size, size_t nmemb, FILE *stream)
 {
 	size_t i, j;
 	uint8_t *cp = (uint8_t *) ptr;
@@ -118,7 +119,7 @@ fread(void *ptr, size_t size, size_t nmemb, FILE *stream)
 #endif
 	for (i = 0; i < nmemb; i++)
 		for (j = 0; j < size; j++) {
-			c = getc(stream);
+			c = FILE_FN_UNLOCKED(fgetc)(stream);
 			if (c == EOF)
 				return i;
 			*cp++ = (uint8_t)c;
@@ -126,3 +127,15 @@ fread(void *ptr, size_t size, size_t nmemb, FILE *stream)
 
 	return i;
 }
+
+#ifdef _WANT_FLOCKFILE
+size_t
+fread(void *ptr, size_t size, size_t nmemb, FILE *stream)
+{
+    size_t ret;
+    __flockfile(stream);
+    ret = FILE_FN_UNLOCKED(fread)(ptr, size, nmemb, stream);
+    __funlockfile(stream);
+    return ret;
+}
+#endif

--- a/newlib/libc/tinystdio/fseek.c
+++ b/newlib/libc/tinystdio/fseek.c
@@ -40,7 +40,6 @@
 #define FSEEK_TYPE long
 #endif
 
-FILE_FN_UNLOCKED_SPECIFIER
 int
 FILE_FN_UNLOCKED(FSEEK)(FILE *stream, FSEEK_TYPE offset, int whence)
 {

--- a/newlib/libc/tinystdio/fseek.c
+++ b/newlib/libc/tinystdio/fseek.c
@@ -40,7 +40,9 @@
 #define FSEEK_TYPE long
 #endif
 
-int FSEEK(FILE *stream, FSEEK_TYPE offset, int whence)
+FILE_FN_UNLOCKED_SPECIFIER
+int
+FILE_FN_UNLOCKED(FSEEK)(FILE *stream, FSEEK_TYPE offset, int whence)
 {
         struct __file_ext *xf = (struct __file_ext *) stream;
         if ((stream->flags & __SEXT) && xf->seek) {
@@ -54,3 +56,15 @@ int FSEEK(FILE *stream, FSEEK_TYPE offset, int whence)
 	errno = ESPIPE;
 	return -1;
 }
+
+#if defined(_WANT_FLOCKFILE) && !defined(_FILE_INCLUDED)
+int
+FSEEK(FILE *stream, FSEEK_TYPE offset, int whence)
+{
+    int ret;
+    __flockfile(stream);
+    ret = FILE_FN_UNLOCKED(FSEEK)(stream, offset, whence);
+    __funlockfile(stream);
+    return ret;
+}
+#endif

--- a/newlib/libc/tinystdio/fseek.c
+++ b/newlib/libc/tinystdio/fseek.c
@@ -56,7 +56,7 @@ FILE_FN_UNLOCKED(FSEEK)(FILE *stream, FSEEK_TYPE offset, int whence)
 	return -1;
 }
 
-#if defined(_WANT_FLOCKFILE) && !defined(_FILE_INCLUDED)
+#if defined(_WANT_FLOCKFILE)
 int
 FSEEK(FILE *stream, FSEEK_TYPE offset, int whence)
 {

--- a/newlib/libc/tinystdio/ftell.c
+++ b/newlib/libc/tinystdio/ftell.c
@@ -55,7 +55,7 @@ FILE_FN_UNLOCKED(FTELL)(FILE *stream)
 	return -1;
 }
 
-#if defined(_WANT_FLOCKFILE) && !defined(_FILE_INCLUDED)
+#if defined(_WANT_FLOCKFILE)
 FTELL_TYPE
 FTELL(FILE *stream)
 {

--- a/newlib/libc/tinystdio/ftell.c
+++ b/newlib/libc/tinystdio/ftell.c
@@ -40,8 +40,9 @@
 #define FTELL_TYPE long
 #endif
 
+FILE_FN_UNLOCKED_SPECIFIER
 FTELL_TYPE
-FTELL(FILE *stream)
+FILE_FN_UNLOCKED(FTELL)(FILE *stream)
 {
         struct __file_ext *xf = (struct __file_ext *) stream;
         if ((stream->flags & __SEXT) && xf->seek) {
@@ -53,3 +54,15 @@ FTELL(FILE *stream)
         errno = ESPIPE;
 	return -1;
 }
+
+#if defined(_WANT_FLOCKFILE) && !defined(_FILE_INCLUDED)
+FTELL_TYPE
+FTELL(FILE *stream)
+{
+    FTELL_TYPE ret;
+    __flockfile(stream);
+    ret = FILE_FN_UNLOCKED(FTELL)(stream);
+    __funlockfile(stream);
+    return ret;
+}
+#endif

--- a/newlib/libc/tinystdio/funlockfile.c
+++ b/newlib/libc/tinystdio/funlockfile.c
@@ -35,7 +35,8 @@
 
 #include "stdio_private.h"
 
-void funlockfile(FILE *f)
+void
+funlockfile (FILE *f)
 {
 #ifdef _WANT_FLOCKFILE
     __funlockfile(f);
@@ -44,4 +45,3 @@ void funlockfile(FILE *f)
     __LIBC_UNLOCK();
 #endif
 }
-

--- a/newlib/libc/tinystdio/funlockfile.c
+++ b/newlib/libc/tinystdio/funlockfile.c
@@ -35,10 +35,13 @@
 
 #include "stdio_private.h"
 
+void funlockfile(FILE *f)
+{
 #ifdef _WANT_FLOCKFILE
-
-void funlockfile(FILE *f) {
     __funlockfile(f);
+#else
+    (void) f;
+    __LIBC_UNLOCK();
+#endif
 }
 
-#endif // _WANT_FLOCKFILE

--- a/newlib/libc/tinystdio/funlockfile.c
+++ b/newlib/libc/tinystdio/funlockfile.c
@@ -35,14 +35,10 @@
 
 #include "stdio_private.h"
 
-/*
- * This only serializes with other threads also using flockfile,
- * but it's about as good as we can reasonably manage without
- * actually adding per-file locking to every API.
- */
-void
-funlockfile (FILE *f)
-{
-    (void) f;
-    __LIBC_UNLOCK();
+#ifdef _WANT_FLOCKFILE
+
+void funlockfile(FILE *f) {
+    __funlockfile(f);
 }
+
+#endif // _WANT_FLOCKFILE

--- a/newlib/libc/tinystdio/fwide.c
+++ b/newlib/libc/tinystdio/fwide.c
@@ -35,10 +35,23 @@
 
 #include "stdio_private.h"
 
+FILE_FN_UNLOCKED_SPECIFIER
 int
-fwide(FILE *stream, int mode)
+FILE_FN_UNLOCKED(fwide)(FILE *stream, int mode)
 {
         if (mode != 0)
                 stream->flags = (stream->flags & ~__SWIDE) | ((mode > 0) ? __SWIDE : 0);
         return (stream->flags & __SWIDE) ? 1 : -1;
 }
+
+#ifdef _WANT_FLOCKFILE
+int
+fwide(FILE *stream, int mode)
+{
+    int ret;
+    __flockfile(stream);
+    ret = FILE_FN_UNLOCKED(fwide)(stream, mode);
+    __funlockfile(stream);
+    return ret;
+}
+#endif

--- a/newlib/libc/tinystdio/fwrite.c
+++ b/newlib/libc/tinystdio/fwrite.c
@@ -35,8 +35,9 @@
 #include "../stdlib/mul_overflow.h"
 #endif
 
+FILE_FN_UNLOCKED_SPECIFIER
 size_t
-fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream)
+FILE_FN_UNLOCKED(fwrite)(const void *ptr, size_t size, size_t nmemb, FILE *stream)
 {
 	size_t i, j;
 	const uint8_t *cp = (const uint8_t *) ptr;
@@ -100,3 +101,15 @@ fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream)
 
 	return i;
 }
+
+#ifdef _WANT_FLOCKFILE
+size_t
+fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream)
+{
+    size_t ret;
+    __flockfile(stream);
+    ret = FILE_FN_UNLOCKED(fwrite)(ptr, size, nmemb, stream);
+    __funlockfile(stream);
+    return ret;
+}
+#endif

--- a/newlib/libc/tinystdio/getdelim.c
+++ b/newlib/libc/tinystdio/getdelim.c
@@ -75,7 +75,7 @@ FILE_FN_UNLOCKED(getdelim) (char **restrict lineptr, size_t *restrict nptr,
 }
 
 #ifdef _WANT_FLOCKFILE
-int
+_ssize_t
 getdelim (char **restrict lineptr, size_t *restrict nptr,
           int delim, FILE *restrict stream)
 {

--- a/newlib/libc/tinystdio/getdelim.c
+++ b/newlib/libc/tinystdio/getdelim.c
@@ -37,8 +37,9 @@
 
 #define INCR    16
 
+FILE_FN_UNLOCKED_SPECIFIER
 _ssize_t
-getdelim (char **restrict lineptr, size_t *restrict nptr,
+FILE_FN_UNLOCKED(getdelim) (char **restrict lineptr, size_t *restrict nptr,
           int delim, FILE *restrict stream)
 {
     char *line = *lineptr;
@@ -46,7 +47,7 @@ getdelim (char **restrict lineptr, size_t *restrict nptr,
     _ssize_t count = 0;
 
     for (;;) {
-        int c = getc(stream);
+        int c = FILE_FN_UNLOCKED(fgetc)(stream);
         if (c == EOF)
             break;
 
@@ -72,3 +73,16 @@ getdelim (char **restrict lineptr, size_t *restrict nptr,
     *nptr = n;
     return count;
 }
+
+#ifdef _WANT_FLOCKFILE
+int
+getdelim (char **restrict lineptr, size_t *restrict nptr,
+          int delim, FILE *restrict stream)
+{
+    int ret;
+    __flockfile(stream);
+    ret = FILE_FN_UNLOCKED(getdelim)(lineptr, nptr, delim, stream);
+    __funlockfile(stream);
+    return ret;
+}
+#endif

--- a/newlib/libc/tinystdio/posixiob_stderr.c
+++ b/newlib/libc/tinystdio/posixiob_stderr.c
@@ -50,6 +50,7 @@ __weak_reference(__posix_stderr,stderr);
 __attribute__((constructor))
 static void posix_init(void)
 {
+    __flockfile_init(&__stderr.xfile.cfile.file);
     __bufio_lock_init(&__stderr.xfile.cfile.file);
 }
 

--- a/newlib/libc/tinystdio/posixiob_stdin.c
+++ b/newlib/libc/tinystdio/posixiob_stdin.c
@@ -46,5 +46,6 @@ __weak_reference(__posix_stdin,stdin);
 __attribute__((constructor))
 static void posix_init(void)
 {
+    __flockfile_init(&__stdin.xfile.cfile.file);
     __bufio_lock_init(&__stdin.xfile.cfile.file);
 }

--- a/newlib/libc/tinystdio/posixiob_stdout.c
+++ b/newlib/libc/tinystdio/posixiob_stdout.c
@@ -46,6 +46,7 @@ __weak_reference(__posix_stdout,stdout);
 __attribute__((constructor))
 static void posix_init(void)
 {
+    __flockfile_init(&__stdout.xfile.cfile.file);
     __bufio_lock_init(&__stdout.xfile.cfile.file);
 }
 

--- a/newlib/libc/tinystdio/rewind.c
+++ b/newlib/libc/tinystdio/rewind.c
@@ -35,8 +35,20 @@
 
 #include "stdio_private.h"
 
-void rewind(FILE *stream)
+FILE_FN_UNLOCKED_SPECIFIER
+void
+FILE_FN_UNLOCKED(rewind)(FILE *stream)
 {
-    (void) fseek(stream, 0L, SEEK_SET);
-    clearerr(stream);
+    (void) FILE_FN_UNLOCKED(fseek)(stream, 0L, SEEK_SET);
+    FILE_FN_UNLOCKED(clearerr)(stream);
 }
+
+#ifdef _WANT_FLOCKFILE
+void
+rewind(FILE *stream)
+{
+    __flockfile(stream);
+    FILE_FN_UNLOCKED(rewind)(stream);
+    __funlockfile(stream);
+}
+#endif

--- a/newlib/libc/tinystdio/setvbuf.c
+++ b/newlib/libc/tinystdio/setvbuf.c
@@ -35,11 +35,24 @@
 
 #include "stdio_private.h"
 
+FILE_FN_UNLOCKED_SPECIFIER
 int
-setvbuf(FILE *stream, char *buf, int mode, size_t size)
+FILE_FN_UNLOCKED(setvbuf)(FILE *stream, char *buf, int mode, size_t size)
 {
         struct __file_ext *xf = (struct __file_ext *) stream;
         if ((stream->flags & __SEXT) && xf->setvbuf)
                 return (xf->setvbuf)(stream, buf, mode, size);
         return 0;
 }
+
+#ifdef _WANT_FLOCKFILE
+int
+setvbuf(FILE *stream, char *buf, int mode, size_t size)
+{
+    int ret;
+    __flockfile(stream);
+    ret = FILE_FN_UNLOCKED(setvbuf)(stream, buf, mode, size);
+    __funlockfile(stream);
+    return ret;
+}
+#endif

--- a/newlib/libc/tinystdio/snprintf.c
+++ b/newlib/libc/tinystdio/snprintf.c
@@ -49,7 +49,7 @@ snprintf(char *s, size_t n, const char *fmt, ...)
 	struct __file_str f = FDEV_SETUP_STRING_WRITE(s, n ? n - 1 : 0);
 
 	va_start(ap, fmt);
-	i = vfprintf(&f.file, fmt, ap);
+	i = FILE_FN_UNLOCKED(vfprintf)(&f.file, fmt, ap);
 	va_end(ap);
 
 	if (n)

--- a/newlib/libc/tinystdio/sprintf.c
+++ b/newlib/libc/tinystdio/sprintf.c
@@ -39,7 +39,7 @@ sprintf(char *s, const char *fmt, ...)
 	int i;
 
 	va_start(ap, fmt);
-	i = vfprintf(&f.file, fmt, ap);
+	i = FILE_FN_UNLOCKED(vfprintf)(&f.file, fmt, ap);
 	va_end(ap);
 	if (i >= 0)
 		s[i] = 0;

--- a/newlib/libc/tinystdio/sscanf.c
+++ b/newlib/libc/tinystdio/sscanf.c
@@ -38,7 +38,7 @@ sscanf(const char *s, const char *fmt, ...)
 	int i;
 	struct __file_str f = FDEV_SETUP_STRING_READ(s);
 	va_start(ap, fmt);
-	i = vfscanf(&f.file, fmt, ap);
+	i = FILE_FN_UNLOCKED(vfscanf)(&f.file, fmt, ap);
 	va_end(ap);
 
 	return i;

--- a/newlib/libc/tinystdio/stdio-bufio.h
+++ b/newlib/libc/tinystdio/stdio-bufio.h
@@ -77,7 +77,9 @@ struct __file_bufio {
                 int     (*close_ptr)(void *ptr);
         };
 #ifndef __SINGLE_THREAD__
+#ifndef _WANT_FLOCKFILE
 	_LOCK_T lock;
+#endif
 #endif
 };
 
@@ -123,23 +125,31 @@ struct __file_bufio {
 
 static inline void __bufio_lock_init(FILE *f) {
 	(void) f;
+#ifndef _WANT_FLOCKFILE
 	__lock_init(((struct __file_bufio *) f)->lock);
+#endif
 }
 
 static inline void __bufio_lock_close(FILE *f) {
 	(void) f;
+#ifndef _WANT_FLOCKFILE
         __lock_release(((struct __file_bufio *) f)->lock);
 	__lock_close(((struct __file_bufio *) f)->lock);
+#endif
 }
 
 static inline void __bufio_lock(FILE *f) {
 	(void) f;
+#ifndef _WANT_FLOCKFILE
 	__lock_acquire(((struct __file_bufio *) f)->lock);
+#endif
 }
 
 static inline void __bufio_unlock(FILE *f) {
 	(void) f;
+#ifndef _WANT_FLOCKFILE
 	__lock_release(((struct __file_bufio *) f)->lock);
+#endif
 }
 
 int

--- a/newlib/libc/tinystdio/stdio.h
+++ b/newlib/libc/tinystdio/stdio.h
@@ -385,16 +385,18 @@ FILE	*funopen (const void *cookie,
 
 #if __POSIX_VISIBLE >= 199309L
 int	getc_unlocked (FILE *);
+int	fgetc_unlocked (FILE *);
 int	getchar_unlocked (void);
 void	flockfile (FILE *);
 int	ftrylockfile (FILE *);
 void	funlockfile (FILE *);
 int	putc_unlocked (int, FILE *);
+int	fputc_unlocked (int, FILE *);
 int	putchar_unlocked (int);
-#define getc_unlocked(f) fgetc(f)
-#define getchar_unlocked(f) fgetc(stdin)
-#define putc_unlocked(c, f) fputc(c, f)
-#define putchar_unlocked(c, f) fgetc(c, stdin)
+#define getc_unlocked(f) fgetc_unlocked(f)
+#define getchar_unlocked(f) fgetc_unlocked(stdin)
+#define putc_unlocked(c, f) fputc_unlocked(c, f)
+#define putchar_unlocked(c, f) fgetc_unlocked(c, stdin)
 #endif
 
 #if __STDC_WANT_LIB_EXT1__ == 1

--- a/newlib/libc/tinystdio/stdio.h
+++ b/newlib/libc/tinystdio/stdio.h
@@ -530,16 +530,14 @@ __printf_float(float f)
 static inline void __flockfile(FILE *f) {
 	(void) f;
 #ifdef _WANT_FLOCKFILE
-	if (f->lock)
-		__lock_acquire_recursive(f->lock);
+	__lock_acquire_recursive(f->lock);
 #endif
 }
 
 static inline void __funlockfile(FILE *f) {
 	(void) f;
 #ifdef _WANT_FLOCKFILE
-	if (f->lock)
-		__lock_release_recursive(f->lock);
+	__lock_release_recursive(f->lock);
 #endif
 }
 

--- a/newlib/libc/tinystdio/stdio.h
+++ b/newlib/libc/tinystdio/stdio.h
@@ -527,6 +527,37 @@ __printf_float(float f)
 # endif
 #endif
 
+static inline void __flockfile(FILE *f) {
+	(void) f;
+#ifdef _WANT_FLOCKFILE
+	if (f->lock)
+		__lock_acquire_recursive(f->lock);
+#endif
+}
+
+static inline void __funlockfile(FILE *f) {
+	(void) f;
+#ifdef _WANT_FLOCKFILE
+	if (f->lock)
+		__lock_release_recursive(f->lock);
+#endif
+}
+
+static inline void __flockfile_init(FILE *f) {
+	(void) f;
+#ifdef _WANT_FLOCKFILE
+	__lock_init_recursive(f->lock);
+#endif
+}
+
+static inline void __flockfile_close(FILE *f) {
+	(void) f;
+#ifdef _WANT_FLOCKFILE
+    __lock_release(f->lock);
+	__lock_close(f->lock);
+#endif
+}
+
 _END_STD_C
 
 #if __SSP_FORTIFY_LEVEL > 0

--- a/newlib/libc/tinystdio/stdio_private.h
+++ b/newlib/libc/tinystdio/stdio_private.h
@@ -216,12 +216,55 @@ __stdio_sflags (const char *mode)
     return __posix_sflags (mode, &omode);
 }
 
-#else
+#else // POSIX_IO
 
 int
 __stdio_sflags (const char *mode);
 
+#endif // POSIX_IO
+
+#ifdef _WANT_FLOCKFILE
+#define FILE_FN_UNLOCKED_SPECIFIER static inline
+#define FILE_FN_UNLOCKED(_fn) _fn##_unlocked
+
+wint_t ungetwc_unlocked(wint_t c, FILE *stream);
+int ungetc_unlocked(int c, FILE *stream);
+int fgetc_unlocked(FILE *stream);
+
+#else
+#define FILE_FN_UNLOCKED_SPECIFIER
+#define FILE_FN_UNLOCKED(_fn) _fn
 #endif
+
+static inline void __flockfile(FILE *f) {
+	(void) f;
+#ifdef _WANT_FLOCKFILE
+	if (f->lock)
+		__lock_acquire_recursive(f->lock);
+#endif
+}
+
+static inline void __funlockfile(FILE *f) {
+	(void) f;
+#ifdef _WANT_FLOCKFILE
+	if (f->lock)
+		__lock_release_recursive(f->lock);
+#endif
+}
+
+static inline void __flockfile_init(FILE *f) {
+	(void) f;
+#ifdef _WANT_FLOCKFILE
+	__lock_init_recursive(f->lock);
+#endif
+}
+
+static inline void __flockfile_close(FILE *f) {
+	(void) f;
+#ifdef _WANT_FLOCKFILE
+	__lock_close(f->lock);
+#endif
+}
 
 int	__d_vfprintf(FILE *__stream, const char *__fmt, va_list __ap) __FORMAT_ATTRIBUTE__(printf, 2, 0);
 int	__f_vfprintf(FILE *__stream, const char *__fmt, va_list __ap) __FORMAT_ATTRIBUTE__(printf, 2, 0);

--- a/newlib/libc/tinystdio/stdio_private.h
+++ b/newlib/libc/tinystdio/stdio_private.h
@@ -235,6 +235,22 @@ int FILE_FN_UNLOCKED(fseek)(FILE *stream, long offset, int whence);
 int FILE_FN_UNLOCKED(fseeko)(FILE *stream, off_t offset, int whence);
 void FILE_FN_UNLOCKED(clearerr)(FILE *stream);
 
+int FILE_FN_UNLOCKED(vfwprintf)(FILE * stream, const wchar_t *fmt, va_list ap_orig);
+int	FILE_FN_UNLOCKED(vfprintf)(FILE * stream, const char *fmt, va_list ap_orig)     __FORMAT_ATTRIBUTE__(printf, 2, 0);
+int FILE_FN_UNLOCKED(__d_vfprintf)(FILE * stream, const char *fmt, va_list ap_orig) __FORMAT_ATTRIBUTE__(printf, 2, 0);
+int FILE_FN_UNLOCKED(__f_vfprintf)(FILE * stream, const char *fmt, va_list ap_orig) __FORMAT_ATTRIBUTE__(printf, 2, 0);
+int FILE_FN_UNLOCKED(__i_vfprintf)(FILE * stream, const char *fmt, va_list ap_orig) __FORMAT_ATTRIBUTE__(printf, 2, 0);
+int FILE_FN_UNLOCKED(__l_vfprintf)(FILE * stream, const char *fmt, va_list ap_orig) __FORMAT_ATTRIBUTE__(printf, 2, 0);
+int FILE_FN_UNLOCKED(__m_vfprintf)(FILE * stream, const char *fmt, va_list ap_orig) __FORMAT_ATTRIBUTE__(printf, 2, 0);
+
+int	FILE_FN_UNLOCKED(vfwscanf)(FILE * stream, const wchar_t *fmt, va_list ap_orig);
+int	FILE_FN_UNLOCKED(vfscanf)(FILE * stream, const char *fmt, va_list ap_orig)     __FORMAT_ATTRIBUTE__(scanf, 2, 0);
+int FILE_FN_UNLOCKED(__d_vfscanf)(FILE * stream, const char *fmt, va_list ap_orig) __FORMAT_ATTRIBUTE__(scanf, 2, 0);
+int FILE_FN_UNLOCKED(__f_vfscanf)(FILE * stream, const char *fmt, va_list ap_orig) __FORMAT_ATTRIBUTE__(scanf, 2, 0);
+int FILE_FN_UNLOCKED(__i_vfscanf)(FILE * stream, const char *fmt, va_list ap_orig) __FORMAT_ATTRIBUTE__(scanf, 2, 0);
+int FILE_FN_UNLOCKED(__l_vfscanf)(FILE * stream, const char *fmt, va_list ap_orig) __FORMAT_ATTRIBUTE__(scanf, 2, 0);
+int FILE_FN_UNLOCKED(__m_vfscanf)(FILE * stream, const char *fmt, va_list ap_orig) __FORMAT_ATTRIBUTE__(scanf, 2, 0);
+
 #else
 #define FILE_FN_UNLOCKED_SPECIFIER
 #define FILE_FN_UNLOCKED(_fn) _fn

--- a/newlib/libc/tinystdio/stdio_private.h
+++ b/newlib/libc/tinystdio/stdio_private.h
@@ -240,36 +240,6 @@ void FILE_FN_UNLOCKED(clearerr)(FILE *stream);
 #define FILE_FN_UNLOCKED(_fn) _fn
 #endif
 
-static inline void __flockfile(FILE *f) {
-	(void) f;
-#ifdef _WANT_FLOCKFILE
-	if (f->lock)
-		__lock_acquire_recursive(f->lock);
-#endif
-}
-
-static inline void __funlockfile(FILE *f) {
-	(void) f;
-#ifdef _WANT_FLOCKFILE
-	if (f->lock)
-		__lock_release_recursive(f->lock);
-#endif
-}
-
-static inline void __flockfile_init(FILE *f) {
-	(void) f;
-#ifdef _WANT_FLOCKFILE
-	__lock_init_recursive(f->lock);
-#endif
-}
-
-static inline void __flockfile_close(FILE *f) {
-	(void) f;
-#ifdef _WANT_FLOCKFILE
-	__lock_close(f->lock);
-#endif
-}
-
 int	__d_vfprintf(FILE *__stream, const char *__fmt, va_list __ap) __FORMAT_ATTRIBUTE__(printf, 2, 0);
 int	__f_vfprintf(FILE *__stream, const char *__fmt, va_list __ap) __FORMAT_ATTRIBUTE__(printf, 2, 0);
 int	__i_vfprintf(FILE *__stream, const char *__fmt, va_list __ap) __FORMAT_ATTRIBUTE__(printf, 2, 0);

--- a/newlib/libc/tinystdio/stdio_private.h
+++ b/newlib/libc/tinystdio/stdio_private.h
@@ -225,11 +225,15 @@ __stdio_sflags (const char *mode);
 
 #ifdef _WANT_FLOCKFILE
 #define FILE_FN_UNLOCKED_SPECIFIER static inline
-#define FILE_FN_UNLOCKED(_fn) _fn##_unlocked
+#define _FILE_FN_UNLOCKED(_fn) _fn##_unlocked
+#define FILE_FN_UNLOCKED(_fn) _FILE_FN_UNLOCKED(_fn)
 
-wint_t ungetwc_unlocked(wint_t c, FILE *stream);
-int ungetc_unlocked(int c, FILE *stream);
-int fgetc_unlocked(FILE *stream);
+wint_t FILE_FN_UNLOCKED(ungetwc)(wint_t c, FILE *stream);
+int FILE_FN_UNLOCKED(ungetc)(int c, FILE *stream);
+int FILE_FN_UNLOCKED(fgetc)(FILE *stream);
+int FILE_FN_UNLOCKED(fseek)(FILE *stream, long offset, int whence);
+int FILE_FN_UNLOCKED(fseeko)(FILE *stream, off_t offset, int whence);
+void FILE_FN_UNLOCKED(clearerr)(FILE *stream);
 
 #else
 #define FILE_FN_UNLOCKED_SPECIFIER

--- a/newlib/libc/tinystdio/ungetc.c
+++ b/newlib/libc/tinystdio/ungetc.c
@@ -32,7 +32,7 @@
 #include "stdio_private.h"
 
 int
-ungetc(int c, FILE *stream)
+FILE_FN_UNLOCKED(ungetc)(int c, FILE *stream)
 {
 	/*
 	 * Streams that are not readable, or streams that already had
@@ -50,3 +50,15 @@ ungetc(int c, FILE *stream)
 
 	return (unsigned char) c;
 }
+
+#if defined(_WANT_FLOCKFILE) && !defined(_FILE_INCLUDED)
+int
+ungetc(int c, FILE *stream)
+{
+    int ret;
+    __flockfile(stream);
+    ret = FILE_FN_UNLOCKED(ungetc)(c, stream);
+    __funlockfile(stream);
+    return ret;
+}
+#endif

--- a/newlib/libc/tinystdio/ungetc.c
+++ b/newlib/libc/tinystdio/ungetc.c
@@ -51,7 +51,7 @@ FILE_FN_UNLOCKED(ungetc)(int c, FILE *stream)
 	return (unsigned char) c;
 }
 
-#if defined(_WANT_FLOCKFILE) && !defined(_FILE_INCLUDED)
+#if defined(_WANT_FLOCKFILE)
 int
 ungetc(int c, FILE *stream)
 {

--- a/newlib/libc/tinystdio/ungetwc.c
+++ b/newlib/libc/tinystdio/ungetwc.c
@@ -49,7 +49,7 @@ FILE_FN_UNLOCKED(ungetwc)(wint_t c, FILE *stream)
 	return c;
 }
 
-#if defined(_WANT_FLOCKFILE) && !defined(_FILE_INCLUDED)
+#if defined(_WANT_FLOCKFILE)
 wint_t
 ungetwc(wint_t c, FILE *stream)
 {

--- a/newlib/libc/tinystdio/ungetwc.c
+++ b/newlib/libc/tinystdio/ungetwc.c
@@ -30,7 +30,7 @@
 #include "stdio_private.h"
 
 wint_t
-ungetwc(wint_t c, FILE *stream)
+FILE_FN_UNLOCKED(ungetwc)(wint_t c, FILE *stream)
 {
 	/*
 	 * Streams that are not readable, or streams that already had
@@ -48,3 +48,15 @@ ungetwc(wint_t c, FILE *stream)
 
 	return c;
 }
+
+#if defined(_WANT_FLOCKFILE) && !defined(_FILE_INCLUDED)
+wint_t
+ungetwc(wint_t c, FILE *stream)
+{
+    wint_t ret;
+    __flockfile(stream);
+    ret = FILE_FN_UNLOCKED(ungetwc)(c, stream);
+    __funlockfile(stream);
+    return ret;
+}
+#endif

--- a/newlib/libc/tinystdio/vasprintf.c
+++ b/newlib/libc/tinystdio/vasprintf.c
@@ -41,7 +41,7 @@ vasprintf(char **strp, const char *fmt, va_list ap)
 	struct __file_str f = FDEV_SETUP_STRING_ALLOC();
 	int i;
 
-	i = vfprintf(&f.file, fmt, ap);
+	i = FILE_FN_UNLOCKED(vfprintf)(&f.file, fmt, ap);
 	if (i >= 0) {
                 char *buf = f.end - f.size;
 		char *s = realloc(buf, i+1);

--- a/newlib/libc/tinystdio/vffprintf.c
+++ b/newlib/libc/tinystdio/vffprintf.c
@@ -43,7 +43,13 @@
 #ifdef _FORMAT_DEFAULT_FLOAT
 #ifdef _HAVE_ALIAS_ATTRIBUTE
 __strong_reference(vfprintf, __f_vfprintf);
+#ifdef _WANT_FLOCKFILE
+__strong_reference(FILE_FN_UNLOCKED(vfprintf), FILE_FN_UNLOCKED(__f_vfprintf));
+#endif
 #else
 int __f_vfprintf (FILE * stream, const char *fmt, va_list ap) { return vfprintf(stream, fmt, ap); }
+#ifdef _WANT_FLOCKFILE
+int FILE_FN_UNLOCKED(__f_vfprintf) (FILE * stream, const char *fmt, va_list ap) { return FILE_FN_UNLOCKED(vfprintf)(stream, fmt, ap); }
+#endif
 #endif
 #endif

--- a/newlib/libc/tinystdio/vffscanf.c
+++ b/newlib/libc/tinystdio/vffscanf.c
@@ -43,7 +43,13 @@
 #ifdef _FORMAT_DEFAULT_FLOAT
 #ifdef _HAVE_ALIAS_ATTRIBUTE
 __strong_reference(vfscanf, __f_vfscanf);
+#ifdef _WANT_FLOCKFILE
+__strong_reference(FILE_FN_UNLOCKED(vfscanf), FILE_FN_UNLOCKED(__f_vfscanf));
+#endif
 #else
 int __f_vfscanf (FILE * stream, const char *fmt, va_list ap) { return vfscanf(stream, fmt, ap); }
+#ifdef _WANT_FLOCKFILE
+int FILE_FN_UNLOCKED(__f_vfscanf) (FILE * stream, const char *fmt, va_list ap) { return FILE_FN_UNLOCKED(vfscanf)(stream, fmt, ap); }
+#endif
 #endif
 #endif

--- a/newlib/libc/tinystdio/vfiprintf.c
+++ b/newlib/libc/tinystdio/vfiprintf.c
@@ -43,7 +43,13 @@
 #ifdef _FORMAT_DEFAULT_INTEGER
 #ifdef _HAVE_ALIAS_ATTRIBUTE
 __strong_reference(vfprintf, __i_vfprintf);
+#ifdef _WANT_FLOCKFILE
+__strong_reference(FILE_FN_UNLOCKED(vfprintf), FILE_FN_UNLOCKED(__i_vfprintf));
+#endif
 #else
 int __i_vfprintf (FILE * stream, const char *fmt, va_list ap) { return vfprintf(stream, fmt, ap); }
+#ifdef _WANT_FLOCKFILE
+int FILE_FN_UNLOCKED(__i_vfprintf) (FILE * stream, const char *fmt, va_list ap) { return FILE_FN_UNLOCKED(vfprintf)(stream, fmt, ap); }
+#endif
 #endif
 #endif

--- a/newlib/libc/tinystdio/vfiscanf.c
+++ b/newlib/libc/tinystdio/vfiscanf.c
@@ -42,7 +42,13 @@
 #ifdef _FORMAT_DEFAULT_INTEGER
 #ifdef _HAVE_ALIAS_ATTRIBUTE
 __strong_reference(vfscanf, __i_vfscanf);
+#ifdef _WANT_FLOCKFILE
+__strong_reference(FILE_FN_UNLOCKED(vfscanf), FILE_FN_UNLOCKED(__i_vfscanf));
+#endif
 #else
 int __i_vfscanf (FILE * stream, const char *fmt, va_list ap) { return vfscanf(stream, fmt, ap); }
+#ifdef _WANT_FLOCKFILE
+int FILE_FN_UNLOCKED(__i_vfscanf) (FILE * stream, const char *fmt, va_list ap) { return FILE_FN_UNLOCKED(vfscanf)(stream, fmt, ap); }
+#endif
 #endif
 #endif

--- a/newlib/libc/tinystdio/vflprintf.c
+++ b/newlib/libc/tinystdio/vflprintf.c
@@ -43,7 +43,13 @@
 #ifdef _FORMAT_DEFAULT_LONG_LONG
 #ifdef _HAVE_ALIAS_ATTRIBUTE
 __strong_reference(vfprintf, __l_vfprintf);
+#ifdef _WANT_FLOCKFILE
+__strong_reference(FILE_FN_UNLOCKED(vfprintf), FILE_FN_UNLOCKED(__l_vfprintf));
+#endif
 #else
 int __l_vfprintf (FILE * stream, const char *fmt, va_list ap) { return vfprintf(stream, fmt, ap); }
+#ifdef _WANT_FLOCKFILE
+int FILE_FN_UNLOCKED(__l_vfprintf) (FILE * stream, const char *fmt, va_list ap) { return FILE_FN_UNLOCKED(vfprintf)(stream, fmt, ap); }
+#endif
 #endif
 #endif

--- a/newlib/libc/tinystdio/vflscanf.c
+++ b/newlib/libc/tinystdio/vflscanf.c
@@ -42,7 +42,13 @@
 #ifdef _FORMAT_DEFAULT_LONG_LONG
 #ifdef _HAVE_ALIAS_ATTRIBUTE
 __strong_reference(vfscanf, __l_vfscanf);
+#ifdef _WANT_FLOCKFILE
+__strong_reference(FILE_FN_UNLOCKED(vfscanf), FILE_FN_UNLOCKED(__l_vfscanf));
+#endif
 #else
 int __l_vfscanf (FILE * stream, const char *fmt, va_list ap) { return vfscanf(stream, fmt, ap); }
+#ifdef _WANT_FLOCKFILE
+int FILE_FN_UNLOCKED(__l_vfscanf) (FILE * stream, const char *fmt, va_list ap) { return FILE_FN_UNLOCKED(vfscanf)(stream, fmt, ap); }
+#endif
 #endif
 #endif

--- a/newlib/libc/tinystdio/vfmprintf.c
+++ b/newlib/libc/tinystdio/vfmprintf.c
@@ -42,7 +42,13 @@
 #ifdef _FORMAT_DEFAULT_MINIMAL
 #ifdef _HAVE_ALIAS_ATTRIBUTE
 __strong_reference(vfprintf, __m_vfprintf);
+#ifdef _WANT_FLOCKFILE
+__strong_reference(FILE_FN_UNLOCKED(vfprintf), FILE_FN_UNLOCKED(__m_vfprintf));
+#endif
 #else
 int __m_vfprintf (FILE * stream, const char *fmt, va_list ap) { return vfprintf(stream, fmt, ap); }
+#ifdef _WANT_FLOCKFILE
+int FILE_FN_UNLOCKED(__m_vfprintf) (FILE * stream, const char *fmt, va_list ap) { return FILE_FN_UNLOCKED(vfprintf)(stream, fmt, ap); }
+#endif
 #endif
 #endif

--- a/newlib/libc/tinystdio/vfmscanf.c
+++ b/newlib/libc/tinystdio/vfmscanf.c
@@ -42,7 +42,13 @@
 #ifdef _FORMAT_DEFAULT_MINIMAL
 #ifdef _HAVE_ALIAS_ATTRIBUTE
 __strong_reference(vfscanf, __m_vfscanf);
+#ifdef _WANT_FLOCKFILE
+__strong_reference(FILE_FN_UNLOCKED(vfscanf), FILE_FN_UNLOCKED(__m_vfscanf));
+#endif
 #else
 int __m_vfscanf (FILE * stream, const char *fmt, va_list ap) { return vfscanf(stream, fmt, ap); }
+#ifdef _WANT_FLOCKFILE
+int FILE_FN_UNLOCKED(__m_vfscanf) (FILE * stream, const char *fmt, va_list ap) { return FILE_FN_UNLOCKED(vfscanf)(stream, fmt, ap); }
+#endif
 #endif
 #endif

--- a/newlib/libc/tinystdio/vfprintf.c
+++ b/newlib/libc/tinystdio/vfprintf.c
@@ -477,7 +477,9 @@ _wcslen(const char *s, size_t maxlen)
 }
 #endif
 
-int vfprintf (FILE * stream, const CHAR *fmt, va_list ap_orig)
+FILE_FN_UNLOCKED_SPECIFIER
+int
+FILE_FN_UNLOCKED(vfprintf)(FILE * stream, const CHAR *fmt, va_list ap_orig)
 {
     unsigned c;		/* holds a char from the format string */
     uint16_t flags;
@@ -1320,6 +1322,18 @@ int vfprintf (FILE * stream, const CHAR *fmt, va_list ap_orig)
     stream_len = -1;
     goto ret;
 }
+
+#ifdef _WANT_FLOCKFILE
+int
+vfprintf(FILE * stream, const CHAR *fmt, va_list ap_orig)
+{
+    int ret;
+    __flockfile(stream);
+    ret = FILE_FN_UNLOCKED(vfprintf)(stream, fmt, ap_orig);
+    __funlockfile(stream);
+    return ret;
+}
+#endif
 
 #if defined(_FORMAT_DEFAULT_DOUBLE) && !defined(vfprintf)
 #ifdef _HAVE_ALIAS_ATTRIBUTE

--- a/newlib/libc/tinystdio/vfprintf.c
+++ b/newlib/libc/tinystdio/vfprintf.c
@@ -477,7 +477,6 @@ _wcslen(const char *s, size_t maxlen)
 }
 #endif
 
-FILE_FN_UNLOCKED_SPECIFIER
 int
 FILE_FN_UNLOCKED(vfprintf)(FILE * stream, const CHAR *fmt, va_list ap_orig)
 {

--- a/newlib/libc/tinystdio/vfprintf.c
+++ b/newlib/libc/tinystdio/vfprintf.c
@@ -1337,7 +1337,13 @@ vfprintf(FILE * stream, const CHAR *fmt, va_list ap_orig)
 #if defined(_FORMAT_DEFAULT_DOUBLE) && !defined(vfprintf)
 #ifdef _HAVE_ALIAS_ATTRIBUTE
 __strong_reference(vfprintf, __d_vfprintf);
+#ifdef _WANT_FLOCKFILE
+__strong_reference(FILE_FN_UNLOCKED(vfprintf), FILE_FN_UNLOCKED(__d_vfprintf));
+#endif
 #else
 int __d_vfprintf (FILE * stream, const char *fmt, va_list ap) { return vfprintf(stream, fmt, ap); }
+#ifdef _WANT_FLOCKFILE
+int FILE_FN_UNLOCKED(__d_vfprintf) (FILE * stream, const char *fmt, va_list ap) { return FILE_FN_UNLOCKED(vfprintf)(stream, fmt, ap); }
+#endif
 #endif
 #endif

--- a/newlib/libc/tinystdio/vfscanf.c
+++ b/newlib/libc/tinystdio/vfscanf.c
@@ -869,7 +869,13 @@ vfscanf (FILE * stream, const CHAR *fmt, va_list ap_orig)
 #if defined(_FORMAT_DEFAULT_DOUBLE) && !defined(vfscanf)
 #ifdef _HAVE_ALIAS_ATTRIBUTE
 __strong_reference(vfscanf, __d_vfscanf);
+#ifdef _WANT_FLOCKFILE
+__strong_reference(FILE_FN_UNLOCKED(vfscanf), FILE_FN_UNLOCKED(__d_vfscanf));
+#endif
 #else
 int __d_vfscanf (FILE * stream, const char *fmt, va_list ap) { return vfscanf(stream, fmt, ap); }
+#ifdef _WANT_FLOCKFILE
+int FILE_FN_UNLOCKED(__d_vfscanf) (FILE * stream, const char *fmt, va_list ap) { return FILE_FN_UNLOCKED(vfscanf)(stream, fmt, ap); }
+#endif
 #endif
 #endif

--- a/newlib/libc/tinystdio/vfscanf.c
+++ b/newlib/libc/tinystdio/vfscanf.c
@@ -64,8 +64,8 @@ typedef long int_scanf_t;
 # define MY_EOF          WEOF
 # define CHAR wchar_t
 # define UCHAR wchar_t
-# define GETC(s) getwc(s)
-# define UNGETC(c,s) ungetwc(c,s)
+# define GETC(s) FILE_FN_UNLOCKED(getwc)(s)
+# define UNGETC(c,s) FILE_FN_UNLOCKED(ungetwc)(c,s)
 # define ISSPACE(c) iswspace(c)
 # undef vfscanf
 # define vfscanf vfwscanf
@@ -79,8 +79,8 @@ typedef long int_scanf_t;
 # define IS_EOF(c)       ((c) < 0)
 # define CHAR char
 # define UCHAR unsigned char
-# define GETC(s) getc(s)
-# define UNGETC(c,s) ungetc(c,s)
+# define GETC(s) FILE_FN_UNLOCKED(fgetc)(s)
+# define UNGETC(c,s) FILE_FN_UNLOCKED(ungetc)(c,s)
 # define ISSPACE(c) isspace(c)
 # ifdef _NEED_IO_MBTOWIDE
 #  define WINT            wint_t

--- a/newlib/libc/tinystdio/vfscanf.c
+++ b/newlib/libc/tinystdio/vfscanf.c
@@ -567,7 +567,8 @@ skip_to_arg(my_va_list *ap, int target_argno)
      -Wl,-u,vfscanf -lscanf_min -lm
      \endcode
 */
-int vfscanf (FILE * stream, const CHAR *fmt, va_list ap_orig)
+int
+FILE_FN_UNLOCKED(vfscanf) (FILE * stream, const CHAR *fmt, va_list ap_orig)
 {
     unsigned char nconvs;
     UCHAR c;
@@ -852,6 +853,18 @@ int vfscanf (FILE * stream, const CHAR *fmt, va_list ap_orig)
 #endif
     return nconvs ? nconvs : EOF;
 }
+
+#ifdef _WANT_FLOCKFILE
+int
+vfscanf (FILE * stream, const CHAR *fmt, va_list ap_orig)
+{
+    int ret;
+    __flockfile(stream);
+    ret = FILE_FN_UNLOCKED(vfscanf)(stream, fmt, ap_orig);
+    __funlockfile(stream);
+    return ret;
+}
+#endif
 
 #if defined(_FORMAT_DEFAULT_DOUBLE) && !defined(vfscanf)
 #ifdef _HAVE_ALIAS_ATTRIBUTE

--- a/newlib/libc/tinystdio/vsnprintf.c
+++ b/newlib/libc/tinystdio/vsnprintf.c
@@ -47,7 +47,7 @@ vsnprintf(char *s, size_t n, const char *fmt, va_list ap)
 
 	struct __file_str f = FDEV_SETUP_STRING_WRITE(s, n ? n - 1 : 0);
 
-	i = vfprintf(&f.file, fmt, ap);
+	i = FILE_FN_UNLOCKED(vfprintf)(&f.file, fmt, ap);
 
 	if (n)
             *f.pos = '\0';

--- a/newlib/libc/tinystdio/vsprintf.c
+++ b/newlib/libc/tinystdio/vsprintf.c
@@ -37,7 +37,7 @@ vsprintf(char *s, const char *fmt, va_list ap)
 	struct __file_str f = FDEV_SETUP_STRING_WRITE(s, INT_MAX);
 	int i;
 
-	i = vfprintf(&f.file, fmt, ap);
+	i = FILE_FN_UNLOCKED(vfprintf)(&f.file, fmt, ap);
 	if (i >= 0)
 		s[i] = 0;
 

--- a/newlib/libc/tinystdio/vsscanf.c
+++ b/newlib/libc/tinystdio/vsscanf.c
@@ -34,5 +34,5 @@ vsscanf(const char *s, const char *fmt, va_list ap)
 {
 	struct __file_str f = FDEV_SETUP_STRING_READ(s);
 
-	return vfscanf(&f.file, fmt, ap);
+	return FILE_FN_UNLOCKED(vfscanf)(&f.file, fmt, ap);
 }

--- a/newlib/libc/tinystdio/vswprintf.c
+++ b/newlib/libc/tinystdio/vswprintf.c
@@ -42,7 +42,7 @@ vswprintf(wchar_t *s, size_t len, const wchar_t *fmt, va_list ap)
 	int i;
 
         f.file.flags |= __SWIDE;
-	i = vfwprintf(&f.file, fmt, ap);
+	i = FILE_FN_UNLOCKED(vfwprintf)(&f.file, fmt, ap);
 	if (i >= 0)
 		s[i] = 0;
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -110,6 +110,8 @@ endif
 
 plain_tests_native = plain_tests_common
 
+plain_tests_native += 'test-flockfile'
+
 math_tests_native = math_tests_common
 foreach target : targets
   value = get_variable('target_' + target)
@@ -735,6 +737,22 @@ endif
 
 if enable_native_tests
 
+  native_lib = static_library('native-lib',
+                              ['native-locks.c'],
+                              c_args: native_c_args)
+
+  test_file_name_arg=['-DTEST_FILE_NAME="' + 'test-flockfile' + '.txt"']
+
+  test('test-flockfile',
+       executable('test-flockfile',
+                  'test-flockfile.c',
+                  c_args: test_c_args + test_file_name_arg,
+                  link_args: test_link_args,
+                  link_with: [native_lib, lib_c],
+                  include_directories: inc),
+       depends: bios_bin,
+       env: test_env)
+
   if have_cplusplus
     test('test-cplusplus-native',
          executable('test-cplusplus-native', 'test-cplusplus.cpp',
@@ -742,7 +760,6 @@ if enable_native_tests
 		    link_args: native_cpp_args))
   endif
 
-  
   foreach t1 : plain_tests_native
     t1_src = t1 + '.c'
     t1_name = t1 + '-native'
@@ -750,7 +767,7 @@ if enable_native_tests
 
     test(t1_name,
 	 executable(t1_name, t1_src,
-		    c_args: native_c_args,
+		    c_args: native_c_args + test_file_name_arg,
 		    link_args: native_c_args))
   endforeach
 

--- a/test/native-locks.c
+++ b/test/native-locks.c
@@ -1,0 +1,170 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2022 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _DEFAULT_SOURCE
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+
+/*
+ * Validate lock usage in libc by creating fake locks
+ * to be used during testing
+ */
+
+#define _LOCK_T struct __lock*
+
+struct __lock {
+    pthread_mutex_t     mut;
+};
+
+struct __lock __lock___libc_recursive_mutex;
+
+__attribute__((constructor))
+static void libc_lock_init(void)
+{
+        pthread_mutexattr_t     mutexattr;
+        pthread_mutexattr_init(&mutexattr);
+        pthread_mutexattr_settype(&mutexattr, PTHREAD_MUTEX_RECURSIVE);
+
+        pthread_mutex_init(&__lock___libc_recursive_mutex.mut, &mutexattr);
+}
+
+#define MAX_LOCKS 32
+
+static struct __lock locks[MAX_LOCKS];
+static _Atomic int in_use[MAX_LOCKS];
+
+/* Create a new dynamic non-recursive lock */
+void __retarget_lock_init(_LOCK_T *lock);
+
+void __retarget_lock_init(_LOCK_T *lock)
+{
+        int lock_id = 0;
+
+        for (lock_id = 0; lock_id < MAX_LOCKS; lock_id++) {
+                int expected = 0;
+                int desired = 1;
+                if (atomic_compare_exchange_strong(&in_use[lock_id], &expected, desired)) {
+                        pthread_mutexattr_t     mutexattr;
+                        pthread_mutexattr_init(&mutexattr);
+                        pthread_mutexattr_settype(&mutexattr, PTHREAD_MUTEX_RECURSIVE);
+
+                        pthread_mutex_init(&locks[lock_id].mut, &mutexattr);
+                        *lock = &locks[lock_id];
+                        return;
+                }
+        }
+}
+
+/* Create a new dynamic recursive lock */
+void __retarget_lock_init_recursive(_LOCK_T *lock);
+
+void __retarget_lock_init_recursive(_LOCK_T *lock)
+{
+        __retarget_lock_init(lock);
+}
+
+/* Close dynamic non-recursive lock */
+void __retarget_lock_close(_LOCK_T lock);
+
+void __retarget_lock_close(_LOCK_T lock)
+{
+        int lock_id = lock - locks;
+        int desired = 0;
+
+        pthread_mutex_destroy(&locks[lock_id].mut);
+
+        atomic_exchange(&in_use[lock_id], desired);
+}
+
+/* Close dynamic recursive lock */
+void __retarget_lock_close_recursive(_LOCK_T lock);
+
+void __retarget_lock_close_recursive(_LOCK_T lock)
+{
+        __retarget_lock_close(lock);
+}
+
+/* Acquiure non-recursive lock */
+void __retarget_lock_acquire(_LOCK_T lock);
+
+void __retarget_lock_acquire(_LOCK_T lock)
+{
+        pthread_mutex_lock(&lock->mut);
+}
+
+/* Acquiure recursive lock */
+void __retarget_lock_acquire_recursive(_LOCK_T lock);
+
+void __retarget_lock_acquire_recursive(_LOCK_T lock)
+{
+        pthread_mutex_lock(&lock->mut);
+}
+
+/* Release non-recursive lock */
+void __retarget_lock_release(_LOCK_T lock);
+
+void __retarget_lock_release(_LOCK_T lock)
+{
+        pthread_mutex_unlock(&lock->mut);
+}
+
+/* Release recursive lock */
+void __retarget_lock_release_recursive(_LOCK_T lock);
+
+void __retarget_lock_release_recursive(_LOCK_T lock)
+{
+        pthread_mutex_unlock(&lock->mut);
+}
+
+static pthread_t thread;
+
+int
+start_thread(void *(*func)(void *), void *arg);
+
+int
+start_thread(void *(*func)(void *), void *arg)
+{
+        return pthread_create(&thread, NULL, func, arg);
+}
+
+int
+stop_thread(void);
+
+int
+stop_thread(void)
+{
+        return pthread_join(thread, NULL);
+}

--- a/test/test-flockfile.c
+++ b/test/test-flockfile.c
@@ -1,0 +1,205 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2024 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _DEFAULT_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#ifndef __PICOLIBC__
+# define ENABLE_TEST
+#elif defined(_RETARGETABLE_LOCKING)
+# if defined(TINY_STDIO)
+#  if defined(_WANT_FLOCKFILE)
+#   define ENABLE_TEST
+#  endif
+# else
+#  define ENABLE_TEST
+# endif
+#endif
+
+#define check(condition, message) do {                  \
+        if (!(condition)) {                             \
+            printf("%s: %s\n", message, #condition);    \
+            exit(1);                                    \
+        }                                               \
+    } while(0)
+
+#ifndef TEST_FILE_NAME
+#define TEST_FILE_NAME "FLOCK.TXT"
+#endif
+
+#ifdef ENABLE_TEST
+static FILE *out;
+
+static void *write_func(void *arg)
+{
+    char *val = arg;
+    char *v;
+    int i;
+    for(i = 0; i < 10; i++) {
+        fprintf(out, "%s", val);
+    }
+    for(i = 0; i < 10; i++) {
+        fputs(val, out);
+    }
+    for(i = 0; i < 10; i++) {
+        flockfile(out);
+        v = val;
+        while (*v) {
+            putc(*v++, out);
+            usleep(rand() & 15);
+        }
+        funlockfile(out);
+    }
+    return NULL;
+}
+
+#define STRING  "hello, world\n"
+
+int
+start_thread(void *(*func)(void *), void *arg);
+
+int
+stop_thread(void);
+
+#ifdef NO_NEWLIB
+#include <pthread.h>
+
+static pthread_t thread;
+
+int
+start_thread(void *(*func)(void *), void *arg)
+{
+        return pthread_create(&thread, NULL, func, arg);
+}
+
+int
+stop_thread(void)
+{
+        return pthread_join(thread, NULL);
+}
+#endif
+
+#ifdef TINY_STDIO
+
+static int fd;
+
+static int myput(char c, FILE *file)
+{
+    (void) file;
+    write(fd, &c, 1);
+    usleep(rand() & 31);
+}
+
+static int myget(FILE *file)
+{
+    (void) file;
+    uint8_t c;
+    if (read(fd, &c, 1) <= 0)
+        return _FDEV_EOF;
+    return c;
+}
+
+static int myclose(FILE *file)
+{
+    (void) file;
+    close(fd);
+    fd = -1;
+    return 0;
+}
+
+static struct __file_close myout = FDEV_SETUP_CLOSE(myput, myget, NULL, myclose, _FDEV_SETUP_WRITE);
+#endif /* TINY_STDIO */
+#endif /* ENABLE_TEST */
+
+int
+main(void)
+{
+#ifndef ENABLE_TEST
+    printf("File locking not enabled, test skipped\n");
+    exit(77);
+#else
+    int ret;
+    int status = 0;
+    char buf[1024];
+    FILE *in;
+
+#ifdef TINY_STDIO
+    fd = creat(TEST_FILE_NAME, 0666);
+    if (fd < 0) {
+        perror(TEST_FILE_NAME);
+        exit(1);
+    }
+    out = &myout.file;
+#ifdef _WANT_FLOCKFILE
+    __lock_init_recursive(out->lock);
+#endif
+#else
+    out = fopen(TEST_FILE_NAME, "w");
+    if (!out) {
+        perror(TEST_FILE_NAME);
+        exit(1);
+    }
+#endif
+    srand(1);
+    ret = start_thread(write_func, STRING);
+    srand(2);
+    if (ret) {
+        perror("pthread_create");
+        exit(1);
+    }
+    write_func(STRING);
+    stop_thread();
+    fclose(out);
+    in = fopen(TEST_FILE_NAME, "r");
+    if (!in) {
+        perror(TEST_FILE_NAME);
+        exit(1);
+    }
+    while (fgets(buf, sizeof(buf), in)) {
+        if (strcmp(buf, STRING) != 0) {
+            printf("line mangled: %s", buf);
+            status = 1;
+        }
+    }
+    fclose(in);
+    remove(TEST_FILE_NAME);
+    exit(status);
+#endif
+}


### PR DESCRIPTION
Related to https://github.com/picolibc/picolibc/issues/760


Initially, I made changes on top of 1.8.6 version. You may see a branch with changes here https://github.com/Lapshin/picolibc/commit/7db1b716ac10ec6fef724a3c78c7d18d212dab93. I tested this change with Espressif's internal tests and was happy with the results.

When rebasing to the latest "main", I resolved some conflicts, tried to build, and ran a simple test.

When `-Dflockfile=true` option is enabled, bufio lock is not used for locking the buffer, but instead, it using for locking whole access to buffered stream call (`printf`/`scanf`/...). I don't know if it is ok for you to use lock from `stdio-bufio.h` or you want to have lock in `struct __file`. It could be easily changed in `__flockfile`/`__funlockfile` functions.


Also, I'm not 100% sure if deadlock is possible with this change, but I did not face any when ran my tests.