### PR TITLE
Initial LoongArch support

### DIFF
--- a/.github/do-linux
+++ b/.github/do-linux
@@ -10,6 +10,7 @@ HERE=`dirname "$0"`
 "$HERE"/do-test-noopt native-m32 "$@"
 "$HERE"/do-test aarch64 "$@"
 "$HERE"/do-build lx106 "$@"
+"$HERE"/do-test loongarch64 "$@"
 "$HERE"/do-test-noopt i386 "$@"
 "$HERE"/do-test m68k-unknown-elf "$@"
 "$HERE"/do-test msp430-unknown-elf "$@"

--- a/.github/linux-files.txt
+++ b/.github/linux-files.txt
@@ -5,3 +5,5 @@ https://github.com/picolibc/toolchains/raw/refs/heads/main/qemu-m68k.tar.xz
 https://github.com/picolibc/toolchains/raw/refs/heads/main/sh-unknown-elf.tar.xz
 https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/download/release-18.1.3/LLVM-ET-Arm-18.1.3-Linux-x86_64.tar.xz
 https://developer.arm.com/-/cdn-downloads/permalink/FVPs-Architecture/FM-11.27/FVP_Base_RevC-2xAEMvA_11.27_19_Linux64.tgz
+https://github.com/FlyGoat/picolibc-ci-tools/releases/download/v20241227/loongarch64-unknown-elf.linux-amd64.tar.xz
+https://github.com/FlyGoat/picolibc-ci-tools/releases/download/v20241227/qemu-stable.linux-amd64.tar.xz

--- a/meson.build
+++ b/meson.build
@@ -81,6 +81,9 @@ cpu_family_aliases = {
 		       'arm64' : 'aarch64',
 		       # cris
 		       'crisv32' : 'cris',
+           # loongarch
+		       'loongarch64' : 'loongarch',
+		       'loongarch32' : 'loongarch',
 		       # m68hc11
 		       'm6811' : 'm68hc11',
 		       'm6812' : 'm68hc11',

--- a/newlib/libc/include/machine/ieeefp.h
+++ b/newlib/libc/include/machine/ieeefp.h
@@ -263,6 +263,17 @@ warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #endif
 #endif
 
+#ifdef __loongarch__
+#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#define __IEEE_BIG_ENDIAN
+#else
+#define __IEEE_LITTLE_ENDIAN
+#endif
+#ifndef __loongarch_soft_float
+# define _SUPPORTS_ERREXCEPT
+#endif
+#endif
+
 #ifdef __riscv
 #if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
 #define __IEEE_BIG_ENDIAN

--- a/newlib/libc/include/machine/setjmp.h
+++ b/newlib/libc/include/machine/setjmp.h
@@ -444,6 +444,18 @@ _BEGIN_STD_C
 #endif
 #endif
 
+#ifdef __loongarch__
+#define _JBTYPE unsigned long
+#ifdef __loongarch_soft_float
+#define _JBLEN 13
+#elif __loongarch_frlen > 32 && __loongarch_grlen <= 32
+/* Extra padding for alignment */
+#define _JBLEN (13 + 1 + (8 * (__loongarch_frlen / __loongarch_grlen)))
+#else
+#define _JBLEN (13 + (8 * (__loongarch_frlen / __loongarch_frlen)))
+#endif
+#endif
+
 #ifdef _JBLEN
 #ifdef _JBTYPE
 typedef	_JBTYPE jmp_buf[_JBLEN];

--- a/newlib/libc/machine/loongarch/asm.h
+++ b/newlib/libc/machine/loongarch/asm.h
@@ -1,0 +1,74 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _SYS_ASM_H
+#define _SYS_ASM_H
+
+/*
+ * Macros to handle different pointer/register sizes for 32/64-bit code
+ */
+#if __loongarch_grlen == 64
+# define PTRLOG 3
+# define SZREG	8
+# define REG_S st.d
+# define REG_L ld.d
+# define ADDI addi.d
+# define ADD  add.d
+#elif __loongarch_grlen == 32
+# define PTRLOG 2
+# define SZREG	4
+# define REG_S st.w
+# define REG_L ld.w
+# define ADDI addi.w
+# define ADD  add.w
+#else
+# error __loongarch_grlen must equal 32 or 64
+#endif
+
+#ifndef __loongarch_soft_float
+# if defined(__loongarch_single_float)
+#  define SZFREG 4
+#  define FREG_L fld.s
+#  define FREG_S fst.s
+# elif defined(__loongarch_double_float)
+#  define SZFREG 8
+#  define FREG_L fld.d
+#  define FREG_S fst.d
+# else
+#  error unsupported FRLEN
+# endif
+#endif
+
+#endif /* sys/asm.h */

--- a/newlib/libc/machine/loongarch/machine/_fpmath.h
+++ b/newlib/libc/machine/loongarch/machine/_fpmath.h
@@ -1,0 +1,65 @@
+/*-
+ * Copyright (c) 2002, 2003 David Schultz <das@FreeBSD.ORG>
+ * Copyright (c) 2014 The FreeBSD Foundation
+ * Copyright (c) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+/*
+ * Change unsigned int/long used by FreeBSD to fixed width types because
+ * ilp32 has a different size for unsigned long. --joel (20 Aug 2022)
+ */
+#include <stdint.h>
+
+union IEEEl2bits {
+	long double	e;
+	struct {
+		uint64_t	manl	:64;
+		uint64_t	manh	:48;
+		uint32_t	exp	:15;
+		uint32_t	sign	:1;
+	} bits;
+	/* TODO andrew: Check the packing here */
+	struct {
+		uint64_t	manl	:64;
+		uint64_t	manh	:48;
+		uint32_t	expsign	:16;
+	} xbits;
+};
+
+#define	LDBL_NBIT	0
+#define	LDBL_IMPLICIT_NBIT
+#define	mask_nbit_l(u)	((void)0)
+
+#define	LDBL_MANH_SIZE	48
+#define	LDBL_MANL_SIZE	64
+
+#define	LDBL_TO_ARRAY32(u, a) do {			\
+	(a)[0] = (uint32_t)(u).bits.manl;		\
+	(a)[1] = (uint32_t)((u).bits.manl >> 32);	\
+	(a)[2] = (uint32_t)(u).bits.manh;		\
+	(a)[3] = (uint32_t)((u).bits.manh >> 32);	\
+} while(0)

