### PR TITLE
include: Add default value for __STDC_WANT_LIB_EXT1__

### DIFF
--- a/newlib/libc/include/sys/_types.h
+++ b/newlib/libc/include/sys/_types.h
@@ -267,6 +267,8 @@ typedef	unsigned long	__useconds_t;	/* microseconds (unsigned) */
 typedef size_t __rsize_t;
 typedef int __errno_t;
 #endif
+#else
+#define __STDC_WANT_LIB_EXT1__ 0
 #endif
 
 #endif	/* _SYS__TYPES_H */


### PR DESCRIPTION
This changes adds a default value 0 for __STDC_WANT_LIB_EXT1__ if it is not defined. This change protects against inconsistencies with compiler provided header files. Some compilers define __STDC_WANT_LIB_EXT1__ in header files (e.g. yvals.h) to 1
 if not defined. The result is a compilation error of picolibc because for some part of the code __rsize_t and __errno_t are not defined.

I check that the picolibc defines all use __STDC_WANT_LIB_EXT1__  == 1, so this change doesn't change any internal behaviour.