### PR TITLE
semihost/x86: Allow link of 'bios' with lld.

### DIFF
--- a/.github/do-linux
+++ b/.github/do-linux
@@ -10,6 +10,8 @@ HERE=`dirname "$0"`
 "$HERE"/do-test clang-thumbv7m "$@"
 "$HERE"/do-test clang-thumbv6m "$@"
 "$HERE"/do-test clang-aarch64 "$@"
+"$HERE"/do-test clang-x86_64 "$@"
+"$HERE"/do-test clang-x86 "$@"
 "$HERE"/do-build mips "$@"
 "$HERE"/do-build mips64 "$@"
 "$HERE"/do-build mipsel "$@"

--- a/newlib/libc/include/sys/config.h
+++ b/newlib/libc/include/sys/config.h
@@ -273,7 +273,13 @@ SUCH DAMAGE.
 #endif
 
 #ifdef PICOLIBC_TLS
+#ifdef __cplusplus
+#define NEWLIB_THREAD_LOCAL thread_local
+#elif defined(__STDC_VERSION__) && (__STDC_VERSION__) >= 201112L
+#define NEWLIB_THREAD_LOCAL _Thread_local
+#else
 #define NEWLIB_THREAD_LOCAL __thread
+#endif
 #else
 #define NEWLIB_THREAD_LOCAL
 #endif

--- a/scripts/cross-aarch64-linux-gnu.txt
+++ b/scripts/cross-aarch64-linux-gnu.txt
@@ -3,7 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'aarch64-linux-gnu-gcc', '-nostdlib', '-Wl,--build-id=none', '-Wl,--no-warn-rwx-segments']
+c = ['aarch64-linux-gnu-gcc', '-nostdlib', '-Wl,--build-id=none', '-Wl,--no-warn-rwx-segments']
+cpp = ['aarch64-linux-gnu-g++', '-nostdlib', '-Wl,--build-id=none', '-Wl,--no-warn-rwx-segments']
 ar = 'aarch64-linux-gnu-ar'
 as = 'aarch64-linux-gnu-as'
 ld = 'aarch64-linux-gnu-ld'

--- a/scripts/cross-aarch64-zephyr-elf.txt
+++ b/scripts/cross-aarch64-zephyr-elf.txt
@@ -3,7 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'aarch64-zephyr-elf-gcc', '-nostdlib']
+c = ['aarch64-zephyr-elf-gcc', '-nostdlib']
+cpp = ['aarch64-zephyr-elf-g++', '-nostdlib']
 ar = 'aarch64-zephyr-elf-ar'
 as = 'aarch64-zephyr-elf-as'
 nm = 'aarch64-zephyr-elf-nm'

--- a/scripts/cross-arc-zephyr-elf.txt
+++ b/scripts/cross-arc-zephyr-elf.txt
@@ -3,7 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'arc-zephyr-elf-gcc', '-nostdlib', '-mno-sdata', '-fno-delayed-branch']
+c = ['arc-zephyr-elf-gcc', '-nostdlib', '-mno-sdata', '-fno-delayed-branch']
+cpp = ['arc-zephyr-elf-g++', '-nostdlib', '-mno-sdata', '-fno-delayed-branch']
 ar = 'arc-zephyr-elf-ar'
 as = 'arc-zephyr-elf-as'
 nm = 'arc-zephyr-elf-nm'

--- a/scripts/cross-arc64-zephyr-elf.txt
+++ b/scripts/cross-arc64-zephyr-elf.txt
@@ -3,7 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'arc64-zephyr-elf-gcc', '-nostdlib']
+c = ['arc64-zephyr-elf-gcc', '-nostdlib']
+cpp = ['arc64-zephyr-elf-g++', '-nostdlib']
 ar = 'arc64-zephyr-elf-ar'
 as = 'arc64-zephyr-elf-as'
 nm = 'arc64-zephyr-elf-nm'

--- a/scripts/cross-arm-none-eabi.txt
+++ b/scripts/cross-arm-none-eabi.txt
@@ -3,8 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'arm-none-eabi-gcc', '-nostdlib']
-cpp = ['ccache', 'arm-none-eabi-g++', '-nostdlib']
+c = ['arm-none-eabi-gcc', '-nostdlib']
+cpp = ['arm-none-eabi-g++', '-nostdlib']
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eabi-as'
 nm = 'arm-none-eabi-nm'

--- a/scripts/cross-arm-zephyr-eabi.txt
+++ b/scripts/cross-arm-zephyr-eabi.txt
@@ -3,7 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'arm-zephyr-eabi-gcc', '-nostdlib']
+c = ['arm-zephyr-eabi-gcc', '-nostdlib']
+cpp = ['arm-zephyr-eabi-g++', '-nostdlib']
 ar = 'arm-zephyr-eabi-ar'
 as = 'arm-zephyr-eabi-as'
 nm = 'arm-zephyr-eabi-nm'

--- a/scripts/cross-avr.txt
+++ b/scripts/cross-avr.txt
@@ -3,7 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'avr-gcc', '-nostdlib', '-D__COMPILING_AVR_LIBC__']
+c = ['avr-gcc', '-nostdlib', '-D__COMPILING_AVR_LIBC__']
+cpp = ['avr-gcc', '-nostdlib', '-D__COMPILING_AVR_LIBC__']
 ar = 'avr-ar'
 as = 'avr-as'
 nm = 'avr-nm'

--- a/scripts/cross-clang-aarch64-none-elf.txt
+++ b/scripts/cross-clang-aarch64-none-elf.txt
@@ -3,8 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'clang', '-m64', '-target', 'aarch64-none-elf', '-march=armv8-a+nofp', '-mabi=aapcs-soft', '-nostdlib']
-cpp = ['ccache', 'clang', '-m64', '-target', 'aarch64-none-elf', '-march=armv8-a+nofp', '-mabi=aapcs-soft', '-nostdlib']
+c = ['clang', '-m64', '-target', 'aarch64-none-elf', '-march=armv8-a+nofp', '-mabi=aapcs-soft', '-nostdlib']
+cpp = ['clang', '-m64', '-target', 'aarch64-none-elf', '-march=armv8-a+nofp', '-mabi=aapcs-soft', '-nostdlib']
 ar = 'ar'
 as = 'as'
 nm = 'nm'