--- a/newlib/libc/machine/loongarch/machine/fenv-fp.h
+++ b/newlib/libc/machine/loongarch/machine/fenv-fp.h
@@ -1,0 +1,481 @@
+/*
+  (c) Copyright 2017 Michael R. Neilly
+  (c) Copyright 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  * Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+  * Neither the names of the copyright holders nor the names of their
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* This implementation is intended to comply with the following
+ * specification:
+ *
+ * http://pubs.opengroup.org/onlinepubs/009695399/functions/feclearexcept.html
+ * Referred to as 'feclearexcept.html below.
+ *
+ * "The feclearexcept() function shall attempt to clear the supported
+ * floating-point exceptions represented by excepts."
+ */
+
+#define _FPU_DEFAULT 0x0
+#define _FPU_IEEE 0x1F
+
+__declare_fenv_inline(int) feclearexcept(int excepts)
+{
+  int fcsr;
+
+  excepts &= FE_ALL_EXCEPT;
+  _movfcsr2gr(fcsr);
+  fcsr &= ~(excepts | (excepts << _FCSR_CAUSE_LSHIFT));
+  _movgr2fcsr(fcsr);
+
+  /* Per 'feclearexcept.html
+   * "If the argument is zero or if all the specified exceptions were
+   * successfully cleared, feclearexcept() shall return zero. Otherwise,
+   * it shall return a non-zero value."
+   */
+
+  return 0;
+}
+
+/* This implementation is intended to comply with the following
+ * specification:
+ *
+ * http://pubs.opengroup.org/onlinepubs/009695399/functions/fegetenv.html
+ * Referred to as 'fegetenv.html below.
+ *
+ * "The fegetenv() function shall attempt to store the current
+ * floating-point environment in the object pointed to by envp."
+ *
+ */
+
+__declare_fenv_inline(int) fegetenv(fenv_t *envp)
+{
+
+  /* Get the current environment (FCSR) */
+  int fcsr;
+
+  _movfcsr2gr(fcsr);
+  *envp = fcsr;
+
+  /* Per 'fegetenv.html:
+   *
+   * "If the representation was successfully stored, fegetenv() shall
+   * return zero. Otherwise, it shall return a non-zero value.
+   */
+
+  return 0;
+}
+
+/* This implementation is intended to comply with the following
+ * specification:
+ *
+ * http://pubs.opengroup.org/onlinepubs/009695399/functions/fegetexceptflag.html
+ * Referred to as 'fegetexceptflag.html below.
+ *
+ * "The fegetexceptflag() function shall attempt to store an
+ * implementation-defined representation of the states of the
+ * floating-point status flags indicated by the argument excepts in
+ * the object pointed to by the argument flagp."
+ */
+
+__declare_fenv_inline(int) fegetexceptflag(fexcept_t *flagp, int excepts)
+{
+
+  int fcsr;
+
+  _movfcsr2gr(fcsr);
+
+  *flagp = fcsr & excepts & FE_ALL_EXCEPT;
+
+  /* Per 'fegetexceptflag.html:
+   *
+   * "If the representation was successfully stored, fegetexceptflag()
+   * shall return zero. Otherwise, it shall return a non-zero
+   * value."
+   */
+
+  return 0;
+}
+
+/* This implementation is intended to comply with the following
+ * specification:
+ *
+ * http://pubs.opengroup.org/onlinepubs/009695399/functions/fegetround.html
+ * Referred to as 'fegetround.html below.
+ *
+ * "The fegetround() function shall get the current rounding direction."
+ */
+
+__declare_fenv_inline(int) fegetround(void)
+{
+
+  /* Get current rounding mode */
+  int fcsr;
+
+  _movfcsr2gr(fcsr);
+
+  /* Per 'fegetround.html:
+   *
+   * "The fegetround() function shall return the value of the rounding
+   * direction macro representing the current rounding direction or a
+   * negative value if there is no such rounding direction macro or
+   * the current rounding direction is not determinable."
+   */
+
+  /* Return the rounding mode */
+
+  return fcsr & FE_RMODE_MASK;
+
+}
+
+/* This implementation is intended to comply with the following
+ * specification:
+ *
+ * http://pubs.opengroup.org/onlinepubs/009695399/functions/feholdexcept.html
+ * Referred to as 'feholdexcept.html below.
+ *
+ * "The feholdexcept() function shall save the current floating-point
+ * environment in the object pointed to by envp, clear the
+ * floating-point status flags, and then install a non-stop (continue
+ * on floating-point exceptions) mode, if available, for all
+ * floating-point exceptions."
+ */
+
+__declare_fenv_inline(int) feholdexcept(fenv_t *envp)
+{
+
+  /* Store the current FP environment in envp*/
+  int fcsr;
+
+  _movfcsr2gr(fcsr);
+  *envp = fcsr;
+
+  /* Clear all exception enable bits and flags.  */
+  fcsr &= ~(FE_ALL_EXCEPT >> _FCSR_ENABLE_RSHIFT | FE_ALL_EXCEPT);
+  _movgr2fcsr(fcsr);
+
+
+  /* Per 'feholdexcept.html:
+   *
+   * "The feholdexcept() function shall return zero if and only if
+   * non-stop floating-point exception handling was successfully
+   * installed."
+   */
+
+  return 0;
+}
+
+/* This implementation is intended to comply with the following
+ * specification:
+ *
+ * http://pubs.opengroup.org/onlinepubs/009695399/functions/feraiseexcept.html
+ * Referred to as 'feraiseexcept.html below.
+ *
+ * "The feraiseexcept() function shall attempt to raise the supported
+ * floating-point exceptions represented by the excepts argument. The
+ * order in which these floating-point exceptions are raised is
+ * unspecified, except that if the excepts argument represents IEC
+ * 60559 valid coincident floating-point exceptions for atomic
+ * operations (namely overflow and inexact, or underflow and inexact),
+ * then overflow or underflow shall be raised before inexact. Whether
+ * the feraiseexcept() function additionally raises the inexact
+ * floating-point exception whenever it raises the overflow or
+ * underflow floating-point exception is implementation-defined."
+ */
+
+__declare_fenv_inline(int) feraiseexcept(int excepts)
+{
+  const float fp_zero = 0.0f;
+  const float fp_one = 1.0f;
+  const float fp_max = FLT_MAX;
+  const float fp_min = FLT_MIN;
+  const float fp_1e32 = 1.0e32f;
+  const float fp_two = 2.0f;
+  const float fp_three = 3.0f;
+
+  if (FE_INVALID & excepts)
+    __asm__ __volatile__("fdiv.s $f0,%0,%0\n\t"
+			 :
+			 : "f"(fp_zero)
+			 : "$f0");
+
+  if (FE_DIVBYZERO & excepts)
+    __asm__ __volatile__("fdiv.s $f0,%0,%1\n\t"
+			 :
+			 : "f"(fp_one), "f"(fp_zero)
+			 : "$f0");
+
+  if (FE_OVERFLOW & excepts)
+    __asm__ __volatile__("fadd.s $f0,%0,%1\n\t"
+			 :
+			 : "f"(fp_max), "f"(fp_1e32)
+			 : "$f0");
+
+  if (FE_UNDERFLOW & excepts)
+    __asm__ __volatile__("fdiv.s $f0,%0,%1\n\t"
+			 :
+			 : "f"(fp_min), "f"(fp_three)
+			 : "$f0");
+
+  if (FE_INEXACT & excepts)
+    __asm__ __volatile__("fdiv.s $f0, %0, %1\n\t"
+			 :
+			 : "f"(fp_two), "f"(fp_three)
+			 : "$f0");
+
+  /* Per 'feraiseexcept.html:
+   * "If the argument is zero or if all the specified exceptions were
+   * successfully raised, feraiseexcept() shall return
+   * zero. Otherwise, it shall return a non-zero value."
+   */
+
+  return 0;
+}
+
+__declare_fenv_inline(int) fesetexcept(int excepts)
+{
+  int fcsr;
+
+  _movfcsr2gr(fcsr);
+  fcsr |= excepts & FE_ALL_EXCEPT;
+  _movgr2fcsr(fcsr);
+
+  return 0;
+}
+
+/* This implementation is intended to comply with the following
+ * specification:
+ *
+ * http://pubs.opengroup.org/onlinepubs/009695399/functions/fegetenv.html
+ * Referred to as 'fegetenv.html below.
+ *
+ * "The fegetenv() function shall attempt to store the current
+ * floating-point environment in the object pointed to by envp.
+ *
+ * The fesetenv() function shall attempt to establish the
+ * floating-point environment represented by the object pointed to by
+ * envp. The argument envp shall point to an object set by a call to
+ * fegetenv() or feholdexcept(), or equal a floating-point environment
+ * macro. The fesetenv() function does not raise floating-point
+ * exceptions, but only installs the state of the floating-point
+ * status flags represented through its argument."
+ */
+
+__declare_fenv_inline(int) fesetenv(const fenv_t *envp)
+{
+
+  /* Set environment (FCSR) */
+
+  fenv_t fcsr;
+  
+  /* Hazard handling */
+  _movfcsr2gr(fcsr);
+  fcsr = *envp;
+  _movgr2fcsr(fcsr);
+
+
+  /* Per 'fegetenv.html:
+   *
+   * "If the environment was successfully established, fesetenv()
+   * shall return zero. Otherwise, it shall return a non-zero value.
+   */
+
+  return 0;
+}
+
+/* This implementation is intended to comply with the following
+ * specification:
+ *
+ * http://pubs.opengroup.org/onlinepubs/009695399/functions/fesetexceptflag.html
+ * Referred to as 'fesetexceptflag.html below.
+ *
+ * "The fesetexceptflag() function shall attempt to set the
+ * floating-point status flags indicated by the argument excepts to
+ * the states stored in the object pointed to by flagp. The value
+ * pointed to by flagp shall have been set by a previous call to
+ * fegetexceptflag() whose second argument represented at least those
+ * floating-point exceptions represented by the argument excepts. This
+ * function does not raise floating-point exceptions, but only sets
+ * the state of the flags."
+ *
+ */
+
+__declare_fenv_inline(int) fesetexceptflag(const fexcept_t *flagp, int excepts)
+{
+  int fcsr;
+
+  _movfcsr2gr(fcsr);
+
+  excepts &= FE_ALL_EXCEPT;
+  fcsr = (fcsr & ~excepts) | (*flagp & excepts);
+
+  _movgr2fcsr(fcsr);
+
+  /* Per 'fesetexceptflag.html:
+   *
+   * "If the excepts argument is zero or if all the specified
+   * exceptions were successfully set, fesetexceptflag() shall return
+   * zero. Otherwise, it shall return a non-zero value."
+   */
+
+  return 0;
+}
+
+/* This implementation is intended to comply with the following
+ * specification:
+ *
+ * http://pubs.opengroup.org/onlinepubs/009695399/functions/fesetround.html
+ * Referred to as 'fegetenv.html below.
+ *
+ * "The fesetround() function shall establish the rounding direction
+ * represented by its argument round. If the argument is not equal to
+ * the value of a rounding direction macro, the rounding direction is
+ * not changed."
+ */
+
+__declare_fenv_inline(int) fesetround(int round)
+{
+
+  int fcsr;
+
+  if ((round & ~FE_RMODE_MASK) != 0)
+    return -1;
+
+  _movfcsr2gr(fcsr);
+  fcsr &= ~FE_RMODE_MASK;
+  fcsr |= round;
+  _movgr2fcsr(fcsr);
+
+
+  /* Per 'fesetround.html:
+   *
+   * "The fesetround() function shall return a zero value if and only
+   * if the requested rounding direction was established."
+   */
+
+  return 0;
+}
+
+/* This implementation is intended to comply with the following
+ * specification:
+ *
+ * http://pubs.opengroup.org/onlinepubs/9699919799/functions/fetestexcept.html
+ *
+ * "The fetestexcept() function shall determine which of a specified
+ * subset of the floating-point exception flags are currently set. The
+ * excepts argument specifies the floating-point status flags to be
+ * queried."
+ */
+
+__declare_fenv_inline(int) fetestexcept(int excepts)
+{
+  int fcsr;
+
+  _movfcsr2gr(fcsr);
+
+  /* "The fetestexcept() function shall return the value of the
+   * bitwise-inclusive OR of the floating-point exception macros
+   * corresponding to the currently set floating-point exceptions
+   * included in excepts."
+   */
+
+  return (fcsr & excepts & FE_ALL_EXCEPT);
+}
+
+/* This implementation is intended to comply with the following
+ * specification:
+ *
+ * http://pubs.opengroup.org/onlinepubs/9699919799/functions/feupdateenv.html
+ *
+ * "The feupdateenv() function shall attempt to save the currently
+ * raised floating-point exceptions in its automatic storage, attempt
+ * to install the floating-point environment represented by the object
+ * pointed to by envp, and then attempt to raise the saved
+ * floating-point exceptions. The argument envp shall point to an
+ * object set by a call to feholdexcept() or fegetenv(), or equal a
+ * floating-point environment macro."
+ */
+
+__declare_fenv_inline(int) feupdateenv(const fenv_t *envp)
+{
+  int fcsr;
+
+  _movfcsr2gr(fcsr);
+
+  fesetenv(envp);
+
+  feraiseexcept(fcsr & FE_ALL_EXCEPT);
+
+  /* "The feupdateenv() function shall return a zero value if and only
+   * if all the required actions were successfully carried out."
+   */
+
+  return 0;
+
+}
+
+__declare_fenv_inline(int) feenableexcept(int excepts)
+{
+  int fcsr, old_excepts;
+
+  _movfcsr2gr(fcsr);
+
+  old_excepts = (fcsr << _FCSR_ENABLE_RSHIFT) & FE_ALL_EXCEPT;
+
+  excepts &= FE_ALL_EXCEPT;
+
+  fcsr |= excepts >> _FCSR_ENABLE_RSHIFT;
+  _movgr2fcsr(fcsr);
+
+  return old_excepts;
+}
+
+__declare_fenv_inline(int) fedisableexcept(int excepts)
+{
+  int fcsr, old_excepts;
+
+  _movfcsr2gr(fcsr);
+
+  old_excepts = (fcsr << _FCSR_ENABLE_RSHIFT) & FE_ALL_EXCEPT;
+
+  excepts &= FE_ALL_EXCEPT;
+
+  fcsr &= ~(excepts >> _FCSR_ENABLE_RSHIFT);
+  _movgr2fcsr(fcsr);
+
+  return old_excepts;
+}
+
+__declare_fenv_inline(int) fegetexcept(void)
+{
+  int fcsr;
+
+  _movfcsr2gr(fcsr);
+  return (fcsr << _FCSR_ENABLE_RSHIFT) & FE_ALL_EXCEPT;
+}

