### PR TITLE
cmake: improve builtin functions detection

### DIFF
--- a/cmake/picolibc.cmake
+++ b/cmake/picolibc.cmake
@@ -127,6 +127,7 @@ _picolibc_supported_compile_options(PICOLIBC_FLAG_OPTIONS
   -Werror=unsupported-floating-point-opt
   -Werror=ignored-optimization-argument
   -Werror=attribute-optimize
+  -Werror=implicit-function-declaration
   -Wno-unused-command-line-argument
   )
 


### PR DESCRIPTION
Add -Werror=implicit-function-declaration to compile options used to check if a builtin function is supported.

If fixes an issue with detection for LLVM, when only warrning is "use of unknown builtin" is retured.

It fixes https://github.com/picolibc/picolibc/issues/805