### PR TITLE
Define char8_t conditionally

### DIFF
--- a/newlib/libc/include/uchar.h
+++ b/newlib/libc/include/uchar.h
@@ -51,7 +51,9 @@ typedef _mbstate_t mbstate_t;
 #define _MBSTATE_DECLARED
 #endif
 
+#ifndef __cpp_char8_t
 typedef unsigned char char8_t;
+#endif
 #if !defined __cplusplus || __cplusplus < 201103L
 typedef __uint_least16_t char16_t;
 typedef __uint_least32_t char32_t;


### PR DESCRIPTION
Following up on commit d55527c12b25cc8bf219053195b1723600c1c09f, this patch also puts the `char8_t` typedef under a macro check.

From C++20, `char8_t` is a builtin type, so in that case the typedef must not be present. The C++ spec has a macro specific to check if `char8_t` is builtin. This macro is called `__cpp_char8_t`.