### PR TITLE
picocrt: Adapt x86 crt0 code for old clang assembler

### DIFF
--- a/picocrt/machine/x86/crt0-32.S
+++ b/picocrt/machine/x86/crt0-32.S
@@ -45,7 +45,8 @@
 	.type	start, @function
 _start:
 	.code16
-	cs lgdtl gdt_desc - _start + 0x10
+	cs
+	lgdtl gdt_desc - _start + 0x10
 	mov $1, %eax
 	mov %eax, %cr0
 	ljmpl $0x10,$_start32

--- a/picocrt/machine/x86/crt0-64.S
+++ b/picocrt/machine/x86/crt0-64.S
@@ -45,7 +45,8 @@
 	.type	start, @function
 _start:
 	.code16
-	cs lgdtl	gdt_desc - _start + 0x10
+	cs
+	lgdtl	gdt_desc - _start + 0x10
 	
 	# enable sse and pae
 	mov	$0x620, %eax


### PR DESCRIPTION
Before clang-12, the built-in x86 assembler seems to treat prefixes as separate instructions. This meant that it wouldn't allow them on the same source line as the rest of the instruction. Split out the 'cs' prefix used in the x86 crt0 code to a separate line so that old clang versions can also assemble the code.

Closes: #849 