### PR TITLE
include: Check C++ (and C) version before using thread_local

### DIFF
--- a/newlib/libc/include/sys/config.h
+++ b/newlib/libc/include/sys/config.h
@@ -273,7 +273,8 @@ SUCH DAMAGE.
 #endif
 
 #ifdef PICOLIBC_TLS
-#ifdef __cplusplus
+#if (defined(__cplusplus) && (__cplusplus) >= 201103L) ||       \
+    (defined(__STDC_VERSION__) && (__STDC_VERSION__) >= 202311L)
 #define NEWLIB_THREAD_LOCAL thread_local
 #elif defined(__STDC_VERSION__) && (__STDC_VERSION__) >= 201112L
 #define NEWLIB_THREAD_LOCAL _Thread_local


### PR DESCRIPTION
C++11 and C23 both use the 'thread_local' keyword. It's not a macro defined in a header file for C anymore.