--- a/scripts/cross-clang-msp430.txt
+++ b/scripts/cross-clang-msp430.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'clang', '-target', 'msp430', '-nostdlib']
+c = ['clang', '-target', 'msp430', '-nostdlib']
 ar = 'msp430-unknown-elf-ar'
 as = 'msp430-unknown-elf-as'
 nm = 'msp430-unknown-elf-nm'

--- a/scripts/cross-clang-riscv64-unknown-elf.txt
+++ b/scripts/cross-clang-riscv64-unknown-elf.txt
@@ -3,8 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'clang', '-target', 'riscv64-unknown-elf', '-mcmodel=medany', '-nostdlib']
-cpp = ['ccache', 'clang', '-target', 'riscv64-unknown-elf', '-mcmodel=medany', '-nostdlib']
+c = ['clang', '-target', 'riscv64-unknown-elf', '-mcmodel=medany', '-nostdlib']
+cpp = ['clang', '-target', 'riscv64-unknown-elf', '-mcmodel=medany', '-nostdlib']
 c_ld = '/usr/bin/riscv64-unknown-elf-ld'
 cpp_ld = '/usr/bin/riscv64-unknown-elf-ld'
 ar = 'riscv64-unknown-elf-ar'

--- a/scripts/cross-clang-riscv64-unknown-elf.txt
+++ b/scripts/cross-clang-riscv64-unknown-elf.txt
@@ -4,7 +4,9 @@
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
 c = ['ccache', 'clang', '-target', 'riscv64-unknown-elf', '-mcmodel=medany', '-nostdlib']
+cpp = ['ccache', 'clang', '-target', 'riscv64-unknown-elf', '-mcmodel=medany', '-nostdlib']
 c_ld = '/usr/bin/riscv64-unknown-elf-ld'
+cpp_ld = '/usr/bin/riscv64-unknown-elf-ld'
 ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'
 nm = 'riscv64-unknown-elf-nm'
@@ -21,6 +23,7 @@ endian = 'little'
 [properties]
 c_args = ['-Werror=double-promotion', '-fshort-enums']
 c_link_args = ['-L/usr/lib/gcc/riscv64-unknown-elf/13.2.0/rv64imac/lp64/', '-L/usr/lib/gcc/riscv64-unknown-elf/12.2.0/rv64imac/lp64/', '-L/usr/lib/gcc/riscv64-unknown-elf/12.1.0/rv64imac/lp64/', '-Wno-unused-command-line-argument']
+cpp_link_args = ['-L/usr/lib/gcc/riscv64-unknown-elf/13.2.0/rv64imac/lp64/', '-L/usr/lib/gcc/riscv64-unknown-elf/12.2.0/rv64imac/lp64/', '-L/usr/lib/gcc/riscv64-unknown-elf/12.1.0/rv64imac/lp64/', '-Wno-unused-command-line-argument']
 skip_sanity_check = true
 has_link_defsym = true
 default_flash_addr = '0x80000000'

--- a/scripts/cross-clang-rv32imafdc-unknown-elf.txt
+++ b/scripts/cross-clang-rv32imafdc-unknown-elf.txt
@@ -3,8 +3,10 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'clang', '-m32', '-target', 'riscv32-unknown-elf', '-march=rv32imafdc', '-mabi=ilp32d', '-nostdlib']
+c = ['clang', '-m32', '-target', 'riscv32-unknown-elf', '-march=rv32imafdc', '-mabi=ilp32d', '-nostdlib']
+cpp = ['clang', '-m32', '-target', 'riscv32-unknown-elf', '-march=rv32imafdc', '-mabi=ilp32d', '-nostdlib']
 c_ld = '/usr/bin/riscv64-unknown-elf-ld'
+cpp_ld = '/usr/bin/riscv64-unknown-elf-ld'
 ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'
 nm = 'riscv64-unknown-elf-nm'
@@ -21,6 +23,7 @@ endian = 'little'
 [properties]
 c_args = ['-Werror=double-promotion']
 c_link_args = ['-Wl,-melf32lriscv', '-L/usr/lib/gcc/riscv64-unknown-elf/13.2.0/rv32imafdc/ilp32d', '-L/usr/lib/gcc/riscv64-unknown-elf/12.2.0/rv32imafdc/ilp32d', '-L/usr/lib/gcc/riscv64-unknown-elf/12.1.0/rv32imafdc/ilp32d']
+cpp_link_args = ['-Wl,-melf32lriscv', '-L/usr/lib/gcc/riscv64-unknown-elf/13.2.0/rv32imafdc/ilp32d', '-L/usr/lib/gcc/riscv64-unknown-elf/12.2.0/rv32imafdc/ilp32d', '-L/usr/lib/gcc/riscv64-unknown-elf/12.1.0/rv32imafdc/ilp32d']
 skip_sanity_check = true
 has_link_defsym = true
 default_flash_addr = '0x80000000'

--- a/scripts/cross-clang-thumb-none-eabi.txt
+++ b/scripts/cross-clang-thumb-none-eabi.txt
@@ -4,6 +4,7 @@
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
 c = ['clang', '-m32', '-target', 'arm-none-eabi', '-mthumb', '-march=armv5', '-mfloat-abi=soft', '-nostdlib']
+cpp = ['clang', '-m32', '-target', 'arm-none-eabi', '-mthumb', '-march=armv5', '-mfloat-abi=soft', '-nostdlib']
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eab-as'
 nm = 'arm-none-eab-nm'
@@ -20,6 +21,7 @@ endian = 'little'
 [properties]
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt', '-fshort-enums']
 c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/nofp/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
