### PR TITLE
add guard to gets function to not be exist in C11, C++14 or larter.

### DIFF
--- a/newlib/libc/tinystdio/gets.c
+++ b/newlib/libc/tinystdio/gets.c
@@ -29,6 +29,7 @@
 
 /* $Id: gets.c 1944 2009-04-01 23:12:20Z arcanum $ */
 
+#define _PICOLIBC_USE_DEPRECATED_GETS
 #include "stdio_private.h"
 
 char *

--- a/newlib/libc/tinystdio/stdio.h
+++ b/newlib/libc/tinystdio/stdio.h
@@ -49,6 +49,12 @@
 
 _BEGIN_STD_C
 
+#if !((defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L) || \
+     (defined(__cplusplus) && __cplusplus >= 201402L))
+     //Provide this function for applications which use an earlier C standard before C11 and C++14
+     #define _PICOLIBC_USE_DEPRECATED_GETS
+#endif
+
 /*
  * This is an internal structure of the library that is subject to be
  * changed without warnings at any time.  Please do *never* reference
@@ -254,7 +260,9 @@ int	sscanf(const char *__buf, const char *__fmt, ...) __FORMAT_ATTRIBUTE__(scanf
 int	vsscanf(const char *__buf, const char *__fmt, __gnuc_va_list ap) __FORMAT_ATTRIBUTE__(scanf, 2, 0);
 
 char	*fgets(char *__str, int __size, FILE *__stream);
-char	*gets(char *__str);
+#ifdef _PICOLIBC_USE_DEPRECATED_GETS
+     char *gets(char *str);
+#endif
 size_t	fread(void *__ptr, size_t __size, size_t __nmemb,
 		      FILE *__stream);
 


### PR DESCRIPTION
This function is impossible to use safely.
It has been officially removed from ISO C11 and ISO C++14. It remains available when explicitly using an old ISO C, Unix, or POSIX standard. Also in glibC it's guarded not be exits in C11, C++14 or beyond: https://github.com/lattera/glibc/blob/master/libio/stdio.h