### PR TITLE
[riscv/math] Make sqrt function aliases for correct types

### DIFF
--- a/newlib/libm/machine/riscv/s_sqrt.c
+++ b/newlib/libm/machine/riscv/s_sqrt.c
@@ -48,6 +48,8 @@ sqrt (double x)
 	return result;
 }
 
+_MATH_ALIAS_d_d(sqrt)
+
 #else
 #include "../../math/s_sqrt.c"
 #endif


### PR DESCRIPTION
Make sqrt function aliases for correct types if double and long double are the same size, then alias double function to the long double name.

Before this change: building picolibc on RISCV with -Zd -Zf with forcing math-errno that calls sqrtl() function; the application will fail compilation as sqrtl is an undefined symbol in this case.