### PR TITLE
Add -Werror=implicit-fallthrough=5 compiler flag

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -826,6 +826,8 @@ common_warnings = [
   '-Wno-unused-command-line-argument',
   '-Wmissing-prototypes',
   '-Wmissing-declarations',
+  '-Werror=implicit-fallthrough=5',
+  '-Werror=unreachable-code-fallthrough',
 ]
 if get_option('analyzer')
   common_warnings += [

--- a/newlib/libc/picolib/machine/aarch64/interrupt.c
+++ b/newlib/libc/picolib/machine/aarch64/interrupt.c
@@ -66,7 +66,7 @@ vector(fiq);
 void
 __weak_vector_table(void);
 
-void __section(".text.init.enter") __attribute__((aligned(1024)))
+void __section(".text.init.enter") __attribute__((aligned(2048)))
 __weak_vector_table(void)
 {
 	/*

--- a/newlib/libc/stdio/vfscanf.c
+++ b/newlib/libc/stdio/vfscanf.c
@@ -1576,7 +1576,7 @@ _SVFSCANF (
 			}
 		      goto fskip;
 		    }
-		  /* Fall through.  */
+                  __PICOLIBC_FALLTHROUGH;
 		case '1':
 		case '2':
 		case '3':

--- a/newlib/libc/stdio/vfwscanf.c
+++ b/newlib/libc/stdio/vfwscanf.c
@@ -1330,7 +1330,7 @@ _SVFWSCANF (
 			}
 		      goto fskip;
 		    }
-		  /* Fall through.  */
+                  __PICOLIBC_FALLTHROUGH;
 		case L'1':
 		case L'2':
 		case L'3':

--- a/newlib/libc/time/strftime.c
+++ b/newlib/libc/time/strftime.c
@@ -1026,7 +1026,7 @@ recurse:
 		break;
 	    }
 #endif /* _WANT_C99_TIME_FORMATS */