--- a/newlib/libc/machine/loongarch/machine/fenv.h
+++ b/newlib/libc/machine/loongarch/machine/fenv.h
@@ -1,0 +1,116 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _MACHINE_FENV_H
+#define _MACHINE_FENV_H
+
+#include <stddef.h>
+
+typedef unsigned int fenv_t;
+typedef unsigned int fexcept_t;
+
+#ifndef __loongarch_soft_float
+
+/* LoongArch FPU floating point control register bits.
+ *
+ * 31-29  -> reserved (read as 0, can not changed by software)
+ * 28     -> cause bit for invalid exception
+ * 27     -> cause bit for division by zero exception
+ * 26     -> cause bit for overflow exception
+ * 25     -> cause bit for underflow exception
+ * 24     -> cause bit for inexact exception
+ * 23-21  -> reserved (read as 0, can not changed by software)
+ * 20     -> flag invalid exception
+ * 19     -> flag division by zero exception
+ * 18     -> flag overflow exception
+ * 17     -> flag underflow exception
+ * 16     -> flag inexact exception
+ *  9-8   -> rounding control
+ *  7-5   -> reserved (read as 0, can not changed by software)
+ *  4     -> enable exception for invalid exception
+ *  3     -> enable exception for division by zero exception
+ *  2     -> enable exception for overflow exception
+ *  1     -> enable exception for underflow exception
+ *  0     -> enable exception for inexact exception
+ *
+ *
+ * Rounding Control:
+ * 00 - rounding ties to even (RNE)
+ * 01 - rounding toward zero (RZ)
+ * 10 - rounding (up) toward plus infinity (RP)
+ * 11 - rounding (down) toward minus infinity (RM)
+ */
+
+
+/* Masks for interrupts.  */
+#define _FCSR_CAUSE_LSHIFT 8
+#define _FCSR_ENABLE_RSHIFT 16
+#define FE_INEXACT    0x010000
+#define FE_UNDERFLOW  0x020000
+#define FE_OVERFLOW   0x040000
+#define FE_DIVBYZERO  0x080000
+#define FE_INVALID    0x100000
+
+/* Flush denormalized numbers to zero.  */
+#define FE_ALL_EXCEPT (FE_INVALID|FE_DIVBYZERO|FE_OVERFLOW|FE_UNDERFLOW|FE_INEXACT)
+
+/* Rounding control.  */
+#define FE_TONEAREST  0x000
+#define FE_TOWARDZERO 0x100
+#define FE_UPWARD     0x200
+#define FE_DOWNWARD   0x300
+
+#define FE_RMODE_MASK 0x300
+
+#define _movfcsr2gr(cw) __asm__ volatile ("movfcsr2gr %0,$fcsr0" : "=r"(cw))
+#define _movgr2fcsr(cw) __asm__ volatile ("movgr2fcsr $fcsr0,%0" : : "r"(cw))
+
+#else
+#define FE_TONEAREST	0
+#endif
+
+#if !defined(__declare_fenv_inline) && defined(__declare_extern_inline)
+#define	__declare_fenv_inline(type) __declare_extern_inline(type)
+#endif
+
+#ifdef __declare_fenv_inline
+#ifndef __loongarch_soft_float
+#include <machine/fenv-fp.h>
+#else
+#include <machine/fenv-softfloat.h>
+#endif
+#endif
+
+#endif /* _MACHINE_FENV_H */

