### PR TITLE
Classify horizontal tab as a blank character

### DIFF
--- a/newlib/libc/ctype/ctype_.c
+++ b/newlib/libc/ctype/ctype_.c
@@ -51,6 +51,24 @@
 	_L,	_L,	_L,	_L,	_L,	_L,	_L,	_L, \
 	_L,	_L,	_L,	_P,	_P,	_P,	_P,	_C
 
+#define _CTYPE_DATA_0_127_WIDE \
+	_C,	_C,	_C,	_C,	_C,	_C,	_C,	_C, \
+	_C,	_C|_S|_T, _C|_S, _C|_S,	_C|_S,	_C|_S,	_C,	_C, \
+	_C,	_C,	_C,	_C,	_C,	_C,	_C,	_C, \
+	_C,	_C,	_C,	_C,	_C,	_C,	_C,	_C, \
+	_S|_B,	_P,	_P,	_P,	_P,	_P,	_P,	_P, \
+	_P,	_P,	_P,	_P,	_P,	_P,	_P,	_P, \
+	_N,	_N,	_N,	_N,	_N,	_N,	_N,	_N, \
+	_N,	_N,	_P,	_P,	_P,	_P,	_P,	_P, \
+	_P,	_U|_X,	_U|_X,	_U|_X,	_U|_X,	_U|_X,	_U|_X,	_U, \
+	_U,	_U,	_U,	_U,	_U,	_U,	_U,	_U, \
+	_U,	_U,	_U,	_U,	_U,	_U,	_U,	_U, \
+	_U,	_U,	_U,	_P,	_P,	_P,	_P,	_P, \
+	_P,	_L|_X,	_L|_X,	_L|_X,	_L|_X,	_L|_X,	_L|_X,	_L, \
+	_L,	_L,	_L,	_L,	_L,	_L,	_L,	_L, \
+	_L,	_L,	_L,	_L,	_L,	_L,	_L,	_L, \
+	_L,	_L,	_L,	_P,	_P,	_P,	_P,	_C
+
 #define _CTYPE_DATA_128_255 \
 	0,	0,	0,	0,	0,	0,	0,	0, \
 	0,	0,	0,	0,	0,	0,	0,	0, \
@@ -97,6 +115,12 @@ const char _ctype_[1 + 256] = {
 };
 
 #endif	/* !ALLOW_NEGATIVE_CTYPE_INDEX */
+
+const short _ctype_wide[1 + 256] = {
+	0,
+	_CTYPE_DATA_0_127_WIDE,
+	_CTYPE_DATA_128_255
+};
 
 #if defined(_MB_CAPABLE)
 /* Cygwin has its own implementation which additionally maintains backward

--- a/newlib/libc/include/ctype.h
+++ b/newlib/libc/include/ctype.h
@@ -229,6 +229,8 @@ __declare_extern_inline(int) toupper_l (int c, locale_t l) { (void) l; return to
 #define _C	040
 #define _X	0100
 #define	_B	0200
+/* _T used for _ctype_wide table */
+#define _T 0400
 
 #ifndef __CHAR_UNSIGNED__
 #define ALLOW_NEGATIVE_CTYPE_INDEX
@@ -240,6 +242,8 @@ extern const char	_ctype_b[];
 #else
 extern const char	_ctype_[];
 #endif
+
+extern const short _ctype_wide[];
 
 #ifdef __HAVE_LOCALE_INFO__
 const char *__locale_ctype_ptr (void);


### PR DESCRIPTION
Update the `_CTYPE_DATA_0_127` macro to include `_B` flag for the horizontal tab character (0x09), ensuring it is correctly recognized as a blank character.  

This change ensures that both horizontal tab and space characters are appropriately classified as blank character.