+cpp_link_args = ['-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/nofp/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
 skip_sanity_check = true
 default_flash_addr = '0x00000000'
 default_flash_size = '0x00400000'

--- a/scripts/cross-clang-thumbv6m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv6m-none-eabi.txt
@@ -3,7 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'clang', '-m32', '--target=thumbv6m-none-eabi', '-nostdlib']
+c = ['clang', '-m32', '--target=thumbv6m-none-eabi', '-nostdlib']
+cpp = ['clang', '-m32', '--target=thumbv6m-none-eabi', '-nostdlib']
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eab-as'
 nm = 'arm-none-eab-nm'
@@ -20,6 +21,7 @@ endian = 'little'
 [properties]
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt', '-fshort-enums']
 c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v6-m/nofp/', '-Wl,-z,noexecstack']
+cpp_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v6-m/nofp/', '-Wl,-z,noexecstack']
 skip_sanity_check = true
 default_flash_addr = '0x00000000'
 default_flash_size = '0x00400000'

--- a/scripts/cross-clang-thumbv7-a-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7-a-none-eabi.txt
@@ -4,6 +4,7 @@
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
 c = ['clang', '-m32', '-target', 'arm-none-eabihf', '-march=armv7-a', '-mfloat-abi=soft', '-nostdlib']
+cpp = ['clang', '-m32', '-target', 'arm-none-eabihf', '-march=armv7-a', '-mfloat-abi=soft', '-nostdlib']
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eab-as'
 nm = 'arm-none-eab-nm'
@@ -20,6 +21,7 @@ endian = 'little'
 [properties]
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt', '-fshort-enums']
 c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v7-a/nofp/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
+cpp_link_args = ['-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v7-a/nofp/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
 skip_sanity_check = true
 default_flash_addr = '0x00000000'
 default_flash_size = '0x00400000'

--- a/scripts/cross-clang-thumbv7e+dp-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7e+dp-none-eabi.txt
@@ -3,7 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'clang', '-m32', '-target', 'arm-none-eabihf', '-march=armv7em', '-mfloat-abi=hard', '-nostdlib']
+c = ['clang', '-m32', '-target', 'arm-none-eabihf', '-march=armv7em', '-mfloat-abi=hard', '-nostdlib']
+cpp = ['clang', '-m32', '-target', 'arm-none-eabihf', '-march=armv7em', '-mfloat-abi=hard', '-nostdlib']
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eab-as'
 nm = 'arm-none-eab-nm'
@@ -20,6 +21,7 @@ endian = 'little'
 [properties]
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt', '-fshort-enums']
 c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v7e-m+dp/hard/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
+cpp_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v7e-m+dp/hard/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
 skip_sanity_check = true
 default_flash_addr = '0x00000000'
 default_flash_size = '0x00400000'

--- a/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
@@ -3,7 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'clang', '-m32', '-target', 'thumbv7e-none-eabi', '-mcpu=cortex-m7', '-mfloat-abi=hard', '-nostdlib']
+c = ['clang', '-m32', '-target', 'thumbv7e-none-eabi', '-mcpu=cortex-m7', '-mfloat-abi=hard', '-nostdlib']
+cpp = ['clang', '-m32', '-target', 'thumbv7e-none-eabi', '-mcpu=cortex-m7', '-mfloat-abi=hard', '-nostdlib']
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eab-as'
 nm = 'arm-none-eab-nm'
@@ -20,6 +21,7 @@ endian = 'little'
 [properties]
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt', '-fshort-enums']
 c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v7e-m+fp/hard/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
+cpp_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v7e-m+fp/hard/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
 skip_sanity_check = true
 default_flash_addr = '0x00000000'
 default_flash_size = '0x00400000'

--- a/scripts/cross-clang-thumbv7m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7m-none-eabi.txt
@@ -3,8 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'clang', '-m32', '-target', 'thumbv7m-none-eabi', '-mfloat-abi=soft', '-nostdlib']
-cpp = ['ccache', 'clang', '-m32', '-target', 'thumbv7m-none-eabi', '-mfloat-abi=soft', '-nostdlib']
+c = ['clang', '-m32', '-target', 'thumbv7m-none-eabi', '-mfloat-abi=soft', '-nostdlib']
+cpp = ['clang', '-m32', '-target', 'thumbv7m-none-eabi', '-mfloat-abi=soft', '-nostdlib']
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eab-as'
 nm = 'arm-none-eab-nm'