--- a/newlib/libc/machine/loongarch/machine/math.h
+++ b/newlib/libc/machine/loongarch/machine/math.h
@@ -1,0 +1,287 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _MACHINE_MATH_H_
+#define _MACHINE_MATH_H_
+
+#ifndef __loongarch_soft_float
+
+#ifdef _WANT_MATH_ERRNO
+#include <errno.h>
+#endif
+
+# define _FCLASS_SNAN     (1 << 0)
+# define _FCLASS_QNAN     (1 << 1)
+# define _FCLASS_MINF     (1 << 2)
+# define _FCLASS_MNORM    (1 << 3)
+# define _FCLASS_MSUBNORM (1 << 4)
+# define _FCLASS_MZERO    (1 << 5)
+# define _FCLASS_PINF     (1 << 6)
+# define _FCLASS_PNORM    (1 << 7)
+# define _FCLASS_PSUBNORM (1 << 8)
+# define _FCLASS_PZERO    (1 << 9)
+
+# define _FCLASS_ZERO     (_FCLASS_MZERO | _FCLASS_PZERO)
+# define _FCLASS_SUBNORM  (_FCLASS_MSUBNORM | _FCLASS_PSUBNORM)
+# define _FCLASS_NORM     (_FCLASS_MNORM | _FCLASS_PNORM)
+# define _FCLASS_INF      (_FCLASS_MINF | _FCLASS_PINF)
+# define _FCLASS_NAN      (_FCLASS_SNAN | _FCLASS_QNAN)
+
+#if __loongarch_frlen >= 64
+
+/* anything with a 64-bit FPU has FMA */
+#define _HAVE_FAST_FMA 1
+
+#define _fclass_d(_x) (__extension__(                                   \
+                               {                                        \
+                                       long __fclass;                   \
+                                       __asm__("fclass.d %0, %1" :      \
+                                               "=f" (__fclass) :        \
+                                               "f" (_x));               \
+                                       __fclass;                        \
+                               }))
+
+#endif
+
+#if __loongarch_frlen >= 32
+
+/* anything with a 32-bit FPU has FMAF */
+#define _HAVE_FAST_FMAF 1
+
+#define _fclass_f(_x) (__extension__(                                   \
+                               {                                        \
+                                       long __fclass;                   \
+                                       __asm__("fclass.s %0, %1" :      \
+                                               "=f" (__fclass) :        \
+                                               "f" (_x));               \
+                                       __fclass;                        \
+                               }))
+
+#endif
+
+
+#ifdef __declare_extern_inline
+
+#if __loongarch_frlen >= 64
+
+/* Double-precision functions */
+__declare_extern_inline(double)
+copysign(double x, double y)
+{
+	double result;
+	__asm__("fcopysign.d\t%0, %1, %2" : "=f" (result) : "f" (x), "f" (y));
+	return result;
+}
+
+__declare_extern_inline(double)
+fabs(double x)
+{
+	double result;
+	__asm__("fabs.d\t%0, %1" : "=f"(result) : "f"(x));
+	return result;
+}
+
+__declare_extern_inline(double)
+fmax (double x, double y)
+{
+	double result;
+        if (issignaling(x) || issignaling(y))
+            return x + y;
+
+	__asm__ volatile("fmax.d\t%0, %1, %2" : "=f" (result) : "f" (x), "f" (y));
+	return result;
+}
+
+__declare_extern_inline(double)
+fmin (double x, double y)
+{
+	double result;
+        if (issignaling(x) || issignaling(y))
+            return x + y;
+
+	__asm__ volatile("fmin.d\t%0, %1, %2" : "=f" (result) : "f" (x), "f" (y));
+	return result;
+}
+
+__declare_extern_inline(int)
+__finite(double x)
+{
+	long fclass = _fclass_d (x);
+	return (fclass & (_FCLASS_INF|_FCLASS_NAN)) == 0;
+}
+
+__declare_extern_inline(int)
+finite(double x)
+{
+        return __finite(x);
+}
+
+__declare_extern_inline(int)
+__fpclassifyd (double x)
+{
+  long fclass = _fclass_d (x);
+
+  if (fclass & _FCLASS_ZERO)
+    return FP_ZERO;
+  else if (fclass & _FCLASS_NORM)
+    return FP_NORMAL;
+  else if (fclass & _FCLASS_SUBNORM)
+    return FP_SUBNORMAL;
+  else if (fclass & _FCLASS_INF)
+    return FP_INFINITE;
+  else
+    return FP_NAN;
+}
+
+__declare_extern_inline(double)
+sqrt (double x)
+{
+	double result;
+#ifdef _WANT_MATH_ERRNO
+        if (isless(x, 0.0))
+            errno = EDOM;
+#endif
+	__asm__ volatile("fsqrt.d %0, %1" : "=f" (result) : "f" (x));
+	return result;
+}
+
+__declare_extern_inline(double)
+fma (double x, double y, double z)
+{
+	double result;
+	__asm__ volatile("fmadd.d %0, %1, %2, %3" : "=f" (result) : "f" (x), "f" (y), "f" (z));
+	return result;
+}
+
+#endif /* __loongarch_frlen >= 64 */
+
+#if __loongarch_frlen >= 32
+
+/* Single-precision functions */
+__declare_extern_inline(float)
+copysignf(float x, float y)
+{
+	float result;
+	__asm__("fcopysign.s\t%0, %1, %2" : "=f" (result) : "f" (x), "f" (y));
+	return result;
+}
+
+__declare_extern_inline(float)
+fabsf (float x)
+{
+	float result;
+	__asm__("fabs.s\t%0, %1" : "=f"(result) : "f"(x));
+	return result;
+}
+
+__declare_extern_inline(float)
+fmaxf (float x, float y)
+{
+	float result;
+        if (issignaling(x) || issignaling(y))
+            return x + y;
+
+	__asm__ volatile("fmax.s\t%0, %1, %2" : "=f" (result) : "f" (x), "f" (y));
+	return result;
+}
+
+__declare_extern_inline(float)
+fminf (float x, float y)
+{
+	float result;
+        if (issignaling(x) || issignaling(y))
+            return x + y;
+
+	__asm__ volatile("fmin.s\t%0, %1, %2" : "=f" (result) : "f" (x), "f" (y));
+	return result;
+}
+
+__declare_extern_inline(int)
+__finitef(float x)
+{
+	long fclass = _fclass_f (x);
+	return (fclass & (_FCLASS_INF|_FCLASS_NAN)) == 0;
+}
+
+__declare_extern_inline(int)
+finitef(float x)
+{
+        return __finitef(x);
+}
+
+__declare_extern_inline(int)
+__fpclassifyf (float x)
+{
+  long fclass = _fclass_f (x);
+
+  if (fclass & _FCLASS_ZERO)
+    return FP_ZERO;
+  else if (fclass & _FCLASS_NORM)
+    return FP_NORMAL;
+  else if (fclass & _FCLASS_SUBNORM)
+    return FP_SUBNORMAL;
+  else if (fclass & _FCLASS_INF)
+    return FP_INFINITE;
+  else
+    return FP_NAN;
+}
+
+__declare_extern_inline(float)
+sqrtf (float x)
+{
+	float result;
+#ifdef _WANT_MATH_ERRNO
+        if (isless(x, 0.0f))
+            errno = EDOM;
+#endif
+	__asm__ volatile("fsqrt.s %0, %1" : "=f" (result) : "f" (x));
+	return result;
+}
+
+__declare_extern_inline(float)
+fmaf (float x, float y, float z)
+{
+	float result;
+	__asm__ volatile("fmadd.s %0, %1, %2, %3" : "=f" (result) : "f" (x), "f" (y), "f" (z));
+	return result;
+}
+
+#endif /* __loongarch_frlen >= 32 */
+
+#endif /* defined(__GNUC_GNU_INLINE__) || defined(__GNUC_STDC_INLINE__) */
+
+#endif /* __loongarch_frlen */
+
+#endif /* _MACHINE_MATH_H_ */

--- a/newlib/libc/machine/loongarch/machine/meson.build
+++ b/newlib/libc/machine/loongarch/machine/meson.build
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
-# Copyright © 2019 Keith Packard
+# Copyright © 2020 Keith Packard
 # Copyright © 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
 #
 # Redistribution and use in source and binary forms, with or without
@@ -33,21 +33,11 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-srcs_machine = [
-  'setjmp.S',
+inc_machine_headers_machine = [
+  'fenv.h',
+  'fenv-fp.h',
+  'math.h'
 ]
 
-subdir('machine')
-
-foreach params : targets
-  target = params['name']
-  target_dir = params['dir']
-  target_c_args = params['c_args']
-  target_lib_prefix = params['lib_prefix']
-	set_variable('lib_machine' + target,
-		static_library('machine' + target,
-			srcs_machine,
-			pic: false,
-			include_directories: inc,
-			c_args: target_c_args + c_args + arg_fnobuiltin))
-endforeach
+install_headers(inc_machine_headers_machine,
+		install_dir: include_dir / 'machine')

--- a/newlib/libc/machine/loongarch/meson.build
+++ b/newlib/libc/machine/loongarch/meson.build
@@ -1,0 +1,51 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2019 Keith Packard
+# Copyright © 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+srcs_machine = [
+  'setjmp.S',
+]
+
+foreach params : targets
+  target = params['name']
+  target_dir = params['dir']
+  target_c_args = params['c_args']
+  target_lib_prefix = params['lib_prefix']
+	set_variable('lib_machine' + target,
+		static_library('machine' + target,
+			srcs_machine,
+			pic: false,
+			include_directories: inc,
+			c_args: target_c_args + c_args + arg_fnobuiltin))
+endforeach

