### PR TITLE
Add bootcode for AArch64-R FVPs.

### DIFF
--- a/picocrt/machine/aarch64/crt0.S
+++ b/picocrt/machine/aarch64/crt0.S
@@ -87,11 +87,11 @@ __identity_page_table:
 #endif
 
 #if defined(MACHINE_qemu)
-  #define BOOT_EL(CPACR) CPACR ## _EL1
+  #define BOOT_EL(Reg) Reg ## _EL1
 #elif defined(MACHINE_fvp) && __ARM_ARCH_PROFILE == 'R'
-  #define BOOT_EL(CPTR) CPTR ## _EL2
+  #define BOOT_EL(Reg) Reg ## _EL2
 #elif defined(MACHINE_fvp) && __ARM_ARCH_PROFILE != 'R'
-  #define BOOT_EL(CPTR) CPTR ## _EL3
+  #define BOOT_EL(Reg) Reg ## _EL3
 #else
 #error "Unknown machine type"
 #endif
@@ -179,18 +179,18 @@ _start:
   str x29, [sp, #232]
   str x30, [sp, #240]
 #if defined(MACHINE_qemu)
-  mrs x0, ELR_EL1
+  mrs x0, BOOT_EL(ELR)
   str x0, [sp, #248]
-  mrs x0, ESR_EL1
+  mrs x0, BOOT_EL(ESR)
   str x0, [sp, #256]
-  mrs x0, FAR_EL1
+  mrs x0, BOOT_EL(FAR)
   str x0, [sp, #264]
 #elif defined(MACHINE_fvp)
-  mrs x0, ELR_EL3
+  mrs x0, BOOT_EL(ELR)
   str x0, [sp, #248]
-  mrs x0, ESR_EL3
+  mrs x0, BOOT_EL(ESR)
   str x0, [sp, #256]
-  mrs x0, FAR_EL3
+  mrs x0, BOOT_EL(FAR)
   str x0, [sp, #264]
 #else
 #error "Unknown machine type"

--- a/picocrt/machine/aarch64/crt0.S
+++ b/picocrt/machine/aarch64/crt0.S
@@ -86,6 +86,16 @@ __identity_page_table:
 #error "Unknown machine type"
 #endif
 
+#if defined(MACHINE_qemu)
+  #define BOOT_EL(CPACR) CPACR ## _EL1
+#elif defined(MACHINE_fvp) && __ARM_ARCH_PROFILE == 'R'
+  #define BOOT_EL(CPTR) CPTR ## _EL2
+#elif defined(MACHINE_fvp) && __ARM_ARCH_PROFILE != 'R'
+  #define BOOT_EL(CPTR) CPTR ## _EL3
+#else
+#error "Unknown machine type"
+#endif
+
 
 /************ Entry point ************/
 
@@ -111,16 +121,16 @@ _start:
 #if __ARM_FP
 #if defined(MACHINE_qemu)
 	mov x1, #(0x3 << 20)
-	msr CPACR_EL1, x1
+	msr BOOT_EL(CPACR), x1
 #elif defined(MACHINE_fvp)
-	mrs x0, CPTR_EL3
+	mrs x0, BOOT_EL(CPTR)
   /* Clear CPTR_ELx.TFP, to enable FP/SIMD instructions at EL0 and EL1. */
 	and x0, x0, #~(1<<10)
   /* Set CPTR_ELx.EZ and .ESM, to enable SVE and SME instructions at EL3. These
    * bits are ignored for cores which don't have the relevant feature. */
   ORR x0, x0, #1<<8
 	ORR x0, x0, #1<<12
-	msr CPTR_EL3, x0
+	msr BOOT_EL(CPTR), x0
 #else
 #error "Unknown machine type"
 #endif


### PR DESCRIPTION
The AArch64 FVP (Fixed Virtual Platform) R models differ from A models in a few ways which affect the crt0 code:

       1. They boot up at EL2, instead of EL3, so we need to set the EL2 versions of the 
           system registers.
       3. It does not implement the full VMSA. Simpler memory management is sufficient.