--- a/scripts/cross-clang-x86.txt
+++ b/scripts/cross-clang-x86.txt
@@ -1,0 +1,31 @@
+[binaries]
+# Meson 0.53.2 doesn't use any cflags when doing basic compiler tests,
+# so we have to add -nostdlib to the compiler configuration itself or
+# early compiler tests will fail. This can be removed when picolibc
+# requires at least version 0.54.2 of meson.
+c = ['clang', '-target', 'i686-none-elf', '-march=core2', '-mfpmath=sse', '-msse2', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
+cpp = ['clang', '-target', 'i686-none-elf', '-march=core2', '-mfpmath=sse', '-msse2', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
+c_ld = 'lld'
+cpp_ld = 'lld'
+ar = 'ar'
+as = 'as'
+nm = 'nm'
+strip = 'strip'
+objcopy = 'objcopy'
+# only needed to run tests
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-i386 "$@"', 'run-i386']
+
+[host_machine]
+system='linux'
+cpu_family='x86'
+cpu='x86'
+endian='little'
+
+[properties]
+skip_sanity_check = true
+needs_exe_wrapper = true
+link_spec = '--build-id=none'
+default_flash_addr = '0x00100000'
+default_flash_size = '0x00400000'
+default_ram_addr   = '0x00500000'
+default_ram_size   = '0x00200000'

--- a/scripts/cross-clang-x86_64.txt
+++ b/scripts/cross-clang-x86_64.txt
@@ -1,0 +1,31 @@
+[binaries]
+# Meson 0.53.2 doesn't use any cflags when doing basic compiler tests,
+# so we have to add -nostdlib to the compiler configuration itself or
+# early compiler tests will fail. This can be removed when picolibc
+# requires at least version 0.54.2 of meson.
+c = ['clang', '-target', 'x86_64-none-elf', '-march=core2', '-mfpmath=sse', '-msse2', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
+cpp = ['clang', '-target', 'x86_64-none-elf', '-march=core2', '-mfpmath=sse', '-msse2', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
+c_ld = 'lld'
+cpp_ld = 'lld'
+ar = 'ar'
+as = 'as'
+nm = 'nm'
+strip = 'strip'
+objcopy = 'objcopy'
+# only needed to run tests
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-x86 "$@"', 'run-x86']
+
+[host_machine]
+system='linux'
+cpu_family='x86_64'
+cpu='x86_64'
+endian='little'
+
+[properties]
+skip_sanity_check = true
+needs_exe_wrapper = true
+link_spec = '--build-id=none'
+default_flash_addr = '0x00100000'
+default_flash_size = '0x00400000'
+default_ram_addr   = '0x00500000'
+default_ram_size   = '0x00200000'

--- a/scripts/cross-cortex-a9-none-eabi.txt
+++ b/scripts/cross-cortex-a9-none-eabi.txt
@@ -3,7 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'arm-none-eabi-gcc', '-mcpu=cortex-a9', '-nostdlib']
+c = ['arm-none-eabi-gcc', '-mcpu=cortex-a9', '-nostdlib']
+cpp = ['arm-none-eabi-g++', '-mcpu=cortex-a9', '-nostdlib']
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eabi-as'
 nm = 'arm-none-eabi-nm'

--- a/scripts/cross-i686-linux-gnu.txt
+++ b/scripts/cross-i686-linux-gnu.txt
@@ -3,7 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'i686-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
+c = ['i686-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
+cpp = ['i686-linux-gnu-g++', '-march=core2', '-mfpmath=sse', '-msse2', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
 ar = 'i686-linux-gnu-ar'
 as = 'i686-linux-gnu-as'
 nm = 'i686-linux-gnu-nm'

--- a/scripts/cross-m68k-linux-gnu.txt
+++ b/scripts/cross-m68k-linux-gnu.txt
@@ -1,5 +1,6 @@
 [binaries]
-c = ['ccache', 'm68k-linux-gnu-gcc', '-march=68020', '-static', '-nostdlib']
+c = ['m68k-linux-gnu-gcc', '-march=68020', '-static', '-nostdlib', '-Wl,--build-id=none']
+cpp = ['m68k-linux-gnu-g++', '-march=68020', '-static', '-nostdlib', '-Wl,--build-id=none']
 ar = 'm68k-linux-gnu-ar'
 as = 'm68k-linux-gnu-as'
 ld = 'm68k-linux-gnu-ld'

--- a/scripts/cross-m68k-unknown-elf.txt
+++ b/scripts/cross-m68k-unknown-elf.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = ['ccache', 'm68k-unknown-elf-gcc', '-static', '-nostdlib', '-fno-builtin-isinfl']
+c = ['m68k-unknown-elf-gcc', '-static', '-nostdlib', '-fno-builtin-isinfl']
 ar = 'm68k-unknown-elf-ar'
 as = 'm68k-unknown-elf-as'
 ld = 'm68k-unknown-elf-ld'

--- a/scripts/cross-microblazeel-zephyr-elf.txt
+++ b/scripts/cross-microblazeel-zephyr-elf.txt
@@ -3,7 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'microblazeel-zephyr-elf-gcc', '-nostdlib']
+c = ['microblazeel-zephyr-elf-gcc', '-nostdlib']
+cpp = ['microblazeel-zephyr-elf-g++', '-nostdlib']
 ar = 'microblazeel-zephyr-elf-ar'
 as = 'microblazeel-zephyr-elf-as'
 ld = 'microblazeel-zephyr-elf-ld'

--- a/scripts/cross-mips-linux-gnu.txt
+++ b/scripts/cross-mips-linux-gnu.txt
@@ -3,7 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'mips-linux-gnu-gcc', '-nostdlib']
+c = ['mips-linux-gnu-gcc', '-nostdlib', '-Wl,--build-id=none']
+cpp = ['mips-linux-gnu-g++', '-nostdlib', '-Wl,--build-id=none']
 ar = 'mips-linux-gnu-ar'
 as = 'mips-linux-gnu-as'
 ld = 'mips-linux-gnu-ld'

--- a/scripts/cross-mips-zephyr-elf.txt
+++ b/scripts/cross-mips-zephyr-elf.txt
@@ -3,7 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'mips-zephyr-elf-gcc', '-nostdlib', '-G0']
+c = ['mips-zephyr-elf-gcc', '-nostdlib', '-G0']
+cpp = ['mips-zephyr-elf-g++', '-nostdlib', '-G0']
 ar = 'mips-zephyr-elf-ar'
 as = 'mips-zephyr-elf-as'
 nm = 'mips-zephyr-elf-nm'

--- a/scripts/cross-mips64-linux-gnuabi64.txt
+++ b/scripts/cross-mips64-linux-gnuabi64.txt
@@ -3,7 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'mips64-linux-gnuabi64-gcc', '-nostdlib']
+c = ['mips64-linux-gnuabi64-gcc', '-nostdlib']
+cpp = ['mips64-linux-gnuabi64-g++', '-nostdlib']
 ar = 'mips64-linux-gnuabi64-ar'
 as = 'mips64-linux-gnuabi64-as'
 ld = 'mips64-linux-gnuabi64-ld'

--- a/scripts/cross-mipsel-linux-gnu.txt
+++ b/scripts/cross-mipsel-linux-gnu.txt
@@ -3,7 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'mipsel-linux-gnu-gcc', '-nostdlib']
+c = ['mipsel-linux-gnu-gcc', '-nostdlib']
+cpp = ['mipsel-linux-gnu-g++', '-nostdlib']
 ar = 'mipsel-linux-gnu-ar'
 as = 'mipsel-linux-gnu-as'
 ld = 'mipsel-linux-gnu-ld'

