### PR TITLE
nano-malloc: include long double in malloc alignment union

### DIFF
--- a/newlib/libc/stdlib/nano-malloc.h
+++ b/newlib/libc/stdlib/nano-malloc.h
@@ -32,6 +32,7 @@
  */
 
 #define _DEFAULT_SOURCE
+#include <stddef.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdbool.h>
@@ -55,6 +56,9 @@ void __malloc_validate_block(chunk_t *r);
 #define MALLOC_UNLOCK __LIBC_UNLOCK()
 #endif
 
+#if __STDC_VERSION__ >= 201112L
+typedef max_align_t align_chunk_t;
+#else
 typedef union {
     void *p;
     double d;
@@ -62,6 +66,7 @@ typedef union {
     size_t s;
     long double ld;
 } align_chunk_t;
+#endif
 
 /*          --------------------------------------
  *          | size                               |

--- a/newlib/libc/stdlib/nano-malloc.h
+++ b/newlib/libc/stdlib/nano-malloc.h
@@ -60,6 +60,7 @@ typedef union {
     double d;
     long long ll;
     size_t s;
+    long double ld;
 } align_chunk_t;
 
 /*          --------------------------------------


### PR DESCRIPTION
This fixes crashes I was seeing with C++ code on RISCV-64 where Clang assumes that the result of operator new is at least 16 byte aligned instead of the current 8 byte alignment.
I noticed this because the code I was running was asserting for sufficient alignment, but this also could cause other difficult to debug issues if the compiler optimizes based on that 16-byte alignment assumption. See Clang's [getNewAlign()](https://github.com/llvm/llvm-project/blob/06499f3672afc371b653bf54422c2e80e1e27c90/clang/include/clang/Basic/TargetInfo.h#L753)