--- a/newlib/libc/machine/loongarch/setjmp.S
+++ b/newlib/libc/machine/loongarch/setjmp.S
@@ -1,0 +1,87 @@
+/* Copyright (c) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
+
+   This copyrighted material is made available to anyone wishing to use,
+   modify, copy, or redistribute it subject to the terms and conditions
+   of the FreeBSD License.   This program is distributed in the hope that
+   it will be useful, but WITHOUT ANY WARRANTY expressed or implied,
+   including the implied warranties of MERCHANTABILITY or FITNESS FOR
+   A PARTICULAR PURPOSE.  A copy of this license is available at
+   http://www.opensource.org/licenses.
+*/
+
+#include <picolibc.h>
+
+#include "asm.h"
+
+/* Align up for FPR to avoid unaligned access on grlen == 32 & frlen == 64 */
+#define ALIGN_UP(x, align) (((x) + (align) - 1) & ~((align) - 1))
+#define FR_OFFSET ALIGN_UP((13*SZREG), SZFREG)
+
+/* int setjmp (jmp_buf);  */
+  .section .text.setjmp
+  .globl  setjmp
+  .type   setjmp, @function
+setjmp:
+	REG_S $ra,  $a0, 0*SZREG
+	REG_S $sp,  $a0, 1*SZREG
+	REG_S $r21, $a0, 2*SZREG /* r21 is reserved */
+	REG_S $fp,  $a0, 3*SZREG
+	REG_S $s0,  $a0, 4*SZREG
+	REG_S $s1,  $a0, 5*SZREG
+	REG_S $s2,  $a0, 6*SZREG
+	REG_S $s3,  $a0, 7*SZREG
+	REG_S $s4,  $a0, 8*SZREG
+	REG_S $s5,  $a0, 9*SZREG
+	REG_S $s6,  $a0, 10*SZREG
+	REG_S $s7,  $a0, 11*SZREG
+	REG_S $s8,  $a0, 12*SZREG
+
+#ifndef __loongarch_soft_float
+	FREG_S $fs0, $a0, FR_OFFSET + 0*SZFREG
+	FREG_S $fs1, $a0, FR_OFFSET + 1*SZFREG
+	FREG_S $fs2, $a0, FR_OFFSET + 2*SZFREG
+	FREG_S $fs3, $a0, FR_OFFSET + 3*SZFREG
+	FREG_S $fs4, $a0, FR_OFFSET + 4*SZFREG
+	FREG_S $fs5, $a0, FR_OFFSET + 5*SZFREG
+	FREG_S $fs6, $a0, FR_OFFSET + 6*SZFREG
+	FREG_S $fs7, $a0, FR_OFFSET + 7*SZFREG
+#endif
+
+	li.w		$a0, 0
+	jirl		$zero, $ra, 0
+	.size	setjmp, .-setjmp
+
+/* volatile void longjmp (jmp_buf, int);  */
+  .section .text.longjmp
+  .globl  longjmp
+  .type   longjmp, @function
+longjmp:
+	REG_L $ra,  $a0, 0*SZREG
+	REG_L $sp,  $a0, 1*SZREG
+	REG_L $r21, $a0, 2*SZREG
+	REG_L $fp,  $a0, 3*SZREG
+	REG_L $s0,  $a0, 4*SZREG
+	REG_L $s1,  $a0, 5*SZREG
+	REG_L $s2,  $a0, 6*SZREG
+	REG_L $s3,  $a0, 7*SZREG
+	REG_L $s4,  $a0, 8*SZREG
+	REG_L $s5,  $a0, 9*SZREG
+	REG_L $s6,  $a0, 10*SZREG
+	REG_L $s7,  $a0, 11*SZREG
+	REG_L $s8,  $a0, 12*SZREG
+
+#ifndef __loongarch_soft_float
+	FREG_L $fs0, $a0, FR_OFFSET + 0*SZFREG
+	FREG_L $fs1, $a0, FR_OFFSET + 1*SZFREG
+	FREG_L $fs2, $a0, FR_OFFSET + 2*SZFREG
+	FREG_L $fs3, $a0, FR_OFFSET + 3*SZFREG
+	FREG_L $fs4, $a0, FR_OFFSET + 4*SZFREG
+	FREG_L $fs5, $a0, FR_OFFSET + 5*SZFREG
+	FREG_L $fs6, $a0, FR_OFFSET + 6*SZFREG
+	FREG_L $fs7, $a0, FR_OFFSET + 7*SZFREG
+#endif
+
+	sltui	$a0, $a1, 1
+	ADD	$a0, $a0, $a1	 # a0 = (a1 == 0) ? 1 : a1
+	jirl	$zero, $ra, 0
+	.size	longjmp, .-longjmp

--- a/newlib/libc/tinystdio/stdio.h
+++ b/newlib/libc/tinystdio/stdio.h
@@ -56,7 +56,7 @@ _BEGIN_STD_C
  */
 
 #ifdef ATOMIC_UNGETC