--- a/scripts/cross-msp430-unknown-elf.txt
+++ b/scripts/cross-msp430-unknown-elf.txt
@@ -3,7 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'msp430-unknown-elf-gcc', '-nostdlib', '-mlarge', '-mdata-region=none']
+c = ['msp430-unknown-elf-gcc', '-nostdlib', '-mlarge', '-mdata-region=none']
+cpp = ['msp430-unknown-elf-g++', '-nostdlib', '-mlarge', '-mdata-region=none']
 ar = 'msp430-unknown-elf-ar'
 as = 'msp430-unknown-elf-as'
 nm = 'msp430-unknown-elf-nm'

--- a/scripts/cross-msp430.txt
+++ b/scripts/cross-msp430.txt
@@ -3,7 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'msp430-elf-gcc', '-nostdlib']
+c = ['msp430-elf-gcc', '-nostdlib']
+cpp = ['msp430-elf-g++', '-nostdlib']
 ar = 'msp430-elf-ar'
 as = 'msp430-elf-as'
 nm = 'msp430-elf-nm'

--- a/scripts/cross-nios2-zephyr-elf.txt
+++ b/scripts/cross-nios2-zephyr-elf.txt
@@ -3,7 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'nios2-zephyr-elf-gcc', '-nostdlib', '-fno-pic', '-fno-pie', '--param=min-pagesize=0', '-mgpopt=global']
+c = ['nios2-zephyr-elf-gcc', '-nostdlib', '-fno-pic', '-fno-pie', '--param=min-pagesize=0', '-mgpopt=global']
+cpp = ['nios2-zephyr-elf-g++', '-nostdlib', '-fno-pic', '-fno-pie', '--param=min-pagesize=0', '-mgpopt=global']
 ar = 'nios2-zephyr-elf-ar'
 as = 'nios2-zephyr-elf-as'
 nm = 'nios2-zephyr-elf-nm'

--- a/scripts/cross-power9-fp128.txt
+++ b/scripts/cross-power9-fp128.txt
@@ -1,5 +1,6 @@
 [binaries]
-c = ['ccache', 'powerpc64-linux-gnu-gcc', '-fno-pic', '-fno-pie', '-static', '-mabi=ieeelongdouble', '-mlong-double-128', '-mfloat128-hardware', '-mvsx', '-mfloat128', '-mpower9-vector', '-mcpu=power9', '-Wno-psabi']
+c = ['powerpc64-linux-gnu-gcc', '-fno-pic', '-fno-pie', '-static', '-mabi=ieeelongdouble', '-mlong-double-128', '-mfloat128-hardware', '-mvsx', '-mfloat128', '-mcpu=power9', '-Wno-psabi', '-Wl,--build=id=none']
+cpp = ['powerpc64-linux-gnu-g++', '-fno-pic', '-fno-pie', '-static', '-mabi=ieeelongdouble', '-mlong-double-128', '-mfloat128-hardware', '-mvsx', '-mfloat128', '-mcpu=power9', '-Wno-psabi', '-Wl,--build=id=none']
 ar = 'powerpc64-linux-gnu-ar'
 nm = 'powerpc64-linux-gnu-nm'
 strip = 'powerpc64-linux-gnu-strip'

--- a/scripts/cross-power9.txt
+++ b/scripts/cross-power9.txt
@@ -1,5 +1,6 @@
 [binaries]
-c = ['ccache', 'powerpc64-linux-gnu-gcc', '-fno-pic', '-fno-pie', '-static', '-mfloat128-hardware', '-mvsx', '-mpower9-vector', '-mcpu=power9', '-Wno-psabi']
+c = ['powerpc64-linux-gnu-gcc', '-fno-pic', '-fno-pie', '-static', '-mfloat128-hardware', '-mvsx', '-mcpu=power9', '-Wno-psabi']
+cpp = ['powerpc64-linux-gnu-g++', '-fno-pic', '-fno-pie', '-static', '-mfloat128-hardware', '-mvsx', '-mcpu=power9', '-Wno-psabi']
 ar = 'powerpc64-linux-gnu-ar'
 nm = 'powerpc64-linux-gnu-nm'
 strip = 'powerpc64-linux-gnu-strip'

--- a/scripts/cross-powerpc64-linux-gnu.txt
+++ b/scripts/cross-powerpc64-linux-gnu.txt
@@ -1,5 +1,6 @@
 [binaries]
-c = ['ccache', 'powerpc64-linux-gnu-gcc', '-fno-pic', '-static']
+c = ['powerpc64-linux-gnu-gcc', '-fno-pic', '-static']
+cpp = ['powerpc64-linux-gnu-g++', '-fno-pic', '-static']
 ar = 'powerpc64-linux-gnu-ar'
 nm = 'powerpc64-linux-gnu-nm'
 strip = 'powerpc64-linux-gnu-strip'

--- a/scripts/cross-powerpc64le-linux-gnu.txt
+++ b/scripts/cross-powerpc64le-linux-gnu.txt
@@ -1,5 +1,6 @@
 [binaries]
-c = ['ccache', 'powerpc64le-linux-gnu-gcc', '-fno-pic', '-static']
+c = ['powerpc64le-linux-gnu-gcc', '-fno-pic', '-static']
+cpp = ['powerpc64le-linux-gnu-g++', '-fno-pic', '-static']
 ar = 'powerpc64le-linux-gnu-ar'
 as = 'powerpc64le-linux-gnu-as'
 nm = 'powerpc64le-linux-gnu-nm'

