### PR TITLE
Add bootcode for AArch64-R FVPs

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1348,6 +1348,18 @@ if get_option('newlib-retargetable-locking') != get_option('newlib-multithread')
   error('newlib-retargetable-locking and newlib-multithread must be set to the same value')
 endif
 
+conf_data.set('_GNU_SOURCE', '',
+        description: '''Enable GNU functions like strtof_l.
+It's necessary to set this globally because inline functions in
+libc++ headers call the GNU functions.'''
+)
+
+conf_data.set('_PICOLIBC_CTYPE_SMALL', '0',
+        description: '''Disable picolibc's small ctype implementation.
+libc++ expects newlib-style ctype tables, and also expects support for locales
+and extended character sets, so picolibc's small ctype is not compatible with it'''
+)
+
 conf_data.set('_HAVE_CC_INHIBIT_LOOP_TO_LIBCALL',
 	      cc.has_argument('-fno-tree-loop-distribute-patterns'),
 	      description: 'Compiler flag to prevent detecting memcpy/memset patterns')

--- a/newlib/libc/machine/aarch64/memchr-stub.c
+++ b/newlib/libc/machine/aarch64/memchr-stub.c
@@ -26,7 +26,7 @@
 
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
 # include "../../string/memchr.c"
 #else
 /* See memchr.S  */

--- a/newlib/libc/machine/aarch64/memchr.S
+++ b/newlib/libc/machine/aarch64/memchr.S
@@ -7,7 +7,7 @@
 
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
 /* See memchr-stub.c  */
 #else
 /* Assumptions:

--- a/newlib/libc/machine/aarch64/memcmp-stub.c
+++ b/newlib/libc/machine/aarch64/memcmp-stub.c
@@ -26,7 +26,7 @@
 
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
 # include "../../string/memcmp.c"
 #else
 /* See memcmp.S  */

--- a/newlib/libc/machine/aarch64/memcmp.S
+++ b/newlib/libc/machine/aarch64/memcmp.S
@@ -6,7 +6,7 @@
 
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
 /* See memcmp-stub.c  */
 #else
 

--- a/newlib/libc/machine/aarch64/memcpy-stub.c
+++ b/newlib/libc/machine/aarch64/memcpy-stub.c
@@ -26,7 +26,7 @@
 
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined (__ARM_FEATURE_UNALIGNED)
 # include "../../string/memcpy.c"
 #else
 /* See memcpy.S  */

--- a/newlib/libc/machine/aarch64/memcpy.S
+++ b/newlib/libc/machine/aarch64/memcpy.S
@@ -13,7 +13,7 @@
 
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_FEATURE_UNALIGNED)
 /* See memcpy-stub.c  */
 #else
 #include "asmdefs.h"

--- a/newlib/libc/machine/aarch64/memmove-stub.c
+++ b/newlib/libc/machine/aarch64/memmove-stub.c
@@ -26,7 +26,7 @@
 
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_FEATURE_UNALIGNED)
 # include "../../string/memmove.c"
 #else
 /* See memcpy.S  */

--- a/newlib/libc/machine/aarch64/memrchr-stub.c
+++ b/newlib/libc/machine/aarch64/memrchr-stub.c
@@ -6,7 +6,7 @@
 
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
 #include "../../string/memrchr.c"
 #else
 /* See memrchr.S */

--- a/newlib/libc/machine/aarch64/memrchr.S
+++ b/newlib/libc/machine/aarch64/memrchr.S
@@ -13,7 +13,7 @@
 
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
 /* See memrchr-stub.c */
 #else
 #include "asmdefs.h"

--- a/newlib/libc/machine/aarch64/memset-stub.c
+++ b/newlib/libc/machine/aarch64/memset-stub.c
@@ -26,7 +26,7 @@
 
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
 # include "../../string/memset.c"
 #else
 /* See memset.S  */

--- a/newlib/libc/machine/aarch64/memset.S
+++ b/newlib/libc/machine/aarch64/memset.S
@@ -13,7 +13,7 @@
 
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
 /* See memset-stub.c  */
 #else
 #include "asmdefs.h"

