### PR TITLE
semihost: Fix the x86 linker script

### DIFF
--- a/semihost/machine/x86/bios.ld
+++ b/semihost/machine/x86/bios.ld
@@ -1,6 +1,6 @@
 MEMORY
 {
-	bios (rxai!w) : ORIGIN = 0xffff0000, LENGTH = 0x10000
+	bios (rx!w) : ORIGIN = 0xffff0000, LENGTH = 0x10000
 }
 
 PHDRS
@@ -12,6 +12,10 @@ SECTIONS {
 	.text : {
 		*(.text*)
 	} >bios AT>bios :text
+
+	.shstrtab : {
+		*(.shstrtab)
+	}
 
 	/DISCARD/ : {
 		*(*)


### PR DESCRIPTION
Sorry for taking so long - I completely forgot about this issue.  I noticed the following when compiling the x86 semihost files with LLVM lld:
```
ld.lld: error: /home/theo/src/picolibc/semihost/machine/x86/bios.ld:3: invalid memory region attribute
```
and
```
ld.lld: error: discarding .shstrtab section is not allowed
````

Unfortunately, It seems like the tests fail locally...