### PR TITLE
zephyr: adopt to Zephyr c_library linker property

### DIFF
--- a/zephyr/zephyr.cmake
+++ b/zephyr/zephyr.cmake
@@ -101,18 +101,16 @@ if(CONFIG_PICOLIBC_USE_MODULE)
   # Fetch zephyr compile flags from interface
   get_property(PICOLIBC_EXTRA_COMPILE_OPTIONS TARGET zephyr_interface PROPERTY INTERFACE_COMPILE_OPTIONS)
 
-  # Enable POSIX APIs
-
-  # Link to C library and libgcc (on non-armclang toolchains)
-
-  if(${ZEPHYR_TOOLCHAIN_VARIANT} STREQUAL "armclang")
-    zephyr_link_libraries(c)
-  else()
-    zephyr_link_libraries(c -lgcc)
-  endif()
+  # Tell Zephyr about the module built picolibc library to link against.
+  # We need to construct the absolute path to picolibc in same fashion as CMake
+  # defines the library file name and location, because a generator expression
+  # cannot be used as the CMake linker rule definition doesn't supports them.
+  set_property(TARGET linker PROPERTY c_library
+      ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}c${CMAKE_STATIC_LIBRARY_SUFFIX}
+  )
+  zephyr_system_include_directories($<TARGET_PROPERTY:c,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>)
 
   # Provide an alias target for zephyr to use
-
   add_custom_target(PicolibcBuild)
   add_dependencies(PicolibcBuild c)
 endif()


### PR DESCRIPTION
Adopt Picolibc C library linking to use Zephyr's c_library linker target property.

The current use of `zephyr_link_libraries(c)` are vulnerable to both symbol deduplication and the risk that the C library may not be linked as the final libraries.

For example if an application creates a regular CMake library like this:
  find_package(Zephyr)
  add_library(foo STATIC bar.c)
  target_link_libraries(app foo)

then `foo` does not (and should not) know about which C library to link against. `foo` should just expect a C library to be available.

Unfortunately, the existing code of
  zephyr_link_libraries(c)

can result in a final link invocation like this:
  <linker> -lapp -lc -lfoo

because `foo` has not explicitly been linked with `c` (only app has).

Zephyr has improved its C library linking by specifying the CMake linker rule. To support late C library definition, then Zephyr provides a c_library linker property.

This allows Picolibc to set the c_library property which again ensures correct linking of Picolibc when built as a module. In the above example, the following link order is guaranteed:
  <linker> -lapp -lfoo -lc

even when `foo` is not explicitly linking to `c`.