### PR TITLE
.github: Switch to debian:sid while debian:testing is broken

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:testing
+FROM debian:sid
 
 COPY .github/linux-packages.txt /
 

--- a/.github/Dockerfile-zephyr
+++ b/.github/Dockerfile-zephyr
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM debian:testing
+FROM debian:sid
 
 COPY .github/zephyr-packages.txt /
 


### PR DESCRIPTION
Debian testing is currently missing some critical packages during a gcc-14 update adventure. Switch to unstable until that gets resolved.