### PR TITLE
time: Build wcsftime.c when using cmake

### DIFF
--- a/newlib/libc/time/CMakeLists.txt
+++ b/newlib/libc/time/CMakeLists.txt
@@ -53,4 +53,5 @@ picolibc_sources(
   tzcalc_limits.c
   tzset.c
   tzvars.c
+  wcsftime.c
   )


### PR DESCRIPTION
This file was left out of the cmake build.