-	  /*FALLTHRU*/
+	  __PICOLIBC_FALLTHROUGH;
 	case CQ('k'):	/* newlib extension */
 	  len = t_snprintf (&s[count], maxsize - count,
 			  *format == CQ('k') ? CQ("%2d") : CQ("%.2d"),
@@ -1036,7 +1036,7 @@ recurse:
 	case CQ('l'):	/* newlib extension */
 	  if (alt == CQ('O'))
 	    alt = CQ('\0');
-	  /*FALLTHRU*/
+	  __PICOLIBC_FALLTHROUGH;
 	case CQ('I'):
 	  {
 	    register int  h12;

--- a/newlib/libm/ld/ld80/e_lgammal_r.c
+++ b/newlib/libm/ld/ld80/e_lgammal_r.c
@@ -391,15 +391,19 @@ lgammal_r(long double x, int *signgamp)
       switch (i)
 	{
 	case 7:
-	  z *= (y + 6.0L);	/* FALLTHRU */
+	  z *= (y + 6.0L);
+          __PICOLIBC_FALLTHROUGH;
 	case 6:
-	  z *= (y + 5.0L);	/* FALLTHRU */
+	  z *= (y + 5.0L);
+          __PICOLIBC_FALLTHROUGH;
 	case 5:
-	  z *= (y + 4.0L);	/* FALLTHRU */
+	  z *= (y + 4.0L);
+          __PICOLIBC_FALLTHROUGH;
 	case 4:
-	  z *= (y + 3.0L);	/* FALLTHRU */
+	  z *= (y + 3.0L);
+          __PICOLIBC_FALLTHROUGH;
 	case 3:
-	  z *= (y + 2.0L);	/* FALLTHRU */
+	  z *= (y + 2.0L);
 	  r += logl (z);
 	  break;
 	}

--- a/newlib/libm/math/sr_lgamma.c
+++ b/newlib/libm/math/sr_lgamma.c
@@ -320,15 +320,19 @@ __math_lgamma_r(__float64 x, int *signgamp, int *divzero)
         z = one; /* lgamma(1+s) = log(s) + lgamma(s) */
         switch (i) {
         case 7:
-            z *= (y + 6.0); /* FALLTHRU */
+            z *= (y + 6.0);
+	  __PICOLIBC_FALLTHROUGH;
         case 6:
-            z *= (y + 5.0); /* FALLTHRU */
+            z *= (y + 5.0);
+	  __PICOLIBC_FALLTHROUGH;
         case 5:
-            z *= (y + 4.0); /* FALLTHRU */
+            z *= (y + 4.0);
+	  __PICOLIBC_FALLTHROUGH;
         case 4:
-            z *= (y + 3.0); /* FALLTHRU */
+            z *= (y + 3.0);
+	  __PICOLIBC_FALLTHROUGH;
         case 3:
-            z *= (y + 2.0); /* FALLTHRU */
+            z *= (y + 2.0);
             r += log64(z);
             break;
         }

--- a/newlib/libm/math/srf_lgamma.c
+++ b/newlib/libm/math/srf_lgamma.c
@@ -252,15 +252,19 @@ __math_lgammaf_r(float x, int *signgamp, int *divzero)
         z = one; /* lgamma(1+s) = log(s) + lgamma(s) */
         switch (i) {
         case 7:
-            z *= (y + (float)6.0); /* FALLTHRU */
+            z *= (y + (float)6.0);
+	  __PICOLIBC_FALLTHROUGH;
         case 6:
-            z *= (y + (float)5.0); /* FALLTHRU */
+            z *= (y + (float)5.0);
+	  __PICOLIBC_FALLTHROUGH;
         case 5:
-            z *= (y + (float)4.0); /* FALLTHRU */
+            z *= (y + (float)4.0);
+	  __PICOLIBC_FALLTHROUGH;
         case 4:
-            z *= (y + (float)3.0); /* FALLTHRU */
+            z *= (y + (float)3.0);
+	  __PICOLIBC_FALLTHROUGH;
         case 3:
-            z *= (y + (float)2.0); /* FALLTHRU */
+            z *= (y + (float)2.0);
             r += logf(z);
             break;
         }

--- a/scripts/cross-clang-thumb-none-eabi.txt
+++ b/scripts/cross-clang-thumb-none-eabi.txt
@@ -20,8 +20,8 @@ endian = 'little'
 
 [properties]
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt', '-fshort-enums']
-c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/nofp/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
-cpp_link_args = ['-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/nofp/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
+c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/13.3.1/thumb/nofp/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/nofp/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
+cpp_link_args = ['-L/usr/lib/gcc/arm-none-eabi/13.3.1/thumb/nofp/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/nofp/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
 skip_sanity_check = true
 default_flash_addr = '0x00000000'
 default_flash_size = '0x00400000'

--- a/scripts/cross-clang-thumbv6m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv6m-none-eabi.txt
@@ -20,8 +20,8 @@ endian = 'little'
 
 [properties]
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt', '-fshort-enums']
-c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v6-m/nofp/', '-Wl,-z,noexecstack']
-cpp_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v6-m/nofp/', '-Wl,-z,noexecstack']
+c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/13.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v6-m/nofp/', '-Wl,-z,noexecstack']
+cpp_link_args = ['-L/usr/lib/gcc/arm-none-eabi/13.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.3.1/thumb/v6-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v6-m/nofp/', '-Wl,-z,noexecstack']
 skip_sanity_check = true
 default_flash_addr = '0x00000000'
 default_flash_size = '0x00400000'

--- a/scripts/cross-clang-thumbv7-a-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7-a-none-eabi.txt
@@ -20,8 +20,8 @@ endian = 'little'
 
 [properties]
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt', '-fshort-enums']
-c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v7-a/nofp/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
-cpp_link_args = ['-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v7-a/nofp/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
+c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/13.3.1/thumb/v7-a/nofp/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v7-a/nofp/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
+cpp_link_args = ['-L/usr/lib/gcc/arm-none-eabi/13.3.1/thumb/v7-a/nofp/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v7-a/nofp/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
 skip_sanity_check = true
 default_flash_addr = '0x00000000'
 default_flash_size = '0x00400000'

--- a/scripts/cross-clang-thumbv7e+dp-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7e+dp-none-eabi.txt
@@ -20,8 +20,8 @@ endian = 'little'
 
 [properties]
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt', '-fshort-enums']
-c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v7e-m+dp/hard/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
-cpp_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v7e-m+dp/hard/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
+c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/13.3.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v7e-m+dp/hard/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
+cpp_link_args = ['-L/usr/lib/gcc/arm-none-eabi/13.3.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7e-m+dp/hard/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v7e-m+dp/hard/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
 skip_sanity_check = true
 default_flash_addr = '0x00000000'
 default_flash_size = '0x00400000'

--- a/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7e+fp-none-eabi.txt
@@ -20,8 +20,8 @@ endian = 'little'
 
 [properties]
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt', '-fshort-enums']
-c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v7e-m+fp/hard/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
-cpp_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v7e-m+fp/hard/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
+c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/13.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v7e-m+fp/hard/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
+cpp_link_args = ['-L/usr/lib/gcc/arm-none-eabi/13.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/12.3.1/thumb/v7e-m+fp/hard/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v7e-m+fp/hard/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
 skip_sanity_check = true
 default_flash_addr = '0x00000000'
 default_flash_size = '0x00400000'

--- a/scripts/cross-clang-thumbv7m-none-eabi.txt
+++ b/scripts/cross-clang-thumbv7m-none-eabi.txt
@@ -20,8 +20,8 @@ endian = 'little'
 
 [properties]
 c_args = ['-Werror=double-promotion', '-Wno-unsupported-floating-point-opt', '-fshort-enums']
-c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v7-m/nofp/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
-cpp_link_args = ['-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v7-m/nofp/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
+c_link_args = ['-L/usr/lib/gcc/arm-none-eabi/13.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v7-m/nofp/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
+cpp_link_args = ['-L/usr/lib/gcc/arm-none-eabi/13.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/11.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.2.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/12.3.1/thumb/v7-m/nofp/', '-L/usr/lib/gcc/arm-none-eabi/13.2.1/thumb/v7-m/nofp/', '-Wl,-z,noexecstack', '-Wno-unused-command-line-argument']
 skip_sanity_check = true
 default_flash_addr = '0x00000000'
 default_flash_size = '0x00400000'

--- a/test/long_double.c
+++ b/test/long_double.c
@@ -41,6 +41,19 @@
 #include <stdlib.h>
 #include <string.h>
 
+/*
+ * fall-through case statement annotations
+ */
+#if __cplusplus >= 201703L || __STDC_VERSION__ > 201710L
+/* Standard C++17/C23 attribute */
+#define __TEST_PICOLIBC_FALLTHROUGH [[fallthrough]]
+#elif __has_attribute(fallthrough)
+/* Non-standard but supported by at least gcc and clang */
+#define __TEST_PICOLIBC_FALLTHROUGH __attribute__((fallthrough))
+#else
+#define __TEST_PICOLIBC_FALLTHROUGH do { } while(0)
+#endif
+
 #ifdef _TEST_LONG_DOUBLE
 
 static long double max_error;
@@ -267,7 +280,6 @@ naive_strtold(const char *buf)
                 }
                 return -(long double)INFINITY;
             }
-            /* FALLTHROUGH */
             if (base == 10.0L) {
                 if (state == LDOUBLE_INT || state == LDOUBLE_FRAC) {
                     state = LDOUBLE_EXP;
@@ -275,7 +287,7 @@ naive_strtold(const char *buf)
                 }
                 return -(long double)INFINITY;
             }
-            /* FALLTHROUGH */
+            __TEST_PICOLIBC_FALLTHROUGH;
         case 'A': case 'B': case 'C':
         case 'D': case 'F':
             if (state == LDOUBLE_INT || state == LDOUBLE_FRAC) {
@@ -291,7 +303,7 @@ naive_strtold(const char *buf)
                 }
                 return -(long double)INFINITY;
             }
-            /* FALLTHROUGH */
+            __TEST_PICOLIBC_FALLTHROUGH;
         case 'a': case 'b': case 'c':
         case 'd': case 'f':
             if (state == LDOUBLE_INT || state == LDOUBLE_FRAC) {


### PR DESCRIPTION
This requires explicit (not just comments) annotation when falling through a switch clause.