### PR TITLE
Fixes for dev version of gcc, 'ninja clean' and -Dsystem-libc=true

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1683,6 +1683,8 @@ endif
 test_env = environment({'PICOLIBC_TEST' : '1'})
 test_env.prepend('PATH', meson.current_source_dir() / 'scripts')
 
+test_link_defaults = cc.get_supported_link_arguments(['-Wl,--gc-sections', '-Wl,--no-warn-rwx-segments'])
+
 if has_semihost
   foreach target : ['default-target'] + targets
     if target == 'default-target'
@@ -1704,7 +1706,7 @@ if has_semihost
     endif
 
     set_variable(test_link_args_variable,
-		 ['-Wl,--gc-sections', '-nostdlib', '-T', picolibc_ld_string]
+		 test_link_defaults + ['-nostdlib', '-T', picolibc_ld_string]
        + additional_libs_list
        + [lib_gcc])
 
@@ -1714,7 +1716,7 @@ if has_semihost
     set_variable(test_link_depends_variable, [picolibc_ld_value])
   endforeach
 else
-  test_link_args = ['-Wl,--gc-sections']
+  test_link_args = test_link_defaults
   test_link_depends = []
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -1233,10 +1233,10 @@ foreach target : ['default-target'] + targets
     else
       picolibc_ld_file = 'picolibc_' + custom_mem_config + '.ld'
       picolibc_ld_variable = 'picolibc_' + target + '_ld'
-      picolibc_ld_config_variable = 'picolibc_' + target + 'ld_config'
+      picolibc_ld_config_variable = 'picolibc_' + custom_mem_config + 'ld_config'
       picolibcpp_ld_file = 'picolibcpp_' + custom_mem_config + '.ld'
       picolibcpp_ld_variable = 'picolibcpp_' + target + '_ld'
-      picolibcpp_ld_config_variable = 'picolibcpp_' + target + 'ld_config'
+      picolibcpp_ld_config_variable = 'picolibcpp_' + custom_mem_config + 'ld_config'
       picolibc_ld_install = false
     endif
 

--- a/meson.build
+++ b/meson.build
@@ -1716,7 +1716,7 @@ if has_semihost
     set_variable(test_link_depends_variable, [picolibc_ld_value])
   endforeach
 else
-  test_link_args = test_link_defaults
+  test_link_args = test_link_defaults + cc.get_supported_link_arguments(['-lgcc'])
   test_link_depends = []
 endif
 

--- a/newlib/libc/stdlib/chacha_private.h
+++ b/newlib/libc/stdlib/chacha_private.h
@@ -65,6 +65,13 @@ typedef struct
   a = PLUS(a,b); d = ROTATE(XOR(d,a), 8); \
   c = PLUS(c,d); b = ROTATE(XOR(b,c), 7);
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#pragma GCC diagnostic ignored "-Wunterminated-string-initialization"
+#endif
+
 static const char sigma[16] = "expand 32-byte k";
 static const char tau[16] = "expand 16-byte k";
 

--- a/newlib/libc/time/asctime_r.c
+++ b/newlib/libc/time/asctime_r.c
@@ -26,6 +26,13 @@ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 #define oob(x,a) ((unsigned)(x) >= sizeof(a)/sizeof(a[0]))
 #define valid(x,a)   (oob(x,a) ? "???" : a[x])
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#pragma GCC diagnostic ignored "-Wunterminated-string-initialization"
+#endif
+
 char *
 asctime_r (const struct tm *__restrict tim_p,
            char result[__restrict static __ASCTIME_SIZE])

--- a/newlib/libc/tinystdio/stdio.h
+++ b/newlib/libc/tinystdio/stdio.h
@@ -440,6 +440,20 @@ __printf_float(float f)
 	return u.u;
 }
 
+#ifdef _PICOLIBC_PRINTF
+#if _PICOLIBC_PRINTF == 'd'
+#define PICOLIBC_DOUBLE_PRINTF_SCANF
+#elif _PICOLIBC_PRINTF == 'f'
+#define PICOLIBC_FLOAT_PRINTF_SCANF
+#elif _PICOLIBC_PRINTF == 'l'
+#define PICOLIBC_LONG_LONG_PRINTF_SCANF
+#elif _PICOLIBC_PRINTF == 'i'
+#define PICOLIBC_INTEGER_PRINTF_SCANF
+#elif _PICOLIBC_PRINTF == 'm'
+#define PICOLIBC_MINIMAL_PRINTF_SCANF
+#endif
+#endif
+
 #if !defined(PICOLIBC_DOUBLE_PRINTF_SCANF) && \
     !defined(PICOLIBC_FLOAT_PRINTF_SCANF) && \
     !defined(PICOLIBC_LONG_LONG_PRINTF_SCANF) && \