--- a/scripts/cross-riscv64-unknown-elf.txt
+++ b/scripts/cross-riscv64-unknown-elf.txt
@@ -3,8 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'riscv64-unknown-elf-gcc', '-nostdlib']
-cpp = ['ccache', 'riscv64-unknown-elf-g++', '-nostdlib']
+c = ['riscv64-unknown-elf-gcc', '-nostdlib']
+cpp = ['riscv64-unknown-elf-g++', '-nostdlib']
 ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'
 strip = 'riscv64-unknown-elf-strip'

--- a/scripts/cross-riscv64-zephyr-elf.txt
+++ b/scripts/cross-riscv64-zephyr-elf.txt
@@ -3,7 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'riscv64-zephyr-elf-gcc', '-nostdlib']
+c = ['riscv64-zephyr-elf-gcc', '-nostdlib']
+cpp = ['riscv64-zephyr-elf-g++', '-nostdlib']
 ar = 'riscv64-zephyr-elf-ar'
 as = 'riscv64-zephyr-elf-as'
 nm = 'riscv64-zephyr-elf-nm'

--- a/scripts/cross-rv32imac.txt
+++ b/scripts/cross-rv32imac.txt
@@ -1,5 +1,6 @@
 [binaries]
-c = ['ccache', 'riscv64-unknown-elf-gcc', '-nostdlib']
+c = ['riscv64-unknown-elf-gcc', '-nostdlib']
+cpp = ['riscv64-unknown-elf-g++', '-nostdlib']
 ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'
 nm = 'riscv64-unknown-elf-nm'
@@ -15,7 +16,9 @@ endian = 'little'
 
 [properties]
 c_args = ['-msave-restore', '-fshort-enums', '-march=rv32imac', '-mabi=ilp32']
+cpp_args = ['-msave-restore', '-fshort-enums', '-march=rv32imac', '-mabi=ilp32']
 c_link_args = ['-msave-restore', '-fshort-enums', '-march=rv32imac', '-mabi=ilp32']
+cpp_link_args = ['-msave-restore', '-fshort-enums', '-march=rv32imac', '-mabi=ilp32']
 skip_sanity_check = true
 default_flash_addr = '0x80000000'
 default_flash_size = '0x00200000'

--- a/scripts/cross-rv32imac_zicsr_zbb.txt
+++ b/scripts/cross-rv32imac_zicsr_zbb.txt
@@ -1,5 +1,6 @@
 [binaries]
-c = ['ccache', 'riscv64-unknown-elf-gcc', '-nostdlib']
+c = ['riscv64-unknown-elf-gcc', '-nostdlib']
+cpp = ['riscv64-unknown-elf-g++', '-nostdlib']
 ar = 'riscv64-unknown-elf-ar'
 as = 'riscv64-unknown-elf-as'
 nm = 'riscv64-unknown-elf-nm'
@@ -15,7 +16,9 @@ endian = 'little'
 
 [properties]
 c_args = ['-msave-restore', '-fshort-enums', '-march=rv32imac_zicsr_zbb', '-mabi=ilp32']
+cpp_args = ['-msave-restore', '-fshort-enums', '-march=rv32imac_zicsr_zbb', '-mabi=ilp32']
 c_link_args = ['-msave-restore', '-fshort-enums', '-march=rv32imac_zicsr_zbb', '-mabi=ilp32']
+cpp_link_args = ['-msave-restore', '-fshort-enums', '-march=rv32imac_zicsr_zbb', '-mabi=ilp32']
 skip_sanity_check = true
 default_flash_addr = '0x80000000'
 default_flash_size = '0x00200000'

--- a/scripts/cross-sh-unknown-elf.txt
+++ b/scripts/cross-sh-unknown-elf.txt
@@ -3,7 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'sh-unknown-elf-gcc', '-nostdlib']
+c = ['sh-unknown-elf-gcc', '-nostdlib']
+cpp = ['sh-unknown-elf-g++', '-nostdlib']
 ar = 'sh-unknown-elf-ar'
 as = 'sh-unknown-elf-as'
 nm = 'sh-unknown-elf-nm'

--- a/scripts/cross-sparc-zephyr-elf.txt
+++ b/scripts/cross-sparc-zephyr-elf.txt
@@ -3,7 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'sparc-zephyr-elf-gcc', '-msoft-float', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
+c = ['sparc-zephyr-elf-gcc', '-msoft-float', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
+cpp = ['sparc-zephyr-elf-g++', '-msoft-float', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
 ar = 'sparc-zephyr-elf-ar'
 as = 'sparc-zephyr-elf-as'
 nm = 'sparc-zephyr-elf-nm'

--- a/scripts/cross-sparc64-linux-gnu.txt
+++ b/scripts/cross-sparc64-linux-gnu.txt
@@ -3,7 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'sparc64-linux-gnu-gcc', '-nostdlib']
+c = ['sparc64-linux-gnu-gcc', '-nostdlib']
+cpp = ['sparc64-linux-gnu-g++', '-nostdlib']
 ar = 'sparc64-linux-gnu-ar'
 as = 'sparc64-linux-gnu-as'
 ld = 'sparc64-linux-gnu-ld'

--- a/scripts/cross-thumbv8_1m-none-eabi.txt
+++ b/scripts/cross-thumbv8_1m-none-eabi.txt
@@ -3,7 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'arm-none-eabi-gcc', '-nostdlib', '-mthumb', '-march=armv8.1-m.main+mve', '-mfloat-abi=hard']
+c = ['arm-none-eabi-gcc', '-nostdlib', '-mthumb', '-march=armv8.1-m.main+mve', '-mfloat-abi=hard']
+cpp = ['arm-none-eabi-g++', '-nostdlib', '-mthumb', '-march=armv8.1-m.main+mve', '-mfloat-abi=hard']
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eabi-as'
 nm = 'arm-none-eabi-nm'