-#if defined(__riscv) || defined(__MICROBLAZE__)
+#if defined(__riscv) || defined(__MICROBLAZE__) || (__loongarch__)
 /*
  * Use 32-bit ungetc storage when doing atomic ungetc on RISC-V and
  * MicroBlaze, which have 4-byte swap intrinsics but not 2-byte swap

--- a/picocrt/machine/loongarch/crt0.c
+++ b/picocrt/machine/loongarch/crt0.c
@@ -1,0 +1,206 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 2024 Jiaxun Yang <<jiaxun.yang@flygoat.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stddef.h>
+#include "../../crt0.h"
+
+static void __attribute__((used)) __section(".init")
+_cstart(void)
+{
+	__start();
+}
+
+#ifdef CRT0_SEMIHOST
+#include <semihost.h>
+#include <unistd.h>
+#include <stdio.h>
+
+#define NUM_REG 32
+
+#if __loongarch_grlen == 32
+#define FMT     "%08lx"
+#define SD      "st.d"
+#define ADDI    "addi.d"
+#else
+#define FMT     "%016lx"
+#define SD      "st.d"
+#define ADDI    "addi.w"
+#endif
+
+struct fault {
+        unsigned long   r[NUM_REG];
+	unsigned long csr_era;
+	unsigned long csr_badvaddr;
+	unsigned long csr_crmd;
+	unsigned long csr_prmd;
+	unsigned long csr_euen;
+	unsigned long csr_ecfg;
+	unsigned long csr_estat;
+};
+
+static const char *const names[NUM_REG] = {
+        "zero", "ra",   "tp",   "sp",   "a0",   "a1",   "a2",   "a3",
+        "a4",   "a5",   "a6",   "a7",   "t0",   "t1",   "t2",   "t3",
+        "t4",   "t5",   "t6",   "t7",   "t8",   "r21",  "fp",   "s0",
+        "s1",   "s2",   "s3",   "s4",   "s5",   "s6",   "s7",   "s8",
+};
+
+static void __attribute__((used)) __section(".init")
+_ctrap(struct fault *fault)
+{
+        int r;
+        printf("LoongArch fault\n");
+        for (r = 0; r < NUM_REG; r++)
+                printf("\tx%d %-5.5s%s 0x" FMT "\n", r, names[r], r < 10 ? " " : "", fault->r[r]);
+        printf("\tera: 0x%lx\n", fault->csr_era);
+        printf("\tbadvaddr: 0x%lx\n", fault->csr_badvaddr);
+        printf("\tcrmd: 0x%lx\n", fault->csr_crmd);
+        printf("\tprmd: 0x%lx\n", fault->csr_prmd);
+        printf("\teuen: 0x%lx\n", fault->csr_euen);
+        printf("\tecfg: 0x%lx\n", fault->csr_ecfg);
+        printf("\testat: 0x%lx\n", fault->csr_estat);
+        _exit(1);
+}
+
+#define _PASTE(r) #r
+#define PASTE(r) _PASTE(r)
+
+void  __section(".init") __attribute__((used)) __attribute((aligned(0x40)))
+_trap(void)
+{
+        /* Build a known-working C environment */
+	__asm__(
+                "csrwr          $sp, 0x30\n" /* Save sp to ksave0 */
+                "la.abs	        $sp, __heap_end\n");
+
+        /* Make space for saved registers */
+        __asm__(ADDI "          $sp, $sp, %0\n"
+                ".cfi_def_cfa   3, 0\n" // sp
+                :: "i"(-sizeof(struct fault)));
+
+        /* Save registers on stack */
+#define SAVE_REG(num)   \
+        __asm__(SD"     $r%0, $sp, %1" :: "i" (num), \
+                "i" ((num) * sizeof(unsigned long) + offsetof(struct fault, r)))
+
+        SAVE_REG(0);
+        SAVE_REG(1);
+        SAVE_REG(2);
+        SAVE_REG(3);
+        SAVE_REG(4);
+        SAVE_REG(5);
+        SAVE_REG(6);
+        SAVE_REG(7);
+        SAVE_REG(8);
+        SAVE_REG(9);
+        SAVE_REG(10);
+        SAVE_REG(11);
+        SAVE_REG(12);
+        SAVE_REG(13);
+        SAVE_REG(14);
+        SAVE_REG(15);
+        SAVE_REG(16);
+        SAVE_REG(17);
+        SAVE_REG(18);
+        SAVE_REG(19);
+        SAVE_REG(20);
+        SAVE_REG(21);
+        SAVE_REG(22);
+        SAVE_REG(23);
+        SAVE_REG(24);
+        SAVE_REG(25);
+        SAVE_REG(26);
+        SAVE_REG(27);
+        SAVE_REG(28);
+        SAVE_REG(29);
+        SAVE_REG(30);
+        SAVE_REG(31);
+
+#define SAVE_CSR(name, reg)  \
+        __asm__("csrrd   $t0, "PASTE(reg)); \
+        __asm__(SD"      $t0, $sp, %0" :: "i" (offsetof(struct fault, name)))
+
+
+        /*
+         * Save the trapping frame's stack pointer that was stashed in ksave0
+         * and tell the unwinder where we can find the return address (csr_era).
+         */
+        __asm__("csrrd   $ra, 0x6\n"
+                SD "     $ra, $sp, %0\n"
+                ".cfi_offset 1, %0\n" // ra
+                "csrrd   $t0, 0x30\n"
+                SD "     $t0, $sp, %0\n"
+                ".cfi_offset 3, %1\n" // sp
+                :: "i"(offsetof(struct fault, csr_era)),
+                   "i"(offsetof(struct fault, r[3])));
+        SAVE_CSR(csr_badvaddr, 0x7);
+        SAVE_CSR(csr_crmd, 0x0);
+        SAVE_CSR(csr_prmd, 0x1);
+        SAVE_CSR(csr_euen, 0x2);
+        SAVE_CSR(csr_ecfg, 0x4);
+        SAVE_CSR(csr_estat, 0x5);
+
+        /*
+         * Pass pointer to saved registers in first parameter register
+         */
+        __asm__("move     $a0, $sp");
+
+        /* Enable FPU (just in case) */
+#ifndef __loongarch_soft_float
+	__asm__("li.w           $t0, 0x1\n"        /* FPEN */
+                "csrxchg	$t0, $t0, 0x2\n"); /* EUEN */
+#endif
+        __asm__("la.pcrel       $t0, _ctrap\n"
+                "jirl		$ra, $t0, 0\n");
+}
+#endif
+
+void __section(".text.init.enter") __attribute__((used))
+_start(void)
+{
+	__asm__("la.abs         $sp, __stack\n");
+
+#ifndef __loongarch_soft_float
+	__asm__("li.w           $t0, 0x1\n"        /* FPEN */
+                "csrxchg	$t0, $t0, 0x2\n"); /* EUEN */
+#endif
+
+#ifdef CRT0_SEMIHOST
+        __asm__("la.abs         $t0, _trap");
+        __asm__("csrwr          $t0, 0xc");
+#endif
+        __asm__("la.pcrel      $t0, _cstart\n"
+                "jirl          $ra, $t0, 0\n");
+}

--- a/picocrt/machine/loongarch/meson.build
+++ b/picocrt/machine/loongarch/meson.build
@@ -1,0 +1,36 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright (c) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
+# Copyright © 2021 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+src_picocrt += files('crt0.c')

--- a/scripts/cross-loongarch64-unknown-elf.txt
+++ b/scripts/cross-loongarch64-unknown-elf.txt
@@ -1,0 +1,26 @@
+[binaries]
+# Meson 0.53.2 doesn't use any cflags when doing basic compiler tests,
+# so we have to add -nostdlib to the compiler configuration itself or
+# early compiler tests will fail. This can be removed when picolibc
+# requires at least version 0.54.2 of meson.
+c = ['loongarch64-unknown-elf-gcc', '-nostdlib']
+cpp = ['loongarch64-unknown-elf-g++', '-nostdlib']
+ar = 'loongarch64-unknown-elf-ar'
+as = 'loongarch64-unknown-elf-as'
+strip = 'loongarch64-unknown-elf-strip'
+nm = 'loongarch64-unknown-elf-nm'
+# only needed to run tests
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-loongarch64 "$@"', 'run-loongarch64']
+
+[host_machine]
+system = 'unknown'
+cpu_family = 'loongarch64'
+cpu = 'loongarch'
+endian = 'little'
+
+[properties]
+# Use secondary flash as first is occupied by boot_code
+default_flash_addr = '0x1d000000'
+default_flash_size = '0x01000000'
+default_ram_addr   = '0x00200000'
+default_ram_size   = '0x00200000'

--- a/scripts/do-configure
+++ b/scripts/do-configure
@@ -69,10 +69,10 @@ esac
 case "$*" in
     *-Dio-long-double=true*)
 	case "$ARCH" in
-	    *rv[36][24]*|*riscv*|*aarch64*|*power9-fp128*|*sparc*)
+	    *rv[36][24]*|*riscv*|*aarch64*|*power9-fp128*|*sparc*|*loongarch*)
 		case "$*" in
 		    *-Dtinystdio=false*)
-			echo "io-long-double for legacy stdio not supported on riscv, aarch64, power-fp128 or sparc"
+			echo "io-long-double for legacy stdio not supported on riscv, aarch64, power-fp128 sparc or loongarch"
 			exit 77
 			;;
 		esac

--- a/scripts/do-loongarch64-configure
+++ b/scripts/do-loongarch64-configure
@@ -1,0 +1,37 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright (c) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
+# Copyright © 2019 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+exec "$(dirname "$0")"/do-configure loongarch64-unknown-elf -Dtests=true "$@"

--- a/scripts/run-loongarch64
+++ b/scripts/run-loongarch64
@@ -1,0 +1,89 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright (c) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
+# Copyright © 2020 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+qemu="qemu-system-loongarch64"
+
+# select the program
+elf="$1"
+shift
+
+# Map stdio to a multiplexed character device so we can use it
+# for the monitor and semihosting output
+
+chardev=stdio,mux=on,id=stdio0
+
+# Point the semihosting driver at our new chardev
+
+cmdline="program-name"
+input=""
+done=0
+
+while [ "$done" != "1" ]; do
+    case "$1" in
+        --)
+            shift
+            done=1
+            ;;
+        -s|"")
+            done=1
+            ;;
+        *)
+            cmdline="$cmdline $1"
+            case "$input" in
+                "")
+                    input="$1"
+                    ;;
+                *)
+                    input="$input $1"
+                    ;;
+            esac
+            shift
+            ;;
+    esac
+done
+
+semi=enable=on,chardev=stdio0,arg="$cmdline"
+
+# Disable monitor
+
+mon=none
+
+# Point serial port at new chardev
+
+serial=none
+
+echo "$input" | $qemu -chardev $chardev -semihosting-config "$semi" -monitor "$mon" -serial "$serial" -M virt  -nographic -kernel "$elf" "$@" -nic none

--- a/semihost/machine/loongarch/meson.build
+++ b/semihost/machine/loongarch/meson.build
@@ -1,0 +1,36 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright (c) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
+# Copyright © 2021 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+src_semihost += files('semihost-loongarch.S')

--- a/semihost/machine/loongarch/semihost-loongarch.S
+++ b/semihost/machine/loongarch/semihost-loongarch.S
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <picolibc.h>
+
+        .global sys_semihost
+sys_semihost:
+        dbcl 0xab
+        ret


