### PR TITLE
Align AArch64 vector table to 2048 bytes

### DIFF
--- a/newlib/libc/picolib/machine/aarch64/interrupt.c
+++ b/newlib/libc/picolib/machine/aarch64/interrupt.c
@@ -66,7 +66,7 @@ vector(fiq);
 void
 __weak_vector_table(void);
 
-void __section(".text.init.enter") __attribute__((aligned(1024)))
+void __section(".text.init.enter") __attribute__((aligned(2048)))
 __weak_vector_table(void)
 {
 	/*


### PR DESCRIPTION
The bottom 11 bits of VBAR_ELx are reserved, so the vector table must be 2048 bytes aligned, not just 1024 byte.