--- a/newlib/libm/test/meson.build
+++ b/newlib/libm/test/meson.build
@@ -173,7 +173,7 @@ foreach target : targets
   endforeach
 
   _c_args = value[1] + get_variable('test_c_args_' + target, test_c_args)
-  _link_args = value[1] + _lib_files + get_variable('test_link_args_' + target, test_link_args)
+  _link_args = value[1] + get_variable('test_link_args_' + target, test_link_args)
   _link_depends = get_variable('test_link_depends_' + target, test_link_depends)
 
   _c_args = double_printf_compile_args + _c_args
@@ -195,7 +195,8 @@ foreach target : targets
 		    c_args: _c_args +  ['-DTEST_PART=' + test_part],
 		    objects: _objs,
 		    link_args: _link_args,
-		    link_depends: _libs + _link_depends,
+                    link_with: _libs,
+		    link_depends: _link_depends,
 		    include_directories: inc),
          depends: bios_bin,
          env: test_env)

--- a/picolibc.specs.in
+++ b/picolibc.specs.in
@@ -4,7 +4,7 @@
 %rename cc1plus	picolibc_cc1plus
 
 *cpp:
-@SPECS_ISYSTEM@ %(picolibc_cpp)
+@SPECS_ISYSTEM@ %{-printf=*: -D_PICOLIBC_PRINTF='%*'} %(picolibc_cpp)
 
 *cc1:
 @TLSMODEL@ %(picolibc_cc1) @CC1_SPEC@
@@ -13,7 +13,7 @@
 @SPECS_ISYSTEM@ @TLSMODEL@ %(picolibc_cc1plus) @CC1_SPEC@ @CC1PLUS_SPEC@
 
 *link:
-@SPECS_PRINTF@ @SPECS_LIBPATH@ %{!T:-T@PICOLIBC_LD@} %(picolibc_link) --gc-sections @LINK_SPEC@
+@SPECS_PRINTF@ @SPECS_LIBPATH@ %{-printf=*:--defsym=vfprintf=__%*_vfprintf} %{!T:-T@PICOLIBC_LD@} %(picolibc_link) --gc-sections @LINK_SPEC@
 
 *lib:
 --start-group %(libgcc) @ADDITIONAL_LIBS@ -lc %{-oslib=*:-l%*} --end-group

--- a/scripts/do-configure
+++ b/scripts/do-configure
@@ -108,21 +108,30 @@ case "$*" in
 	;;
 esac
 
+case "$*" in
+    *system-libc=true*)
+	picolibcdir=""
+	;;
+    *)
+	picolibcdir="picolibc/"
+	;;
+esac
+
 # Run meson
 
 case "$PREFIX" in
     "")
 	meson setup \
-	      -Dincludedir=picolibc/"$ARCH"/include \
-	      -Dlibdir=picolibc/"$ARCH"/lib \
+	      -Dincludedir="$picolibcdir""$ARCH"/include \
+	      -Dlibdir="$picolibcdir""$ARCH"/lib \
 	      --cross-file "$CROSS" \
 	      "$@" \
 	      "$DIR"/..
 	;;
     *)
 	meson setup \
-	      -Dincludedir=picolibc/"$ARCH"/include \
-	      -Dlibdir=picolibc/"$ARCH"/lib \
+	      -Dincludedir="$picolibcdir""$ARCH"/include \
+	      -Dlibdir="$picolibcdir""$ARCH"/lib \
 	      --cross-file "$CROSS" \
 	      "$PREFIX" "$@" \
 	      "$DIR"/..

--- a/test/libc-testsuite/meson.build
+++ b/test/libc-testsuite/meson.build
@@ -70,7 +70,7 @@ foreach target : targets
 
   _c_args = value[1] + get_variable('test_c_args_' + target, test_c_args)
   _link_args = value[1] + _lib_files + get_variable('test_link_args_' + target, test_link_args)
-  _link_depends = get_variable('test_link_depends_' + target, test_link_depends) + _libs
+  _link_depends = get_variable('test_link_depends_' + target, test_link_depends)
 
   foreach t1 : libc_tests_picolibc
     t1_src = t1 + '.c'
@@ -92,6 +92,7 @@ foreach target : targets
 		    link_args: double_printf_link_args + _link_args,
 		    objects: _objs,
 		    link_depends:  _link_depends,
+                    link_with: _libs,
 		    include_directories: inc),
          depends: bios_bin,
 	 timeout: timeout,

--- a/test/meson.build
+++ b/test/meson.build
@@ -151,7 +151,7 @@ foreach target : targets
 
   _c_args = value[1] + get_variable('test_c_args_' + target, test_c_args)
   _link_args = value[1] + _lib_files + get_variable('test_link_args_' + target, test_link_args)
