### PR TITLE
Support locale ("") in newlocale implementation

### DIFF
--- a/newlib/libc/locale/newlocale.c
+++ b/newlib/libc/locale/newlocale.c
@@ -127,8 +127,12 @@ newlocale (int category_mask, const char *locale,
     return __get_C_locale ();
 
 #ifndef _MB_CAPABLE
-  _REENT_ERRNO(p) = EINVAL;
-  return NULL;
+  if (locale[0] != '\0')
+  {
+	_REENT_ERRNO(p) = EINVAL;
+	return NULL;
+  }
+  return __get_C_locale ();
 #else /* _MB_CAPABLE */
   char new_categories[_LC_LAST][ENCODING_LEN + 1];
   struct __locale_t tmp_locale, *new_locale;


### PR DESCRIPTION
- Updated newlocale function to handle empty string `""` as a valid locale input.
- If the locale is an empty string, the function now returns the default C locale `__get_C_locale`.
- Ensures compatibility with cases where locale `""` is expected to resolve to the default locale.
- Added error handling for unsupported configurations when `_MB_CAPABLE` is not defined.

This change improves compliance with locale handling expectations and provides better support for default behavior in minimal configurations.