### PR TITLE
string: Don't use GCC void * extension in strnlen_s

### DIFF
--- a/newlib/libc/string/strnlen_s.c
+++ b/newlib/libc/string/strnlen_s.c
@@ -34,6 +34,7 @@
  */
 #define __STDC_WANT_LIB_EXT1__ 1
 #include <string.h>
+#include <stddef.h>
 #include "string_private.h"
 
 size_t
@@ -50,8 +51,8 @@ strnlen_s(const char *s, size_t maxsize)
         if (s_end == NULL) {
             rtn = maxsize;
         } else {
-            int s_size;
-            s_size = s_end - (const void *)s;
+            ptrdiff_t s_size;
+            s_size = (const char *) s_end - s;
             rtn = (size_t)s_size;
         }
     }


### PR DESCRIPTION
Switch to using 'const char *' for the result computation, and then store the value in a ptrdiff_t instead of an int.