### PR TITLE
time: Make gmtime_r() visible to Zephyr

### DIFF
--- a/newlib/libc/include/time.h
+++ b/newlib/libc/include/time.h
@@ -228,7 +228,7 @@ int	   getdate_r (const char *, struct tm *);
 
 struct tm *gmtime (const time_t *_timer);
 
-#if __POSIX_VISIBLE
+#if __POSIX_VISIBLE || __ZEPHYR_VISIBLE
 struct tm *gmtime_r (const time_t *__restrict,
                      struct tm *__restrict);
 #endif


### PR DESCRIPTION
The commit 5e4d0c80f49b4efe8be85e36b5e85d65bd343214 made gmtime_r(), which was previously always visible, only visible to POSIX.

Since gmtime_r() is part of the allowed non-standard libc functions in the Zephyr Coding Guidelines Rule A.5, make it also visible to Zephyr.