--- a/scripts/cross-thumbv8m_main_fp-none-eabi.txt
+++ b/scripts/cross-thumbv8m_main_fp-none-eabi.txt
@@ -3,7 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'arm-none-eabi-gcc', '-nostdlib', '-mthumb', '-march=armv8-m.main+fp', '-mfloat-abi=hard']
+c = ['arm-none-eabi-gcc', '-nostdlib', '-mthumb', '-march=armv8-m.main+fp', '-mfloat-abi=hard']
+cpp = ['arm-none-eabi-g++', '-nostdlib', '-mthumb', '-march=armv8-m.main+fp', '-mfloat-abi=hard']
 ar = 'arm-none-eabi-ar'
 as = 'arm-none-eabi-as'
 nm = 'arm-none-eabi-nm'

--- a/scripts/cross-x86-linux-gnu.txt
+++ b/scripts/cross-x86-linux-gnu.txt
@@ -3,7 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'x86_64-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
+c = ['x86_64-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
+cpp = ['x86_64-linux-gnu-g++', '-march=core2', '-mfpmath=sse', '-msse2', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
 ar = 'x86_64-linux-gnu-ar'
 as = 'x86_64-linux-gnu-as'
 nm = 'x86_64-linux-gnu-nm'

--- a/scripts/cross-x86_64-linux-gnu.txt
+++ b/scripts/cross-x86_64-linux-gnu.txt
@@ -3,7 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'x86_64-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
+c = ['x86_64-linux-gnu-gcc', '-march=core2', '-mfpmath=sse', '-msse2', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
+cpp = ['x86_64-linux-gnu-g++', '-march=core2', '-mfpmath=sse', '-msse2', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
 ar = 'x86_64-linux-gnu-ar'
 as = 'x86_64-linux-gnu-as'
 nm = 'x86_64-linux-gnu-nm'

--- a/scripts/cross-x86_64-zephyr-elf.txt
+++ b/scripts/cross-x86_64-zephyr-elf.txt
@@ -3,7 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'x86_64-zephyr-elf-gcc', '-m32', '-msoft-float', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
+c = ['x86_64-zephyr-elf-gcc', '-m32', '-msoft-float', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
+cpp = ['x86_64-zephyr-elf-g++', '-m32', '-msoft-float', '-fno-pic', '-fno-PIE', '-static', '-nostdlib']
 ar = 'x86_64-zephyr-elf-ar'
 as = 'x86_64-zephyr-elf-as'
 nm = 'x86_64-zephyr-elf-nm'

--- a/scripts/cross-xtensa-esp32-elf.txt
+++ b/scripts/cross-xtensa-esp32-elf.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = ['ccache', 'xtensa-esp32-elf-gcc']
+c = ['xtensa-esp32-elf-gcc']
 ar = 'xtensa-esp32-elf-ar'
 as = 'xtensa-esp32-elf-as'
 nm = 'xtensa-esp32-elf-nm'

--- a/scripts/cross-xtensa-espressif_esp32_zephyr-elf.txt
+++ b/scripts/cross-xtensa-espressif_esp32_zephyr-elf.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'xtensa-espressif_esp32_zephyr-elf-gcc', '-nostdlib']
+c = ['xtensa-espressif_esp32_zephyr-elf-gcc', '-nostdlib']
 ar = 'xtensa-espressif_esp32_zephyr-elf-ar'
 as = 'xtensa-espressif_esp32_zephyr-elf-as'
 nm = 'xtensa-espressif_esp32_zephyr-elf-nm'

--- a/scripts/cross-xtensa-espressif_esp32s2_zephyr-elf.txt
+++ b/scripts/cross-xtensa-espressif_esp32s2_zephyr-elf.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'xtensa-espressif_esp32s2_zephyr-elf-gcc', '-nostdlib']
+c = ['xtensa-espressif_esp32s2_zephyr-elf-gcc', '-nostdlib']
 ar = 'xtensa-espressif_esp32s2_zephyr-elf-ar'
 as = 'xtensa-espressif_esp32s2_zephyr-elf-as'
 nm = 'xtensa-espressif_esp32s2_zephyr-elf-nm'

--- a/scripts/cross-xtensa-intel_apl_adsp_zephyr-elf.txt
+++ b/scripts/cross-xtensa-intel_apl_adsp_zephyr-elf.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'xtensa-intel_apl_adsp_zephyr-elf-gcc', '-nostdlib']
+c = ['xtensa-intel_apl_adsp_zephyr-elf-gcc', '-nostdlib']
 ar = 'xtensa-intel_apl_adsp_zephyr-elf-ar'
 as = 'xtensa-intel_apl_adsp_zephyr-elf-as'
 nm = 'xtensa-intel_apl_adsp_zephyr-elf-nm'

--- a/scripts/cross-xtensa-intel_s1000_zephyr-elf.txt
+++ b/scripts/cross-xtensa-intel_s1000_zephyr-elf.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'xtensa-intel_s1000_zephyr-elf-gcc', '-nostdlib']
+c = ['xtensa-intel_s1000_zephyr-elf-gcc', '-nostdlib']
 ar = 'xtensa-intel_s1000_zephyr-elf-ar'
 as = 'xtensa-intel_s1000_zephyr-elf-as'
 nm = 'xtensa-intel_s1000_zephyr-elf-nm'

--- a/scripts/cross-xtensa-lx106-elf.txt
+++ b/scripts/cross-xtensa-lx106-elf.txt
@@ -1,5 +1,5 @@
 [binaries]
-c = ['ccache', 'xtensa-lx106-elf-gcc']
+c = ['xtensa-lx106-elf-gcc']
 ar = 'xtensa-lx106-elf-ar'
 as = 'xtensa-lx106-elf-as'
 nm = 'xtensa-lx106-elf-nm'

--- a/scripts/cross-xtensa-nxp_imx8m_adsp_zephyr-elf.txt
+++ b/scripts/cross-xtensa-nxp_imx8m_adsp_zephyr-elf.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'xtensa-nxp_imx8m_adsp_zephyr-elf-gcc', '-nostdlib']
+c = ['xtensa-nxp_imx8m_adsp_zephyr-elf-gcc', '-nostdlib']
 ar = 'xtensa-nxp_imx8m_adsp_zephyr-elf-ar'
 as = 'xtensa-nxp_imx8m_adsp_zephyr-elf-as'
 nm = 'xtensa-nxp_imx8m_adsp_zephyr-elf-nm'

