### PR TITLE
scripts: Ignore File symbols in duplicate-names script

### DIFF
--- a/scripts/duplicate-names
+++ b/scripts/duplicate-names
@@ -3,7 +3,7 @@ NM="$1"
 FILE="$2"
 OUTPUT="$3"
 
-"$NM" -g "$FILE" 2>/dev/null | grep ' [A-TVX-Z] ' | grep -v '__x86' | sort | uniq -d > "$OUTPUT"
+"$NM" -g "$FILE" 2>/dev/null | grep ' [A-EG-TVX-Z] ' | grep -v '__x86' | sort | uniq -d > "$OUTPUT"
 if [ -e "$OUTPUT" ] && [ -s "$OUTPUT" ]; then
     echo "Duplicate names in ${FILE}"
     cat "$OUTPUT"


### PR DESCRIPTION
The math library has a couple of duplicate basenames which generate complaints from the duplicate-names script on some systems.