### PR DESCRIPTION
Hi All,

This PR implemented initial support for LoongArch.
Currently, only LoongArch 64 build is supported as upstream LoongArch32 ABI is not ratified yet, but all implementations are 32bit aware and build tested against downstream toolchain.

It requires a custom `loongarch64-unknown-elf` toolchain to build, my `ct-ng` config built for current crosstool-ng master:
```
CT_CONFIG_VERSION="4"
CT_EXPERIMENTAL=y
CT_ARCH_LOONGARCH=y
# CT_DEMULTILIB is not set
CT_ARCH_USE_MMU=y
CT_ARCH_ARCH="loongarch64"
CT_LIBC_NONE=y
CT_CC_GCC_LIBSTDCXX_VERBOSE=m
CT_CC_LANG_CXX=y
CT_DEBUG_GDB=y
# CT_GDB_CROSS_PYTHON is not set
CT_GETTEXT_NEEDED=y
```

For QEMU testing, a patch to enable semihosting is also required:
https://lore.kernel.org/qemu-devel/20241222-semihosting-v1-1-8a770df60e9c@flygoat.com/

All tests are passing on my side:
```
ninja test
[0/1] Running all tests.
  1/206 picolibc:headers / check-cdef-semihost.h                    OK               0.05s
  2/206 picolibc:headers / check-cdef-stdio.h                       OK               0.05s
  3/206 picolibc:headers / check-cdef-stdio-bufio.h                 OK               0.05s
  4/206 picolibc:headers / check-cdef-sys-auxv.h                    OK               0.05s
  5/206 picolibc:headers / check-cdef-sys-cdefs.h                   OK               0.05s
  6/206 picolibc:headers / check-cdef-sys-errno.h                   OK               0.04s
  7/206 picolibc:headers / check-cdef-sys-fcntl.h                   OK               0.04s
  8/206 picolibc:headers / check-cdef-sys-file.h                    OK               0.04s
  9/206 picolibc:headers / check-cdef-sys-iconvnls.h                OK               0.03s
 10/206 picolibc:headers / check-cdef-sys-lock.h                    OK               0.03s
 11/206 picolibc:headers / check-cdef-sys-param.h                   OK               0.03s
 12/206 picolibc:headers / check-cdef-sys-queue.h                   OK               0.03s
 13/206 picolibc:headers / check-cdef-sys-dir.h                     OK               0.09s
 14/206 picolibc:headers / check-cdef-sys-resource.h                OK               0.07s
 15/206 picolibc:headers / check-cdef-sys-sched.h                   OK               0.07s
 16/206 picolibc:headers / check-cdef-sys-select.h                  OK               0.08s
 17/206 picolibc:headers / check-cdef-sys-stat.h                    OK               0.07s
 18/206 picolibc:headers / check-cdef-sys-syslimits.h               OK               0.07s
 19/206 picolibc:headers / check-cdef-sys-timeb.h                   OK               0.06s
 20/206 picolibc:headers / check-cdef-sys-time.h                    OK               0.06s
 21/206 picolibc:headers / check-cdef-sys-times.h                   OK               0.06s
 22/206 picolibc:headers / check-cdef-sys-timespec.h                OK               0.06s
 23/206 picolibc:headers / check-cdef-sys-types.h                   OK               0.05s
 24/206 picolibc:headers / check-cdef-sys-unistd.h                  OK               0.05s
 25/206 picolibc:headers / check-cdef-sys-utime.h                   OK               0.05s
 26/206 picolibc:headers / check-cdef-sys-wait.h                    OK               0.04s
 27/206 picolibc:headers / check-cdef-rpc-types.h                   OK               0.04s
 28/206 picolibc:headers / check-cdef-sys-tree.h                    OK               0.09s
 29/206 picolibc:headers / check-cdef-rpc-xdr.h                     OK               0.07s
 30/206 picolibc:headers / check-cdef-arpa-inet.h                   OK               0.08s
 31/206 picolibc:headers / check-cdef-alloca.h                      OK               0.07s
 32/206 picolibc:headers / check-cdef-argz.h                        OK               0.07s
 33/206 picolibc:headers / check-cdef-ar.h                          OK               0.07s
 34/206 picolibc:headers / check-cdef-assert.h                      OK               0.06s
 35/206 picolibc:headers / check-cdef-byteswap.h                    OK               0.06s
 36/206 picolibc:headers / check-cdef-ctype.h                       OK               0.06s
 37/206 picolibc:headers / check-cdef-devctl.h                      OK               0.05s
 38/206 picolibc:headers / check-cdef-elf.h                         OK               0.05s
 39/206 picolibc:headers / check-cdef-endian.h                      OK               0.05s
 40/206 picolibc:headers / check-cdef-envlock.h                     OK               0.04s
 41/206 picolibc:headers / check-cdef-envz.h                        OK               0.04s
 42/206 picolibc:headers / check-cdef-errno.h                       OK               0.04s
 43/206 picolibc:headers / check-cdef-dirent.h                      OK               0.09s
 44/206 picolibc:headers / check-cdef-fastmath.h                    OK               0.07s
 45/206 picolibc:headers / check-cdef-fcntl.h                       OK               0.06s
 46/206 picolibc:headers / check-cdef-fenv.h                        OK               0.07s
 47/206 picolibc:headers / check-cdef-fnmatch.h                     OK               0.07s
 48/206 picolibc:headers / check-cdef-getopt.h                      OK               0.07s
 49/206 picolibc:headers / check-cdef-glob.h                        OK               0.07s
 50/206 picolibc:headers / check-cdef-grp.h                         OK               0.07s
 51/206 picolibc:headers / check-cdef-iconv.h                       OK               0.06s
 52/206 picolibc:headers / check-cdef-ieeefp.h                      OK               0.06s
 53/206 picolibc:headers / check-cdef-inttypes.h                    OK               0.06s
 54/206 picolibc:headers / check-cdef-langinfo.h                    OK               0.06s
 55/206 picolibc:headers / check-cdef-libgen.h                      OK               0.05s
 56/206 picolibc:headers / check-cdef-limits.h                      OK               0.05s
 57/206 picolibc:headers / check-cdef-locale.h                      OK               0.05s
 58/206 picolibc:headers / check-cdef-malloc.h                      OK               0.05s
 59/206 picolibc:headers / check-cdef-math.h                        OK               0.07s
 60/206 picolibc:headers / check-cdef-memory.h                      OK               0.07s
 61/206 picolibc:headers / check-cdef-ndbm.h                        OK               0.08s
 62/206 picolibc:headers / check-cdef-pwd.h                         OK               0.08s
 63/206 picolibc:headers / check-cdef-regex.h                       OK               0.08s
 64/206 picolibc:headers / check-cdef-sched.h                       OK               0.08s
 65/206 picolibc:headers / check-cdef-search.h                      OK               0.08s
 66/206 picolibc:headers / check-cdef-setjmp.h                      OK               0.07s
 67/206 picolibc:headers / check-cdef-signal.h                      OK               0.07s
 68/206 picolibc:headers / check-cdef-spawn.h                       OK               0.07s
 69/206 picolibc:headers / check-cdef-stdint.h                      OK               0.07s
 70/206 picolibc:headers / check-cdef-stdnoreturn.h                 OK               0.06s
 71/206 picolibc:headers / check-cdef-stdlib.h                      OK               0.06s
 72/206 picolibc:headers / check-cdef-string.h                      OK               0.06s
 73/206 picolibc:headers / check-cdef-strings.h                     OK               0.05s
 74/206 picolibc:headers / check-cdef-threads.h                     OK               0.09s
 75/206 picolibc:headers / check-cdef-time.h                        OK               0.08s
 76/206 picolibc:headers / check-cdef-uchar.h                       OK               0.08s
 77/206 picolibc:headers / check-cdef-unctrl.h                      OK               0.09s
 78/206 picolibc:headers / check-cdef-unistd.h                      OK               0.09s
 79/206 picolibc:headers / check-cdef-utime.h                       OK               0.09s
 80/206 picolibc:headers / check-cdef-wchar.h                       OK               0.09s
 81/206 picolibc:headers / check-cdef-wctype.h                      OK               0.09s
 82/206 picolibc:headers / check-cdef-wordexp.h                     OK               0.09s
 83/206 picolibc:headers / check-cdef-complex.h                     OK               0.09s
 84/206 picolibc:headers / check-cdef-picotls.h                     OK               0.08s
 85/206 picolibc / iconvjp                                          OK               0.14s
 86/206 picolibc / iconvru                                          OK               0.14s
 87/206 picolibc / hsearchtest                                      OK               0.16s
 88/206 picolibc / atexit                                           OK               0.18s
 89/206 picolibc / nulprintf                                        OK               0.19s
 90/206 picolibc / iconvnm                                          OK               0.21s
 91/206 picolibc / size_max                                         OK               0.21s
 92/206 picolibc / memcpy-1                                         OK               0.20s
 93/206 picolibc / memmove1                                         OK               0.23s
 94/206 picolibc / tzset                                            OK               0.21s
 95/206 picolibc / twctrans                                         OK               0.18s
 96/206 picolibc / tstring                                          OK               0.23s
 97/206 picolibc / asctime                                          OK               0.20s
 98/206 picolibc / tiswctype                                        OK               0.23s
 99/206 picolibc / printf_scanf                                     OK               0.19s
100/206 picolibc / printff_scanff                                   OK               0.18s
101/206 picolibc / printfi_scanfi                                   OK               0.16s
102/206 picolibc / printfm_scanfm                                   OK               0.15s
103/206 picolibc / printf-tests                                     OK               0.18s
104/206 picolibc / printfl_scanfl                                   OK               0.25s
105/206 picolibc / printff-tests                                    OK               0.18s
106/206 picolibc / printfi-tests                                    OK               0.17s
107/206 picolibc / printfm-tests                                    OK               0.15s
108/206 picolibc / time-sprintf                                     OK               0.17s
109/206 picolibc / hosted-exit                                      OK               0.15s
110/206 picolibc / hosted-exit-fail                                 EXPECTEDFAIL     0.15s   exit status 1
111/206 picolibc / try-ilp32                                        OK               0.20s
112/206 picolibc / math_test                                        OK               0.37s
113/206 picolibc / abort                                            EXPECTEDFAIL     0.16s   (exit status 134 or signal 6 SIGABRT)
114/206 picolibc / constructor-skip                                 OK               0.15s
115/206 picolibc / rounding-mode                                    OK               0.16s
116/206 picolibc / math_errhandling                                 OK               0.19s
117/206 picolibc / test-except                                      SKIP             0.16s   exit status 77
118/206 picolibc / ungetc                                           OK               0.14s
119/206 picolibc / regex                                            OK               0.15s
120/206 picolibc / malloc                                           OK               0.14s
121/206 picolibc / test-ubsan                                       OK               0.18s
122/206 picolibc / atexit                                           OK               0.15s
123/206 picolibc / setjmp                                           OK               0.18s
124/206 picolibc / on_exit                                          OK               0.17s
125/206 picolibc / long_double                                      OK               0.26s
126/206 picolibc / ffs                                              OK               0.22s
127/206 picolibc / timegm                                           OK               0.19s
128/206 picolibc / test-strchr                                      OK               0.20s
129/206 picolibc / test-raise                                       OK               0.18s
130/206 picolibc / test-sprintf-percent-n                           SKIP             0.15s   exit status 77
131/206 picolibc / test-put                                         OK               0.21s
132/206 picolibc / test-ctype                                       OK               0.18s
133/206 picolibc / test-uchar                                       OK               0.18s
134/206 picolibc / constructor                                      OK               0.18s
135/206 picolibc / test-vfscanf-percent-a                           OK               0.16s
136/206 picolibc / posix-io                                         OK               0.15s
137/206 picolibc / test-atomic                                      OK               0.17s
138/206 picolibc / test-fopen                                       OK               0.16s
139/206 picolibc / test-mktemp                                      OK               0.16s
140/206 picolibc / test-tmpnam                                      OK               0.18s
141/206 picolibc / t_fmemopen                                       OK               0.29s
142/206 picolibc / test-ungetc-ftell                                OK               0.19s
143/206 picolibc / test-wchar                                       OK               0.16s
144/206 picolibc / test-fgetc                                       OK               0.19s
145/206 picolibc / test-fgets-eof                                   OK               0.18s
146/206 picolibc / strcmp-1                                         OK               0.87s
147/206 picolibc / fenv                                             OK               0.19s
148/206 picolibc / rand                                             OK               0.18s
149/206 picolibc / test-efcvt                                       OK               0.17s
150/206 picolibc / test-strtod                                      OK               0.15s
151/206 picolibc / complex-funcs                                    OK               0.18s
152/206 picolibc / test-fma                                         OK               0.21s
153/206 picolibc / test-funopen                                     OK               0.13s
154/206 picolibc / time-tests                                       OK               0.13s
155/206 picolibc / tls                                              OK               0.13s
156/206 picolibc / math-funcs                                       OK               0.18s
157/206 picolibc / test-memset                                      OK               0.56s
158/206 picolibc / test-cplusplus                                   OK               0.03s
159/206 picolibc / test-memset_s                                    OK               0.15s
160/206 picolibc / test-memcpy_s                                    OK               0.16s
161/206 picolibc / test-memmove_s                                   OK               0.17s
162/206 picolibc / test-strcpy_s                                    OK               0.15s
163/206 picolibc / test-strerror_s                                  OK               0.16s
164/206 picolibc / test-strcat_s                                    OK               0.19s
165/206 picolibc / test-strerrorlen_s                               OK               0.17s
166/206 picolibc / test-strncat_s                                   OK               0.18s
167/206 picolibc / test-strnlen_s                                   OK               0.16s
168/206 picolibc / test-strncpy_s                                   OK               0.20s
169/206 picolibc / stack-smash                                      OK               0.17s
170/206 picolibc / test-sprintf_s                                   OK               0.18s
171/206 picolibc / dirname                                          OK               0.16s
172/206 picolibc / basename                                         OK               0.17s
173/206 picolibc / fnmatch                                          OK               0.19s
174/206 picolibc / qsort                                            OK               0.19s
175/206 picolibc / snprintf                                         OK               0.20s
176/206 picolibc / strtol                                           OK               0.16s
177/206 picolibc / sscanf                                           OK               0.21s
178/206 picolibc / string                                           OK               0.21s
179/206 picolibc:semihost / semihost-argv                           OK               0.17s
180/206 picolibc / strtod                                           OK               0.21s
181/206 picolibc:semihost / semihost-exit                           OK               0.19s
182/206 picolibc:semihost / semihost-errno                          OK               0.17s
183/206 picolibc:semihost / semihost-clock                          OK               0.18s
184/206 picolibc:semihost / semihost-exit-extended                  OK               0.19s
185/206 picolibc:semihost / semihost-flen                           OK               0.20s
186/206 picolibc:semihost / semihost-gettimeofday                   OK               0.17s
187/206 picolibc:semihost / semihost-get-cmdline                    OK               0.19s
188/206 picolibc:semihost / semihost-istty                          OK               0.16s
189/206 picolibc:semihost / semihost-open                           OK               0.18s
190/206 picolibc:semihost / semihost-read                           OK               0.18s
191/206 picolibc:semihost / semihost-remove                         OK               0.17s
192/206 picolibc:semihost / semihost-rename                         OK               0.16s
193/206 picolibc:semihost / semihost-seek                           OK               0.17s
194/206 picolibc:semihost / semihost-time                           OK               0.15s
195/206 picolibc:semihost / semihost-system                         OK               0.18s
196/206 picolibc:semihost / semihost-times                          OK               0.16s
197/206 picolibc:semihost / semihost-write0                         OK               0.13s
198/206 picolibc:semihost / semihost-writec                         OK               0.16s
199/206 picolibc:semihost / semihost-exit-failure                   EXPECTEDFAIL     0.14s   exit status 1
200/206 picolibc:semihost / semihost-exit-extended-failure          EXPECTEDFAIL     0.13s   exit status 1
201/206 picolibc:semihost / semihost-system-failure                 EXPECTEDFAIL     0.13s   exit status 1
202/206 picolibc:semihost / semihost-no-argv                        OK               0.13s
203/206 picolibc / malloc_stress                                    OK               0.81s
204/206 picolibc / test-fread-fwrite                                OK               1.09s
205/206 picolibc / test-long-longl                                  OK               1.42s
206/206 picolibc / test-long-long                                   OK               1.42s

Ok:                 199 
Expected Fail:      5   
Fail:               0   
Unexpected Pass:    0   
Skipped:            2   
Timeout:            0   
```