### PR TITLE
aarch64: Remove 'machine/aarch64/sys' directory from cmake build

### DIFF
--- a/newlib/libc/machine/aarch64/CMakeLists.txt
+++ b/newlib/libc/machine/aarch64/CMakeLists.txt
@@ -68,5 +68,4 @@ picolibc_sources_flags("-fno-builtin"
   strrchr.S
   )
 
-add_subdirectory(sys)
 add_subdirectory(machine)


### PR DESCRIPTION
fenv.h was moved to machine/ but the cmake config wasn't changed.