--- a/newlib/libc/machine/aarch64/rawmemchr-stub.c
+++ b/newlib/libc/machine/aarch64/rawmemchr-stub.c
@@ -26,7 +26,7 @@
 
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_FEATURE_UNALIGNED)
 # include "../../string/rawmemchr.c"
 #else
 /* See rawmemchr.S.  */

--- a/newlib/libc/machine/aarch64/rawmemchr.S
+++ b/newlib/libc/machine/aarch64/rawmemchr.S
@@ -32,7 +32,7 @@
 
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_FEATURE_UNALIGNED)
 /* See rawmemchr-stub.c.  */
 #else
 

--- a/newlib/libc/machine/aarch64/stpcpy-stub.c
+++ b/newlib/libc/machine/aarch64/stpcpy-stub.c
@@ -26,7 +26,7 @@
 
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined (__ARM_FEATURE_UNALIGNED)
 # include "../../string/stpcpy.c"
 #else
 /* See stpcpy.S  */

--- a/newlib/libc/machine/aarch64/strchr-stub.c
+++ b/newlib/libc/machine/aarch64/strchr-stub.c
@@ -26,7 +26,7 @@
 
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined (__ARM_FEATURE_UNALIGNED)
 # include "../../string/strchr.c"
 #else
 /* See strchr.S  */

--- a/newlib/libc/machine/aarch64/strchr.S
+++ b/newlib/libc/machine/aarch64/strchr.S
@@ -28,7 +28,7 @@
    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  */
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
 /* See strchr-stub.c  */
 #else
 

--- a/newlib/libc/machine/aarch64/strchrnul-stub.c
+++ b/newlib/libc/machine/aarch64/strchrnul-stub.c
@@ -26,7 +26,7 @@
 
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
 # include "../../string/strchrnul.c"
 #else
 /* See strchrnul.S  */

--- a/newlib/libc/machine/aarch64/strchrnul.S
+++ b/newlib/libc/machine/aarch64/strchrnul.S
@@ -28,7 +28,7 @@
    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  */
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
 /* See strchrnul-stub.c  */
 #else
 

--- a/newlib/libc/machine/aarch64/strcmp-stub.c
+++ b/newlib/libc/machine/aarch64/strcmp-stub.c
@@ -26,7 +26,7 @@
 
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined (__ARM_FEATURE_UNALIGNED)
 # include "../../string/strcmp.c"
 #else
 /* See strcmp.S  */

--- a/newlib/libc/machine/aarch64/strcmp.S
+++ b/newlib/libc/machine/aarch64/strcmp.S
@@ -7,7 +7,7 @@
 
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_FEATURE_UNALIGNED)
 /* See strcmp-stub.c  */
 #else
 

--- a/newlib/libc/machine/aarch64/strcpy-stub.c
+++ b/newlib/libc/machine/aarch64/strcpy-stub.c
@@ -26,7 +26,7 @@
 
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined (__ARM_FEATURE_UNALIGNED)
 # include "../../string/strcpy.c"
 #else
 /* See strcpy.S  */

--- a/newlib/libc/machine/aarch64/strcpy.S
+++ b/newlib/libc/machine/aarch64/strcpy.S
@@ -28,7 +28,7 @@
    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  */
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
 /* See strcpy-stub.c  */
 #else
 

--- a/newlib/libc/machine/aarch64/strlen-stub.c
+++ b/newlib/libc/machine/aarch64/strlen-stub.c
@@ -26,7 +26,7 @@
 
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
 # include "../../string/strlen.c"
 #else
 /* See strlen.S  */

--- a/newlib/libc/machine/aarch64/strlen.S
+++ b/newlib/libc/machine/aarch64/strlen.S
@@ -25,7 +25,7 @@
    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
 /* See strlen-stub.c  */
 #else
 

--- a/newlib/libc/machine/aarch64/strncmp-stub.c
+++ b/newlib/libc/machine/aarch64/strncmp-stub.c
@@ -26,7 +26,7 @@
 
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined (__ARM_FEATURE_UNALIGNED)
 # include "../../string/strncmp.c"
 #else
 /* See strncmp.S  */

--- a/newlib/libc/machine/aarch64/strncmp.S
+++ b/newlib/libc/machine/aarch64/strncmp.S
@@ -26,7 +26,7 @@
 
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_FEATURE_UNALIGNED)
 /* See strncmp-stub.c  */
 #else
 

