### PR TITLE
ctype: In "C" locale, make iswblank return true for only space and tab

### DIFF
--- a/newlib/libc/ctype/iswalnum_l.c
+++ b/newlib/libc/ctype/iswalnum_l.c
@@ -13,7 +13,7 @@ iswalnum_l (wint_t c, struct __locale_t *locale)
 {
   (void) locale;
 #ifdef _MB_CAPABLE
-  uint16_t cat = __ctype_table_lookup (c);
+  uint16_t cat = __ctype_table_lookup (c, locale);
   return cat & CLASS_alnum;
 #else
   return c < (wint_t)0x100 ? isalnum (c) : 0;

--- a/newlib/libc/ctype/iswalpha_l.c
+++ b/newlib/libc/ctype/iswalpha_l.c
@@ -13,7 +13,7 @@ iswalpha_l (wint_t c, struct __locale_t *locale)
 {
   (void) locale;
 #ifdef _MB_CAPABLE
-  uint16_t cat = __ctype_table_lookup (c);
+  uint16_t cat = __ctype_table_lookup (c, locale);
   return cat & CLASS_alpha;
 #else
   return c < (wint_t)0x100 ? isalpha (c) : 0;

--- a/newlib/libc/ctype/iswblank_l.c
+++ b/newlib/libc/ctype/iswblank_l.c
@@ -13,7 +13,7 @@ iswblank_l (wint_t c, struct __locale_t *locale)
 {
   (void) locale;
 #ifdef _MB_CAPABLE
-  uint16_t cat = __ctype_table_lookup(c);
+  uint16_t cat = __ctype_table_lookup(c, locale);
   return cat & CLASS_blank;
 #else
   return c < 0x100 ? isblank (c) : 0;

--- a/newlib/libc/ctype/iswcntrl_l.c
+++ b/newlib/libc/ctype/iswcntrl_l.c
@@ -13,7 +13,7 @@ iswcntrl_l (wint_t c, struct __locale_t *locale)
 {
   (void) locale;
 #ifdef _MB_CAPABLE
-  uint16_t cat = __ctype_table_lookup (c);
+  uint16_t cat = __ctype_table_lookup (c, locale);
   return cat & CLASS_cntrl;
 #else
   return c < 0x100 ? iscntrl (c) : 0;

--- a/newlib/libc/ctype/iswgraph_l.c
+++ b/newlib/libc/ctype/iswgraph_l.c
@@ -13,8 +13,7 @@ iswgraph_l (wint_t c, struct __locale_t *locale)
 {
   (void) locale;
 #ifdef _MB_CAPABLE
-  //return iswprint (c, locale) && !iswspace (c, locale);
-  uint16_t cat = __ctype_table_lookup (c);
+  uint16_t cat = __ctype_table_lookup (c, locale);
   return cat & CLASS_graph;
 #else
   return c < (wint_t)0x100 ? isgraph (c) : 0;

--- a/newlib/libc/ctype/iswlower_l.c
+++ b/newlib/libc/ctype/iswlower_l.c
@@ -15,7 +15,7 @@ iswlower_l (wint_t c, struct __locale_t *locale)
 #ifdef _MB_CAPABLE
   // The wide-character class "lower" contains at least those characters wc
   // which are equal to towlower(wc) and different from towupper(wc).
-  uint16_t cat = __ctype_table_lookup (c);
+  uint16_t cat = __ctype_table_lookup (c, locale);
   return (cat & CLASS_lower) || ((cat & CLASS_case) && towupper_l(c, locale) != c);
 #else
   return c < 0x100 ? islower (c) : 0;

--- a/newlib/libc/ctype/iswprint_l.c
+++ b/newlib/libc/ctype/iswprint_l.c
@@ -13,7 +13,7 @@ iswprint_l (wint_t c, struct __locale_t *locale)
 {
   (void) locale;
 #ifdef _MB_CAPABLE
-  uint16_t cat = __ctype_table_lookup (c);
+  uint16_t cat = __ctype_table_lookup (c, locale);
   return cat & CLASS_print;
 #else
   return c < (wint_t)0x100 ? isprint (c) : 0;

--- a/newlib/libc/ctype/iswpunct_l.c
+++ b/newlib/libc/ctype/iswpunct_l.c
@@ -13,7 +13,7 @@ iswpunct_l (wint_t c, struct __locale_t *locale)
 {
   (void) locale;
 #ifdef _MB_CAPABLE
-  uint16_t cat = __ctype_table_lookup (c);
+  uint16_t cat = __ctype_table_lookup (c, locale);
   return cat & CLASS_punct;
 #else
   return c < (wint_t)0x100 ? ispunct (c) : 0;

--- a/newlib/libc/ctype/iswspace_l.c
+++ b/newlib/libc/ctype/iswspace_l.c
@@ -13,7 +13,7 @@ iswspace_l (wint_t c, struct __locale_t *locale)
 {
   (void) locale;
 #ifdef _MB_CAPABLE
-  uint16_t cat = __ctype_table_lookup (c);
+  uint16_t cat = __ctype_table_lookup (c, locale);
   return cat & CLASS_space;
 #else
   return c < 0x100 ? isspace (c) : 0;

--- a/newlib/libc/ctype/iswupper_l.c
+++ b/newlib/libc/ctype/iswupper_l.c
@@ -13,7 +13,7 @@ iswupper_l (wint_t c, struct __locale_t *locale)
 {
   (void) locale;
 #ifdef _MB_CAPABLE
-  uint16_t cat = __ctype_table_lookup (c);
+  uint16_t cat = __ctype_table_lookup (c, locale);
   return (cat & CLASS_upper) || ((cat & CLASS_case) && towlower_l(c, locale) != c);
 #else
   return c < 0x100 ? isupper (c) : 0;

--- a/newlib/libc/ctype/local.h
+++ b/newlib/libc/ctype/local.h
@@ -69,7 +69,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CLASS_xdigit    (1 << 12)
 
 uint16_t
-__ctype_table_lookup(wint_t ic);
+__ctype_table_lookup(wint_t ic, struct __locale_t *locale);
 
 /* Japanese encoding types supported */
 #define JP_JIS		1

--- a/newlib/libc/locale/nl_langinfo.c
+++ b/newlib/libc/locale/nl_langinfo.c
@@ -191,7 +191,7 @@ char *nl_langinfo_l (nl_item item, struct __locale_t *locale)
 do_codeset:
 #endif
 #if   !defined (_MB_CAPABLE)
-		ret = "US-ASCII";
+		ret = "ASCII";
 #endif /* __CYGWIN__ */
 		break;
 	case D_T_FMT:

--- a/test/meson.build
+++ b/test/meson.build
@@ -604,32 +604,61 @@ if enable_native_tests
 		    link_args: native_c_args))
   endforeach
 
-  if newlib_mb
-    diff = find_program('diff', required: false)
+  diff = find_program('diff', required: false)
 
-    if diff.found()
-      wctype = executable('test-wctype', 'test-wctype.c',
-                          c_args: _c_args,
-                          link_args: _link_args,
-                          objects: _objs,
-                          link_depends: _link_depends,
-                          link_with: _libs,
-                          include_directories: inc)
+  if diff.found()
+    wctype_c_args = []
+    if newlib_mb
+      wctype_c_args += ['-DHAVE_UTF_CHARSETS']
+    endif
 
-      wctype_native = executable('test-wctype-native', 'test-wctype.c',
-                                 c_args: native_c_args,
-                                 link_args: native_c_args)
+    localedef = find_program('localedef', required: false)
 
-      wctype_out = custom_target ('wctype-out', output: 'wctype-out',
-                                  command: [wctype, '@OUTPUT@'])
+    locales=[]
+    # need meson 0.57 so we can use 'env' in custom_target
+    if mb_extended_charsets and localedef.found() and meson.version().version_compare('>=0.57')
+      foreach ctype : ['ISO-8859-2', 'CP1125', 'SJIS']
+        locale = 'C.' + ctype
+        if ctype == 'SJIS'
+          ctype = 'SHIFT_JIS'
+        endif
+        locales += [custom_target(locale, output: locale,
+                                  command: [localedef, '--no-warnings=ascii',
+                                            '-f', ctype, '-i', 'C', '.' / '@OUTPUT@'])]
+      endforeach
+      wctype_c_args += ['-DHAVE_ISO_CHARSETS',
+                        '-DHAVE_WINDOWS_CHARSETS',
+                        '-DHAVE_JIS_CHARSETS'
+                       ]
+    endif
 
+    wctype = executable('test-wctype', 'test-wctype.c',
+                        c_args: _c_args + wctype_c_args,
+                        link_args: _link_args,
+                        objects: _objs,
+                        link_depends: _link_depends,
+                        link_with: _libs,
+                        include_directories: inc)
+
+    wctype_native = executable('test-wctype-native', 'test-wctype.c',
+                               c_args: native_c_args + wctype_c_args,
+                               link_args: native_c_args)
+
+    wctype_out = custom_target ('wctype-out', output: 'wctype-out',
+                                command: [wctype, '@OUTPUT@'])
+
+    if locales != [] and meson.version().version_compare('>=0.57')
+      wctype_native_out = custom_target ('wctype-native-out', output: 'wctype-native-out',
+                                         depends: locales,
+                                         env: ['LOCPATH=' + meson.current_build_dir()],
+                                         command: [wctype_native, '@OUTPUT@'])
+    else
       wctype_native_out = custom_target ('wctype-native-out', output: 'wctype-native-out',
                                          command: [wctype_native, '@OUTPUT@'])
-
-      test('wctype-compare', diff, args: [wctype_out, wctype_native_out])
     endif
+
+    test('wctype-compare', diff, args: [wctype_out, wctype_native_out])
   endif
-       
 endif
 
 subdir('libc-testsuite')


### PR DESCRIPTION
This is required by the C language. To match glibc, make *all* of the wide ctype functions return false for non-ASCII values in the C locale.

This should resolve the question raised in #917 