### PR TITLE
[ARM] On Thumb-1 targets, don't overwrite current sp in _set_stacks

### DIFF
--- a/picocrt/machine/arm/crt0.c
+++ b/picocrt/machine/arm/crt0.c
@@ -188,8 +188,11 @@ extern char __stack[];
 #define I_BIT           (1 << 7)
 #define F_BIT           (1 << 6)
 
+#define SET_MODE(mode) \
+    __asm__("mov r0, %0\nmsr cpsr_c, r0" :: "r" (mode | I_BIT | F_BIT): "r0")
+
 #define SET_SP(mode) \
-    __asm__("mov r0, %0\nmsr cpsr_c, r0" :: "r" (mode | I_BIT | F_BIT): "r0");   \
+    SET_MODE(mode);  \
     __asm__("mov sp, %0" : : "r" (__stack))
 
 #define SET_SPS()                               \
@@ -197,14 +200,16 @@ extern char __stack[];
         SET_SP(MODE_ABT);                       \
         SET_SP(MODE_UND);                       \
         SET_SP(MODE_FIQ);                       \
-        SET_SP(MODE_SVC);                       \
         SET_SP(MODE_SYS);
 
 #if __ARM_ARCH_ISA_THUMB == 1
+// _set_stacks presumes we're in supervisor mode and the stack for that
+// mode has already been set up correctly (in _start).
 static __noinline __attribute__((target("arm"))) void
 _set_stacks(void)
 {
         SET_SPS();
+        SET_MODE(MODE_SVC);
 }
 #endif
 


### PR DESCRIPTION
In the startup code, when setting the various SPs of the different modes, we also overwrite the SP of the current mode, which on reset/startup is the supervisor mode.

Besides this, _set_stacks also switches from supervisor mode to system mode. Which on first sight seems unintentional, also because this isn't done for the other targets.

In most cases this happens to work out, because this early in the startup code, nothing has been written to the stack yet. However when frame pointers for leaf functions are enabled, which for Clang is now the default when frame pointers are enabled, we do have stack movement. Both _cstart and _set_stacks copy r11 and lr to the stack on entry and pop them off on exit. And so will write garbage in the link register.

This patch changes the behaviour of _set_stacks to switches back to supervisor mode instead of switching to system mode, without overwriting the supervisor mode SP.