### PR TITLE
Use `__restrict` instead of `restrict` in Annex-K functions

### DIFF
--- a/newlib/libc/include/stdlib.h
+++ b/newlib/libc/include/stdlib.h
@@ -421,13 +421,13 @@ typedef __rsize_t rsize_t;
 #define _RSIZE_T_DEFINED
 #endif
 
-typedef void (*constraint_handler_t)(const char *restrict msg,
-                                     void *restrict ptr, __errno_t error);
+typedef void (*constraint_handler_t)(const char *__restrict msg,
+                                     void *__restrict ptr, __errno_t error);
 
 constraint_handler_t set_constraint_handler_s(constraint_handler_t handler);
-void abort_handler_s(const char *restrict msg, void *restrict ptr,
+void abort_handler_s(const char *__restrict msg, void *__restrict ptr,
                      __errno_t error);
-void ignore_handler_s(const char *restrict msg, void *restrict ptr,
+void ignore_handler_s(const char *__restrict msg, void *__restrict ptr,
                      __errno_t error);
 #endif
 

--- a/newlib/libc/stdlib/ignore_handler_s.c
+++ b/newlib/libc/stdlib/ignore_handler_s.c
@@ -36,7 +36,7 @@
 #include <stdlib.h>
 
 void
-ignore_handler_s(const char *restrict msg, void *restrict ptr, __errno_t error)
+ignore_handler_s(const char *__restrict msg, void *__restrict ptr, __errno_t error)
 {
     (void)msg;
     (void)ptr;

--- a/newlib/libc/stdlib/set_constraint_handler_s.c
+++ b/newlib/libc/stdlib/set_constraint_handler_s.c
@@ -38,7 +38,7 @@
 constraint_handler_t __cur_handler = abort_handler_s;
 
 void
-abort_handler_s(const char *restrict msg, void *restrict ptr, __errno_t error)
+abort_handler_s(const char *__restrict msg, void *__restrict ptr, __errno_t error)
 {
     (void)msg;
     (void)ptr;

--- a/newlib/libc/string/memcpy_s.c
+++ b/newlib/libc/string/memcpy_s.c
@@ -38,7 +38,7 @@
 #include "string_private.h"
 
 __errno_t
-memcpy_s(void *restrict s1, rsize_t s1max, const void *restrict s2, rsize_t n)
+memcpy_s(void *__restrict s1, rsize_t s1max, const void *__restrict s2, rsize_t n)
 {
     const char *msg = "";
 

--- a/newlib/libc/string/strcat_s.c
+++ b/newlib/libc/string/strcat_s.c
@@ -38,7 +38,7 @@
 #include "string_private.h"
 
 __errno_t
-strcat_s(char *restrict s1, rsize_t s1max, const char *restrict s2)
+strcat_s(char *__restrict s1, rsize_t s1max, const char *__restrict s2)
 {
     const char *msg = "";
     size_t s1_len = 0;

--- a/newlib/libc/string/strcpy_s.c
+++ b/newlib/libc/string/strcpy_s.c
@@ -38,7 +38,7 @@
 #include "string_private.h"
 
 __errno_t
-strcpy_s(char *restrict s1, rsize_t s1max, const char *restrict s2)
+strcpy_s(char *__restrict s1, rsize_t s1max, const char *__restrict s2)
 {
     const char *msg = "";
     bool write_null = true;

--- a/newlib/libc/string/strncat_s.c
+++ b/newlib/libc/string/strncat_s.c
@@ -38,7 +38,7 @@
 #include "string_private.h"
 
 __errno_t
-strncat_s(char *restrict s1, rsize_t s1max, const char *restrict s2, rsize_t n)
+strncat_s(char *__restrict s1, rsize_t s1max, const char *__restrict s2, rsize_t n)
 {
     const char *msg = "";
     size_t s1_len = 0;

--- a/newlib/libc/string/strncpy_s.c
+++ b/newlib/libc/string/strncpy_s.c
@@ -38,7 +38,7 @@
 #include "string_private.h"
 
 __errno_t
-strncpy_s(char *restrict s1, rsize_t s1max, const char *restrict s2, rsize_t n)
+strncpy_s(char *__restrict s1, rsize_t s1max, const char *__restrict s2, rsize_t n)
 {
     const char *msg = "";
     bool write_null = true;

--- a/newlib/libc/tinystdio/sprintf_s.c
+++ b/newlib/libc/tinystdio/sprintf_s.c
@@ -40,7 +40,7 @@
 #include "../stdlib/local_s.h"
 
 int
-sprintf_s(char *restrict s, rsize_t bufsize, const char *restrict fmt, ...)
+sprintf_s(char *__restrict s, rsize_t bufsize, const char *__restrict fmt, ...)
 {
     bool write_null = true;
     const char *msg = "";

--- a/newlib/libc/tinystdio/stdio.h
+++ b/newlib/libc/tinystdio/stdio.h
@@ -402,9 +402,9 @@ typedef __rsize_t rsize_t;
 
 int sprintf_s(char *__restrict __s, rsize_t __bufsize,
               const char *__restrict __format, ...);
-int vsnprintf_s(char *restrict s, rsize_t n, const char *restrict fmt,
+int vsnprintf_s(char *__restrict s, rsize_t n, const char *__restrict fmt,
                 va_list arg);
-int vfprintf_s(FILE *restrict stream, const char *restrict fmt,
+int vfprintf_s(FILE *__restrict stream, const char *__restrict fmt,
                va_list ap_orig);
 #endif
 

--- a/newlib/libc/tinystdio/vfprintf.c
+++ b/newlib/libc/tinystdio/vfprintf.c
@@ -479,7 +479,7 @@ _wcslen(const char *s, size_t maxlen)
 
 #ifdef VFPRINTF_S
 int
-vfprintf_s(FILE *restrict stream, const char *restrict fmt, va_list ap_orig)
+vfprintf_s(FILE *__restrict stream, const char *__restrict fmt, va_list ap_orig)
 #else
 int vfprintf (FILE * stream, const CHAR *fmt, va_list ap_orig)
 #endif

--- a/newlib/libc/tinystdio/vsnprintf_s.c
+++ b/newlib/libc/tinystdio/vsnprintf_s.c
@@ -40,7 +40,7 @@
 #include "../stdlib/local_s.h"
 
 int
-vsnprintf_s(char *restrict s, rsize_t n, const char *restrict fmt, va_list arg)
+vsnprintf_s(char *__restrict s, rsize_t n, const char *__restrict fmt, va_list arg)
 {
     bool write_null = true;
     const char *msg = "";


### PR DESCRIPTION
Updating the Annex-K functions to use the compiler-specific `__restrict` keyword instead of the standard `restrict`. 
This change ensures better compatibility with environments where `restrict` is not available or where `__restrict` is the preferred aliasing hint, such as in certain C++ or pre-C99 contexts.