### PR TITLE
Add bootcode and CI scripts for AArch64 FVPs

### DIFF
--- a/.github/do-linux
+++ b/.github/do-linux
@@ -25,6 +25,7 @@ HERE=`dirname "$0"`
 "$HERE"/do-test-noopt riscv "$@"
 "$HERE"/do-test-noopt rv32imac "$@"
 "$HERE"/do-test clang-aarch64 "$@"
+"$HERE"/do-test clang-aarch64-fvp "$@"
 "$HERE"/do-test clang-arm "$@"
 "$HERE"/do-test-noopt clang-x86_64 "$@"
 "$HERE"/do-test-noopt clang-x86 "$@"

--- a/.github/do-test
+++ b/.github/do-test
@@ -4,7 +4,7 @@ DIR=build-"$TARGET"
 CONFIGURE=do-"$TARGET"-configure
 shift
 
-for p in /opt/*/bin; do
+for p in /opt/*/bin /opt/*/models/*; do
     PATH="$p":$PATH
 done
 

--- a/.github/linux-files.txt
+++ b/.github/linux-files.txt
@@ -5,3 +5,4 @@ https://maps.altusmetrum.org/msp430-unknown-elf.tar.xz
 https://maps.altusmetrum.org/sh-unknown-elf-1.tar.xz
 https://maps.altusmetrum.org/qemu-arm.tar.xz
 https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/download/release-18.1.3/LLVM-ET-Arm-18.1.3-Linux-x86_64.tar.xz
+https://developer.arm.com/-/cdn-downloads/permalink/FVPs-Architecture/FM-11.27/FVP_Base_RevC-2xAEMvA_11.27_19_Linux64.tgz

--- a/.github/linux-packages.txt
+++ b/.github/linux-packages.txt
@@ -34,3 +34,4 @@ qemu-system-x86
 qemu-system-arm
 qemu-system-misc
 qemu-system-ppc64
+libdbus-1-dev

--- a/meson.build
+++ b/meson.build
@@ -151,7 +151,7 @@ multilib_exclude = get_option('multilib-exclude')
 enable_picolib = get_option('picolib')
 enable_picocrt = get_option('picocrt')
 enable_picocrt_lib = get_option('picocrt-lib')
-picocrt_machine = get_option('picocrt-machine')
+test_machine = get_option('test-machine')
 enable_semihost = get_option('semihost')
 enable_tests = get_option('tests')
 if get_option('tests-cdefs') == 'auto'

--- a/meson.build
+++ b/meson.build
@@ -151,6 +151,7 @@ multilib_exclude = get_option('multilib-exclude')
 enable_picolib = get_option('picolib')
 enable_picocrt = get_option('picocrt')
 enable_picocrt_lib = get_option('picocrt-lib')
+picocrt_machine = get_option('picocrt-machine')
 enable_semihost = get_option('semihost')
 enable_tests = get_option('tests')
 if get_option('tests-cdefs') == 'auto'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -68,6 +68,9 @@ option('picocrt-enable-mmu', type: 'boolean', value: true,
 option('picocrt-lib', type: 'boolean', value: true,
        description: 'Include pico crt bits in lib form')
 
+option('picocrt-machine', type: 'combo', choices: ['qemu', 'fvp'], value: 'qemu',
+       description: 'Machine to build crt0 startup code for')
+
 option('semihost', type: 'boolean', value: true,
        description: 'Include semihost bits')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -68,9 +68,6 @@ option('picocrt-enable-mmu', type: 'boolean', value: true,
 option('picocrt-lib', type: 'boolean', value: true,
        description: 'Include pico crt bits in lib form')
 
-option('picocrt-machine', type: 'combo', choices: ['qemu', 'fvp'], value: 'qemu',
-       description: 'Machine to build crt0 startup code for')
-
 option('semihost', type: 'boolean', value: true,
        description: 'Include semihost bits')
 
@@ -135,6 +132,9 @@ option('test-stdin', type: 'boolean', value: false,
        description: 'Enable tests that use stdin. This only works on a few targets')
 option('fortify-source', type: 'combo', choices: ['none', '1', '2', '3'], value: '3',
        description: 'Set _FORTIFY_SOURCE=<value> when building tests')
+option('test-machine', type: 'combo', choices: ['qemu', 'fvp'], value: 'qemu',
+       description: 'Machine-specific startup code to use when running tests')
+
 
 option('tinystdio', type: 'boolean', value: true,
        description: 'Use tiny stdio from avr libc')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -132,7 +132,7 @@ option('test-stdin', type: 'boolean', value: false,
        description: 'Enable tests that use stdin. This only works on a few targets')
 option('fortify-source', type: 'combo', choices: ['none', '1', '2', '3'], value: '3',
        description: 'Set _FORTIFY_SOURCE=<value> when building tests')
-option('test-machine', type: 'combo', choices: ['qemu', 'fvp'], value: 'qemu',
+option('test-machine', type: 'string', value: 'qemu',
        description: 'Machine-specific startup code to use when running tests')
 
 

--- a/picocrt/machine/aarch64/crt0.S
+++ b/picocrt/machine/aarch64/crt0.S
@@ -1,0 +1,209 @@
+/************ Page table ************/
+/*
+ * The smallest VA we can construct is 8GB, which needs 8 block page table
+ * entries, each covering 1GiB.
+ */
+#define MMU_BLOCK_COUNT       8
+
+#define MMU_DESCRIPTOR_VALID    (1 << 0)
+#define MMU_DESCRIPTOR_BLOCK    (0 << 1)
+#define MMU_DESCRIPTOR_TABLE    (1 << 1)
+
+#define MMU_BLOCK_XN            (1LL << 54)
+#define MMU_BLOCK_PXN           (1LL << 53)
+#define MMU_BLOCK_CONTIG        (1LL << 52)
+#define MMU_BLOCK_DBM           (1LL << 51)
+#define MMU_BLOCK_GP            (1LL << 50)
+
+#define MMU_BLOCK_NT            (1 << 16)
+#define MMU_BLOCK_OA_BIT        12
+#define MMU_BLOCK_NG            (1 << 11)
+#define MMU_BLOCK_AF            (1 << 10)
+#define MMU_BLOCK_SH_BIT        8
+#define MMU_BLOCK_SH_NS         (0 << MMU_BLOCK_SH_BIT)
+#define MMU_BLOCK_SH_OS         (2 << MMU_BLOCK_SH_BIT)
+#define MMU_BLOCK_SH_IS         (3 << MMU_BLOCK_SH_BIT)
+#define MMU_BLOCK_AP_BIT        6
+#define MMU_BLOCK_NS            (1 << 5)
+#define MMU_BLOCK_ATTR_BIT      2
+
+#define MMU_NORMAL_FLAGS        (MMU_DESCRIPTOR_VALID |         \
+                                 MMU_DESCRIPTOR_BLOCK |         \
+                                 MMU_BLOCK_AF |                 \
+                                 MMU_BLOCK_SH_IS |              \
+                                 (0 << MMU_BLOCK_ATTR_BIT))
+
+#define MMU_DEVICE_FLAGS        (MMU_DESCRIPTOR_VALID | \
+                                 MMU_DESCRIPTOR_BLOCK | \
+                                 MMU_BLOCK_AF | \
+                                 (1 << MMU_BLOCK_ATTR_BIT))
+
+#define MMU_INVALID_FLAGS       0
+
+  .macro start_page_table
+  .section .rodata
+  .global __identity_page_table
+  .balign 65536
+__identity_page_table:
+  .set block_num, 0
+  .endm
+
+  .macro page_table_entries count, flags
+  .rept \count
+    .8byte (block_num << 30) | \flags
+    .set block_num, block_num + 1
+  .endr
+  .endm
+
+  .macro end_page_table
+  .size __identity_page_table, MMU_BLOCK_COUNT * 8
+  .if block_num != MMU_BLOCK_COUNT
+  .error "Wrong number of page table entries"
+  .endif
+  .endm
+
+#if defined(MACHINE_qemu)
+  start_page_table
+  // [0x0000_0000,0x8000_0000): 2GiB normal memory
+  page_table_entries 2, MMU_NORMAL_FLAGS
+  // [0x8000_0000,0x1_0000_0000): 2GiB device memory
+  page_table_entries 2, MMU_DEVICE_FLAGS
+  // [0x1_0000_0000,0x2_0000_0000): 4GiB un-mapped
+  page_table_entries 4, MMU_INVALID_FLAGS
+  end_page_table
+#elif defined(MACHINE_fvp)
+  start_page_table
+  // [0x0000_0000,0x8000_0000): 2GiB unmapped. This actually contains a lot
+  // of different memory regions and devices, but we don't need any of them
+  // for testing.
+  page_table_entries 2, MMU_INVALID_FLAGS
+  // [0x8000_0000,0x1_0000_0000): 2GiB normal memory
+  page_table_entries 2, MMU_NORMAL_FLAGS
+  // [0x1_0000_0000,0x2_0000_0000): 4GiB un-mapped
+  page_table_entries 4, MMU_INVALID_FLAGS
+  end_page_table
+#else
+#error "Unknown machine type"
+#endif
+
+
+/************ Entry point ************/
+
+  // Defined in crt0.c
+  .global _cstart
+  .type cstart, %function
+
+  // _start: Main entry point function, sets up the hardware to the point where
+  // we can execute C code.
+  .section .text.init.enter, "ax", %progbits
+  .global _start
+  .type _start, %function
+_start:
+  /* Use EL-banked stack pointer */
+	msr     SPSel, #1
+
+	/* Initialize stack */
+	adrp x1, __stack
+	add  x1, x1, :lo12:__stack
+	mov sp, x1
+
+	/* Enable FPU */
+#if __ARM_FP
+#if defined(MACHINE_qemu)
+	mov x1, #(0x3 << 20)
+	msr CPACR_EL1, x1
+#elif defined(MACHINE_fvp)
+	mrs x0, CPTR_EL3
+  /* Clear CPTR_ELx.TFP, to enable FP/SIMD instructions at EL0 and EL1. */
+	and x0, x0, #~(1<<10)
+  /* Set CPTR_ELx.EZ and .ESM, to enable SVE and SME instructions at EL3. These
+   * bits are ignored for cores which don't have the relevant feature. */
+  ORR x0, x0, #1<<8
+	ORR x0, x0, #1<<12
+	msr CPTR_EL3, x0
+#else
+#error "Unknown machine type"
+#endif
+#endif // __ARM_FP
+
+	/* Jump into C code */
+	bl _cstart
+  .size _start, .-_start
+
+
+
+/************ Exception handlers ************/
+#ifdef CRT0_SEMIHOST
+
+  .macro vector_common
+  sub sp, sp, #256
+  str x0, [sp, #0]
+  str x1, [sp, #8]
+  str x2, [sp, #16]
+  str x3, [sp, #24]
+  str x4, [sp, #32]
+  str x5, [sp, #40]
+  str x6, [sp, #48]
+  str x7, [sp, #56]
+  str x8, [sp, #64]
+  str x9, [sp, #72]
+  str x10, [sp, #80]
+  str x11, [sp, #88]
+  str x12, [sp, #96]
+  str x13, [sp, #104]
+  str x14, [sp, #112]
+  str x15, [sp, #120]
+  str x16, [sp, #128]
+  str x17, [sp, #136]
+  str x18, [sp, #144]
+  str x19, [sp, #152]
+  str x20, [sp, #160]
+  str x21, [sp, #168]
+  str x22, [sp, #176]
+  str x23, [sp, #184]
+  str x24, [sp, #192]
+  str x25, [sp, #200]
+  str x26, [sp, #208]
+  str x27, [sp, #216]
+  str x28, [sp, #224]
+  str x29, [sp, #232]
+  str x30, [sp, #240]
+#if defined(MACHINE_qemu)
+  mrs x0, ELR_EL1
+  str x0, [sp, #248]
+  mrs x0, ESR_EL1
+  str x0, [sp, #256]
+  mrs x0, FAR_EL1
+  str x0, [sp, #264]
+#elif defined(MACHINE_fvp)
+  mrs x0, ELR_EL3
+  str x0, [sp, #248]
+  mrs x0, ESR_EL3
+  str x0, [sp, #256]
+  mrs x0, FAR_EL3
+  str x0, [sp, #264]
+#else
+#error "Unknown machine type"
+#endif
+  mov x0, sp
+  .endm
+
+  .global aarch64_fault
+  .type aarch64_fault, %function
+
+  .macro exception_handler name, number
+  .section .init, "ax", %progbits
+  .global aarch64_\name\()_vector
+  .type aarch64_\name\()_vector, %function
+aarch64_\name\()_vector:
+  vector_common
+  mov x1, #\number
+  b  aarch64_fault
+  .endm
+
+  exception_handler sync, 0
+  exception_handler irq, 1
+  exception_handler fiq, 2
+  exception_handler serror, 3
+
+#endif // CRT0_SEMIHOST

--- a/picocrt/machine/aarch64/crt0.c
+++ b/picocrt/machine/aarch64/crt0.c
@@ -60,99 +60,11 @@ _set_tls(void *tls)
 
 #include "../../crt0.h"
 
-/*
- * The smallest VA we can construct is 8GB, which needs 8 block page table
- * entries, each covering 1GiB.
- */
+/* Defined in crt0.S */
 #define MMU_BLOCK_COUNT       8
 extern uint64_t __identity_page_table[MMU_BLOCK_COUNT];
-
-#define MMU_DESCRIPTOR_VALID    (1 << 0)
-#define MMU_DESCRIPTOR_BLOCK    (0 << 1)
-#define MMU_DESCRIPTOR_TABLE    (1 << 1)
-
-#define MMU_BLOCK_XN            (1LL << 54)
-#define MMU_BLOCK_PXN           (1LL << 53)
-#define MMU_BLOCK_CONTIG        (1LL << 52)
-#define MMU_BLOCK_DBM           (1LL << 51)
-#define MMU_BLOCK_GP            (1LL << 50)
-
-#define MMU_BLOCK_NT            (1 << 16)
-#define MMU_BLOCK_OA_BIT        12
-#define MMU_BLOCK_NG            (1 << 11)
-#define MMU_BLOCK_AF            (1 << 10)
-#define MMU_BLOCK_SH_BIT        8
-#define MMU_BLOCK_SH_NS         (0 << MMU_BLOCK_SH_BIT)
-#define MMU_BLOCK_SH_OS         (2 << MMU_BLOCK_SH_BIT)
-#define MMU_BLOCK_SH_IS         (3 << MMU_BLOCK_SH_BIT)
-#define MMU_BLOCK_AP_BIT        6
-#define MMU_BLOCK_NS            (1 << 5)
-#define MMU_BLOCK_ATTR_BIT      2
-
-#define MMU_NORMAL_FLAGS        (MMU_DESCRIPTOR_VALID |         \
-                                 MMU_DESCRIPTOR_BLOCK |         \
-                                 MMU_BLOCK_AF |                 \
-                                 MMU_BLOCK_SH_IS |              \
-                                 (0 << MMU_BLOCK_ATTR_BIT))
-
-#define MMU_DEVICE_FLAGS        (MMU_DESCRIPTOR_VALID | \
-                                 MMU_DESCRIPTOR_BLOCK | \
-                                 MMU_BLOCK_AF | \
-                                 (1 << MMU_BLOCK_ATTR_BIT))
-
-#define MMU_INVALID_FLAGS       0
-
-__asm__(
-    ".macro start_page_table\n"
-    ".section .rodata\n"
-    ".global __identity_page_table\n"
-    ".balign 65536\n"
-    "__identity_page_table:\n"
-    ".set block_num, 0\n"
-    ".endm\n"
-
-    ".macro page_table_entries count, flags\n"
-    ".rept \\count\n"
-    "  .8byte (block_num << 30) | \\flags\n"
-    "  .set block_num, block_num + 1\n"
-    ".endr\n"
-    ".endm\n"
-
-    ".macro end_page_table\n"
-    ".size __identity_page_table, " __XSTRING(MMU_BLOCK_COUNT * 8) "\n"
-    ".if block_num != " __XSTRING(MMU_BLOCK_COUNT) "\n"
-    ".error \"Wrong number of page table entries\"\n"
-    ".endif\n"
-    ".endm\n"
-);
-
-#if defined(MACHINE_qemu)
-__asm__(
-    "start_page_table\n"
-    // [0x0000_0000,0x8000_0000): 2GiB normal memory
-    "page_table_entries 2, " __XSTRING(MMU_NORMAL_FLAGS) "\n"
-    // [0x8000_0000,0x1_0000_0000): 2GiB device memory
-    "page_table_entries 2, " __XSTRING(MMU_DEVICE_FLAGS) "\n"
-    // [0x1_0000_0000,0x2_0000_0000): 4GiB un-mapped
-    "page_table_entries 4, " __XSTRING(MMU_INVALID_FLAGS) "\n"
-    "end_page_table\n"
-);
-#elif defined(MACHINE_fvp)
-__asm__(
-    "start_page_table\n"
-    // [0x0000_0000,0x8000_0000): 2GiB unmapped. This actually contains a lot
-    // of different memory regions and devices, but we don't need any of them
-    // for testing.
-    "page_table_entries 2, " __XSTRING(MMU_INVALID_FLAGS) "\n"
-    // [0x8000_0000,0x1_0000_0000): 2GiB normal memory
-    "page_table_entries 2, " __XSTRING(MMU_NORMAL_FLAGS) "\n"
-    // [0x1_0000_0000,0x2_0000_0000): 4GiB un-mapped
-    "page_table_entries 4, " __XSTRING(MMU_INVALID_FLAGS) "\n"
-    "end_page_table\n"
-);
-#else
-#error "Unknown machine type"
-#endif
+extern void _start(void);
+extern const void *__vector_table[];
 
 #define SCTLR_MMU       (1 << 0)
 #define SCTLR_A         (1 << 1)
@@ -193,10 +105,7 @@ __asm__(
 #error "Unknown machine type"
 #endif
 
-extern const void *__vector_table[];
-
-static void __attribute((used))
-_cstart(void)
+void _cstart(void)
 {
         uint64_t        sctlr;
 
@@ -244,24 +153,6 @@ _cstart(void)
 	__start();
 }
 
-void __section(".text.init.enter")
-_start(void)
-{
-        /* Use EL-banked stack pointer */
-	__asm__("msr     SPSel, #1");
-
-	/* Initialize stack */
-	__asm__("adrp x1, __stack");
-	__asm__("add  x1, x1, :lo12:__stack");
-	__asm__("mov sp, x1");
-#if __ARM_FP
-	/* Enable FPU */
-	__asm__("mov x1, #(0x3 << 20)");
-	__asm__("msr cpacr_"BOOT_EL",x1");
-#endif
-	/* Jump into C code */
-	__asm__("bl _cstart");
-}
 
 #ifdef CRT0_SEMIHOST
 
@@ -303,13 +194,9 @@ static const char *const reasons[] = {
     "serror\n"
 };
 
-#define REASON_SYNC     0
-#define REASON_IRQ      1
-#define REASON_FIQ      2
-#define REASON_SERROR   3
-
-static void __attribute__((used))
-aarch64_fault(struct fault *f, int reason)
+/* Called from assembly wrappers in crt0.S, which fills *f with the register
+ * values at the point the fault happened. */
+void aarch64_fault(struct fault *f, int reason)
 {
     int r;
     fputs("AARCH64 fault: ", stdout);
@@ -324,71 +211,6 @@ aarch64_fault(struct fault *f, int reason)
     aarch64_fault_write_reg("\tESR:   0x", f->esr);
     aarch64_fault_write_reg("\tFAR:   0x", f->far);
     _exit(1);
-}
-
-#define VECTOR_COMMON \
-    __asm__("sub sp, sp, #256"); \
-    __asm__("str x0, [sp, #0]"); \
-    __asm__("str x1, [sp, #8]"); \
-    __asm__("str x2, [sp, #16]"); \
-    __asm__("str x3, [sp, #24]"); \
-    __asm__("str x4, [sp, #32]"); \
-    __asm__("str x5, [sp, #40]"); \
-    __asm__("str x6, [sp, #48]"); \
-    __asm__("str x7, [sp, #56]"); \
-    __asm__("str x8, [sp, #64]"); \
-    __asm__("str x9, [sp, #72]"); \
-    __asm__("str x10, [sp, #80]"); \
-    __asm__("str x11, [sp, #88]"); \
-    __asm__("str x12, [sp, #96]"); \
-    __asm__("str x13, [sp, #104]"); \
-    __asm__("str x14, [sp, #112]"); \
-    __asm__("str x15, [sp, #120]"); \
-    __asm__("str x16, [sp, #128]"); \
-    __asm__("str x17, [sp, #136]"); \
-    __asm__("str x18, [sp, #144]"); \
-    __asm__("str x19, [sp, #152]"); \
-    __asm__("str x20, [sp, #160]"); \
-    __asm__("str x21, [sp, #168]"); \
-    __asm__("str x22, [sp, #176]"); \
-    __asm__("str x23, [sp, #184]"); \
-    __asm__("str x24, [sp, #192]"); \
-    __asm__("str x25, [sp, #200]"); \
-    __asm__("str x26, [sp, #208]"); \
-    __asm__("str x27, [sp, #216]"); \
-    __asm__("str x28, [sp, #224]"); \
-    __asm__("str x29, [sp, #232]"); \
-    __asm__("str x30, [sp, #240]"); \
-    __asm__("mrs x0, ELR_EL1\n"); \
-    __asm__("str x0, [sp, #248]"); \
-    __asm__("mrs x0, ESR_EL1\n"); \
-    __asm__("str x0, [sp, #256]"); \
-    __asm__("mrs x0, FAR_EL1\n"); \
-    __asm__("str x0, [sp, #264]"); \
-    __asm__("mov x0, sp")
-
-void __section(".init")
-aarch64_sync_vector(void)
-{
-    VECTOR_COMMON;
-    __asm__("mov x1, #" REASON(REASON_SYNC));
-    __asm__("b  aarch64_fault");
-}
-
-void __section(".init")
-aarch64_irq_vector(void)
-{
-    VECTOR_COMMON;
-    __asm__("mov x1, #" REASON(REASON_IRQ));
-    __asm__("b  aarch64_fault");
-}
-
-void __section(".init")
-aarch64_fiq_vector(void)
-{
-    VECTOR_COMMON;
-    __asm__("mov x1, #" REASON(REASON_FIQ));
-    __asm__("b  aarch64_fault");
 }
 
 #endif /* CRT0_SEMIHOST */

--- a/picocrt/machine/aarch64/meson.build
+++ b/picocrt/machine/aarch64/meson.build
@@ -32,7 +32,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-src_picocrt += files('crt0.c')
+src_picocrt += files('crt0.c', 'crt0.S')
 
 picocrt_machines += [
   {

--- a/picocrt/machine/aarch64/meson.build
+++ b/picocrt/machine/aarch64/meson.build
@@ -33,3 +33,10 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 src_picocrt += files('crt0.c')
+
+picocrt_machines += [
+  {
+    'name': 'fvp',
+    'suffix': '-fvp',
+  },
+]

--- a/picocrt/meson.build
+++ b/picocrt/meson.build
@@ -90,7 +90,7 @@ foreach target : targets
   crt0_semihost_name = 'crt0_semihost' + target
   crt0_none_name = 'crt0_none' + target
 
-  _c_args = value[1] + arg_fnobuiltin + ['-ffreestanding']
+  _c_args = value[1] + arg_fnobuiltin + ['-ffreestanding', '-DMACHINE_' + picocrt_machine]
   _link_args = value[1] + ['-r', '-ffreestanding']
 
   # The normal variant does not call 'exit' after return from main (c lingo: freestanding execution environment)

--- a/picocrt/meson.build
+++ b/picocrt/meson.build
@@ -36,6 +36,17 @@
 src_picocrt = []
 src_picocrt_none = files('crt0-none.c')
 
+# Machine-specific crt0 variants to build.
+picocrt_machines = [
+  {
+    # Must match a valid value of the 'test-machine' option, and will cause the
+    # MACHINE_<name> preprocessor macro to be defined when compiling crt0.
+    'name': 'qemu',
+    # Suffix used on file names, QEMU's is empty because it is the default.
+    'suffix': '',
+  },
+]
+
 machine_dir = 'machine' / host_cpu_family
 picocrt_march_add=''
 if fs.is_dir(machine_dir)
@@ -60,150 +71,163 @@ foreach target : targets
     value = [value[0], new_cflags]
   endif
 
-  if target == ''
-    crt_name = 'crt0.o'
-    crt_hosted_name = 'crt0-hosted.o'
-    crt_minimal_name = 'crt0-minimal.o'
-    crt_semihost_name = 'crt0-semihost.o'
-    crt_none_name = 'crt0-none.o'
-    libcrt_name = 'crt0'
-    libcrt_hosted_name = 'crt0-hosted'
-    libcrt_minimal_name = 'crt0-minimal'
-    libcrt_semihost_name = 'crt0-semihost'
-    libcrt_none_name = 'crt0-none'
-  else
-    crt_name = join_paths(target, 'crt0.o')
-    crt_hosted_name = join_paths(target, 'crt0-hosted.o')
-    crt_minimal_name = join_paths(target, 'crt0-minimal.o')
-    crt_semihost_name = join_paths(target, 'crt0-semihost.o')
-    crt_none_name = join_paths(target, 'crt0-none.o')
-    libcrt_name = join_paths(target, 'libcrt0')
-    libcrt_hosted_name = join_paths(target, 'libcrt0-hosted')
-    libcrt_minimal_name = join_paths(target, 'libcrt0-minimal')
-    libcrt_semihost_name = join_paths(target, 'libcrt0-semihost')
-    libcrt_none_name = join_paths(target, 'libcrt0-none')
-  endif
+  foreach machine : picocrt_machines
+    suffix = machine['suffix']
+    if target == ''
+      crt_name = 'crt0' + suffix + '.o'
+      crt_hosted_name = 'crt0-hosted' + suffix + '.o'
+      crt_minimal_name = 'crt0-minimal' + suffix + '.o'
+      crt_semihost_name = 'crt0-semihost' + suffix + '.o'
+      crt_none_name = 'crt0-none' + suffix + '.o'
+      libcrt_name = 'crt0' + suffix
+      libcrt_hosted_name = 'crt0-hosted' + suffix
+      libcrt_minimal_name = 'crt0-minimal' + suffix
+      libcrt_semihost_name = 'crt0-semihost' + suffix
+      libcrt_none_name = 'crt0-none' + suffix
+    else
+      crt_name = join_paths(target, 'crt0' + suffix + '.o')
+      crt_hosted_name = join_paths(target, 'crt0-hosted' + suffix + '.o')
+      crt_minimal_name = join_paths(target, 'crt0-minimal' + suffix + '.o')
+      crt_semihost_name = join_paths(target, 'crt0-semihost' + suffix + '.o')
+      crt_none_name = join_paths(target, 'crt0-none' + suffix + '.o')
+      libcrt_name = join_paths(target, 'libcrt0' + suffix)
+      libcrt_hosted_name = join_paths(target, 'libcrt0-hosted' + suffix)
+      libcrt_minimal_name = join_paths(target, 'libcrt0-minimal' + suffix)
+      libcrt_semihost_name = join_paths(target, 'libcrt0-semihost' + suffix)
+      libcrt_none_name = join_paths(target, 'libcrt0-none' + suffix)
+    endif
 
-  crt0_name = 'crt0' + target
-  crt0_hosted_name = 'crt0_hosted' + target
-  crt0_minimal_name = 'crt0_minimal' + target
-  crt0_semihost_name = 'crt0_semihost' + target
-  crt0_none_name = 'crt0_none' + target
+    crt0_name = 'crt0' + target
+    crt0_hosted_name = 'crt0_hosted' + target
+    crt0_minimal_name = 'crt0_minimal' + target
+    crt0_semihost_name = 'crt0_semihost' + target
+    crt0_none_name = 'crt0_none' + target
 
-  _c_args = value[1] + arg_fnobuiltin + ['-ffreestanding', '-DMACHINE_' + picocrt_machine]
-  _link_args = value[1] + ['-r', '-ffreestanding']
+    _c_args = value[1] + arg_fnobuiltin + ['-ffreestanding', '-DMACHINE_' + machine['name']]
+    _link_args = value[1] + ['-r', '-ffreestanding']
 
-  # The normal variant does not call 'exit' after return from main (c lingo: freestanding execution environment)
-  _crt = executable(crt_name,
-		    src_picocrt,
-		    include_directories : inc,
-		    install : true,
-		    install_dir : instdir,
-		    c_args : _c_args,
-		    link_args : _link_args)
+    # The normal variant does not call 'exit' after return from main (c lingo: freestanding execution environment)
+    _crt = executable(crt_name,
+                      src_picocrt,
+                      include_directories : inc,
+                      install : true,
+                      install_dir : instdir,
+                      c_args : _c_args,
+                      link_args : _link_args)
 
-  set_variable(crt0_name,
-	       _crt.extract_objects(src_picocrt)
-	      )
-
-  if enable_picocrt_lib
-    static_library(libcrt_name,
-                   [],
-		   include_directories : inc,
-                   install : true,
-                   install_dir : instdir,
-		   c_args : _c_args,
-                   objects: get_variable(crt0_name),
-                   pic: false)
-  endif
-
-  # The 'hosted' variant calls 'exit' after return from main (c lingo: hosted execution environment)
-  _crt = executable(crt_hosted_name,
-		    src_picocrt,
-		    include_directories : inc,
-		    install : true,
-		    install_dir : instdir,
-		    c_args : _c_args + ['-DCRT0_EXIT'],
-		    link_args : _link_args)
-
-  set_variable(crt0_hosted_name,
-	       _crt.extract_objects(src_picocrt)
-	      )
-
-  if enable_picocrt_lib
-    static_library(libcrt_hosted_name,
-                   [],
-		   include_directories : inc,
-                   install : true,
-                   install_dir : instdir,
-                   pic: false,
-                   objects: get_variable(crt0_hosted_name),
-		   c_args : value[1] + ['-DCRT0_EXIT'])
-  endif
-
-  # The 'minimal' variant doesn't call exit, nor does it invoke any constructors
-  _crt = executable(crt_minimal_name,
-		    src_picocrt,
-		    include_directories : inc,
-		    install : true,
-		    install_dir : instdir,
-		    c_args : _c_args + ['-DCONSTRUCTORS=0'],
-		    link_args : _link_args)
-
-  set_variable(crt0_minimal_name,
-	       _crt.extract_objects(src_picocrt)
-	      )
-
-  if enable_picocrt_lib
-    static_library(libcrt_minimal_name,
-                   [],
-		   include_directories : inc,
-                   install : true,
-                   install_dir : instdir,
-                   pic: false,
-                   objects: get_variable(crt0_minimal_name),
-		   c_args : _c_args + ['-DCONSTRUCTORS=0'])
-  endif
-
-  if has_arm_semihost
-    # The 'semihost' variant calls sys_semihost_get_cmdline to build argv
-    # and calls exit when main returns
-    _crt = executable(crt_semihost_name,
-		      src_picocrt,
-		      include_directories : inc,
-		      install : true,
-		      install_dir : instdir,
-		      c_args : _c_args + ['-DCRT0_EXIT', '-DCRT0_SEMIHOST'],
-		      link_args : _link_args)
-
-    set_variable(crt0_semihost_name,
-		 _crt.extract_objects(src_picocrt)
-		)
+    if machine['name'] == test_machine
+      set_variable(crt0_name,
+                   _crt.extract_objects(src_picocrt)
+                  )
+    endif
 
     if enable_picocrt_lib
-      static_library(libcrt_semihost_name,
+      static_library(libcrt_name,
                      [],
-		     include_directories : inc,
+                     include_directories : inc,
+                     install : true,
+                     install_dir : instdir,
+                     c_args : _c_args,
+                     objects: _crt.extract_objects(src_picocrt),
+                     pic: false)
+    endif
+
+    # The 'hosted' variant calls 'exit' after return from main (c lingo: hosted execution environment)
+    _crt = executable(crt_hosted_name,
+                      src_picocrt,
+                      include_directories : inc,
+                      install : true,
+                      install_dir : instdir,
+                      c_args : _c_args + ['-DCRT0_EXIT'],
+                      link_args : _link_args)
+
+    if machine['name'] == test_machine
+    set_variable(crt0_hosted_name,
+                 _crt.extract_objects(src_picocrt)
+                )
+    endif
+
+    if enable_picocrt_lib
+      static_library(libcrt_hosted_name,
+                     [],
+                     include_directories : inc,
                      install : true,
                      install_dir : instdir,
                      pic: false,
-                     objects: get_variable(crt0_semihost_name),
-		     c_args : value[1] + ['-DCRT0_EXIT', '-DCRT0_SEMIHOST'])
+                     objects: _crt.extract_objects(src_picocrt),
+                     c_args : value[1] + ['-DCRT0_EXIT'])
     endif
-  endif
 
-  # The 'none' variant is completely empty
-  _crt = executable(crt_none_name,
-		    src_picocrt_none,
-		    include_directories : inc,
-		    install : true,
-		    install_dir : instdir,
-		    c_args : _c_args,
-		    link_args : _link_args)
+    # The 'minimal' variant doesn't call exit, nor does it invoke any constructors
+    _crt = executable(crt_minimal_name,
+                      src_picocrt,
+                      include_directories : inc,
+                      install : true,
+                      install_dir : instdir,
+                      c_args : _c_args + ['-DCONSTRUCTORS=0'],
+                      link_args : _link_args)
 
-  set_variable(crt0_none_name,
-	       _crt.extract_objects(src_picocrt_none)
-	      )
+    if machine['name'] == test_machine
+    set_variable(crt0_minimal_name,
+                 _crt.extract_objects(src_picocrt)
+                )
+    endif
 
+    if enable_picocrt_lib
+      static_library(libcrt_minimal_name,
+                     [],
+                     include_directories : inc,
+                     install : true,
+                     install_dir : instdir,
+                     pic: false,
+                     objects: _crt.extract_objects(src_picocrt),
+                     c_args : _c_args + ['-DCONSTRUCTORS=0'])
+    endif
+
+    if has_arm_semihost
+      # The 'semihost' variant calls sys_semihost_get_cmdline to build argv
+      # and calls exit when main returns
+      _crt = executable(crt_semihost_name,
+                        src_picocrt,
+                        include_directories : inc,
+                        install : true,
+                        install_dir : instdir,
+                        c_args : _c_args + ['-DCRT0_EXIT', '-DCRT0_SEMIHOST'],
+                        link_args : _link_args)
+
+      if machine['name'] == test_machine
+        set_variable(crt0_semihost_name,
+                     _crt.extract_objects(src_picocrt)
+                    )
+      endif
+
+      if enable_picocrt_lib
+        static_library(libcrt_semihost_name,
+                       [],
+                       include_directories : inc,
+                       install : true,
+                       install_dir : instdir,
+                       pic: false,
+                       objects: _crt.extract_objects(src_picocrt),
+                       c_args : value[1] + ['-DCRT0_EXIT', '-DCRT0_SEMIHOST'])
+      endif
+    endif
+
+    # The 'none' variant is completely empty
+    _crt = executable(crt_none_name,
+                      src_picocrt_none,
+                      include_directories : inc,
+                      install : true,
+                      install_dir : instdir,
+                      c_args : _c_args,
+                      link_args : _link_args)
+
+    if machine['name'] == test_machine
+    set_variable(crt0_none_name,
+                 _crt.extract_objects(src_picocrt_none)
+                )
+    endif
+
+  endforeach
   
 endforeach

--- a/picocrt/meson.build
+++ b/picocrt/meson.build
@@ -55,6 +55,16 @@ else
   src_picocrt = files('shared/crt0.c')
 endif
 
+machine_found = false
+foreach machine : picocrt_machines
+  if machine['name'] == test_machine
+    machine_found = true
+  endif
+endforeach
+if not machine_found
+  error(test_machine + ': requested test machine not found')
+endif
+
 foreach target : targets
   value = get_variable('target_' + target)
 

--- a/scripts/cross-clang-aarch64-none-elf-fvp.txt
+++ b/scripts/cross-clang-aarch64-none-elf-fvp.txt
@@ -1,0 +1,29 @@
+# Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+
+[binaries]
+# Meson 0.53.2 doesn't use any cflags when doing basic compiler tests,
+# so we have to add -nostdlib to the compiler configuration itself or
+# early compiler tests will fail. This can be removed when picolibc
+# requires at least version 0.54.2 of meson.
+c = ['clang', '-target', 'aarch64-none-elf', '-nostdlib']
+cpp = ['clang', '-target', 'aarch64-none-elf', '-nostdlib']
+ar = 'llvm-ar'
+as = 'llvm-as'
+nm = 'llvm-nm'
+strip = 'llvm-strip'
+# only needed to run tests
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-aarch64-fvp "$@"', 'run-aarch64-fvp']
+
+[host_machine]
+system = 'none'
+cpu_family = 'aarch64'
+cpu = 'aarch64'
+endian = 'little'
+
+[properties]
+skip_sanity_check = true
+libgcc='-lclang_rt.builtins'
+default_flash_addr = '0x80000000'
+default_flash_size = '0x01000000'
+default_ram_addr   = '0x81000000'
+default_ram_size   = '0x01000000'

--- a/scripts/do-clang-aarch64-fvp-configure
+++ b/scripts/do-clang-aarch64-fvp-configure
@@ -33,5 +33,5 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-exec "$(dirname "$0")"/do-configure clang-aarch64-none-elf \
-	-Dtests=true -Dmultilib-exclude=arm "$@"
+exec "$(dirname "$0")"/do-configure clang-aarch64-none-elf-fvp \
+	-Dtests=true -Dmultilib-exclude=arm -Dtest-machine=fvp "$@"

--- a/scripts/run-aarch64-fvp
+++ b/scripts/run-aarch64-fvp
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
-# Copyright © 2019 Keith Packard
+# Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -33,8 +33,47 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-exec "$(dirname "$0")"/do-configure clang-aarch64-none-elf \
-	-Dtests=true -Dmultilib-exclude=arm "$@"
 
-exec "$(dirname "$0")"/do-configure clang-aarch64-none-elf-fvp \
-	-Dtests=true -Dmultilib-exclude=arm -Dtest-machine=fvp "$@"
+fvp_exe="FVP_Base_RevC-2xAEMvA"
+
+# select the program
+elf="$1"
+shift
+
+cmdline_param="cluster0.cpu0.semihosting-cmd_line"
+input="program-name"
+done=0
+
+while [ "$done" != "1" ]; do
+    case "$1" in
+        --)
+            shift
+            done=1
+            ;;
+        -s|"")
+            done=1
+            ;;
+        *)
+            case "$input" in
+                "")
+                    input="$1"
+                    ;;
+                *)
+                    input="$input $1"
+                    ;;
+            esac
+            shift
+            ;;
+    esac
+done
+
+$fvp_exe --quiet --application "$elf" --parameter "$cmdline_param=$input" \
+    --parameter "bp.vis.disable_visualisation=1" \
+    --parameter "bp.terminal_0.quiet=1" \
+    --parameter "bp.terminal_1.quiet=1" \
+    --parameter "bp.terminal_2.quiet=1" \
+    --parameter "bp.terminal_3.quiet=1" \
+    --parameter "cluster0.NUM_CORES=1" \
+    --parameter "cluster1.NUM_CORES=0" \
+    --parameter "bp.secure_memory=0" \
+    --parameter "cluster0.cpu0.CONFIG64=1"

--- a/scripts/run-aarch64-fvp
+++ b/scripts/run-aarch64-fvp
@@ -77,3 +77,18 @@ $fvp_exe --quiet --application "$elf" --parameter "$cmdline_param=$input" \
     --parameter "cluster1.NUM_CORES=0" \
     --parameter "bp.secure_memory=0" \
     --parameter "cluster0.cpu0.CONFIG64=1"
+
+result=$?
+if [ $result != 0 ]; then
+    case "$elf" in
+        *test-fread-fwrite*|*posix-io*|*semihost-seek*)
+            echo "SYS_SEEK broken in FVP"
+            result=77
+            ;;
+        *semihost-gettimeofday*)
+            echo "SYS_ELAPSED broken in FVP"
+            result=77
+            ;;
+    esac
+fi
+exit $result


### PR DESCRIPTION
The AArch64 FVP (Fixed Virtual Platform) models differ from QEMU in a few ways which affect the crt0 code:

* The memory map is different, so needs different page tables.
* They boot up at EL3, instead of EL1, so we need to set the EL3 versions of the system registers.

This change also introduces new CI scripts for running tests on FVPs.

Based on work from PR #852.

Co-authored-by: Oliver Stannard <oliver.stannard@arm.com>

