### PR TITLE
scripts: Force use of exe_wrapper on aarch64

### DIFF
--- a/newlib/libm/math/sf_pow.c
+++ b/newlib/libm/math/sf_pow.c
@@ -199,7 +199,8 @@ powf(float x, float y)
         GET_FLOAT_WORD(is, s_h);
         SET_FLOAT_WORD(s_h, is & 0xfffff000);
         /* t_h=ax+bp[k] High */
-        SET_FLOAT_WORD(t_h, ((ix >> 1) | 0x20000000) + 0x0040000 + (k << 21));
+        is = ((ix >> 1) & 0xfffff000U) | 0x20000000;
+        SET_FLOAT_WORD(t_h, is + 0x00400000 + (k << 21));
         t_l = ax - (t_h - bp[k]);
         s_l = v * ((u - s_h * t_h) - s_h * t_l);
         /* compute log(ax) */

--- a/newlib/libm/test/pow_vec.c
+++ b/newlib/libm/test/pow_vec.c
@@ -154,5 +154,8 @@
 {64, 0,123,__LINE__, 0x792ffffe, 0x0bc9e399, 0x3ff00000, 0x2c5e2e99, 0x41ec9eee, 0x35374af6},
 {64, 0,123,__LINE__, 0x18bfffff, 0xec16bafd, 0x3fefffff, 0xd2e3e669, 0x41f344c9, 0x823eb66c},
 
+/* x -1.1 y 101. float result is -15158.707 */
+{64, 0,123,__LINE__, 0xc0cd9b5a, 0x770b46a4, 0xbff19999, 0xa0000000, 0x40594000, 0x00000000},
+
 {0},};
 void test_pow_vec(int m)   {run_vector_1(m,pow_vec,(char *)(pow),"pow","ddd");   }

--- a/scripts/cross-aarch64-linux-gnu.txt
+++ b/scripts/cross-aarch64-linux-gnu.txt
@@ -20,6 +20,7 @@ endian = 'little'
 
 [properties]
 skip_sanity_check = true
+need_exe_wrapper = true
 link_spec = '--build-id=none --no-warn-rwx-segments'
 specs_extra = ['*libgcc:', '-lgcc']
 default_flash_addr = '0x40000000'


### PR DESCRIPTION
When building aarch64 target on aarch64 host, we still need to use qemu to run the tests. Set need_exe_wrapper = true to make this happen.