--- a/newlib/libc/machine/aarch64/strnlen-stub.c
+++ b/newlib/libc/machine/aarch64/strnlen-stub.c
@@ -26,7 +26,7 @@
 
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
 # include "../../string/strnlen.c"
 #else
 /* See strnlen.S  */

--- a/newlib/libc/machine/aarch64/strnlen.S
+++ b/newlib/libc/machine/aarch64/strnlen.S
@@ -28,7 +28,7 @@
 
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
 /* See strnlen-stub.c  */
 #else
 

--- a/newlib/libc/machine/aarch64/strrchr-stub.c
+++ b/newlib/libc/machine/aarch64/strrchr-stub.c
@@ -26,7 +26,7 @@
 
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined (__ARM_FEATURE_UNALIGNED)
 # include "../../string/strrchr.c"
 #else
 /* See strrchr.S  */

--- a/newlib/libc/machine/aarch64/strrchr.S
+++ b/newlib/libc/machine/aarch64/strrchr.S
@@ -29,7 +29,7 @@
 
 #include <picolibc.h>
 
-#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
 /* See strrchr-stub.c  */
 #else
 

--- a/picocrt/machine/aarch64/crt0.S
+++ b/picocrt/machine/aarch64/crt0.S
@@ -86,6 +86,16 @@ __identity_page_table:
 #error "Unknown machine type"
 #endif
 
+#if defined(MACHINE_qemu)
+  #define BOOT_EL(CPACR) CPACR ## _EL1
+#elif defined(MACHINE_fvp) && __ARM_ARCH_PROFILE == 'R'
+  #define BOOT_EL(CPTR) CPTR ## _EL2
+#elif defined(MACHINE_fvp) && __ARM_ARCH_PROFILE != 'R'
+  #define BOOT_EL(CPTR) CPTR ## _EL3
+#else
+#error "Unknown machine type"
+#endif
+
 
 /************ Entry point ************/
 
@@ -111,16 +121,16 @@ _start:
 #if __ARM_FP
 #if defined(MACHINE_qemu)
 	mov x1, #(0x3 << 20)
-	msr CPACR_EL1, x1
+	msr BOOT_EL(CPACR), x1
 #elif defined(MACHINE_fvp)
-	mrs x0, CPTR_EL3
+	mrs x0, BOOT_EL(CPTR)
   /* Clear CPTR_ELx.TFP, to enable FP/SIMD instructions at EL0 and EL1. */
 	and x0, x0, #~(1<<10)
   /* Set CPTR_ELx.EZ and .ESM, to enable SVE and SME instructions at EL3. These
    * bits are ignored for cores which don't have the relevant feature. */
   ORR x0, x0, #1<<8
 	ORR x0, x0, #1<<12
-	msr CPTR_EL3, x0
+	msr BOOT_EL(CPTR), x0
 #else
 #error "Unknown machine type"
 #endif

--- a/picocrt/machine/arm/meson.build
+++ b/picocrt/machine/arm/meson.build
@@ -33,3 +33,10 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 src_picocrt += files('crt0.c')
+
+picocrt_machines += [
+  {
+    'name': 'fvp',
+    'suffix': '-fvp',
+  },
+]

--- a/picolibc.ld.in
+++ b/picolibc.ld.in
@@ -68,6 +68,9 @@ SECTIONS
 		*(.literal.unlikely .text.unlikely .literal.unlikely.* .text.unlikely.*)
 		*(.literal.startup .text.startup .literal.startup.* .text.startup.*)
 		*(.literal .text .literal.* .text.* .opd .opd.*)
+		PROVIDE (__start___lcxx_override = .);
+		*(__lcxx_override)
+		PROVIDE (__stop___lcxx_override = .);
 		*(.gnu.linkonce.t.*)
 		KEEP (*(.fini .fini.*))
 		@PREFIX@__text_end = .;


### PR DESCRIPTION
The AArch64 FVP (Fixed Virtual Platform) R models differ from A models in a
few ways which affect the crt0 code:

1. They boot up at EL2, instead of EL3, so we need to set the EL2 versions of the system 
     registers.
3.  It does not implement the full VMSA, as it is designed for real-time systems
     where simpler memory management is sufficient.