### PR TITLE
Link compiler-rt after libc in tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1669,8 +1669,9 @@ if has_semihost
     endif
 
     set_variable(test_link_args_variable,
-		 ['-Wl,--gc-sections', '-nostdlib', '-T', picolibc_ld_string,
-		  lib_gcc] + additional_libs_list)
+		 ['-Wl,--gc-sections', '-nostdlib', '-T', picolibc_ld_string]
+       + additional_libs_list
+       + [lib_gcc])
 
     set_variable(test_linker_files_variable, [picolibc_ld_value])
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -133,7 +133,7 @@ foreach target : targets
   endif
 
   _c_args = value[1] + get_variable('test_c_args_' + target, test_c_args)
-  _link_args = value[1] + get_variable('test_link_args_' + target, test_link_args) + _lib_files
+  _link_args = value[1] + _lib_files + get_variable('test_link_args_' + target, test_link_args)
   _link_depends = get_variable('test_link_depends_' + target, test_link_depends) + _libs
   if have_cplusplus
     _cpp_args = value[1] + get_variable('test_cpp_args_' + target, test_cpp_args)


### PR DESCRIPTION
For ARM, when using clang and compiler-rt, some tests fail because the C library contains calls to the __aeabi_memcpy* functions, which are defined in libgcc or compiler-rt. To make these work, compiler-rt needs to be after libc on the linker command line.