### PR TITLE
libc: Clean up missed __IMPORT in unctrl.h

### DIFF
--- a/newlib/libc/include/unctrl.h
+++ b/newlib/libc/include/unctrl.h
@@ -36,7 +36,7 @@
 #define unctrl(c)		__unctrl[(c) & 0xff]
 #define unctrllen(ch)		__unctrllen[(ch) & 0xff]
 
-extern __IMPORT const char * const __unctrl[256];	/* Control strings. */
-extern __IMPORT const char __unctrllen[256];	/* Control strings length. */
+extern const char * const __unctrl[256];	/* Control strings. */
+extern const char __unctrllen[256];	        /* Control strings length. */
 
 #endif /* _UNCTRL_H_ */


### PR DESCRIPTION
Looks like I missed a couple of __IMPORT removals in bd3ad59.

Reported-by: Pablo Martínez

Closes: #835
