### PR TITLE
sys/types.h: Add defines that Zephyr uses for type detection

### DIFF
--- a/newlib/libc/include/sys/types.h
+++ b/newlib/libc/include/sys/types.h
@@ -216,11 +216,17 @@ typedef	__nlink_t	nlink_t;	/* link count */
 #ifndef _CLOCKID_T_DECLARED
 typedef	__clockid_t	clockid_t;
 #define	_CLOCKID_T_DECLARED
+#ifdef __ZEPHYR__
+#define __clockid_t_defined             /* Zephyr <= 3.7 compat */
+#endif
 #endif
 
 #ifndef _TIMER_T_DECLARED
 typedef	__timer_t	timer_t;
 #define	_TIMER_T_DECLARED
+#ifdef __ZEPHYR__
+#define __timer_t_defined               /* Zephyr <= 3.7 compat */
+#endif
 #endif
 
 #ifndef _USECONDS_T_DECLARED


### PR DESCRIPTION
Zephyr wants to define a couple of POSIX types when the C library doesn't provide them. It uses internal details for newlib and picolibc to know when this has happened. Picolibc changed these internal details and broke existing Zephyr code.

Add these two defines back so that Zephyr 3.7 code continues to work.