### PR TITLE
picocrt/arm: Don't reset SP after _start on thumb-1 targets

### DIFF
--- a/newlib/libc/include/sys/cdefs.h
+++ b/newlib/libc/include/sys/cdefs.h
@@ -900,21 +900,19 @@
   as the Gnu C 'extern inline'.  */
 #if defined(__GNUC__) && !defined(__GNUC_STDC_INLINE__)
 /* We're using GCC, but without the new C99-compatible behaviour.  */
-#define _ELIDABLE_INLINE extern __inline__ _ATTRIBUTE ((__always_inline__))
+#define __elidable_inline extern __always_inline
 #else
 /* We're using GCC in C99 mode, or an unknown compiler which
   we just have to hope obeys the C99 semantics of inline.  */
-#define _ELIDABLE_INLINE static __inline__
+#define __elidable_inline static __inline__
 #endif
 
 #if __GNUC_PREREQ (3, 1)
-#define _NOINLINE		__attribute__ ((__noinline__))
-#define _NOINLINE_STATIC	_NOINLINE static
+#define __noinline_static	__noinline static
 #else
 /* On non-GNU compilers and GCC prior to version 3.1 the compiler can't be
    trusted not to inline if it is static. */
-#define _NOINLINE
-#define _NOINLINE_STATIC
+#define __noinline_static
 #endif
 
 #endif /* !_SYS_CDEFS_H_ */

--- a/newlib/libc/locale/setlocale.h
+++ b/newlib/libc/locale/setlocale.h
@@ -209,7 +209,7 @@ extern NEWLIB_THREAD_LOCAL_LOCALE struct __locale_t *_locale;
    using locale info without providing a locale as parameter (*_l functions).
    The current locale is either the locale of the current thread, if the
    thread called uselocale, or the global locale if not. */
