### PR TITLE
tinystdio: fix bug in bufio flush

### DIFF
--- a/newlib/libc/tinystdio/bufio.c
+++ b/newlib/libc/tinystdio/bufio.c
@@ -53,6 +53,7 @@ __bufio_flush_locked(FILE *f)
                                 return _FDEV_ERR;
                                 break;
 			}
+                        buf += this;
 			bf->pos += this;
 			bf->len -= this;
 		}


### PR DESCRIPTION
Forgot to advance buffer pointer when making mutiple passes to send whole buffer.