--- a/scripts/cross-xtensa-nxp_imx_adsp_zephyr-elf.txt
+++ b/scripts/cross-xtensa-nxp_imx_adsp_zephyr-elf.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'xtensa-nxp_imx_adsp_zephyr-elf-gcc', '-nostdlib']
+c = ['xtensa-nxp_imx_adsp_zephyr-elf-gcc', '-nostdlib']
 ar = 'xtensa-nxp_imx_adsp_zephyr-elf-ar'
 as = 'xtensa-nxp_imx_adsp_zephyr-elf-as'
 nm = 'xtensa-nxp_imx_adsp_zephyr-elf-nm'

--- a/scripts/cross-xtensa-sample_controller_zephyr-elf.txt
+++ b/scripts/cross-xtensa-sample_controller_zephyr-elf.txt
@@ -3,7 +3,7 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'xtensa-sample_controller_zephyr-elf-gcc', '-nostdlib']
+c = ['xtensa-sample_controller_zephyr-elf-gcc', '-nostdlib']
 ar = 'xtensa-sample_controller_zephyr-elf-ar'
 as = 'xtensa-sample_controller_zephyr-elf-as'
 nm = 'xtensa-sample_controller_zephyr-elf-nm'

--- a/scripts/do-clang-x86-configure
+++ b/scripts/do-clang-x86-configure
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2024 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+exec "$(dirname "$0")"/do-configure clang-x86 -Dtests=true -Dtests-enable-posix-io=false -Dmultilib=false "$@"

--- a/scripts/do-clang-x86_64-configure
+++ b/scripts/do-clang-x86_64-configure
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2024 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+exec "$(dirname "$0")"/do-configure clang-x86_64 -Dtests=true -Dtests-enable-posix-io=false -Dmultilib=false "$@"

--- a/scripts/run-power9
+++ b/scripts/run-power9
@@ -65,6 +65,6 @@ mon=none
 	-serial none \
 	-device isa-serial,chardev=s1 \
 	-chardev stdio,id=s1 \
-	-machine powernv,accel=tcg \
+	-machine powernv9,accel=tcg \
 	-kernel "$one_elf" \
 	-nographic "$@" < /dev/null

--- a/semihost/machine/x86/bios.S
+++ b/semihost/machine/x86/bios.S
@@ -35,9 +35,11 @@
 #include <picolibc.h>
 
 	.text
+	.globl _start
+	.code16
 __bios:	
 	.space	0xfff0
-	.code16
+_start:
 	ljmp	$0xffff,$0x0010
 	.space	0xb
 __bios_end:

--- a/semihost/machine/x86/bios.ld
+++ b/semihost/machine/x86/bios.ld
@@ -1,6 +1,6 @@
 MEMORY
 {
-	bios (rxai!w) : ORIGIN = 0xffff0000, LENGTH = 0x10000
+	bios (rx!w) : ORIGIN = 0xffff0000, LENGTH = 0x10000
 }
 
 PHDRS
@@ -12,8 +12,4 @@ SECTIONS {
 	.text : {
 		*(.text*)
 	} >bios AT>bios :text
-
-	/DISCARD/ : {
-		*(*)
-	}
 }

--- a/semihost/machine/x86/meson.build
+++ b/semihost/machine/x86/meson.build
@@ -79,6 +79,7 @@ if objcopy.found()
   bios = executable('bios', 'bios.S',
 		    c_args: ['-m32'] + c_args,
                     include_directories: inc,
+                    link_depends: [bios_ld],
 		    link_args: ['-nostdlib', '-m32', '-Wl,--build-id=none', '-T', bios_ld])
 
   bios_bin = custom_target('bios.bin',
@@ -87,6 +88,6 @@ if objcopy.found()
 		           install: true,
 		           install_dir: instdir,
 		           output: 'bios.bin',
-		           command: [objcopy, '-O', 'binary', '@INPUT@', '@OUTPUT@'])
+		           command: [objcopy, '-O', 'binary', '--only-section=.text', '@INPUT@', '@OUTPUT@'])
 endif
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -559,6 +559,7 @@ foreach target : targets
 		  include_directories: inc),
        depends: bios_bin,
        timeout: 120,
+       priority: -1,
        env: test_env)
 
   t1 = 'test-long-long'
@@ -577,6 +578,7 @@ foreach target : targets
 		  include_directories: inc),
        depends: bios_bin,
        timeout: 120,
+       priority: -1,
        env: test_env)
 
   plain_tests = ['rand', 'regex', 'ungetc', 'fenv',

--- a/test/test-cplusplus.cpp
+++ b/test/test-cplusplus.cpp
@@ -145,9 +145,13 @@
 #include <wctype.h>
 #include <wordexp.h>
 
-extern "C" { int main(void); }
+extern "C" {
 
-int main() {
+int main(void);
+
+int main(void) {
 	printf("Hello, world!\n");
 	return 0;
+}
+
 }

--- a/test/test-cplusplus.cpp
+++ b/test/test-cplusplus.cpp
@@ -145,6 +145,12 @@
 #include <wctype.h>
 #include <wordexp.h>
 
+#ifdef __clang__
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#pragma GCC diagnostic ignored "-Wmain"
+#endif
+
 extern "C" {
 
 int main(void);


### PR DESCRIPTION
lld does not fully support the GNU linker command language.

It doens't allow discarding of arbitrary elf sections, including .shstrtab. Work around this by using objcopy to extract only the bits we need rather than trying to get the linker to only emit those sections.
    
Change the flags on the bios section from (rxai!w) to just (rx!w).
    
Eliminate an lld warning by marking the bios entry point.

Add sample scripts for x86 and x86_64 using clang and then run those in CI.