-  _link_depends = get_variable('test_link_depends_' + target, test_link_depends) + _libs
+  _link_depends = get_variable('test_link_depends_' + target, test_link_depends)
   if have_cplusplus
     _cpp_args = value[1] + get_variable('test_cpp_args_' + target, test_cpp_args)
   endif
@@ -168,7 +168,8 @@ foreach target : targets
 		  c_args: double_printf_compile_args + _c_args,
 		  link_args: double_printf_link_args + _link_args,
 		  objects: _objs,
-		  link_depends:  _link_depends + _libs,
+		  link_depends:  _link_depends,
+		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
        env: test_env)
@@ -185,7 +186,8 @@ foreach target : targets
 		  c_args: float_printf_compile_args + _c_args,
 		  link_args: float_printf_link_args + _link_args,
 		  objects: _objs,
-		  link_depends:  _link_depends + _libs,
+		  link_depends:  _link_depends,
+		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
        env: test_env)
@@ -202,7 +204,8 @@ foreach target : targets
 		  c_args: llong_printf_compile_args + _c_args,
 		  link_args: llong_printf_link_args + _link_args,
 		  objects: _objs,
-		  link_depends:  _link_depends + _libs,
+		  link_depends:  _link_depends,
+		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
        env: test_env)
@@ -219,7 +222,8 @@ foreach target : targets
 		  c_args: int_printf_compile_args + _c_args,
 		  link_args: int_printf_link_args + _link_args,
 		  objects: _objs,
-		  link_depends:  _link_depends + _libs,
+		  link_depends:  _link_depends,
+		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
        env: test_env)
@@ -236,7 +240,8 @@ foreach target : targets
 		  c_args: min_printf_compile_args + _c_args,
 		  link_args: min_printf_link_args + _link_args,
 		  objects: _objs,
-		  link_depends:  _link_depends + _libs,
+		  link_depends:  _link_depends,
+		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
        env: test_env)
@@ -253,7 +258,8 @@ foreach target : targets
 		  c_args: double_printf_compile_args + _c_args,
 		  link_args: double_printf_link_args + _link_args,
 		  objects: _objs,
-		  link_depends:  _link_depends + _libs,
+		  link_depends:  _link_depends,
+		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
        env: test_env)
@@ -270,7 +276,8 @@ foreach target : targets
 		  c_args: float_printf_compile_args + _c_args,
 		  link_args: float_printf_link_args + _link_args,
 		  objects: _objs,
-		  link_depends:  _link_depends + _libs,
+		  link_depends:  _link_depends,
+		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
        env: test_env)
@@ -287,7 +294,8 @@ foreach target : targets
 		  c_args: int_printf_compile_args + _c_args,
 		  link_args: int_printf_link_args + _link_args,
 		  objects: _objs,
-		  link_depends:  _link_depends + _libs,
+		  link_depends:  _link_depends,
+		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
        env: test_env)
@@ -304,7 +312,8 @@ foreach target : targets
 		  c_args: min_printf_compile_args + _c_args,
 		  link_args: min_printf_link_args + _link_args,
 		  objects: _objs,
-		  link_depends:  _link_depends + _libs,
+		  link_depends:  _link_depends,
+		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
        env: test_env)
@@ -328,7 +337,8 @@ foreach target : targets
 		  c_args: int_printf_compile_args + _c_args + ['-fno-builtin'],
 		  link_args: int_printf_link_args + _link_args,
 		  objects: _objs,
-		  link_depends:  _link_depends + _libs,
+		  link_depends:  _link_depends,
+		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
        env: test_env)
@@ -345,7 +355,8 @@ foreach target : targets
 		  c_args: _c_args,
 		  link_args: _link_args,
 		  objects: _objs,
-		  link_depends:  _link_depends + _libs,
+		  link_depends:  _link_depends,
+		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
        env: test_env)
@@ -364,7 +375,8 @@ foreach target : targets
 		  c_args: _c_args,
 		  link_args:  _link_args,
 		  objects: _objs,
-		  link_depends:  _link_depends + _libs,
+		  link_depends:  _link_depends,
+		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
        env: test_env)
@@ -374,7 +386,8 @@ foreach target : targets
 		  c_args: _c_args + ['-DRETVAL=1'],
 		  link_args:  _link_args,
 		  objects: _objs,
-		  link_depends:  _link_depends + _libs,
+		  link_depends:  _link_depends,
+		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
        env: test_env,
@@ -393,7 +406,8 @@ foreach target : targets
 		  c_args: _c_args,
 		  link_args:  _link_args,
 		  objects: _objs,
-		  link_depends:  _link_depends + _libs,
+		  link_depends:  _link_depends,
+		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
        env: test_env,
