### PR TITLE
zephyr: Disable LTO when building the library

### DIFF
--- a/zephyr/zephyr.cmake
+++ b/zephyr/zephyr.cmake
@@ -101,6 +101,9 @@ if(CONFIG_PICOLIBC_USE_MODULE)
   # Fetch zephyr compile flags from interface
   get_property(PICOLIBC_EXTRA_COMPILE_OPTIONS TARGET zephyr_interface PROPERTY INTERFACE_COMPILE_OPTIONS)
 
+  # Disable LTO
+  list(APPEND PICOLIBC_EXTRA_COMPILE_OPTIONS $<TARGET_PROPERTY:compiler,prohibit_lto>)
+
   # Tell Zephyr about the module built picolibc library to link against.
   # We need to construct the absolute path to picolibc in same fashion as CMake
   # defines the library file name and location, because a generator expression


### PR DESCRIPTION
[Zephyr's fork of picolibc](https://github.com/zephyrproject-rtos/picolibc) currently carries a [single patch](https://github.com/zephyrproject-rtos/picolibc/commit/82d62ed1ac55b4e34a12d0390aced2dc9af13fc9) written by @kiethp , which disables LTO from the picolibc build for Zephyr. However, this patch has a flaw in that it hard-codes use of the `-fno-lto` flag which is not necessarily available on legacy versions of GCC, or certain non-GCC compilers.

This PR contains an updated version of the patch that instead uses the `prohibit_lto` CMake target compiler property which is determined by the Zephyr build system in [compiler_flags.cmake](https://github.com/zephyrproject-rtos/zephyr/blob/main/cmake/compiler/gcc/compiler_flags.cmake#L27).

Furthermore, this PR proposes this patch for inclusion in the picolibc *main* branch so the Zephyr project can, in the near future return to using the *main* branch instead of needing a fork.