### PR TITLE
.github: Switch most CI tools to picolibc-ci-tools

### DIFF
--- a/.github/linux-files.txt
+++ b/.github/linux-files.txt
@@ -1,9 +1,8 @@
-https://github.com/ZakKemble/avr-gcc-build/releases/download/v12.1.0-1/avr-gcc-12.1.0-x64-linux.tar.bz2
-https://github.com/picolibc/toolchains/raw/refs/heads/main/m68k-unknown-elf.tar.xz
-https://github.com/picolibc/toolchains/raw/refs/heads/main/msp430-unknown-elf.tar.xz
-https://github.com/picolibc/toolchains/raw/refs/heads/main/qemu-m68k.tar.xz
-https://github.com/picolibc/toolchains/raw/refs/heads/main/sh-unknown-elf.tar.xz
+https://github.com/picolibc/picolibc-ci-tools/releases/download/v1/avr.linux-amd64.tar.xz
+https://github.com/picolibc/picolibc-ci-tools/releases/download/v1/m68k-unknown-elf.linux-amd64.tar.xz
+https://github.com/picolibc/picolibc-ci-tools/releases/download/v1/qemu-stable.linux-amd64.tar.xz
+https://github.com/picolibc/picolibc-ci-tools/releases/download/v1/loongarch64-unknown-elf.linux-amd64.tar.xz
 https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/download/release-18.1.3/LLVM-ET-Arm-18.1.3-Linux-x86_64.tar.xz
 https://developer.arm.com/-/cdn-downloads/permalink/FVPs-Architecture/FM-11.27/FVP_Base_RevC-2xAEMvA_11.27_19_Linux64.tgz
-https://github.com/FlyGoat/picolibc-ci-tools/releases/download/v20241227/loongarch64-unknown-elf.linux-amd64.tar.xz
-https://github.com/FlyGoat/picolibc-ci-tools/releases/download/v20241227/qemu-stable.linux-amd64.tar.xz
+https://github.com/picolibc/toolchains/raw/refs/heads/main/msp430-unknown-elf.tar.xz
+https://github.com/picolibc/toolchains/raw/refs/heads/main/sh-unknown-elf.tar.xz

--- a/.github/zephyr-files.txt
+++ b/.github/zephyr-files.txt
@@ -15,5 +15,6 @@ https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.17.0/toolchain
 https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.17.0/toolchain_linux-x86_64_xtensa-nxp_imx_adsp_zephyr-elf.tar.xz
 https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.17.0/toolchain_linux-x86_64_xtensa-sample_controller_zephyr-elf.tar.xz
 https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.17.0/hosttools_linux-x86_64.tar.xz
-https://github.com/picolibc/toolchains/raw/refs/heads/main/qemu-nios2-2.tar.xz
-https://github.com/picolibc/toolchains/raw/refs/heads/main/qemu-arc.tar.xz
+https://github.com/picolibc/picolibc-ci-tools/releases/download/v1/qemu-9.0.linux-amd64.tar.xz
+https://github.com/picolibc/picolibc-ci-tools/releases/download/v1/qemu-arc.linux-amd64.tar.xz
+


### PR DESCRIPTION
These are built in CI instead of by hand