@@ -418,7 +432,8 @@ foreach target : targets
 		    c_args: _c_args,
 		    link_args:  _link_args,
 		    objects: _objs_minimal,
-		    link_depends:  _link_depends + _libs,
+		    link_depends:  _link_depends,
+		    link_with: _libs,
 		    include_directories: inc),
          depends: bios_bin,
 	 env: test_env)
@@ -436,7 +451,8 @@ foreach target : targets
 		  c_args: arg_fnobuiltin + _c_args,
 		  link_args: _link_args,
 		  objects: _objs,
-		  link_depends:  _link_depends + _libs,
+		  link_depends:  _link_depends,
+		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
        env: test_env)
@@ -453,7 +469,8 @@ foreach target : targets
 		  c_args: arg_fnobuiltin + _c_args,
 		  link_args: _link_args,
 		  objects: _objs,
-		  link_depends:  _link_depends + _libs,
+		  link_depends:  _link_depends,
+		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
        env: test_env)
@@ -471,7 +488,8 @@ foreach target : targets
 		  c_args: double_printf_compile_args + arg_fnobuiltin + _c_args,
 		  link_args: double_printf_link_args + _link_args,
 		  objects: _objs,
-		  link_depends:  _link_depends + _libs,
+		  link_depends:  _link_depends,
+		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
        env: test_env,
@@ -491,7 +509,8 @@ foreach target : targets
 		  c_args: double_printf_compile_args + _c_args,
 		  link_args: double_printf_link_args + _link_args,
 		  objects: _objs,
-		  link_depends:  _link_depends + _libs,
+		  link_depends:  _link_depends,
+		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
        env: test_env,
@@ -511,7 +530,8 @@ foreach target : targets
 		           c_args: _c_args,
 		           link_args: _link_args,
 		           objects: _objs,
-		           link_depends:  _link_depends + _libs,
+		           link_depends:  _link_depends,
+		           link_with: _libs,
 		           include_directories: inc)
 
     test(t1_name + '-success',
@@ -552,7 +572,8 @@ foreach target : targets
 		    c_args: c_sanitize_bounds_flags + _c_args + test_ubsan_flags,
 		    link_args: _link_args,
 		    objects: _objs,
-		    link_depends:  _link_depends + _libs,
+		    link_depends:  _link_depends,
+		    link_with: _libs,
 		    include_directories: inc),
 	 depends: bios_bin,
 	 env: test_env,
@@ -572,7 +593,8 @@ foreach target : targets
 		  c_args: llong_printf_compile_args + _c_args,
 		  link_args: llong_printf_link_args + _link_args,
 		  objects: _objs,
-		  link_depends:  _link_depends + _libs,
+		  link_depends:  _link_depends,
+		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
        timeout: 120,
@@ -591,7 +613,8 @@ foreach target : targets
 		  c_args: double_printf_compile_args + _c_args,
 		  link_args: double_printf_link_args + _link_args,
 		  objects: _objs,
-		  link_depends:  _link_depends + _libs,
+		  link_depends:  _link_depends,
+		  link_with: _libs,
 		  include_directories: inc),
        depends: bios_bin,
        timeout: 120,
@@ -612,7 +635,8 @@ foreach target : targets
 		    c_args: double_printf_compile_args + test_file_name_arg + _c_args,
 		    link_args: double_printf_link_args + _link_args,
 		    objects: _objs,
-		    link_depends:  _link_depends + _libs,
+		    link_depends:  _link_depends,
+		    link_with: _libs,
 		    include_directories: inc),
          depends: bios_bin,
 	 timeout: 60,
@@ -632,7 +656,8 @@ foreach target : targets
                     cpp_args: _cpp_args,
 		    link_args: _cpp_args + _link_args,
 		    objects: _objs,
-		    link_depends:  _link_depends + _libs,
+		    link_depends:  _link_depends,
+		    link_with: _libs,
                     include_directories: inc))
   endif
 endforeach
@@ -716,7 +741,8 @@ if enable_native_tests
                           c_args: _c_args,
                           link_args: _link_args,
                           objects: _objs,
-                          link_depends: _link_depends + _libs,
+                          link_depends: _link_depends,
+                          link_with: _libs,
                           include_directories: inc)
 
       wctype_native = executable('test-wctype-native', 'test-wctype.c',


### PR DESCRIPTION
A selection of minor fixes
 1. Fix warnings about overwriting linker scripts during meson run
 2. GCC warning fixes
 3. Support new --printf= option for gcc
 4. Ignore rwx segment warnings during link
 5. Remove picolibc/ in do-configure script when -Dsystem-libc=true
 6. Use link_with when building tests to make 'ninja clean' work