### PR TITLE
tinystdio: Add asnprintf and vasnprintf

### DIFF
--- a/newlib/libc/tinystdio/CMakeLists.txt
+++ b/newlib/libc/tinystdio/CMakeLists.txt
@@ -33,6 +33,7 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 picolibc_sources(
+  asnprintf.c
   asprintf.c
   atold_engine.c
   bufio.c
@@ -142,6 +143,7 @@ picolibc_sources(
   tmpnam.c
   ungetc.c
   ungetwc.c
+  vasnprintf.c
   vasprintf.c
   vffprintf.c
   vffscanf.c

--- a/newlib/libc/tinystdio/asnprintf.c
+++ b/newlib/libc/tinystdio/asnprintf.c
@@ -35,29 +35,14 @@
 
 #include "stdio_private.h"
 
-int
-__file_str_put_alloc(char c, FILE *stream)
+char *
+asnprintf(char *str, size_t *lenp, const char *fmt, ...)
 {
-	struct __file_str *sstream = (struct __file_str *) stream;
-	if (sstream->pos == sstream->end) {
-                size_t old_size = sstream->size;
-                char *old = sstream->end - old_size;
-                size_t new_size = old_size + 32;
-                char *new;
-                if (sstream->alloc)
-                        new = realloc(old, new_size);
-                else {
-                        new = malloc(new_size);
-                        if (new)
-                                memcpy(new, old, old_size);
-                }
-		if (!new)
-			return EOF;
-		sstream->size = new_size;
-                sstream->pos = new + old_size;
-                sstream->end = new + new_size;
-                sstream->alloc = true;
-	}
-	*sstream->pos++ = c;
-	return (unsigned char) c;
+        va_list ap;
+        char    *ret;
+
+        va_start(ap, fmt);
+	ret = vasnprintf(str, lenp, fmt, ap);
+        va_end(ap);
+        return ret;
 }

--- a/newlib/libc/tinystdio/asprintf.c
+++ b/newlib/libc/tinystdio/asprintf.c
@@ -45,16 +45,17 @@ asprintf(char **strp, const char *fmt, ...)
 	va_start(ap, fmt);
 	i = vfprintf(&f.file, fmt, ap);
 	va_end(ap);
+        char *buf = f.end - f.size;
 	if (i >= 0) {
-                char *buf = f.end - f.size;
 		char *s = realloc(buf, i+1);
 		if (s) {
 			s[i] = 0;
 			*strp = s;
 		} else {
-			free(buf);
 			i = EOF;
 		}
 	}
+        if (i < 0)
+                free(buf);
 	return i;
 }

--- a/newlib/libc/tinystdio/meson.build
+++ b/newlib/libc/tinystdio/meson.build
@@ -33,6 +33,7 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 srcs_tinystdio = [
+  'asnprintf.c',
   'asprintf.c',
   'atomic_load.c',
   'atold_engine.c',
@@ -145,6 +146,7 @@ srcs_tinystdio = [
   'tmpnam.c',
   'ungetc.c',
   'ungetwc.c',
+  'vasnprintf.c',
   'vasprintf.c',
   'vffprintf.c',
   'vffscanf.c',

--- a/newlib/libc/tinystdio/stdio.h
+++ b/newlib/libc/tinystdio/stdio.h
@@ -230,7 +230,9 @@ int	snprintf(char *__s, size_t __n, const char *__fmt, ...) __PRINTF_ATTRIBUTE__
 int	vsprintf(char *__s, const char *__fmt, __gnuc_va_list ap) __PRINTF_ATTRIBUTE__(2, 0);
 int	vsnprintf(char *__s, size_t __n, const char *__fmt, __gnuc_va_list ap) __PRINTF_ATTRIBUTE__(3, 0);
 int     asprintf(char **strp, const char *fmt, ...) __PRINTF_ATTRIBUTE__(2,3);
+char    *asnprintf(char *str, size_t *lenp, const char *fmt, ...) __PRINTF_ATTRIBUTE__(3,4);
 int     vasprintf(char **strp, const char *fmt, __gnuc_va_list ap) __PRINTF_ATTRIBUTE__(2,0);
+char    *vasnprintf(char *str, size_t *lenp, const char *fmt, __gnuc_va_list ap) __PRINTF_ATTRIBUTE__(3,0);
 
 int	fputs(const char *__str, FILE *__stream);
 int	puts(const char *__str);

--- a/newlib/libc/tinystdio/stdio_private.h
+++ b/newlib/libc/tinystdio/stdio_private.h
@@ -68,6 +68,7 @@ struct __file_str {
         char	*pos;		/* current buffer position */
         char    *end;           /* end of buffer */
         size_t  size;           /* size of allocated storage */
+        bool    alloc;          /* current storage was allocated */
 };
 
 int
@@ -125,14 +126,26 @@ bool __matchcaseprefix(const char *input, const char *pattern);
                 .end = (_s) + (_size),          \
 	}
 
-#define FDEV_SETUP_STRING_ALLOC() {		\
+#define FDEV_SETUP_STRING_ALLOC() {  \
 		.file = {			\
 			.flags = __SWR,		\
 			.put = __file_str_put_alloc	\
 		},				\
 		.pos = NULL,			\
-		.end = NULL,			\
+                .end = NULL,                    \
                 .size = 0,                      \
+                .alloc = false,                 \
+	}
+
+#define FDEV_SETUP_STRING_ALLOC_BUF(_buf, _size) {  \
+		.file = {			\
+			.flags = __SWR,		\
+			.put = __file_str_put_alloc	\
+		},				\
+		.pos = _buf,			\
+                .end = (char *) (_buf) + (_size), \
+                .size = _size,                  \
+                .alloc = false,                 \
 	}
 
 #define _FDEV_BUFIO_FD(bf) ((int)((intptr_t) (bf)->ptr))

--- a/newlib/libc/tinystdio/vasprintf.c
+++ b/newlib/libc/tinystdio/vasprintf.c
@@ -38,7 +38,7 @@
 int
 vasprintf(char **strp, const char *fmt, va_list ap)
 {
-	struct __file_str f = FDEV_SETUP_STRING_ALLOC();
+        struct __file_str f = FDEV_SETUP_STRING_ALLOC();
 	int i;
 
 	i = vfprintf(&f.file, fmt, ap);

--- a/newlib/libc/tinystdio/vasprintf.c
+++ b/newlib/libc/tinystdio/vasprintf.c
@@ -42,16 +42,17 @@ vasprintf(char **strp, const char *fmt, va_list ap)
 	int i;
 
 	i = vfprintf(&f.file, fmt, ap);
+        char *buf = f.end - f.size;
 	if (i >= 0) {
-                char *buf = f.end - f.size;
 		char *s = realloc(buf, i+1);
 		if (s) {
 			s[i] = 0;
 			*strp = s;
 		} else {
-			free(buf);
 			i = EOF;
 		}
 	}
+        if (i < 0)
+                free(buf);
 	return i;
 }


### PR DESCRIPTION
These are like asprintf/vasprintf except they permit an application to use a pre-allocated buffer; if that overflows, only allocating space when that overflows.