### PR TITLE
tinystdio: Fix handling `%n` in vfprintf.c

### DIFF
--- a/newlib/libc/tinystdio/vfprintf.c
+++ b/newlib/libc/tinystdio/vfprintf.c
@@ -1139,8 +1139,19 @@ int vfprintf (FILE * stream, const CHAR *fmt, va_list ap_orig)
 #endif
 #ifdef _PRINTF_PERCENT_N
             } else if (c == 'n') {
-                int *n_ptr = va_arg(ap, int *);
-                *n_ptr = stream_len;
+                if (flags & FL_LONG) {
+                    if (flags & FL_REPD_TYPE)
+                        *va_arg(ap, long long *) = stream_len;
+                    else
+                        *va_arg(ap, long *) = stream_len;
+                } else if (flags & FL_SHORT) {
+                    if (flags & FL_REPD_TYPE)
+                        *va_arg(ap, char *) = stream_len;
+                    else
+                        *va_arg(ap, short *) = stream_len;
+                } else {
+                    *va_arg(ap, int *) = stream_len;
+                }
 #endif
             } else {
                 if (c == 'd' || c == 'i') {

--- a/test/libc-testsuite/snprintf.c
+++ b/test/libc-testsuite/snprintf.c
@@ -197,6 +197,33 @@ static int test_snprintf(void)
 #endif
 #endif
 
+#if !defined(TINY_STDIO) || defined(_PRINTF_PERCENT_N)
+        /* Tests for %hhn, %hn, %n, %ln, %lln */
+        int len;
+        short slen;
+        char clen;
+        long llen;
+	int n = 123;
+
+        TEST(i, snprintf(b, sizeof b, "%d%n456", n, &len), 6, "length for %n");
+        TEST_S(b, "123456", "incorrect output");
+        TEST(i, len, 3, "incorrect len");
+        TEST(i, snprintf(b, sizeof b, "%d%hn456", n, &slen), 6, "length for %hn");
+        TEST_S(b, "123456", "incorrect output");
+        TEST(i, slen, 3, "incorrect len");
+        TEST(i, snprintf(b, sizeof b, "%d%hhn456", n, &clen), 6, "length for %hhn");
+        TEST_S(b, "123456", "incorrect output");
+        TEST(i, clen, 3, "incorrect len");
+        TEST(i, snprintf(b, sizeof b, "%d%ln456", n, &llen), 6, "length for %ln");
+        TEST_S(b, "123456", "incorrect output");
+        TEST(i, llen, 3, "incorrect len");
+#if !defined(__PICOLIBC__) || defined(TINY_STDIO) || defined(_WANT_IO_LONG_LONG)
+        long long lllen;
+        TEST(i, snprintf(b, sizeof b, "%d%lln456", n, &lllen), 6, "length for %lln");
+        TEST_S(b, "123456", "incorrect output");
+        TEST(i, lllen, 3, "incorrect len");
+#endif
+#endif
 
 #ifndef DISABLE_SLOW_TESTS
 	errno = 0;


### PR DESCRIPTION
Support for `%hn`, `%hhn`, `%ln` and `%lln`

Extends the handling of the `%n` specifier to support different integer types, including `%hn` (short) and `%hhn` (char), `%ln` (long) and `%lln` (long long), . This ensures correct and consistent behavior for various specifier types.
This fix addresses and resolves the issue #804 

Issue found by running [SuperTest by SolidSands](https://solidsands.com/products/supertest).