### PR TITLE
cmake: Use non-common symbol for 'alias' attribute check.

### DIFF
--- a/cmake/have-alias-attribute.c
+++ b/cmake/have-alias-attribute.c
@@ -1,2 +1,2 @@
-int x;
+int x = 10;
 extern int aliasx __attribute__((__alias__("x")));

--- a/meson.build
+++ b/meson.build
@@ -542,7 +542,12 @@ if sysroot_install
     if not get_option('sysroot-install-skip-checks')
       error('sysroot install requested, but compiler has no sysroot')
     endif
+    # The default value of GCC_EXEC_PREFIX is "prefix/lib/gcc/"
+    # Since toolchain may be moved and to another directory, let's get actual path using "gcc -print-search-dirs"
+    # Note that the "install path" obtained with this command points to the "$GCC_EXEC_PREFIX/$ARCH/$GCC-VERSION"
+    # That's why obtained path appended with '../../'
     sysroot = run_command(cc.cmd_array() + ['-print-search-dirs'], check : true).stdout().split('\n')[0].split(' ')[1]
+    sysroot += '../../'
     specs_prefix_format_format = '%:getenv(GCC_EXEC_PREFIX @0@)'
     specs_prefix_format_default = '%:getenv(GCC_EXEC_PREFIX ../../@0@)'
   endif

--- a/newlib/libc/tinystdio/vfscanf.c
+++ b/newlib/libc/tinystdio/vfscanf.c
@@ -853,6 +853,8 @@ int vfscanf (FILE * stream, const CHAR *fmt, va_list ap_orig)
     return nconvs ? nconvs : EOF;
 }
 
+#undef ap
+
 #if defined(_FORMAT_DEFAULT_DOUBLE) && !defined(vfscanf)
 #ifdef _HAVE_ALIAS_ATTRIBUTE
 __strong_reference(vfscanf, __d_vfscanf);


### PR DESCRIPTION
common symbols cannot be aliased using the 'alias' attribute, so compilers which don't use -fno-common by default would complain when the have-alias-attribute.c check is build as that used a bare 'int x;' definition. Change that to an initialized value so that it is never a common symbol.

This series also includes a fix for the backwards-compatibility path in vfscanf which is triggered when the alias attribute is not supported.