### PR TITLE
Define char16_t and char32_t in uchar.h conditionally

### DIFF
--- a/newlib/libc/include/uchar.h
+++ b/newlib/libc/include/uchar.h
@@ -52,8 +52,10 @@ typedef _mbstate_t mbstate_t;
 #endif
 
 typedef unsigned char char8_t;
+#if !defined __cplusplus || __cplusplus < 201103L
 typedef __uint_least16_t char16_t;
 typedef __uint_least32_t char32_t;
+#endif
 
 size_t mbrtoc8(char8_t * __restrict pc8, const char * __restrict s, size_t n,
                _mbstate_t * __restrict ps);


### PR DESCRIPTION
This patch adds a macro guard around the typedefs for `char16_t` and `char32_t`.

These two types have become built-in in C++ starting from C++11. Because of that, the presence of the typedefs leads to an error as the types are already defined.

For C++11 or later, there's a difference in how libstdc++ and LLVM's libcxx use the C library's `uchar.h`. The former only includes the C library's `uchar.h` under certain conditions, whereas libcxx always does.

In the case of libcxx, this introduces a problem since picolibc's `uchar.h` has the typedefs unconditionally. Glibc, on the other hand, has them under a macro guard called `__USE_ISOCXX11`, defined as `defined __cplusplus && __cplusplus >= 201103L`
([link](https://sourceware.org/git/?p=glibc.git;a=blob;f=wcsmbs/uchar.h;h=7123f46500ef2162f214208007a9af50f5cd6d5d;hb=HEAD#l49)). Thus even in the case where libstdc++ performs the inclusion of C library's `uchar.h`, glibc defensively disables the typedefs.