### PR TITLE
scripts: Fix duplicate-names script for FreeBSD

### DIFF
--- a/scripts/duplicate-names
+++ b/scripts/duplicate-names
@@ -3,7 +3,7 @@ NM="$1"
 FILE="$2"
 OUTPUT="$3"
 
-"$NM" -g "$FILE" 2>/dev/null | grep ' [A-EG-TVX-Z] ' | grep -v '__x86' | sort | uniq -d > "$OUTPUT"
+"$NM" -g "$FILE" 2>/dev/null | grep ' [A-EG-MO-TVX-Z] ' | grep -v '__x86' | sort | uniq -d > "$OUTPUT"
 if [ -e "$OUTPUT" ] && [ -s "$OUTPUT" ]; then
     echo "Duplicate names in ${FILE}"
     cat "$OUTPUT"


### PR DESCRIPTION
FreeBSD's nm labels some symbols with 'N' that aren't global names. Ignore these when looking for duplicate symbols.