-_ELIDABLE_INLINE struct __locale_t *
+__elidable_inline struct __locale_t *
 __get_current_locale (void)
 {
 #ifdef __HAVE_LOCALE_INFO__
@@ -221,7 +221,7 @@ __get_current_locale (void)
 
 /* Only access fixed "C" locale using this function.  Fake for !_MB_CAPABLE
    targets by returning ptr to globale locale. */
-_ELIDABLE_INLINE struct __locale_t *
+__elidable_inline struct __locale_t *
 __get_C_locale (void)
 {
 #ifndef _MB_CAPABLE
@@ -234,13 +234,13 @@ __get_C_locale (void)
 
 
 #ifdef __HAVE_LOCALE_INFO__
-_ELIDABLE_INLINE const struct lc_ctype_T *
+__elidable_inline const struct lc_ctype_T *
 __get_ctype_locale (struct __locale_t *locale)
 {
   return (const struct lc_ctype_T *) (locale)->lc_cat[LC_CTYPE].ptr;
 }
 
-_ELIDABLE_INLINE const struct lc_ctype_T *
+__elidable_inline const struct lc_ctype_T *
 __get_current_ctype_locale (void)
 {
   return (const struct lc_ctype_T *)
@@ -248,7 +248,7 @@ __get_current_ctype_locale (void)
 }
 #endif
 
-_ELIDABLE_INLINE int
+__elidable_inline int
 __locale_mb_cur_max_l (struct __locale_t *locale)
 {
 #ifdef __HAVE_LOCALE_INFO__
@@ -259,52 +259,52 @@ __locale_mb_cur_max_l (struct __locale_t *locale)
 }
 
 #ifdef __HAVE_LOCALE_INFO__
-_ELIDABLE_INLINE const struct lc_monetary_T *
+__elidable_inline const struct lc_monetary_T *
 __get_monetary_locale (struct __locale_t *locale)
 {
   return (const struct lc_monetary_T *) (locale)->lc_cat[LC_MONETARY].ptr;
 }
 
-_ELIDABLE_INLINE const struct lc_monetary_T *
+__elidable_inline const struct lc_monetary_T *
 __get_current_monetary_locale (void)
 {
   return (const struct lc_monetary_T *)
 	 _locale->lc_cat[LC_MONETARY].ptr;
 }
 
-_ELIDABLE_INLINE const struct lc_numeric_T *
+__elidable_inline const struct lc_numeric_T *
 __get_numeric_locale (struct __locale_t *locale)
 {
   return (const struct lc_numeric_T *) (locale)->lc_cat[LC_NUMERIC].ptr;
 }
 
-_ELIDABLE_INLINE const struct lc_numeric_T *
+__elidable_inline const struct lc_numeric_T *
 __get_current_numeric_locale (void)
 {
   return (const struct lc_numeric_T *)
 	 _locale->lc_cat[LC_NUMERIC].ptr;
 }
 
-_ELIDABLE_INLINE const struct lc_time_T *
+__elidable_inline const struct lc_time_T *
 __get_time_locale (struct __locale_t *locale)
 {
   return (const struct lc_time_T *) (locale)->lc_cat[LC_TIME].ptr;
 }
 
-_ELIDABLE_INLINE const struct lc_time_T *
+__elidable_inline const struct lc_time_T *
 __get_current_time_locale (void)
 {
   return (const struct lc_time_T *)
 	 _locale->lc_cat[LC_TIME].ptr;
 }
 
-_ELIDABLE_INLINE const struct lc_messages_T *
+__elidable_inline const struct lc_messages_T *
 __get_messages_locale (struct __locale_t *locale)
 {
   return (const struct lc_messages_T *) (locale)->lc_cat[_LC_MESSAGES].ptr;
 }
 
-_ELIDABLE_INLINE const struct lc_messages_T *
+__elidable_inline const struct lc_messages_T *
 __get_current_messages_locale (void)
 {
   return (const struct lc_messages_T *)
@@ -312,60 +312,60 @@ __get_current_messages_locale (void)
 }
 
 #else /* ! __HAVE_LOCALE_INFO__ */
-_ELIDABLE_INLINE const struct lc_monetary_T *
+__elidable_inline const struct lc_monetary_T *
 __get_monetary_locale (struct __locale_t *locale)
 {
   (void) locale;
   return &_C_monetary_locale;
 }
 
-_ELIDABLE_INLINE const struct lc_monetary_T *
+__elidable_inline const struct lc_monetary_T *
 __get_current_monetary_locale (void)
 {
   return &_C_monetary_locale;
 }
 
-_ELIDABLE_INLINE const struct lc_numeric_T *
+__elidable_inline const struct lc_numeric_T *
 __get_numeric_locale (struct __locale_t *locale)
 {
   (void) locale;
   return &_C_numeric_locale;
 }
 
-_ELIDABLE_INLINE const struct lc_numeric_T *
+__elidable_inline const struct lc_numeric_T *
 __get_current_numeric_locale (void)
 {
   return &_C_numeric_locale;
 }
 
-_ELIDABLE_INLINE const struct lc_time_T *
+__elidable_inline const struct lc_time_T *
 __get_time_locale (struct __locale_t *locale)
 {
   (void) locale;
   return &_C_time_locale;
 }
 
-_ELIDABLE_INLINE const struct lc_time_T *
+__elidable_inline const struct lc_time_T *
 __get_current_time_locale (void)
 {
   return &_C_time_locale;
 }
 
-_ELIDABLE_INLINE const struct lc_messages_T *
+__elidable_inline const struct lc_messages_T *
 __get_messages_locale (struct __locale_t *locale)
 {
   (void) locale;
   return &_C_messages_locale;
 }
 
-_ELIDABLE_INLINE const struct lc_messages_T *
+__elidable_inline const struct lc_messages_T *
 __get_current_messages_locale (void)
 {
   return &_C_messages_locale;
 }
 #endif /* !__HAVE_LOCALE_INFO__ */
 
-_ELIDABLE_INLINE const char *
+__elidable_inline const char *
 __locale_charset (struct __locale_t *locale)
 {
   (void) locale;
@@ -376,7 +376,7 @@ __locale_charset (struct __locale_t *locale)
 #endif
 }
 
-_ELIDABLE_INLINE const char *
+__elidable_inline const char *
 __current_locale_charset (void)
 {
 #ifdef __HAVE_LOCALE_INFO__
@@ -386,7 +386,7 @@ __current_locale_charset (void)
 #endif
 }
 
-_ELIDABLE_INLINE const char *
+__elidable_inline const char *
 __locale_msgcharset (void)
 {
 #ifdef __HAVE_LOCALE_INFO__
@@ -400,7 +400,7 @@ __locale_msgcharset (void)
 #endif
 }
 
-_ELIDABLE_INLINE int
+__elidable_inline int
 __locale_cjk_lang (void)
 {
   return __get_current_locale()->cjk_lang;

--- a/newlib/libc/stdio/findfp.c
+++ b/newlib/libc/stdio/findfp.c
@@ -54,7 +54,7 @@ NEWLIB_THREAD_LOCAL void (*_tls_cleanup)(void);
 #endif
 
 #if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED))
-_NOINLINE_STATIC void
+__noinline_static void
 #else
 static void
 #endif

--- a/newlib/libc/stdio/local.h
+++ b/newlib/libc/stdio/local.h
@@ -279,7 +279,7 @@ void _reclaim_reent (void *);
    from inside the wide-char functions. */
 int	__swbufw (int, FILE *);
 #ifdef __GNUC__
-_ELIDABLE_INLINE int __swputc(int _c, FILE *_p) {
+__elidable_inline int __swputc(int _c, FILE *_p) {
 #ifdef __SCLE
 	if ((_p->_flags & __SCLE) && _c == '\n')
 	  __swputc ('\r', _p);

--- a/newlib/libc/stdio/nano-vfprintf.c
+++ b/newlib/libc/stdio/nano-vfprintf.c
@@ -386,7 +386,7 @@ out:
   return err;
 }
 
-_NOINLINE_STATIC int
+__noinline_static int
 _sfputc (
        int c,
        FILE *fp)

--- a/newlib/libc/stdio/stdio.h
+++ b/newlib/libc/stdio/stdio.h
@@ -675,9 +675,9 @@ FILE *fopencookie ( void *__cookie,
   compilers we're just stuck.  At the moment, this issue only
   affects the Cygwin target, so we'll most likely be using GCC. */
 
-_ELIDABLE_INLINE int _sgetc( FILE *__p);
+__elidable_inline int _sgetc( FILE *__p);
 
-_ELIDABLE_INLINE int _sgetc( FILE *__p)
+__elidable_inline int _sgetc( FILE *__p)
   {
     int __c = _sgetc_raw( __p);
     if ((__p->_flags & __SCLE) && (__c == '\r'))
@@ -695,7 +695,7 @@ _ELIDABLE_INLINE int _sgetc( FILE *__p)
 #endif
 
 #ifdef __GNUC__
-_ELIDABLE_INLINE int _sputc( int _c, FILE *_p) {
+__elidable_inline int _sputc( int _c, FILE *_p) {
 #ifdef __SCLE
 	if ((_p->_flags & __SCLE) && _c == '\n')
 	  _sputc ( '\r', _p);

--- a/newlib/libc/stdio/vfprintf.c
+++ b/newlib/libc/stdio/vfprintf.c
@@ -195,7 +195,7 @@ static char *rcsid = "$Id$";
  *
  * Make sure to avoid inlining.
  */
-_NOINLINE_STATIC int
+__noinline_static int
 __sbprintf (
        register FILE *fp,
        const char *fmt,

--- a/newlib/libc/string/str-two-way.h
+++ b/newlib/libc/string/str-two-way.h
@@ -288,7 +288,7 @@ two_way_short_needle (const unsigned char *haystack, size_t haystack_len,
    If AVAILABLE modifies HAYSTACK_LEN (as in strstr), then at most 3 *
    HAYSTACK_LEN - NEEDLE_LEN comparisons occur in searching, and
    sublinear performance is not possible.  */
-_NOINLINE_STATIC RETURN_TYPE __attribute__ ((__used__))
+__noinline_static RETURN_TYPE __attribute__ ((__used__))
 two_way_long_needle (const unsigned char *haystack, size_t haystack_len,
 		     const unsigned char *needle, size_t needle_len)
 {

--- a/newlib/libc/xdr/xdr_private.h
+++ b/newlib/libc/xdr/xdr_private.h
@@ -48,7 +48,7 @@ void xdr_warnx (const char *, ...)
 
 /* byteswap and ntohl stuff; platform may provide optimzed version
  * of this, but we don't have access to that here.*/
-_ELIDABLE_INLINE uint32_t xdr_ntohl (uint32_t x)
+__elidable_inline uint32_t xdr_ntohl (uint32_t x)
 {
 #if _BYTE_ORDER == _BIG_ENDIAN
   return x;

--- a/newlib/libm/common/math_config.h
+++ b/newlib/libm/common/math_config.h
@@ -54,18 +54,6 @@
 #define _IEEE_  -1
 #define _POSIX_ 0
 
-#ifdef _HAVE_ATTRIBUTE_ALWAYS_INLINE
-#define ALWAYS_INLINE __inline__ __attribute__((__always_inline__))
-#else
-#define ALWAYS_INLINE __inline__
-#endif
-
-#ifdef _HAVE_ATTRIBUTE_NOINLINE
-# define NOINLINE __attribute__ ((__noinline__))
-#else
-# define NOINLINE
-#endif
-
 #ifdef _HAVE_BUILTIN_EXPECT
 # define likely(x) __builtin_expect (!!(x), 1)
 # define unlikely(x) __builtin_expect (x, 0)
@@ -100,7 +88,7 @@
 /* Round x to nearest int in all rounding modes, ties have to be rounded
    consistently with converttoint so the results match.  If the result
    would be outside of [-2^31, 2^31-1] then the semantics is unspecified.  */
-static ALWAYS_INLINE double_t
+static __always_inline double_t
 roundtoint (double_t x)
 {
   return round (x);
@@ -109,7 +97,7 @@ roundtoint (double_t x)
 /* Convert x to nearest int in all rounding modes, ties have to be rounded
    consistently with roundtoint.  If the result is not representible in an
    int32_t then the semantics is unspecified.  */
-static ALWAYS_INLINE int32_t
+static __always_inline int32_t
 converttoint (double_t x)
 {
 # if HAVE_FAST_LROUND
@@ -132,7 +120,7 @@ typedef long double __float64;
 # define _NEED_FLOAT64
 #endif
 
-static ALWAYS_INLINE uint32_t
+static __always_inline uint32_t
 asuint (float f)
 {
 #if defined(__riscv_flen) && __riscv_flen >= 32
@@ -149,7 +137,7 @@ asuint (float f)
 #endif
 }
 
-static ALWAYS_INLINE float
+static __always_inline float
 asfloat (uint32_t i)
 {
 #if defined(__riscv_flen) && __riscv_flen >= 32
@@ -166,37 +154,37 @@ asfloat (uint32_t i)
 #endif
 }
 
-static ALWAYS_INLINE int32_t
+static __always_inline int32_t
 _asint32 (float f)
 {
     return (int32_t) asuint(f);
 }
 
-static ALWAYS_INLINE int
+static __always_inline int
 _sign32(int32_t ix)
 {
     return ((uint32_t) ix) >> 31;
 }
 
-static ALWAYS_INLINE int
+static __always_inline int
 _exponent32(int32_t ix)
 {
     return (ix >> 23) & 0xff;
 }
 
-static ALWAYS_INLINE int32_t
+static __always_inline int32_t
 _significand32(int32_t ix)
 {
     return ix & 0x7fffff;
 }
 
-static ALWAYS_INLINE float
+static __always_inline float
 _asfloat(int32_t i)
 {
     return asfloat((uint32_t) i);
 }
 
-static ALWAYS_INLINE int
+static __always_inline int
 issignalingf_inline (float x)
 {
   uint32_t ix = asuint (x);
@@ -206,25 +194,25 @@ issignalingf_inline (float x)
 }
 
 #ifdef _NEED_FLOAT64
-static ALWAYS_INLINE int
+static __always_inline int
 _sign64(int64_t ix)
 {
     return ((uint64_t) ix) >> 63;
 }
 
-static ALWAYS_INLINE int
+static __always_inline int
 _exponent64(int64_t ix)
 {
     return (ix >> 52) & 0x7ff;
 }
 
-static ALWAYS_INLINE int64_t
+static __always_inline int64_t
 _significand64(int64_t ix)
 {
     return ix & 0xfffffffffffffLL;
 }
 
-static ALWAYS_INLINE uint64_t
+static __always_inline uint64_t
 asuint64 (__float64 f)
 {
 #if defined(__riscv_flen) && __riscv_flen >= 64 && __riscv_xlen >= 64
@@ -241,7 +229,7 @@ asuint64 (__float64 f)
 #endif
 }
 
-static ALWAYS_INLINE __float64
+static __always_inline __float64
 asfloat64 (uint64_t i)
 {
 #if defined(__riscv_flen) && __riscv_flen >= 64 && __riscv_xlen >= 64
@@ -258,19 +246,19 @@ asfloat64 (uint64_t i)
 #endif
 }
 
-static ALWAYS_INLINE int64_t
+static __always_inline int64_t
 _asint64(__float64 f)
 {
     return (int64_t) asuint64(f);
 }
 
-static ALWAYS_INLINE __float64
+static __always_inline __float64
 _asfloat64(int64_t i)
 {
     return asfloat64((uint64_t) i);
 }
 
-static ALWAYS_INLINE int
+static __always_inline int
 issignaling64_inline (__float64 x)
 {
   uint64_t ix = asuint64 (x);
@@ -325,28 +313,28 @@ issignaling64_inline (__float64 x)
 #define pick_long_double_except(expr,val)       (expr)
 #endif
 
-static ALWAYS_INLINE float
+static __always_inline float
 opt_barrier_float (float x)
 {
   FORCE_FLOAT y = x;
   return y;
 }
 
-static ALWAYS_INLINE double
+static __always_inline double
 opt_barrier_double (double x)
 {
   FORCE_DOUBLE y = x;
   return y;
 }
 
-static ALWAYS_INLINE void
+static __always_inline void
 force_eval_float (float x)
 {
   FORCE_FLOAT y = x;
   (void) y;
 }
 
-static ALWAYS_INLINE void
+static __always_inline void
 force_eval_double (double x)
 {
   FORCE_DOUBLE y = x;
@@ -354,14 +342,14 @@ force_eval_double (double x)
 }
 
 #ifdef _HAVE_LONG_DOUBLE
-static ALWAYS_INLINE long double
+static __always_inline long double
 opt_barrier_long_double (long double x)
 {
   FORCE_LONG_DOUBLE y = x;
   return y;
 }
 
-static ALWAYS_INLINE void
+static __always_inline void
 force_eval_long_double (long double x)
 {
     FORCE_LONG_DOUBLE y = x;
@@ -875,12 +863,12 @@ force_eval_long_double (long double x)
    cast should be enough, but compilers implement non-standard
    excess-precision handling, so when FLT_EVAL_METHOD != 0 then
    these functions may need to be customized.  */
-static ALWAYS_INLINE float
+static __always_inline float
 eval_as_float (float x)
 {
   return x;
 }
-static ALWAYS_INLINE double
+static __always_inline double
 eval_as_double (double x)
 {
   return x;

--- a/newlib/libm/common/math_err_with_errno.c
+++ b/newlib/libm/common/math_err_with_errno.c
@@ -32,9 +32,9 @@
 
 #if WANT_ERRNO
 #include <errno.h>
-/* NOINLINE reduces code size and avoids making math functions non-leaf
+/* __noinline reduces code size and avoids making math functions non-leaf
    when the error handling is inlined.  */
-NOINLINE HIDDEN __float64
+__noinline HIDDEN __float64
 __math_with_errno (__float64 y, int e)
 {
   errno = e;

--- a/newlib/libm/ld/math_errl_with_errnol.c
+++ b/newlib/libm/ld/math_errl_with_errnol.c
@@ -30,9 +30,9 @@
 
 #if WANT_ERRNO
 #include <errno.h>
-/* NOINLINE reduces code size and avoids making math functions non-leaf
+/* __noinline reduces code size and avoids making math functions non-leaf
    when the error handling is inlined.  */
-NOINLINE HIDDEN long double
+__noinline HIDDEN long double
 __math_with_errnol (long double y, int e)
 {
   errno = e;

--- a/newlib/libm/ld/math_private_openbsd.h
+++ b/newlib/libm/ld/math_private_openbsd.h
@@ -116,7 +116,7 @@ do {								\
 #define	LDBL_MANH_SIZE	48
 #define	LDBL_MANL_SIZE	64
 
-static ALWAYS_INLINE int
+static __always_inline int
 isnanl_inline(long double x)
 {
     u_int64_t high, low;
@@ -131,7 +131,7 @@ isnanl_inline(long double x)
     return 1;
 }
 
-static ALWAYS_INLINE int
+static __always_inline int
 issignalingl_inline(long double x)
 {
     if (!isnanl_inline(x))
@@ -144,7 +144,7 @@ issignalingl_inline(long double x)
         return (high & 0x0000800000000000ULL) == 0;
 }
 
-static ALWAYS_INLINE int
+static __always_inline int
 signbitl_inline(long double x)
 {
     int64_t high;
@@ -314,7 +314,7 @@ do {								\
 	(a)[1] = (uint32_t)(u).bits.manh;		\
 } while (0)
 
-static ALWAYS_INLINE int
+static __always_inline int
 isnanl_inline(long double x)
 {
     u_int32_t exp, msw, lsw;
@@ -328,7 +328,7 @@ isnanl_inline(long double x)
     return 1;
 }
 
-static ALWAYS_INLINE int
+static __always_inline int
 issignalingl_inline(long double x)
 {
     u_int32_t msw;
@@ -341,7 +341,7 @@ issignalingl_inline(long double x)
         return (msw & 0x40000000U) == 0;
 }
 
-static ALWAYS_INLINE int
+static __always_inline int
 signbitl_inline(long double x)
 {
     int exp;
@@ -510,7 +510,7 @@ do {								\
   (d) = se_u.value;						\
 } while (0)
 
-static ALWAYS_INLINE int
+static __always_inline int
 isnanl_inline(long double x)
 {
     uint64_t high;
@@ -524,7 +524,7 @@ isnanl_inline(long double x)
     return 1;
 }
 
-static ALWAYS_INLINE int
+static __always_inline int
 issignalingl_inline(long double x)
 {
     uint64_t high;
@@ -537,7 +537,7 @@ issignalingl_inline(long double x)
         return (high & 0x0008000000000000ULL) == 0;
 }
 
-static ALWAYS_INLINE int
+static __always_inline int
 signbitl_inline(long double x)
 {
     int exp;

--- a/picocrt/crt0.h
+++ b/picocrt/crt0.h
@@ -88,7 +88,7 @@ extern void __libc_init_array(void);
 #define CONSTRUCTORS 1
 #endif
 
-static inline void
+static _Noreturn __always_inline void
 __start(void)
 {
 	memcpy(__data_start, __data_source, (uintptr_t) __data_size);

--- a/picocrt/machine/arm/crt0.c
+++ b/picocrt/machine/arm/crt0.c
@@ -188,8 +188,11 @@ extern char __stack[];
 #define I_BIT           (1 << 7)
 #define F_BIT           (1 << 6)
 
-#define SET_SP(mode) \
-    __asm__("mov r0, %0\nmsr cpsr_c, r0" :: "r" (mode | I_BIT | F_BIT): "r0");   \
+#define SET_MODE(mode)                                                  \
+    __asm__("mov r0, %0\nmsr cpsr_c, r0" :: "I" (mode | I_BIT | F_BIT) : "r0"); \
+
+#define SET_SP(mode)                                \
+    SET_MODE(mode);                                 \
     __asm__("mov sp, %0" : : "r" (__stack))
 
 #define SET_SPS()                               \
@@ -197,8 +200,8 @@ extern char __stack[];
         SET_SP(MODE_ABT);                       \
         SET_SP(MODE_UND);                       \
         SET_SP(MODE_FIQ);                       \
-        SET_SP(MODE_SVC);                       \
-        SET_SP(MODE_SYS);
+        SET_SP(MODE_SYS);                       \
+        SET_MODE(MODE_SVC);
 
 #if __ARM_ARCH_ISA_THUMB == 1
 static __noinline __attribute__((target("arm"))) void
@@ -303,9 +306,8 @@ _start(void)
 	/* Generate a reference to __vector_table so we get one loaded */
 	__asm__(".equ __my_vector_table, __vector_table");
 
-#if __ARM_ARCH_ISA_THUMB == 1
         __asm__("mov sp, %0" : : "r" (__stack));
-#else
+#if __ARM_ARCH_ISA_THUMB != 1
         SET_SPS();
 #endif
 	/* Branch to C code */

--- a/picocrt/machine/arm/crt0.c
+++ b/picocrt/machine/arm/crt0.c
@@ -217,7 +217,7 @@ _set_stacks(void)
  * and then branches here.
  */
 
-static void __attribute__((used)) __section(".init")
+static _Noreturn __attribute__((used)) __section(".init") void
 _cstart(void)
 {
 #if __ARM_ARCH_ISA_THUMB == 1


### PR DESCRIPTION
We have to use a separate ARM-mode function, _set_stacks, to perform processor mode selection as the thumb-1 ISA doesn't include the msr instruction. But, by the time we get there, the compiler may have used the stack for some other operations. So, we want to avoid smashing the stack pointer. Leave the SVC mode stack pointer alone, and only set the other stack pointers. Then, switch back to SVC mode.

This is a simplified version of #897, but still doesn't resolve the fact that all of these stacks overlap, which only works because the only usage we've got with the current code is to terminate on any exception.