### PR TITLE
meson: Add missing long-long option in conf_data.set for tinystdio

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1415,6 +1415,9 @@ if tinystdio
   conf_data.set('_FORMAT_DEFAULT_FLOAT',
                 format_default == 'float',
                 description: 'The default printf functions is the float variant')
+  conf_data.set('_FORMAT_DEFAULT_LONG_LONG',
+                format_default == 'long-long',
+                description: 'The default printf functions is the long-long variant')
   conf_data.set('_FORMAT_DEFAULT_INTEGER',
                 format_default == 'integer',
                 description: 'The default printf functions is the integer variant')


### PR DESCRIPTION
Seems like adding the 'long-long' option to the conf_data.set() options for 'tinystdio' was accidentally missed. This leads '_FORMAT_DEFAULT_LONG_LONG' not being set when using the 'format-default=long-long' option, which ultimately leads to the 'vfprintf' etc functions not being registered properly:

    picolibc/newlib/libc/tinystdio/printf.c:41: \
        undefined reference to `vfprintf'

Fix this by adding in the missing entry for the 'long-long' variant.

Fixes: ca70b2a7ad8b ("libc/tinystdio: Add 'long-long' printf/scanf variants")