### PR TITLE
Create a minimal locale implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,9 @@ set(REENTRANT_SYSCALLS_PROVIDED 0)
 # Use tiny stdio from gcc avr
 option(TINY_STDIO "Use tiny stdio from avr libc" ON)
 
+# Use tiny locale
+option(_TINY_LOCALE "Use tiny locale" ON)
+
 if(NOT TLS_MODEL)
   set(TLS_MODEL "local-exec")
 endif()
@@ -373,6 +376,18 @@ endif()
 
 if(NOT DEFINED _MB_EXTENDED_CHARSETS_ALL)
   option(_MB_EXTENDED_CHARSETS_ALL "Enable ISO, Windows and JIS multibyte encodings" OFF)
+endif()
+
+if(NOT DEFINED _MB_EXTENDED_CHARSETS_ISO)
+  option(_MB_EXTENDED_CHARSETS_ISO "Enable ISO encodings" OFF)
+endif()
+
+if(NOT DEFINED _MB_EXTENDED_CHARSETS_WINDOWS)
+  option(_MB_EXTENDED_CHARSETS_WINDOWS "Enable Windows encodings" OFF)
+endif()
+
+if(NOT DEFINED _MB_EXTENDED_CHARSETS_JIS)
+  option(_MB_EXTENDED_CHARSETS_JIS "Enable JIS multibyte encodings" OFF)
 endif()
 
 set(_NANO_FORMATTED_IO OFF)

--- a/meson.build
+++ b/meson.build
@@ -1630,13 +1630,15 @@ conf_data.set('__NEWLIB__', NEWLIB_MAJOR_VERSION, description: 'The newlib major
 conf_data.set('__NEWLIB_MINOR__', NEWLIB_MINOR_VERSION, description: 'The newlib minor version number.')
 conf_data.set('__NEWLIB_PATCHLEVEL__', NEWLIB_PATCHLEVEL_VERSION, description: 'The newlib patch level.')
 
+locale_inc_dir = 'newlib/libc/locale'
+
 if tinystdio
   stdio_inc_dir = 'newlib/libc/tinystdio'
 else
   stdio_inc_dir = 'newlib/libc/stdio'
 endif
 
-inc_dirs = [stdio_inc_dir, '.', 'newlib/libc/include']
+inc_dirs = [stdio_inc_dir, locale_inc_dir, '.', 'newlib/libc/include']
 
 machine_dir = 'newlib/libc/machine' / host_cpu_family
 if fs.is_dir(machine_dir)

--- a/meson.build
+++ b/meson.build
@@ -247,6 +247,7 @@ else
 endif
 fast_strcmp = get_option('fast-strcmp')
 
+tiny_locale = get_option('tiny-locale')
 mb_capable = get_option('mb-capable') or get_option('newlib-mb')
 mb_extended_charsets = mb_capable and get_option('mb-extended-charsets')
 if get_option('mb-iso-charsets') == 'auto'
@@ -1398,6 +1399,7 @@ if not tinystdio
   conf_data.set('__LARGE64_FILES', newlib_stdio64)
 endif
 conf_data.set('_WANT_REENT_SMALL', get_option('newlib-reent-small'))
+conf_data.set('_TINY_LOCALE', tiny_locale)
 conf_data.set('_MB_CAPABLE', mb_capable)
 conf_data.set('_MB_EXTENDED_CHARSETS_ISO', mb_iso_charsets)
 conf_data.set('_MB_EXTENDED_CHARSETS_WINDOWS', mb_windows_charsets)
@@ -1630,7 +1632,11 @@ conf_data.set('__NEWLIB__', NEWLIB_MAJOR_VERSION, description: 'The newlib major
 conf_data.set('__NEWLIB_MINOR__', NEWLIB_MINOR_VERSION, description: 'The newlib minor version number.')
 conf_data.set('__NEWLIB_PATCHLEVEL__', NEWLIB_PATCHLEVEL_VERSION, description: 'The newlib patch level.')
 
-locale_inc_dir = 'newlib/libc/locale'
+if tiny_locale
+  locale_inc_dir = 'newlib/libc/tinylocale'
+else
+  locale_inc_dir = 'newlib/libc/locale'
+endif
 
 if tinystdio
   stdio_inc_dir = 'newlib/libc/tinystdio'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -232,6 +232,8 @@ option('newlib-iconv-runtime-dir', type: 'string',
 option('newlib-iconv-encodings-exclude', type: 'array',
        description: 'enable specific comma-separated list of bidirectional iconv encodings to be excluded')
 
+option('tiny-locale', type: 'boolean', value: true,
+       description: 'enable small locale implementation')
 option('locale-info', type: 'boolean', value: false,
        description: 'enable locale info support be')
 option('locale-info-extended', type: 'boolean', value: false,

--- a/newlib/libc/ctype/caseconv.c
+++ b/newlib/libc/ctype/caseconv.c
@@ -24,12 +24,8 @@ __caseconv_lookup (wint_t ucs, struct __locale_t *locale)
   size_t min = 0;
   size_t max = NCASECONV-1;
   size_t mid;
-  const char *ctype_locale;
 
-  if (!locale)
-      locale = __get_current_locale();
-  ctype_locale = locale->categories[NL_LOCALE_NAME(LC_CTYPE) - NL_LOCALE_NAME(LC_ALL)];
-  if (ucs >= 0x80 && !strcmp (ctype_locale, "C"))
+  if (ucs >= 0x80 && __locale_is_C(locale))
     return 0;
 
   if (ucs < first(table[0]) || ucs > last(table[max]))

--- a/newlib/libc/ctype/ctype_.c
+++ b/newlib/libc/ctype/ctype_.c
@@ -31,7 +31,7 @@
 /* Make sure we're using fast ctype */
 #define _PICOLIBC_CTYPE_SMALL 0
 #include "ctype_.h"
-#include "../locale/setlocale.h"
+#include "setlocale.h"
 #include "../stdlib/local.h"
 
 #if defined(ALLOW_NEGATIVE_CTYPE_INDEX)

--- a/newlib/libc/ctype/ctype_.c
+++ b/newlib/libc/ctype/ctype_.c
@@ -68,6 +68,89 @@ const char _ctype_[1 + 256] = {
 #include "ctype_jis.h"
 #endif
 
+#ifdef _TINY_LOCALE
+#if defined(ALLOW_NEGATIVE_CTYPE_INDEX)
+#define __ctype_ascii   _ctype_b
+#define CTYPE_OFFSET    127
+#else
+#define __ctype_ascii   _ctype_
+#define CTYPE_OFFSET    0
+#endif
+
+void
+__set_ctype(enum locale_id id,
+            const char ** ctype)
+{
+    switch (id) {
+    default:
+    case locale_C:
+    case locale_UTF_8:
+        *ctype = __ctype_ascii + CTYPE_OFFSET;
+        break;
+#ifdef _MB_EXTENDED_CHARSETS_ISO
+    case locale_ISO_8859_1:
+    case locale_ISO_8859_2:
+    case locale_ISO_8859_3:
+    case locale_ISO_8859_4:
+    case locale_ISO_8859_5:
+    case locale_ISO_8859_6:
+    case locale_ISO_8859_7:
+    case locale_ISO_8859_8:
+    case locale_ISO_8859_9:
+    case locale_ISO_8859_10:
+    case locale_ISO_8859_11:
+    case locale_ISO_8859_13:
+    case locale_ISO_8859_14:
+    case locale_ISO_8859_15:
+    case locale_ISO_8859_16:
+        *ctype = __ctype_iso[id - locale_ISO_8859_1] + CTYPE_OFFSET;
+        break;
+#endif
+#ifdef _MB_EXTENDED_CHARSETS_WINDOWS
+    case locale_GEORGIAN_PS:
+    case locale_PT154:
+    case locale_KOI8_T:
+    case locale_CP437:
+    case locale_CP720:
+    case locale_CP737:
+    case locale_CP775:
+    case locale_CP850:
+    case locale_CP852:
+    case locale_CP855:
+    case locale_CP857:
+    case locale_CP858:
+    case locale_CP862:
+    case locale_CP866:
+    case locale_CP874:
+    case locale_CP1125:
+    case locale_CP1250:
+    case locale_CP1251:
+    case locale_CP1252:
+    case locale_CP1253:
+    case locale_CP1254:
+    case locale_CP1255:
+    case locale_CP1256:
+    case locale_CP1257:
+    case locale_CP1258:
+    case locale_KOI8_R:
+    case locale_KOI8_U:
+        *ctype = __ctype_cp[id - locale_CP437] + CTYPE_OFFSET;
+        break;
+#endif
+#ifdef _MB_EXTENDED_CHARSETS_JIS
+    case locale_JIS:
+        *ctype = __ctype_ascii + CTYPE_OFFSET;
+        break;
+    case locale_EUCJP:
+        *ctype = __ctype_eucjp + CTYPE_OFFSET;
+        break;
+    case locale_SJIS:
+        *ctype = __ctype_sjis + CTYPE_OFFSET;
+        break;
+#endif
+    }
+}
+#else
 void
 __set_ctype (struct __locale_t *loc, const char *charset)
 {
@@ -124,4 +207,5 @@ __set_ctype (struct __locale_t *loc, const char *charset)
   loc->ctype_ptr = ctype_ptr;
 #  endif
 }
+#endif
 #endif /* _MB_EXTENDED_CHARSETS_ANY */

--- a/newlib/libc/ctype/ctype_.h
+++ b/newlib/libc/ctype/ctype_.h
@@ -6,10 +6,19 @@
 # define DEFAULT_CTYPE_PTR	((char *) _ctype_)
 
 #ifdef _MB_EXTENDED_CHARSETS_ANY
+#ifdef _TINY_LOCALE
+void
+__set_ctype(enum locale_id, const char ** ctype);
+#else
 void
 __set_ctype (struct __locale_t *loc, const char *charset);
+#endif
+#else
+#ifdef _TINY_LOCALE
+#define __set_ctype(id, ctype, wc, mb)
 #else
 #define __set_ctype(loc, charset)
+#endif
 #endif
 
 #define _CTYPE_DATA_0_127 \

--- a/newlib/libc/ctype/ctype_.h
+++ b/newlib/libc/ctype/ctype_.h
@@ -1,5 +1,7 @@
 /* Copyright (c) 2016 Corinna Vinschen <corinna@vinschen.de> */
 #include <ctype.h>
+#include <wchar.h>
+#include "setlocale.h"
 
 # define DEFAULT_CTYPE_PTR	((char *) _ctype_)
 

--- a/newlib/libc/ctype/ctype_table.c
+++ b/newlib/libc/ctype/ctype_table.c
@@ -56,7 +56,6 @@ __ctype_table_lookup(wint_t ic, struct __locale_t *locale)
     size_t      low = 0;
     size_t      high = N_CAT_TABLE - 1;
     size_t      mid;
-    const char  *ctype_locale;
     wchar_t     c;
 
     if (ic == WEOF)
@@ -64,12 +63,8 @@ __ctype_table_lookup(wint_t ic, struct __locale_t *locale)
 
     c = (wchar_t) ic;
 
-    if (!locale)
-        locale = __get_current_locale();
-
     /* Be compatible with glibc where the C locale has no classes outside of ASCII */
-    ctype_locale = locale->categories[NL_LOCALE_NAME(LC_CTYPE) - NL_LOCALE_NAME(LC_ALL)];
-    if (c >= 0x80 && !strcmp (ctype_locale, "C"))
+    if (c >= 0x80 && __locale_is_C(locale))
         return CLASS_none;
 
     while (low < high) {

--- a/newlib/libc/ctype/ctype_wide.c
+++ b/newlib/libc/ctype/ctype_wide.c
@@ -31,7 +31,7 @@
 /* Make sure we're using fast ctype */
 #define _PICOLIBC_CTYPE_SMALL 0
 #include "ctype_.h"
-#include "../locale/setlocale.h"
+#include "setlocale.h"
 
 const short _ctype_wide[1 + 256] = {
 	0,

--- a/newlib/libc/ctype/local.h
+++ b/newlib/libc/ctype/local.h
@@ -33,7 +33,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /* wctrans constants */
 
 #include <stdint.h>
-#include "../locale/setlocale.h"
+#include <wctype.h>
+#include <wchar.h>
+#include <string.h>
+#include "setlocale.h"
 
 /* valid values for wctrans_t */
 #define WCT_TOLOWER 1

--- a/newlib/libc/ctype/tolower_l.c
+++ b/newlib/libc/ctype/tolower_l.c
@@ -10,7 +10,7 @@ Modified (m) 2017 Thomas Wolff: revise Unicode and locale/wchar handling
 #include <stdlib.h>
 #include <wctype.h>
 #include <wchar.h>
-#include "../locale/setlocale.h"
+#include "setlocale.h"
 #endif
 
 int
@@ -27,8 +27,8 @@ tolower_l (int c, struct __locale_t *locale)
       mbstate_t state;
 
       memset (&state, 0, sizeof state);
-      if (locale->mbtowc (&wc, s, 1, &state) >= 0
-	  && locale->wctomb (s,
+      if (__MBTOWC_L(locale) (&wc, s, 1, &state) >= 0
+	  && __WCTOMB_L(locale) (s,
 			     (wchar_t) towlower_l ((wint_t) wc, locale),
 			     &state) == 1)
 	c = (unsigned char) s[0];

--- a/newlib/libc/ctype/toupper_l.c
+++ b/newlib/libc/ctype/toupper_l.c
@@ -11,7 +11,7 @@ Modified (m) 2017 Thomas Wolff: revise Unicode and locale/wchar handling
 #include <stdlib.h>
 #include <wctype.h>
 #include <wchar.h>
-#include <../locale/setlocale.h>
+#include "setlocale.h"
 #endif
 
 int
@@ -29,8 +29,8 @@ toupper_l (int c, struct __locale_t *locale)
       mbstate_t state;
 
       memset (&state, 0, sizeof state);
-      if (locale->mbtowc (&wc, s, 1, &state) >= 0
-	  && locale->wctomb (s,
+      if (__MBTOWC_L(locale) (&wc, s, 1, &state) >= 0
+	  && __WCTOMB_L(locale) (s,
 			     (wchar_t) towupper_l ((wint_t) wc, locale),
 			     &state) == 1)
 	c = (unsigned char) s[0];

--- a/newlib/libc/include/locale.h
+++ b/newlib/libc/include/locale.h
@@ -52,6 +52,7 @@ SUCH DAMAGE.
 #define LC_NUMERIC  4
 #define LC_TIME     5
 #define _LC_MESSAGES    6
+#define _LC_LAST        7
 
 _BEGIN_STD_C
 
@@ -111,11 +112,7 @@ locale_t uselocale (locale_t);
 
 #endif
 
-#if __POSIX_VISIBLE >= 202405
-const char *getlocalename_l (int, struct __locale_t *);
-#endif
-
-#if __MISC_VISIBLE
+#if __POSIX_VISIBLE >= 202405 || __MISC_VISIBLE
 const char *getlocalename_l (int, struct __locale_t *);
 #endif
 

--- a/newlib/libc/locale/locale.c
+++ b/newlib/libc/locale/locale.c
@@ -41,7 +41,7 @@ for instance <<"C.UTF-8">>, which keeps all settings as in the C locale,
 but uses the UTF-8 charset.
 
 The following charsets are recognized:
-<<"UTF-8">>, <<"JIS">>, <<"EUCJP">>, <<"SJIS">>, <<"KOI8-R">>, <<"KOI8-U">>,
+<<"UTF-8">>, <<"JIS">>, <<"EUCJP">>, <<"SHIFT-JIS">>, <<"KOI8-R">>, <<"KOI8-U">>,
 <<"KOI8-T">>, <<"GEORGIAN-PS">>, <<"PT154">>, <<"TIS-620">>, <<"ISO-8859-x">>
 with 1 <= x <= 16, or <<"CPxxx">> with xxx in [437, 720, 737, 775, 850, 852,
 855, 857, 858, 862, 866, 874, 932, 1125, 1250, 1251, 1252, 1253, 1254, 1255,
@@ -618,9 +618,9 @@ __loadlocale (struct __locale_t *loc, int category, char *new_locale)
     break;
     case 'S':
     case 's':
-      if (strcasecmp (charset, "SJIS"))
+      if (strcasecmp (charset, "SJIS") && strcasecmp (charset, "SHIFT-JIS"))
 	FAIL;
-      strcpy (charset, "SJIS");
+      strcpy (charset, "SHIFT-JIS");
       mbc_max = 2;
       l_wctomb = __sjis_wctomb;
       l_mbtowc = __sjis_mbtowc;

--- a/newlib/libc/locale/setlocale.h
+++ b/newlib/libc/locale/setlocale.h
@@ -36,6 +36,7 @@
 #include <wchar.h>
 #include <locale.h>
 #include <langinfo.h>
+#include <stdbool.h>
 
 __BEGIN_DECLS
 
@@ -45,7 +46,6 @@ extern struct __locale_t __global_locale;
 
 #define ENCODING_LEN 31
 #define CATEGORY_LEN 11
-#define _LC_LAST      7
 
 
 struct lc_ctype_T
@@ -192,15 +192,17 @@ struct __locale_t
 #endif
 };
 
+#define __WCTOMB        (__get_current_locale()->wctomb)
+#define __MBTOWC        (__get_current_locale()->mbtowc)
+#define __WCTOMB_L(l)   ((l)->wctomb)
+#define __MBTOWC_L(l)   ((l)->mbtowc)
+
 #ifdef _MB_CAPABLE
 extern char *__loadlocale (struct __locale_t *, int, char *);
 extern const char *__get_locale_env(int);
 #endif /* _MB_CAPABLE */
 
 extern struct lconv *__localeconv_l (struct __locale_t *locale);
-
-extern size_t _wcsnrtombs_l (char *, const wchar_t **,
-			     size_t, size_t, mbstate_t *, struct __locale_t *);
 
 #ifdef __HAVE_LOCALE_INFO__
 #define NEWLIB_THREAD_LOCAL_LOCALE NEWLIB_THREAD_LOCAL
@@ -367,6 +369,63 @@ __get_current_messages_locale (void)
 }
 #endif /* !__HAVE_LOCALE_INFO__ */
 
+/* LC_NUMERIC data */
+#define DECIMAL_POINT           (__get_current_numeric_locale()->decimal_point)
+#define DECIMAL_POINT_L(l)      (__get_numeric_locale(l)->decimal_point)
+#define THOUSANDS_SEP           (__get_current_numeric_locale()->thousands_sep)
+#define THOUSANDS_SEP_L(l)      (__get_numeric_locale(l)->thousands_sep)
+#define NUMERIC_GROUPING        (__get_current_numeric_locale()->grouping)
+#define NUMERIC_GROUPING_L(l)   (__get_numeric_locale(l)->grouping)
+#ifdef __HAVE_LOCALE_INFO_EXTENDED__
+#define WDECIMAL_POINT          (__get_current_numeric_locale()->wdecimal_point)
+#define WDECIMAL_POINT_L(l)     (__get_numeric_locale(l)->wdecimal_point)
+#define WTHOUSANDS_SEP          (__get_current_numeric_locale()->wthousands_sep)
+#define WTHOUSANDS_SEP_L(l)     (__get_numeric_locale(l)->wthousands_sep
+#endif
+
+/* LC_TIME data */
+#define TIME_ERA_L(l)           (__get_time_locale(l)->era)
+#define TIME_ERA                (__get_current_time_locale()->era)
+#define TIME_ERA_D_T_FMT_L(l)   (__get_time_locale(l)->era_d_t_fmt)
+#define TIME_ERA_D_T_FMT        (__get_current_time_locale()->era_d_t_fmt)
+#define TIME_ERA_D_FMT_L(l)     (__get_time_locale(l)->era_d_fmt)
+#define TIME_ERA_D_FMT          (__get_current_time_locale()->era_d_fmt)
+#define TIME_ERA_T_FMT_L(l)     (__get_time_locale(l)->era_t_fmt)
+#define TIME_ERA_T_FMT          (__get_current_time_locale()->era_t_fmt)
+#define TIME_ALT_DIGITS_L(l)    (__get_time_locale(l)->alt_digits)
+#define TIME_ALT_DIGITS         (__get_current_time_locale()->alt_digits)
+#define TIME_WDAY               (__get_current_time_locale()->wday)
+#define TIME_WEEKDAY            (__get_current_time_locale()->weekday)
+#define TIME_MON                (__get_current_time_locale()->mon)
+#define TIME_MONTH              (__get_current_time_locale()->month)
+#define TIME_AM_PM              (__get_current_time_locale()->am_pm)
+#define TIME_C_FMT              (__get_current_time_locale()->c_fmt)
+#define TIME_X_FMT              (__get_current_time_locale()->x_fmt)
+#define TIME_UX_FMT             (__get_current_time_locale()->X_fmt)
+#define TIME_AMPM_FMT           (__get_current_time_locale()->ampm_fmt)
+
+#ifdef __HAVE_LOCALE_INFO_EXTENDED__
+#define WTIME_ERA_L(l)          (__get_time_locale(l)->wera)
+#define WTIME_ERA               (__get_current_time_locale()->wera)
+#define WTIME_ERA_D_T_FMT_L(l)  (__get_time_locale(l)->wera_d_t_fmt)
+#define WTIME_ERA_D_T_FMT       (__get_current_time_locale()->wera_d_t_fmt)
+#define WTIME_ERA_D_FMT_L(l)    (__get_time_locale(l)->wera_d_fmt)
+#define WTIME_ERA_D_FMT         (__get_current_time_locale()->wera_d_fmt)
+#define WTIME_ERA_T_FMT_L(l)    (__get_time_locale(l)->wera_t_fmt)
+#define WTIME_ERA_T_FMT         (__get_current_time_locale()->wera_t_fmt)
+#define WTIME_ALT_DIGITS_L(l)   (__get_time_locale(l)->walt_digits)
+#define WTIME_ALT_DIGITS        (__get_current_time_locale()->walt_digits)
+#define WTIME_WDAY              (__get_current_time_locale()->wwday)
+#define WTIME_WEEKDAY           (__get_current_time_locale()->wweekday)
+#define WTIME_MON               (__get_current_time_locale()->wmon)
+#define WTIME_MONTH             (__get_current_time_locale()->wmonth)
+#define WTIME_AM_PM             (__get_current_time_locale()->wam_pm)
+#define WTIME_C_FMT             (__get_current_time_locale()->wc_fmt)
+#define WTIME_X_FMT             (__get_current_time_locale()->wx_fmt)
+#define WTIME_UX_FMT            (__get_current_time_locale()->wX_fmt)
+#define WTIME_AMPM_FMT          (__get_current_time_locale()->wampm_fmt)
+#endif
+
 __elidable_inline const char *
 __locale_charset (struct __locale_t *locale)
 {
@@ -406,6 +465,16 @@ __elidable_inline int
 __locale_cjk_lang (void)
 {
   return __get_current_locale()->cjk_lang;
+}
+
+__elidable_inline bool
+__locale_is_C(struct __locale_t *locale)
+{
+    if (!locale)
+        locale = __get_current_locale();
+    const char *ctype_locale = locale->categories[LC_CTYPE - LC_ALL];
+
+    return strcmp (ctype_locale, "C") == 0;
 }
 
 int __ctype_load_locale (struct __locale_t *, const char *, void *,

--- a/newlib/libc/meson.build
+++ b/newlib/libc/meson.build
@@ -35,7 +35,7 @@
 
 libdirs = ['argz', 'ctype', 'errno', 'iconv', 'misc',
 	   'posix', 'search', 'signal', 'ssp', 'stdlib',
-	   'string', 'time', 'xdr', 'locale', 'uchar']
+	   'string', 'time', 'xdr', 'uchar']
 
 if enable_picolib
   libdirs += 'picolib'
@@ -48,6 +48,12 @@ else
   if newlib_stdio64
     libdirs += 'stdio64'
   endif
+endif
+
+if tiny_locale
+  libdirs += 'tinylocale'
+else
+  libdirs += 'locale'
 endif
 
 libnames = libdirs

--- a/newlib/libc/stdio/nano-vfprintf_float.c
+++ b/newlib/libc/stdio/nano-vfprintf_float.c
@@ -168,7 +168,7 @@ _printf_float (struct _reent *data,
 {
 #define _fpvalue (pdata->_double_)
 
-  char *decimal_point = localeconv ()->decimal_point;
+  char *decimal_point = DECIMAL_POINT;
   size_t decp_len = strlen (decimal_point);
   /* Temporary negative sign for floats.  */
   char softsign;

--- a/newlib/libc/stdio/vfprintf.c
+++ b/newlib/libc/stdio/vfprintf.c
@@ -413,7 +413,7 @@ VFPRINTF (
 	const char *grouping = NULL;
 #endif
 #ifdef FLOATING_POINT
-	char *decimal_point = localeconv ()->decimal_point;
+	char *decimal_point = DECIMAL_POINT;
 	size_t decp_len = strlen (decimal_point);
 	char softsign;		/* temporary negative sign for floats */
 	union { int i; _PRINTF_FLOAT_TYPE fp; } _double_ = {0};
@@ -701,9 +701,9 @@ rflag:		ch = *fmt++;
 reswitch:	switch (ch) {
 #ifdef _WANT_IO_C99_FORMATS
 		case '\'':
-			thousands_sep = localeconv ()->thousands_sep;
+			thousands_sep = THOUSANDS_SEP;
 			thsnd_len = strlen (thousands_sep);
-			grouping = localeconv ()->grouping;
+			grouping = NUMERIC_GROUPING;
 			if (thsnd_len > 0 && grouping && *grouping)
 			  flags |= GROUPING;
 			goto rflag;
@@ -1353,8 +1353,14 @@ number:			if ((dprec = prec) >= 0)
 					      && *grouping != CHAR_MAX
 					      && _uquad > 9) {
 					    cp -= thsnd_len;
-					    strncpy (cp, thousands_sep,
-						     thsnd_len);
+/* when thousands_sep is a constant empty string, the compiler complains */
+#ifdef __GNUCLIKE_PRAGMA_DIAGNOSTIC
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+#endif
+                                            strncpy (cp, thousands_sep,
+                                                     thsnd_len);
 					    ndig = 0;
 					    /* If (grouping[1] == '\0') then we
 					       have to use *grouping character

--- a/newlib/libc/stdio/vfscanf.c
+++ b/newlib/libc/stdio/vfscanf.c
@@ -1539,7 +1539,7 @@ _SVFSCANF (
 	  unsigned width_left = 0;
 	  char nancount = 0;
 	  char infcount = 0;
-	  const char *decpt = localeconv ()->decimal_point;
+	  const char *decpt = DECIMAL_POINT;
 #ifdef _MB_CAPABLE
 	  int decptpos = 0;
 #endif

--- a/newlib/libc/stdio/vfwprintf.c
+++ b/newlib/libc/stdio/vfwprintf.c
@@ -120,9 +120,7 @@ SEEALSO
 #include "local.h"
 #include "fvwrite.h"
 #include "vfieeefp.h"
-#ifdef __HAVE_LOCALE_INFO_EXTENDED__
-#include "../locale/setlocale.h"
-#endif
+#include "setlocale.h"
 
 int VFWPRINTF (FILE *, const wchar_t *, va_list);
 
@@ -380,7 +378,7 @@ VFWPRINTF (
 	wchar_t thousands_sep = L'\0';
 	const char *grouping = NULL;
 #endif
-#if defined (_MB_CAPABLE) && !defined (__HAVE_LOCALE_INFO_EXTENDED__) \
+#if defined (_MB_CAPABLE) && !defined (WDECIMAL_POINT) \
     && (defined (FLOATING_POINT) || defined (_WANT_IO_C99_FORMATS))
 	mbstate_t state;        /* mbtowc calls from library must not change state */
 #endif
@@ -432,22 +430,22 @@ VFWPRINTF (
 
 #ifdef FLOATING_POINT
 #ifdef _MB_CAPABLE
-#ifdef __HAVE_LOCALE_INFO_EXTENDED__
-	decimal_point = *__get_current_numeric_locale ()->wdecimal_point;
+#ifdef WDECIMAL_POINT
+	decimal_point = *WDECIMAL_POINT;
 #else
 	{
 	  size_t nconv;
 
 	  memset (&state, '\0', sizeof (state));
 	  nconv = mbrtowc (&decimal_point,
-			      localeconv ()->decimal_point,
+			      DECIMAL_POINT,
 			      MB_CUR_MAX, &state);
 	  if (nconv == (size_t) -1 || nconv == (size_t) -2)
 	    decimal_point = L'.';
 	}
 #endif
 #else
-	decimal_point = (wchar_t) *localeconv ()->decimal_point;
+	decimal_point = (wchar_t) *DECIMAL_POINT;
 #endif
 #endif
 	/*
@@ -652,24 +650,24 @@ reswitch:	switch (ch) {
 #ifdef _WANT_IO_C99_FORMATS
 		case L'\'':
 #ifdef _MB_CAPABLE
-#ifdef __HAVE_LOCALE_INFO_EXTENDED__
-		  thousands_sep = *__get_current_numeric_locale ()->wthousands_sep;
+#ifdef WTHOUSANDS_SEP
+                  thousands_sep = *WTHOUSANDS_SEP;
 #else
 		  {
 		    size_t nconv;
 
 		    memset (&state, '\0', sizeof (state));
 		    nconv = mbrtowc (&thousands_sep,
-					localeconv ()->thousands_sep,
+					THOUSANDS_SEP,
 					MB_CUR_MAX, &state);
 		    if (nconv == (size_t) -1 || nconv == (size_t) -2)
 		      thousands_sep = L'\0';
 		  }
 #endif
 #else
-		  thousands_sep = (wchar_t) *localeconv ()->thousands_sep;
+		  thousands_sep = (wchar_t) *THOUSANDS_SEP;
 #endif
-		  grouping = localeconv ()->grouping;
+		  grouping = NUMERIC_GROUPING;
 		  if (thousands_sep && grouping && *grouping)
 		    flags |= GROUPING;
 		  goto rflag;

--- a/newlib/libc/stdio/vfwscanf.c
+++ b/newlib/libc/stdio/vfwscanf.c
@@ -123,9 +123,7 @@ __typeof(vfwscanf) vfiwscanf;
 #include <math.h>
 #include <float.h>
 #include <locale.h>
-#ifdef __HAVE_LOCALE_INFO_EXTENDED__
-#include "../locale/setlocale.h"
-#endif
+#include "setlocale.h"
 
 /* Currently a test is made to see if long double processing is warranted.
    This could be changed in the future should the __ldtoa code be
@@ -472,22 +470,22 @@ _SVFWSCANF (
 
 #ifdef FLOATING_POINT
 #ifdef _MB_CAPABLE
-#ifdef __HAVE_LOCALE_INFO_EXTENDED__
-	  decpt = *__get_current_numeric_locale ()->wdecimal_point;
+#ifdef WDECIMAL_POINT
+          decpt = *WDECIMAL_POINT;
 #else
 	  {
 	    size_t nconv;
 
 	    memset (&mbs, '\0', sizeof (mbs));
 	    nconv = mbrtowc (&decpt,
-				localeconv ()->decimal_point,
+				DECIMAL_POINT,
 				MB_CUR_MAX, &mbs);
 	    if (nconv == (size_t) -1 || nconv == (size_t) -2)
 	      decpt = L'.';
 	  }
-#endif /* !__HAVE_LOCALE_INFO_EXTENDED__ */
+#endif /* !WDECIMAL_POINT */
 #else
-	  decpt = (wchar_t) *localeconv ()->decimal_point;
+	  decpt = (wchar_t) *DECIMAL_POINT;
 #endif /* !_MB_CAPABLE */
 #endif /* FLOATING_POINT */
 

--- a/newlib/libc/stdlib/gdtoa-gethex.c
+++ b/newlib/libc/stdlib/gdtoa-gethex.c
@@ -157,15 +157,15 @@ gethex (const char **sp, const FPI *fpi,
 	Long e, e1;
 #ifdef __HAVE_LOCALE_INFO__
 	const unsigned char *decimalpoint = (const unsigned char *)
-				      __get_numeric_locale(loc)->decimal_point;
+				      DECIMAL_POINT_L(loc);
 	const size_t decp_len = strlen ((const char *) decimalpoint);
 	const unsigned char decp_end = decimalpoint[decp_len - 1];
 #else
 	const unsigned char *decimalpoint = (const unsigned char *) ".";
 	const size_t decp_len = 1;
 	const unsigned char decp_end = (unsigned char) '.';
-        (void) loc;
 #endif
+        (void) loc;
 
 	havedig = 0;
 	s0 = *(const unsigned char **)sp + 2;

--- a/newlib/libc/stdlib/local.h
+++ b/newlib/libc/stdlib/local.h
@@ -61,13 +61,13 @@ mbtowc_p __cp_mbtowc (int val);
 #define __MBTOWC (__get_current_locale()->mbtowc)
 
 #ifdef _MB_EXTENDED_CHARSETS_ISO
-extern uint16_t __iso_8859_conv[14][0x60];
+extern const uint16_t __iso_8859_conv[14][0x60];
 int __iso_8859_val_index (int);
 int __iso_8859_index (const char *);
 #endif
 
 #ifdef _MB_EXTENDED_CHARSETS_WINDOWS
-extern uint16_t __cp_conv[][0x80];
+extern const uint16_t __cp_conv[][0x80];
 int __cp_val_index (int);
 int __cp_index (const char *);
 #endif

--- a/newlib/libc/stdlib/local.h
+++ b/newlib/libc/stdlib/local.h
@@ -11,7 +11,7 @@ All rights reserved.
 
 char *	_gcvt (double , int , char *, char, int);
 
-#include "../locale/setlocale.h"
+#include "setlocale.h"
 
 #ifndef __machine_mbstate_t_defined
 #include <wchar.h>
@@ -36,8 +36,6 @@ wctomb_p __cp_wctomb (int val);
 #endif
 #endif
 
-#define __WCTOMB (__get_current_locale()->wctomb)
-
 typedef int mbtowc_f (wchar_t *, const char *, size_t,
 		      mbstate_t *);
 typedef mbtowc_f *mbtowc_p;
@@ -58,8 +56,6 @@ mbtowc_p __cp_mbtowc (int val);
 #endif
 #endif
 
-#define __MBTOWC (__get_current_locale()->mbtowc)
-
 #ifdef _MB_EXTENDED_CHARSETS_ISO
 extern const uint16_t __iso_8859_conv[14][0x60];
 int __iso_8859_val_index (int);
@@ -71,5 +67,8 @@ extern const uint16_t __cp_conv[][0x80];
 int __cp_val_index (int);
 int __cp_index (const char *);
 #endif
+
+size_t _wcsnrtombs_l (char *, const wchar_t **,
+                      size_t, size_t, mbstate_t *, struct __locale_t *);
 
 #endif

--- a/newlib/libc/stdlib/mk-sb-charsets.py
+++ b/newlib/libc/stdlib/mk-sb-charsets.py
@@ -368,7 +368,7 @@ def dump_table():
    table is a value computed from the value x (function __iso_8859_index),
    the second index is the value of the incoming character - 0xa0.
    Values < 0xa0 don't have to be converted anyway. */
-wchar_t __iso_8859_conv[14][0x60] = {''')
+const uint16_t __iso_8859_conv[14][0x60] = {''')
     for val in (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16):
         encoding = 'ISO-8859-%d' % val
         dump_range(encoding, 0xa0, 0xff)
@@ -381,7 +381,7 @@ wchar_t __iso_8859_conv[14][0x60] = {''')
    value (function __cp_index), the second index is the value of the
    incoming character - 0x80.
    Values < 0x80 don't have to be converted anyway. */
-wchar_t __cp_conv[27][0x80] = {''')
+const uint16_t __cp_conv[27][0x80] = {''')
     for cp in ('CP437', 'CP720', 'CP737', 'CP775', 'CP850', 'CP852', 'CP855',
                'CP857', 'CP858', 'CP862', 'CP866', 'CP874', 'CP1125', 'CP1250', 'CP1251',
                'CP1252', 'CP1253', 'CP1254', 'CP1255', 'CP1256', 'CP1257',

--- a/newlib/libc/stdlib/mprec.h
+++ b/newlib/libc/stdlib/mprec.h
@@ -32,7 +32,7 @@
 #include <errno.h>
 #include <assert.h>
 #include <sys/types.h>
-#include "../locale/setlocale.h"
+#include "setlocale.h"
 
 #ifdef __IEEE_LITTLE_ENDIAN
 #define IEEE_8087

--- a/newlib/libc/stdlib/sb_charsets.h
+++ b/newlib/libc/stdlib/sb_charsets.h
@@ -40,7 +40,7 @@
    table is a value computed from the value x (function __iso_8859_index),
    the second index is the value of the incoming character - 0xa0.
    Values < 0xa0 don't have to be converted anyway. */
-uint16_t __iso_8859_conv[14][0x60] = {
+const uint16_t __iso_8859_conv[14][0x60] = {
   /* ISO-8859-2 */
   { 0xa0, 0x104, 0x2d8, 0x141, 0xa4, 0x13d, 0x15a, 0xa7,
     0xa8, 0x160, 0x15e, 0x164, 0x179, 0xad, 0x17d, 0x17b,
@@ -232,7 +232,7 @@ uint16_t __iso_8859_conv[14][0x60] = {
    value (function __cp_index), the second index is the value of the
    incoming character - 0x80.
    Values < 0x80 don't have to be converted anyway. */
-uint16_t __cp_conv[27][0x80] = {
+const uint16_t __cp_conv[27][0x80] = {
   /* CP437 */
   { 0xc7, 0xfc, 0xe9, 0xe2, 0xe4, 0xe0, 0xe5, 0xe7,
     0xea, 0xeb, 0xe8, 0xef, 0xee, 0xec, 0xc4, 0xc5,

--- a/newlib/libc/stdlib/strtod.c
+++ b/newlib/libc/stdlib/strtod.c
@@ -136,7 +136,7 @@ THIS SOFTWARE.
 #include <string.h>
 #include "mprec.h"
 #include "gdtoa.h"
-#include "../locale/setlocale.h"
+#include "setlocale.h"
 
 /* #ifndef NO_FENV_H */
 /* #include <fenv.h> */
@@ -263,7 +263,7 @@ strtod_l (const char *__restrict s00, char **__restrict se,
 	int rounding;
 #endif
 #ifdef __HAVE_LOCALE_INFO__
-	const char *decimal_point = __get_numeric_locale(loc)->decimal_point;
+	const char *decimal_point = DECIMAL_POINT_L(loc);
 	const int dec_len = strlen (decimal_point);
 #else
 	const char *decimal_point = ".";

--- a/newlib/libc/stdlib/strtodg.c
+++ b/newlib/libc/stdlib/strtodg.c
@@ -449,7 +449,7 @@ _strtodg_l (const char *s00, char **se, FPI *fpi, Long *exp,
 	Long L;
 	__ULong y, z;
 	_Bigint *ab = NULL, *bb = NULL, *bb1 = NULL, *bd = NULL, *bd0 = NULL, *bs = NULL, *delta = NULL, *rvb = NULL, *rvb0 = NULL;
-	const char *decimal_point = __get_numeric_locale(loc)->decimal_point;
+	const char *decimal_point = DECIMAL_POINT_L(loc);
 	int dec_len = strlen (decimal_point);
 
 	irv = STRTOG_Zero;

--- a/newlib/libc/stdlib/strtoimax.c
+++ b/newlib/libc/stdlib/strtoimax.c
@@ -42,7 +42,7 @@ static char sccsid[] = "from @(#)strtol.c	8.1 (Berkeley) 6/4/93";
 #include <stdlib.h>
 #include <inttypes.h>
 #include <stdint.h>
-#include "../locale/setlocale.h"
+#include "setlocale.h"
 
 /*
  * Convert a string to an intmax_t integer.

--- a/newlib/libc/stdlib/strtol.c
+++ b/newlib/libc/stdlib/strtol.c
@@ -113,7 +113,7 @@ No supporting OS subroutines are required.
 #include <ctype.h>
 #include <errno.h>
 #include <stdlib.h>
-#include "../locale/setlocale.h"
+#include "setlocale.h"
 
 /*
  * Convert a string to a long integer.

--- a/newlib/libc/stdlib/strtoll.c
+++ b/newlib/libc/stdlib/strtoll.c
@@ -121,7 +121,7 @@ No supporting OS subroutines are required.
 #include <ctype.h>
 #include <errno.h>
 #include <stdlib.h>
-#include "../locale/setlocale.h"
+#include "setlocale.h"
 
 /*
  * Convert a string to a long long integer.

--- a/newlib/libc/stdlib/strtoul.c
+++ b/newlib/libc/stdlib/strtoul.c
@@ -119,7 +119,7 @@ PORTABILITY
 #include <ctype.h>
 #include <errno.h>
 #include <stdlib.h>
-#include "../locale/setlocale.h"
+#include "setlocale.h"
 
 /*
  * Convert a string to an unsigned long integer.

--- a/newlib/libc/stdlib/strtoull.c
+++ b/newlib/libc/stdlib/strtoull.c
@@ -117,7 +117,7 @@ PORTABILITY
 #include <ctype.h>
 #include <errno.h>
 #include <stdlib.h>
-#include "../locale/setlocale.h"
+#include "setlocale.h"
 
 /*
  * Convert a string to an unsigned long long integer.

--- a/newlib/libc/stdlib/strtoumax.c
+++ b/newlib/libc/stdlib/strtoumax.c
@@ -42,7 +42,7 @@ static char sccsid[] = "from @(#)strtoul.c	8.1 (Berkeley) 6/4/93";
 #include <stdlib.h>
 #include <inttypes.h>
 #include <stdint.h>
-#include "../locale/setlocale.h"
+#include "setlocale.h"
 
 /*
  * Convert a string to a uintmax_t integer.

--- a/newlib/libc/stdlib/wcsnrtombs.c
+++ b/newlib/libc/stdlib/wcsnrtombs.c
@@ -70,7 +70,7 @@ PORTABILITY
 #include <stdio.h>
 #include <errno.h>
 #include "local.h"
-#include "../locale/setlocale.h"
+#include "setlocale.h"
 
 size_t
 _wcsnrtombs_l (char *dst, const wchar_t **src, size_t nwc,
@@ -101,7 +101,7 @@ _wcsnrtombs_l (char *dst, const wchar_t **src, size_t nwc,
     {
       int count = ps->__count;
       wint_t wch = ps->__value.__wch;
-      int bytes = loc->wctomb (buff, *pwcs, ps);
+      int bytes = __WCTOMB_L(loc) (buff, *pwcs, ps);
       if (bytes == -1)
 	{
 	  _REENT_ERRNO(r) = EILSEQ;

--- a/newlib/libc/stdlib/wcstod.c
+++ b/newlib/libc/stdlib/wcstod.c
@@ -139,7 +139,7 @@ Supporting OS subroutines required: <<close>>, <<fstat>>, <<isatty>>,
 #include <wctype.h>
 #include <locale.h>
 #include <math.h>
-#include "../locale/setlocale.h"
+#include "local.h"
 
 #ifndef _REENT_ONLY
 
@@ -190,7 +190,7 @@ wcstod_l (const wchar_t *nptr, wchar_t **endptr,
          * corresponding position in the wide char string.
          */
         if (endptr != NULL) {
-		const char *decimal_point = __get_numeric_locale(loc)->decimal_point;
+		const char *decimal_point = DECIMAL_POINT_L(loc);
 		/* The only valid multibyte char in a float converted by
 		   strtod/wcstod is the radix char.  What we do here is,
 		   figure out if the radix char was in the valid leading
@@ -262,7 +262,7 @@ wcstof_l (const wchar_t *nptr, wchar_t **endptr,
          * corresponding position in the wide char string.
          */
         if (endptr != NULL) {
-		const char *decimal_point = __get_numeric_locale(loc)->decimal_point;
+		const char *decimal_point = DECIMAL_POINT_L(loc);
 		/* The only valid multibyte char in a float converted by
 		   strtod/wcstod is the radix char.  What we do here is,
 		   figure out if the radix char was in the valid leading

--- a/newlib/libc/stdlib/wcstoimax.c
+++ b/newlib/libc/stdlib/wcstoimax.c
@@ -45,7 +45,7 @@ static char sccsid[] = "from @(#)strtol.c	8.1 (Berkeley) 6/4/93";
 #include <wchar.h>
 #include <wctype.h>
 #include <stdint.h>
-#include "../locale/setlocale.h"
+#include "setlocale.h"
 
 /*
  * Convert a wide character string to an intmax_t integer.

--- a/newlib/libc/stdlib/wcstol.c
+++ b/newlib/libc/stdlib/wcstol.c
@@ -121,7 +121,7 @@ No supporting OS subroutines are required.
 #include <wctype.h>
 #include <errno.h>
 #include <wchar.h>
-#include "../locale/setlocale.h"
+#include "setlocale.h"
 
 /*
  * Convert a wide string to a long integer.

--- a/newlib/libc/stdlib/wcstold.c
+++ b/newlib/libc/stdlib/wcstold.c
@@ -35,7 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <wctype.h>
 #include <locale.h>
 #include "local.h"
-#include "../locale/setlocale.h"
+#include "setlocale.h"
 
 #if defined(_HAVE_LONG_DOUBLE) && __LDBL_MANT_DIG == 64
 
@@ -85,7 +85,7 @@ wcstold_l (const wchar_t *__restrict nptr, wchar_t **__restrict endptr,
 
   if (endptr != NULL)
     {
-      const char *decimal_point = __get_numeric_locale(loc)->decimal_point;
+      const char *decimal_point = DECIMAL_POINT_L(loc);
       /* The only valid multibyte char in a float converted by
 	 strtold/wcstold is the radix char.  What we do here is,
 	 figure out if the radix char was in the valid leading

--- a/newlib/libc/stdlib/wcstoll.c
+++ b/newlib/libc/stdlib/wcstoll.c
@@ -120,7 +120,7 @@ No supporting OS subroutines are required.
 #include <wctype.h>
 #include <errno.h>
 #include <wchar.h>
-#include "../locale/setlocale.h"
+#include "setlocale.h"
 
 /*
  * Convert a wide string to a long long integer.

--- a/newlib/libc/stdlib/wcstoul.c
+++ b/newlib/libc/stdlib/wcstoul.c
@@ -121,7 +121,7 @@ PORTABILITY
 #include <wchar.h>
 #include <errno.h>
 #include <stdlib.h>
-#include "../locale/setlocale.h"
+#include "setlocale.h"
 
 /*
  * Convert a wide string to an unsigned long integer.

--- a/newlib/libc/stdlib/wcstoull.c
+++ b/newlib/libc/stdlib/wcstoull.c
@@ -126,7 +126,7 @@ PORTABILITY
 #include <wchar.h>
 #include <wctype.h>
 #include <errno.h>
-#include "../locale/setlocale.h"
+#include "setlocale.h"
 
 /* Make up for older non-compliant limits.h.  (This is a C99/POSIX function,
  * and both require ULLONG_MAX in limits.h.)  */

--- a/newlib/libc/stdlib/wcstoumax.c
+++ b/newlib/libc/stdlib/wcstoumax.c
@@ -45,7 +45,7 @@ static char sccsid[] = "from @(#)strtoul.c	8.1 (Berkeley) 6/4/93";
 #include <wchar.h>
 #include <wctype.h>
 #include <stdint.h>
-#include "../locale/setlocale.h"
+#include "setlocale.h"
 
 /*
  * Convert a wide character string to a uintmax_t integer.

--- a/newlib/libc/time/strftime.c
+++ b/newlib/libc/time/strftime.c
@@ -878,7 +878,7 @@ recurse:
 		if (width < 2)
 		  width = 2;
 		len = t_snprintf (&s[count], maxsize - count, fmt,
-				neg ? "-" : pos, width - neg, century);
+                                  neg ? "-" : pos, (int) (width - neg), century);
 	      }
             CHECK_LENGTH ();
 	  }
@@ -1010,7 +1010,7 @@ recurse:
 	    if (pad)
 	      *fmt++ = CQ('0');
 	    STRCPY (fmt, CQ(".*u"));
-	    len = t_snprintf (&s[count], maxsize - count, fmtbuf, width, p_year);
+	    len = t_snprintf (&s[count], maxsize - count, fmtbuf, (int) width, p_year);
             if (len < 0  ||  (count+=len) >= maxsize)
               return 0;
 	  }
@@ -1362,7 +1362,7 @@ recurse:
 	      if (pad)
 		*fmt++ = CQ('0');
 	      STRCPY (fmt, CQ(".*u"));
-	      len = t_snprintf (&s[count], maxsize - count, fmtbuf, width,
+	      len = t_snprintf (&s[count], maxsize - count, fmtbuf, (int) width,
 			      year);
 	      CHECK_LENGTH ();
 	    }

--- a/newlib/libc/time/strftime.c
+++ b/newlib/libc/time/strftime.c
@@ -289,7 +289,7 @@ locale, hard-coding the "C" locale settings.
 #include <wctype.h>
 #include <wchar.h>
 #include "local.h"
-#include "../locale/setlocale.h"
+#include "setlocale.h"
 
 /* Defines to make the file dual use for either strftime() or wcsftime().
  * To get wcsftime, define MAKE_WCSFTIME.
@@ -304,7 +304,7 @@ locale, hard-coding the "C" locale settings.
 #  define t_snprintf	snprintf	/* char equivalent function name */
 #  define t_strncmp	strncmp		/* char equivalent function name */
 #  define SFLG				/* %s flag (null for normal char) */
-#  define _ctloc(x)     (ctloclen = strlen (ctloc = _CurrentTimeLocale->x))
+#  define _ctloc(x)     (ctloclen = strlen (ctloc = x))
 #  define TOLOWER(c)	tolower((int)(unsigned char)(c))
 #  define STRTOUL(c,p,b) strtoul((c),(p),(b))
 #  define STRCPY(a,b)	strcpy((a),(b))
@@ -323,8 +323,8 @@ locale, hard-coding the "C" locale settings.
 #  define STRCHR(a,b)	wcschr((a),(b))
 #  define STRLEN(a)	wcslen(a)
 #  define SFLG		"l"		/* %s flag (l for wide char) */
-#  ifdef __HAVE_LOCALE_INFO_EXTENDED__
-#   define _ctloc(x)    (ctloclen = wcslen (ctloc = _CurrentTimeLocale->w##x))
+#  ifdef WTIME_WDAY
+#   define _ctloc(x)    (ctloclen = wcslen (ctloc = W ## x))
 #  else
 #   define CTLOCBUFLEN   256		/* Arbitrary big buffer size */
     static const wchar_t *
@@ -336,7 +336,7 @@ locale, hard-coding the "C" locale settings.
 	*len_ret = 0;
       return buf;
     }
-#   define _ctloc(x)    (ctloc = __ctloc (ctlocbuf, _CurrentTimeLocale->x, \
+#   define _ctloc(x)    (ctloc = __ctloc (ctlocbuf, x, \
 					  &ctloclen))
 #  endif
 #endif  /* MAKE_WCSFTIME */
@@ -403,13 +403,13 @@ typedef struct {
 } era_info_t;
 
 static era_info_t *
-#if defined (MAKE_WCSFTIME) && defined (__HAVE_LOCALE_INFO_EXTENDED__)
+#if defined (MAKE_WCSFTIME) && defined (WTIME_ERA)
 get_era_info (const struct tm *tim_p, const wchar_t *era)
 #else
 get_era_info (const struct tm *tim_p, const char *era)
 #endif
 {
-#if defined (MAKE_WCSFTIME) && defined (__HAVE_LOCALE_INFO_EXTENDED__)
+#if defined (MAKE_WCSFTIME) && defined (WTIME_ERA)
   wchar_t *c;
   const wchar_t *dir;
 # define ERA_STRCHR(a,b)	wcschr((a),(b))
@@ -495,7 +495,7 @@ get_era_info (const struct tm *tim_p, const char *era)
 	    ei->year = etm.tm_year - tim_p->tm_year + offset;
 	  /* era_C */
 	  c = ERA_STRCHR (era, ':');
-#if defined (MAKE_WCSFTIME) && !defined (__HAVE_LOCALE_INFO_EXTENDED__)
+#if defined (MAKE_WCSFTIME) && !defined (WTIME_ERA)
 	  len = mbsnrtowcs (NULL, &era, c - era, 0, NULL);
 	  if (len == (size_t) -1)
 	    {
@@ -511,7 +511,7 @@ get_era_info (const struct tm *tim_p, const char *era)
 	      free (ei);
 	      return NULL;
 	    }
-#if defined (MAKE_WCSFTIME) && !defined (__HAVE_LOCALE_INFO_EXTENDED__)
+#if defined (MAKE_WCSFTIME) && !defined (WTIME_ERA)
 	  len = mbsnrtowcs (ei->era_C, &era, c - era, len + 1, NULL);
 #else
 	  ERA_STRNCPY (ei->era_C, era, len);
@@ -523,7 +523,7 @@ get_era_info (const struct tm *tim_p, const char *era)
 	  c = ERA_STRCHR (era, ';');
 	  if (!c)
 	    c = ERA_STRCHR (era, '\0');
-#if defined (MAKE_WCSFTIME) && !defined (__HAVE_LOCALE_INFO_EXTENDED__)
+#if defined (MAKE_WCSFTIME) && !defined (WTIME_ERA)
 	  len = mbsnrtowcs (NULL, &era, c - era, 0, NULL);
 	  if (len == (size_t) -1)
 	    {
@@ -541,7 +541,7 @@ get_era_info (const struct tm *tim_p, const char *era)
 	      free (ei);
 	      return NULL;
 	    }
-#if defined (MAKE_WCSFTIME) && !defined (__HAVE_LOCALE_INFO_EXTENDED__)
+#if defined (MAKE_WCSFTIME) && !defined (WTIME_ERA)
 	  len = mbsnrtowcs (ei->era_Y, &era, c - era, len + 1, NULL);
 #else
 	  ERA_STRNCPY (ei->era_Y, era, len);
@@ -573,14 +573,14 @@ typedef struct {
 } alt_digits_t;
 
 static alt_digits_t *
-#if defined (MAKE_WCSFTIME) && defined (__HAVE_LOCALE_INFO_EXTENDED__)
+#if defined (MAKE_WCSFTIME) && defined (WTIME_ALT_DIGITS)
 get_alt_digits (const wchar_t *alt_digits)
 #else
 get_alt_digits (const char *alt_digits)
 #endif
 {
   alt_digits_t *adi;
-#if defined (MAKE_WCSFTIME) && defined (__HAVE_LOCALE_INFO_EXTENDED__)
+#if defined (MAKE_WCSFTIME) && defined (WTIME_ALT_DIGITS)
   const wchar_t *a, *e;
 # define ALT_STRCHR(a,b)	wcschr((a),(b))
 # define ALT_STRCPY(a,b)	wcscpy((a),(b))
@@ -611,7 +611,7 @@ get_alt_digits (const char *alt_digits)
       return NULL;
     }
   /* Compute memory required for `buffer'. */
-#if defined (MAKE_WCSFTIME) && !defined (__HAVE_LOCALE_INFO_EXTENDED__)
+#if defined (MAKE_WCSFTIME) && !defined (WTIME_ALT_DIGITS)
   len = mbstowcs (NULL, alt_digits, 0);
   if (len == (size_t) -1)
     {
@@ -631,7 +631,7 @@ get_alt_digits (const char *alt_digits)
       return NULL;
     }
   /* Store digits in it. */
-#if defined (MAKE_WCSFTIME) && !defined (__HAVE_LOCALE_INFO_EXTENDED__)
+#if defined (MAKE_WCSFTIME) && !defined (WTIME_ALT_DIGITS)
   mbstowcs (adi->buffer, alt_digits, len + 1);
 #else
   ALT_STRCPY (adi->buffer, alt_digits);
@@ -687,7 +687,7 @@ __strftime (CHAR *s, size_t maxsize, const CHAR *format,
   size_t count = 0;
   int len = 0;
   const CHAR *ctloc;
-#if defined (MAKE_WCSFTIME) && !defined (__HAVE_LOCALE_INFO_EXTENDED__)
+#if defined (MAKE_WCSFTIME) && !defined (WTIME_WDAY)
   CHAR ctlocbuf[CTLOCBUFLEN];
 #endif
   size_t i, ctloclen;
@@ -696,7 +696,6 @@ __strftime (CHAR *s, size_t maxsize, const CHAR *format,
   unsigned long width;
   int tzset_called = 0;
 
-  const struct lc_time_T *_CurrentTimeLocale = __get_time_locale (locale);
   for (;;)
     {
       while (*format && *format != CQ('%'))
@@ -730,12 +729,12 @@ __strftime (CHAR *s, size_t maxsize, const CHAR *format,
 	{
 	  alt = *format++;
 #ifdef _WANT_C99_TIME_FORMATS
-#if defined (MAKE_WCSFTIME) && defined (__HAVE_LOCALE_INFO_EXTENDED__)
-	  if (!*era_info && *_CurrentTimeLocale->wera)
-	    *era_info = get_era_info (tim_p, _CurrentTimeLocale->wera);
+#if defined (MAKE_WCSFTIME) && defined (TIME_WERA)
+	  if (!*era_info && *TIME_WERA)
+	    *era_info = get_era_info (tim_p, TIME_WERA);
 #else
-	  if (!*era_info && *_CurrentTimeLocale->era)
-	    *era_info = get_era_info (tim_p, _CurrentTimeLocale->era);
+          if (!*era_info && *TIME_ERA)
+	    *era_info = get_era_info (tim_p, TIME_ERA);
 #endif
 #endif /* _WANT_C99_TIME_FORMATS */
 	}
@@ -743,12 +742,12 @@ __strftime (CHAR *s, size_t maxsize, const CHAR *format,
 	{
 	  alt = *format++;
 #ifdef _WANT_C99_TIME_FORMATS
-#if defined (MAKE_WCSFTIME) && defined (__HAVE_LOCALE_INFO_EXTENDED__)
-	  if (!*alt_digits && *_CurrentTimeLocale->walt_digits)
-	    *alt_digits = get_alt_digits (_CurrentTimeLocale->walt_digits);
+#if defined (MAKE_WCSFTIME) && defined (TIME_WALT_DIGITS)
+	  if (!*alt_digits && *TIME_WALT_DIGITS)
+            *alt_digits = get_alt_digits (TIME_WALT_DIGITS);
 #else
-	  if (!*alt_digits && *_CurrentTimeLocale->alt_digits)
-	    *alt_digits = get_alt_digits (_CurrentTimeLocale->alt_digits);
+	  if (!*alt_digits && *TIME_ALT_DIGITS)
+	    *alt_digits = get_alt_digits (TIME_ALT_DIGITS);
 #endif
 #endif /* _WANT_C99_TIME_FORMATS */
 	}
@@ -756,7 +755,7 @@ __strftime (CHAR *s, size_t maxsize, const CHAR *format,
       switch (*format)
 	{
 	case CQ('a'):
-	  _ctloc (wday[tim_p->tm_wday]);
+	  _ctloc (TIME_WDAY[tim_p->tm_wday]);
 	  for (i = 0; i < ctloclen; i++)
 	    {
 	      if (count < maxsize - 1)
@@ -766,7 +765,7 @@ __strftime (CHAR *s, size_t maxsize, const CHAR *format,
 	    }
 	  break;
 	case CQ('A'):
-	  _ctloc (weekday[tim_p->tm_wday]);
+	  _ctloc (TIME_WEEKDAY[tim_p->tm_wday]);
 	  for (i = 0; i < ctloclen; i++)
 	    {
 	      if (count < maxsize - 1)
@@ -777,7 +776,7 @@ __strftime (CHAR *s, size_t maxsize, const CHAR *format,
 	  break;
 	case CQ('b'):
 	case CQ('h'):
-	  _ctloc (mon[tim_p->tm_mon]);
+	  _ctloc (TIME_MON[tim_p->tm_mon]);
 	  for (i = 0; i < ctloclen; i++)
 	    {
 	      if (count < maxsize - 1)
@@ -787,7 +786,7 @@ __strftime (CHAR *s, size_t maxsize, const CHAR *format,
 	    }
 	  break;
 	case CQ('B'):
-	  _ctloc (month[tim_p->tm_mon]);
+	  _ctloc (TIME_MONTH[tim_p->tm_mon]);
 	  for (i = 0; i < ctloclen; i++)
 	    {
 	      if (count < maxsize - 1)
@@ -798,30 +797,30 @@ __strftime (CHAR *s, size_t maxsize, const CHAR *format,
 	  break;
 	case CQ('c'):
 #ifdef _WANT_C99_TIME_FORMATS
-	  if (alt == 'E' && *era_info && *_CurrentTimeLocale->era_d_t_fmt)
-	    _ctloc (era_d_t_fmt);
+	  if (alt == 'E' && *era_info && *TIME_ERA_D_T_FMT)
+	    _ctloc (TIME_ERA_E_T_FMT);
 	  else
 #endif /* _WANT_C99_TIME_FORMATS */
-	    _ctloc (c_fmt);
+	    _ctloc (TIME_C_FMT);
 	  goto recurse;
 	case CQ('r'):
-	  _ctloc (ampm_fmt);
+	  _ctloc (TIME_AMPM_FMT);
 	  goto recurse;
 	case CQ('x'):
 #ifdef _WANT_C99_TIME_FORMATS
-	  if (alt == 'E' && *era_info && *_CurrentTimeLocale->era_d_fmt)
-	    _ctloc (era_d_fmt);
+	  if (alt == 'E' && *era_info && *TIME_ERA_D_FMT)
+	    _ctloc (TIME_ERA_D_FMT);
 	  else
 #endif /* _WANT_C99_TIME_FORMATS */
-	    _ctloc (x_fmt);
+	    _ctloc (TIME_X_FMT);
 	  goto recurse;
 	case CQ('X'):
 #ifdef _WANT_C99_TIME_FORMATS
-	  if (alt == 'E' && *era_info && *_CurrentTimeLocale->era_t_fmt)
-	    _ctloc (era_t_fmt);
+	  if (alt == 'E' && *era_info && *TIME_ERA_T_FMT)
+	    _ctloc (TIME_ERA_T_FMT)
 	  else
 #endif /* _WANT_C99_TIME_FORMATS */
-	    _ctloc (X_fmt);
+	    _ctloc (TIME_UX_FMT);
 recurse:
 	  if (*ctloc)
 	    {
@@ -1085,7 +1084,7 @@ recurse:
 	  break;
 	case CQ('p'):
 	case CQ('P'):
-	  _ctloc (am_pm[tim_p->tm_hour < 12 ? 0 : 1]);
+	  _ctloc (TIME_AM_PM[tim_p->tm_hour < 12 ? 0 : 1]);
 	  for (i = 0; i < ctloclen; i++)
 	    {
 	      if (count < maxsize - 1)

--- a/newlib/libc/time/strptime.c
+++ b/newlib/libc/time/strptime.c
@@ -41,9 +41,7 @@
 #include <errno.h>
 #include <inttypes.h>
 #include <limits.h>
-#include "../locale/setlocale.h"
-
-#define _ctloc(x) (_CurrentTimeLocale->x)
+#include "setlocale.h"
 
 static const int _DAYS_BEFORE_MONTH[12] =
 {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334};
@@ -160,7 +158,6 @@ strptime_l (const char *buf, const char *format, struct tm *timeptr,
     char c;
     int ymd = 0;
 
-    const struct lc_time_T *_CurrentTimeLocale = __get_time_locale (locale);
     for (; (c = *format) != '\0'; ++format) {
 	char *s;
 	int ret;
@@ -174,21 +171,21 @@ strptime_l (const char *buf, const char *format, struct tm *timeptr,
 		c = *++format;
 	    switch (c) {
 	    case 'A' :
-		ret = match_string (&buf, _ctloc (weekday), locale);
+		ret = match_string (&buf, TIME_WEEKDAY, locale);
 		if (ret < 0)
 		    return NULL;
 		timeptr->tm_wday = ret;
 		ymd |= SET_WDAY;
 		break;
 	    case 'a' :
-		ret = match_string (&buf, _ctloc (wday), locale);
+		ret = match_string (&buf, TIME_WDAY, locale);
 		if (ret < 0)
 		    return NULL;
 		timeptr->tm_wday = ret;
 		ymd |= SET_WDAY;
 		break;
 	    case 'B' :
-		ret = match_string (&buf, _ctloc (month), locale);
+		ret = match_string (&buf, TIME_MONTH, locale);
 		if (ret < 0)
 		    return NULL;
 		timeptr->tm_mon = ret;
@@ -196,7 +193,7 @@ strptime_l (const char *buf, const char *format, struct tm *timeptr,
 		break;
 	    case 'b' :
 	    case 'h' :
-		ret = match_string (&buf, _ctloc (mon), locale);
+		ret = match_string (&buf, TIME_MON, locale);
 		if (ret < 0)
 		    return NULL;
 		timeptr->tm_mon = ret;
@@ -211,7 +208,7 @@ strptime_l (const char *buf, const char *format, struct tm *timeptr,
 		ymd |= SET_YEAR;
 		break;
 	    case 'c' :		/* %a %b %e %H:%M:%S %Y */
-		s = strptime_l (buf, _ctloc (c_fmt), timeptr, locale);
+		s = strptime_l (buf, TIME_C_FMT, timeptr, locale);
 		if (s == NULL)
 		    return NULL;
 		buf = s;
@@ -289,7 +286,7 @@ strptime_l (const char *buf, const char *format, struct tm *timeptr,
 		    return NULL;
 		break;
 	    case 'p' :
-		ret = match_string (&buf, _ctloc (am_pm), locale);
+		ret = match_string (&buf, TIME_AM_PM, locale);
 		if (ret < 0)
 		    return NULL;
 		if (timeptr->tm_hour > 12)
@@ -308,7 +305,7 @@ strptime_l (const char *buf, const char *format, struct tm *timeptr,
 		ymd |= SET_MON;
 		break;
 	    case 'r' :		/* %I:%M:%S %p */
-		s = strptime_l (buf, _ctloc (ampm_fmt), timeptr, locale);
+		s = strptime_l (buf, TIME_AMPM_FMT, timeptr, locale);
 		if (s == NULL)
 		    return NULL;
 		buf = s;
@@ -399,14 +396,14 @@ strptime_l (const char *buf, const char *format, struct tm *timeptr,
 		ymd |= SET_YDAY;
 		break;
 	    case 'x' :
-		s = strptime_l (buf, _ctloc (x_fmt), timeptr, locale);
+		s = strptime_l (buf, TIME_X_FMT, timeptr, locale);
 		if (s == NULL)
 		    return NULL;
 		buf = s;
 		ymd |= SET_YMD;
 		break;
 	    case 'X' :
-		s = strptime_l (buf, _ctloc (X_fmt), timeptr, locale);
+		s = strptime_l (buf, TIME_UX_FMT, timeptr, locale);
 		if (s == NULL)
 		    return NULL;
 		buf = s;

--- a/newlib/libc/tinylocale/CMakeLists.txt
+++ b/newlib/libc/tinylocale/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
-# Copyright © 2022 Keith Packard
+# Copyright © 2025 Keith Packard
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,25 +32,23 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+picolibc_sources(
+  duplocale.c
+  freelocale.c
+  getlocalename_l.c
+  localeconv.c
+  localedata.c
+  locale_ctype_ptr.c
+  locale_ctype_ptr_l.c
+  localedata.c
+  locale_mb_cur_max.c
+  locale_names.c
+  newlocale.c
+  posix_locale.c
+  setlocale.c
+  setwcfuncs.c
+  timedata.c
+  uselocale.c
+  )
 
-add_subdirectory(machine)
-
-add_subdirectory(include)
-
-add_subdirectory(argz)
-add_subdirectory(ctype)
-add_subdirectory(errno)
-add_subdirectory(iconv)
-add_subdirectory(misc)
-add_subdirectory(picolib)
-add_subdirectory(posix)
-add_subdirectory(search)
-add_subdirectory(signal)
-add_subdirectory(ssp)
-add_subdirectory(stdlib)
-add_subdirectory(string)
-add_subdirectory(time)
-add_subdirectory(tinystdio)
-add_subdirectory(uchar)
-add_subdirectory(xdr)
-add_subdirectory(tinylocale)
+target_include_directories(c PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/newlib/libc/tinylocale/duplocale.c
+++ b/newlib/libc/tinylocale/duplocale.c
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2025 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _DEFAULT_SOURCE
+#include "locale_private.h"
+
+locale_t
+duplocale (locale_t old)
+{
+    locale_t    dup;
+
+    if (old == LC_GLOBAL_LOCALE)
+        old = &__global_locale;
+
+    dup = calloc(1, sizeof(*dup));
+    if (!dup)
+        return NULL;
+    memcpy(dup, old, sizeof *dup);
+    return dup;
+}

--- a/newlib/libc/tinylocale/freelocale.c
+++ b/newlib/libc/tinylocale/freelocale.c
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2025 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _DEFAULT_SOURCE
+#include "locale_private.h"
+
+#ifdef _HAVE_POSIX_LOCALE_API
+
+void
+freelocale (locale_t locale)
+{
+    if (locale == &__global_locale || locale == LC_GLOBAL_LOCALE)
+        return;
+
+    free(locale);
+}
+
+#endif

--- a/newlib/libc/tinylocale/getlocalename_l.c
+++ b/newlib/libc/tinylocale/getlocalename_l.c
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2025 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _DEFAULT_SOURCE
+#include "locale_private.h"
+
+const char *
+getlocalename_l (int category, locale_t locale)
+{
+    if (category < LC_ALL || category >= _LC_LAST)
+    {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    if (locale == LC_GLOBAL_LOCALE)
+        locale = &__global_locale;
+
+    return __locale_name(locale->id[category]);
+}

--- a/newlib/libc/tinylocale/locale_ctype_ptr.c
+++ b/newlib/libc/tinylocale/locale_ctype_ptr.c
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2025 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _DEFAULT_SOURCE
+#include "locale_private.h"
+#include "../ctype/ctype_.h"
+
+#ifdef _MB_EXTENDED_CHARSETS_ANY
+
+const char *
+__locale_ctype_ptr(void)
+{
+    return __get_current_locale()->ctype;
+}
+
+#endif

--- a/newlib/libc/tinylocale/locale_ctype_ptr_l.c
+++ b/newlib/libc/tinylocale/locale_ctype_ptr_l.c
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2025 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _DEFAULT_SOURCE
+#include "locale_private.h"
+
+#ifdef _MB_EXTENDED_CHARSETS_ANY
+
+const char *
+__locale_ctype_ptr_l(locale_t locale)
+{
+    return locale->ctype;
+}
+
+#endif

--- a/newlib/libc/tinylocale/locale_mb_cur_max.c
+++ b/newlib/libc/tinylocale/locale_mb_cur_max.c
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2025 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "locale_private.h"
+
+size_t
+__locale_mb_cur_max(void)
+{
+    return __locale_mb_cur_max_l(__get_current_locale());
+}
+

--- a/newlib/libc/tinylocale/locale_names.c
+++ b/newlib/libc/tinylocale/locale_names.c
@@ -1,0 +1,188 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2025 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "locale_private.h"
+
+const char * const __locale_names[] = {
+    [locale_C] = "C",
+    [locale_UTF_8] = "C.UTF-8",
+#ifdef _MB_EXTENDED_CHARSETS_ISO
+    [locale_ISO_8859_1] = "C.ISO-8859-1",
+    [locale_ISO_8859_2] = "C.ISO-8859-2",
+    [locale_ISO_8859_3] = "C.ISO-8859-3",
+    [locale_ISO_8859_4] = "C.ISO-8859-4",
+    [locale_ISO_8859_5] = "C.ISO-8859-5",
+    [locale_ISO_8859_6] = "C.ISO-8859-6",
+    [locale_ISO_8859_7] = "C.ISO-8859-7",
+    [locale_ISO_8859_8] = "C.ISO-8859-8",
+    [locale_ISO_8859_9] = "C.ISO-8859-9",
+    [locale_ISO_8859_10] = "C.ISO-8859-10",
+    [locale_ISO_8859_11] = "C.ISO-8859-11",
+    [locale_ISO_8859_13] = "C.ISO-8859-13",
+    [locale_ISO_8859_14] = "C.ISO-8859-14",
+    [locale_ISO_8859_15] = "C.ISO-8859-15",
+    [locale_ISO_8859_16] = "C.ISO-8859-16",
+#endif
+#ifdef _MB_EXTENDED_CHARSETS_WINDOWS
+    [locale_CP437] = "C.CP437",
+    [locale_CP720] = "C.CP720",
+    [locale_CP737] = "C.CP737",
+    [locale_CP775] = "C.CP775",
+    [locale_CP850] = "C.CP850",
+    [locale_CP852] = "C.CP852",
+    [locale_CP855] = "C.CP855",
+    [locale_CP857] = "C.CP857",
+    [locale_CP858] = "C.CP858",
+    [locale_CP862] = "C.CP862",
+    [locale_CP866] = "C.CP866",
+    [locale_CP874] = "C.CP874",
+    [locale_CP1125] = "C.CP1125",
+    [locale_CP1250] = "C.CP1250",
+    [locale_CP1251] = "C.CP1251",
+    [locale_CP1252] = "C.CP1252",
+    [locale_CP1253] = "C.CP1253",
+    [locale_CP1254] = "C.CP1254",
+    [locale_CP1255] = "C.CP1255",
+    [locale_CP1256] = "C.CP1256",
+    [locale_CP1257] = "C.CP1257",
+    [locale_CP1258] = "C.CP1258",
+    [locale_KOI8_R] = "C.KOI8-R",
+    [locale_KOI8_U] = "C.KOI8-U",
+    [locale_GEORGIAN_PS] = "C.GEORGIAN-PS",
+    [locale_PT154] = "C.PT154",
+    [locale_KOI8_T] = "C.KOI8-T",
+#endif
+#ifdef _MB_EXTENDED_CHARSETS_JIS
+    [locale_JIS] = "C.JIS",
+    [locale_EUCJP] = "C.EUC-JP",
+    [locale_SJIS] = "C.SHIFT-JIS",
+#endif
+};
+
+static const char *
+__find_locale_sep(const char *str)
+{
+    char c;
+    for (;;) {
+        c = *str;
+        switch (c) {
+        case '\0':
+        case '.':
+        case '-':
+            return str;
+        }
+        ++str;
+    }
+}
+
+static bool
+__skip_char(char c)
+{
+    return c == '.' || c == '_' || c == '-';
+}
+
+/*
+ * Match two charset strings, ignoring ., _ and - unless
+ * those occur at the end of the input string.
+ * This is a case-insensitive match
+ */
+
+static bool
+__match_charset(const char *str, const char *name)
+{
+    for (;;) {
+        char    sc, nc;
+
+        while (__skip_char(nc = *name++));
+        while (__skip_char(sc = *str++) && nc);
+        if (LOCALE_ISUPPER(sc)) sc = LOCALE_TOLOWER(sc);
+        if (LOCALE_ISUPPER(nc)) nc = LOCALE_TOLOWER(nc);
+        if (sc != nc)
+            return false;
+        if (!sc)
+            return true;
+    }
+}
+
+/*
+ * Map a charset name to one of our internal locale ids.
+ * Returns locale_INVALID for an invalid charset
+ */
+enum locale_id
+__find_charset(const char *charset)
+{
+    enum locale_id id;
+
+    if (__match_charset(charset, "ascii") ||
+        __match_charset(charset, "us_ascii"))
+        return locale_C;
+
+    for (id = locale_UTF_8; id < locale_END; id++) {
+        if (__match_charset(charset, __locale_names[id] + 2))
+            break;
+    }
+    if (id == locale_END)
+        id = locale_INVALID;
+    return id;
+}
+
+/*
+ * Map a locale name to one of our internal locale ids.
+ * Returns locale_INVALID for an invalid charset
+ */
+enum locale_id
+__find_locale(const char *name)
+{
+    enum locale_id     id = locale_UTF_8;
+    const char          *lang_end;
+
+    if (!*name)
+        return _DEFAULT_LOCALE;
+
+    /* POSIX is an alias for C */
+    if (!strcmp(name, "POSIX"))
+        name = __locale_names[locale_C];
+
+    lang_end = __find_locale_sep(name);
+
+    /* Switch the default locale to C when the territory is 'C' */
+    if (lang_end == name + 1 && LOCALE_TOLOWER(*name) == 'c')
+        id = locale_C;
+
+    if (*lang_end)
+        id = __find_charset(lang_end + 1);
+
+    return id;
+}

--- a/newlib/libc/tinylocale/locale_private.h
+++ b/newlib/libc/tinylocale/locale_private.h
@@ -1,0 +1,291 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2025 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _LOCALE_PRIVATE_H_
+#define _LOCALE_PRIVATE_H_
+
+#include <locale.h>
+#include <stdbool.h>
+#include <wchar.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <ctype.h>
+
+#define _HAVE_POSIX_LOCALE_API
+
+#define NUMCAT  ((_LC_MESSAGES - LC_ALL) + 1)
+
+/*
+ * This operates like _tolower on upper case letters, but also works
+ * correctly on lower case letters.
+ */
+#define LOCALE_ISUPPER(c)      ('A' <= (c) && (c) <= 'Z')
+#define LOCALE_TOLOWER(c)      ((c) | ('a' - 'A'))
+
+enum locale_id {
+    locale_C,
+    locale_UTF_8,
+#ifdef _MB_EXTENDED_CHARSETS_ISO
+    locale_ISO_8859_1,
+    locale_ISO_8859_2,
+    locale_ISO_8859_3,
+    locale_ISO_8859_4,
+    locale_ISO_8859_5,
+    locale_ISO_8859_6,
+    locale_ISO_8859_7,
+    locale_ISO_8859_8,
+    locale_ISO_8859_9,
+    locale_ISO_8859_10,
+    locale_ISO_8859_11,
+    locale_ISO_8859_13,
+    locale_ISO_8859_14,
+    locale_ISO_8859_15,
+    locale_ISO_8859_16,
+#endif
+#ifdef _MB_EXTENDED_CHARSETS_WINDOWS
+    locale_CP437,
+    locale_CP720,
+    locale_CP737,
+    locale_CP775,
+    locale_CP850,
+    locale_CP852,
+    locale_CP855,
+    locale_CP857,
+    locale_CP858,
+    locale_CP862,
+    locale_CP866,
+    locale_CP874,
+    locale_CP1125,
+    locale_CP1250,
+    locale_CP1251,
+    locale_CP1252,
+    locale_CP1253,
+    locale_CP1254,
+    locale_CP1255,
+    locale_CP1256,
+    locale_CP1257,
+    locale_CP1258,
+    locale_KOI8_R,
+    locale_KOI8_U,
+    locale_GEORGIAN_PS,
+    locale_PT154,
+    locale_KOI8_T,
+#endif
+#ifdef _MB_EXTENDED_CHARSETS_JIS
+    locale_JIS,
+    locale_EUCJP,
+    locale_SJIS,
+#endif
+    locale_END,
+    locale_INVALID = locale_END,
+} __packed;
+
+typedef int (*wctomb_t)(char *, wchar_t, mbstate_t *);
+typedef int (*mbtowc_t)(wchar_t *, const char *, size_t, mbstate_t *);
+
+struct __locale_t {
+    enum locale_id id[NUMCAT];
+#ifdef _MB_CAPABLE
+    wctomb_t    wctomb;
+    mbtowc_t    mbtowc;
+#ifdef _MB_EXTENDED_CHARSETS_ANY
+    const char *ctype;
+#endif
+#endif
+};
+
+#ifndef _DEFAULT_LOCALE
+#define _DEFAULT_LOCALE  locale_C
+#endif
+
+extern const char       * const __locale_names[];
+
+extern struct __locale_t        __global_locale;
+
+#ifdef _HAVE_POSIX_LOCALE_API
+extern NEWLIB_THREAD_LOCAL struct __locale_t    *_locale;
+#endif
+
+#ifdef _MB_CAPABLE
+void                    __set_wc_funcs(enum locale_id,
+                                       wctomb_t *wctomb,
+                                       mbtowc_t *mbtowc);
+
+#ifdef _HAVE_POSIX_LOCALE_API
+#define __WCTOMB_L(l)   ((l)->wctomb)
+#define __MBTOWC_L(l)   ((l)->mbtowc)
+#define __WCTOMB        (__WCTOMB_L(__get_current_locale()))
+#define __MBTOWC        (__MBTOWC_L(__get_current_locale()))
+#else
+#define __WCTOMB        (__global_locale.wctomb)
+#define __MBTOWC        (__global_locale.mbtowc)
+#endif
+
+#else
+
+#define __WCTOMB        __ascii_wctomb
+#define __MBTOWC        __ascii_mbtowc
+#define __WCTOMB_L(l)   ((void) (l), __ascii_wctomb)
+#define __MBTOWC_L(l)   ((void) (l), __ascii_mbtowc)
+
+#endif
+
+static inline struct __locale_t *
+__get_current_locale(void) {
+#ifdef _HAVE_POSIX_LOCALE_API
+    if (_locale)
+        return _locale;
+#endif
+    return &__global_locale;
+}
+
+static inline const char *
+__locale_name(enum locale_id id) {
+    return __locale_names[id];
+}
+
+enum locale_id
+__find_charset(const char *name);
+
+enum locale_id
+__find_locale(const char *name);
+
+/* LC_NUMERIC data */
+#define DECIMAL_POINT           "."
+#define DECIMAL_POINT_L(l)      ((void) (l), DECIMAL_POINT)
+#define THOUSANDS_SEP           ""
+#define THOUSANDS_SEP_L(l)      ((void) (l), THOUSANDS_SEP)
+#define NUMERIC_GROUPING        ""
+#define NUMERIC_GROUPING_L(l)   ((void) (l), "")
+#define WDECIMAL_POINT          L"."
+#define WDECIMAL_POINT_L(l)     ((void) (l), DECIMAL_POINT)
+#define WTHOUSANDS_SEP          L""
+#define WTHOUSANDS_SEP_L(l)     ((void) (l), THOUSANDS_SEP)
+
+/* LC_TIME data */
+extern const char *const __time_wday[7];
+extern const char *const __time_weekday[7];
+extern const char *const __time_mon[12];
+extern const char *const __time_month[12];
+extern const char *const __time_am_pm[2];
+extern const wchar_t *const __wtime_wday[7];
+extern const wchar_t *const __wtime_weekday[7];
+extern const wchar_t *const __wtime_mon[12];
+extern const wchar_t *const __wtime_month[12];
+extern const wchar_t *const __wtime_am_pm[2];
+
+#define TIME_ERA                ""
+#define TIME_ERA_D_T_FMT_L(l)   ((void) (l), "")
+#define TIME_ERA_D_T_FMT        ""
+#define TIME_ERA_D_FMT_L(l)     ((void) (l), "")
+#define TIME_ERA_D_FMT          ""
+#define TIME_ERA_T_FMT_L(l)     ((void) (l), "")
+#define TIME_ERA_T_FMT          ""
+#define TIME_ALT_DIGITS         ""
+#define TIME_WDAY               __time_wday
+#define TIME_WEEKDAY            __time_weekday
+#define TIME_MON                __time_mon
+#define TIME_MONTH              __time_month
+#define TIME_AM_PM              __time_am_pm
+#define TIME_C_FMT              "%a %b %e %H:%M:%S %Y"
+#define TIME_X_FMT              "%m/%d/%y"
+#define TIME_UX_FMT             "%M/%D/%Y"
+#define TIME_AMPM_FMT           "%I:%M:%S %p"
+
+#define WTIME_ERA               L""
+#define WTIME_ERA_D_T_FMT_L(l)  ((void) (l), L"")
+#define WTIME_ERA_D_T_FMT       L""
+#define WTIME_ERA_D_FMT_L(l)    ((void) (l), L"")
+#define WTIME_ERA_D_FMT         L""
+#define WTIME_ERA_T_FMT_L(l)    ((void) (l), L"")
+#define WTIME_ERA_T_FMT         L""
+#define WTIME_ALT_DIGITS_L(l)   ((void) (l), L"")
+#define WTIME_ALT_DIGITS        L""
+#define WTIME_WDAY              __wtime_wday
+#define WTIME_WEEKDAY           __wtime_weekday
+#define WTIME_MON               __wtime_mon
+#define WTIME_MONTH             __wtime_month
+#define WTIME_AM_PM             __wtime_am_pm
+#define WTIME_C_FMT             L"%a %b %e %H:%M:%S %Y"
+#define WTIME_X_FMT             L"%m/%d/%y"
+#define WTIME_UX_FMT            L"%M/%D/%Y"
+#define WTIME_AMPM_FMT          L"%I:%M:%S %p"
+
+static inline bool
+__locale_is_C(struct __locale_t *locale)
+{
+    if (!locale)
+        locale = __get_current_locale();
+    return locale->id[LC_CTYPE] == locale_C;
+}
+
+static inline size_t
+__locale_mb_cur_max_l(struct __locale_t *locale)
+{
+    switch (locale->id[LC_CTYPE]) {
+    case locale_UTF_8:
+        return 6;
+#ifdef _MB_EXTENDED_CHARSETS_JIS
+    case locale_JIS:
+        return 8;
+    case locale_EUCJP:
+        return 3;
+    case locale_SJIS:
+        return 2;
+#endif
+    default:
+        return 1;
+    }
+}
+
+static inline int
+__locale_cjk_lang(void)
+{
+#ifdef _MB_EXTENDED_CHARSETS_JIS
+    switch (__get_current_locale()->id[LC_CTYPE]) {
+    case locale_JIS:
+    case locale_EUCJP:
+    case locale_SJIS:
+        return 1;
+    default:
+        break;
+    }
+#endif
+    return 0;
+}
+
+#endif /* _LOCALE_PRIVATE_H_ */

--- a/newlib/libc/tinylocale/localeconv.c
+++ b/newlib/libc/tinylocale/localeconv.c
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2025 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "locale_private.h"
+
+static const char decimal[] = ".";
+static const char empty[] = "";
+
+static const struct lconv lconv = {
+    .decimal_point = (char *) decimal,
+    .thousands_sep = (char *) empty,
+    .grouping = (char *) empty,
+    .mon_decimal_point = (char *) empty,
+    .mon_thousands_sep = (char *) empty,
+    .mon_grouping = (char *) empty,
+    .positive_sign = (char *) empty,
+    .negative_sign = (char *) empty,
+    .currency_symbol = (char *) empty,
+    .frac_digits = CHAR_MAX,
+    .p_cs_precedes = CHAR_MAX,
+    .n_cs_precedes = CHAR_MAX,
+    .p_sep_by_space = CHAR_MAX,
+    .n_sep_by_space = CHAR_MAX,
+    .p_sign_posn = CHAR_MAX,
+    .n_sign_posn = CHAR_MAX,
+    .int_curr_symbol = (char *) empty,
+    .int_frac_digits = CHAR_MAX,
+    .int_p_cs_precedes = CHAR_MAX,
+    .int_n_cs_precedes = CHAR_MAX,
+    .int_p_sep_by_space = CHAR_MAX,
+    .int_n_sep_by_space = CHAR_MAX,
+    .int_p_sign_posn = CHAR_MAX,
+    .int_n_sign_posn = CHAR_MAX,
+};
+
+struct lconv *
+localeconv(void)
+{
+    return (struct lconv *) &lconv;
+}

--- a/newlib/libc/tinylocale/localedata.c
+++ b/newlib/libc/tinylocale/localedata.c
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2025 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "locale_private.h"
+#include "../ctype/ctype_.h"
+#include "../stdlib/local.h"
+
+struct __locale_t       __global_locale
+#ifdef _MB_CAPABLE
+= {
+    .wctomb = __ascii_wctomb,
+    .mbtowc = __ascii_mbtowc,
+#ifdef _MB_EXTENDED_CHARSETS_ANY
+    .ctype = _ctype_,
+#endif
+}
+#endif
+;

--- a/newlib/libc/tinylocale/meson.build
+++ b/newlib/libc/tinylocale/meson.build
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
-# Copyright © 2022 Keith Packard
+# Copyright © 2025 Keith Packard
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -33,24 +33,34 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-add_subdirectory(machine)
+srcs_tinylocale = [
+  'duplocale.c',
+  'freelocale.c',
+  'getlocalename_l.c',
+  'localeconv.c',
+  'localedata.c',
+  'locale_ctype_ptr.c',
+  'locale_ctype_ptr_l.c',
+  'locale_mb_cur_max.c',
+  'locale_names.c',
+  'newlocale.c',
+  'posix_locale.c',
+  'setlocale.c',
+  'setwcfuncs.c',
+  'timedata.c',
+  'uselocale.c',
+]
 
-add_subdirectory(include)
+srcs_tinylocale_use = []
+foreach file : srcs_tinylocale
+  s_file = fs.replace_suffix(file, '.S')
+  if file in srcs_machine
+    message('libc/tinylocale/' + file + ': machine overrides generic')
+  elif s_file in srcs_machine
+    message('libc/tinylocale/' + s_file + ': machine overrides generic')
+  else
+    srcs_tinylocale_use += file
+  endif
+endforeach
 
-add_subdirectory(argz)
-add_subdirectory(ctype)
-add_subdirectory(errno)
-add_subdirectory(iconv)
-add_subdirectory(misc)
-add_subdirectory(picolib)
-add_subdirectory(posix)
-add_subdirectory(search)
-add_subdirectory(signal)
-add_subdirectory(ssp)
-add_subdirectory(stdlib)
-add_subdirectory(string)
-add_subdirectory(time)
-add_subdirectory(tinystdio)
-add_subdirectory(uchar)
-add_subdirectory(xdr)
-add_subdirectory(tinylocale)
+src_tinylocale = files(srcs_tinylocale_use)

--- a/newlib/libc/tinylocale/newlocale.c
+++ b/newlib/libc/tinylocale/newlocale.c
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2025 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _DEFAULT_SOURCE
+#include "locale_private.h"
+#include "../ctype/ctype_.h"
+
+#ifdef _HAVE_POSIX_LOCALE_API
+
+locale_t
+newlocale (int category_mask, const char *locale, locale_t base)
+{
+    enum locale_id id;
+    int category;
+
+    id = __find_locale(locale);
+    /*
+     * Make sure the mask doesn't contain invalid bits and that locale
+     * specifies a known locale value
+     */
+    if ((category_mask & ~LC_ALL_MASK) != 0 || id == locale_INVALID) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!base) {
+        base = calloc(1, sizeof (struct __locale_t));
+        if (!base)
+            return NULL;
+        base->id[LC_ALL] = id;
+    } else {
+        if (base == LC_GLOBAL_LOCALE)
+            return NULL;
+    }
+
+    for (category = LC_ALL + 1; category < _LC_LAST; category++)
+        if (category_mask & (1 << category))
+            base->id[category] = id;
+
+#ifdef _MB_CAPABLE
+    __set_wc_funcs(base->id[LC_CTYPE], &base->wctomb, &base->mbtowc);
+#ifdef _MB_EXTENDED_CHARSETS_ANY
+    __set_ctype(base->id[LC_CTYPE], &base->ctype);
+#endif
+#endif
+
+    return base;
+}
+
+#endif

--- a/newlib/libc/tinylocale/posix_locale.c
+++ b/newlib/libc/tinylocale/posix_locale.c
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2025 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "locale_private.h"
+
+#ifdef _HAVE_POSIX_LOCALE_API
+
+NEWLIB_THREAD_LOCAL struct __locale_t    *_locale;
+
+#ifdef _MB_EXTENDED_CHARSETS_ANY
+
+NEWLIB_THREAD_LOCAL const char           *_ctype;
+NEWLIB_THREAD_LOCAL int                  (*_wctomb)(char *, wchar_t, mbstate_t *);
+NEWLIB_THREAD_LOCAL int                  (*_mbtowc)(wchar_t *, const char *, size_t, mbstate_t *);
+
+#endif
+
+#endif

--- a/newlib/libc/tinylocale/setlocale.c
+++ b/newlib/libc/tinylocale/setlocale.c
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2025 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "locale_private.h"
+#include "../ctype/ctype_.h"
+
+char *
+setlocale(int category, const char *locale)
+{
+    enum locale_id      id;
+
+    if (category < LC_ALL || category >= _LC_LAST)
+    {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    /* Return current locale value */
+    if (locale == NULL)
+        return (char *) __locale_name(__global_locale.id[category]);
+
+    /* Set the global locale */
+    id = __find_locale(locale);
+    if (id == locale_INVALID)
+        return NULL;
+
+    __global_locale.id[category] = id;
+    if (category == LC_ALL) {
+        for (category = LC_ALL + 1; category < _LC_LAST; category++)
+            __global_locale.id[category] = id;
+    }
+#ifdef _MB_CAPABLE
+    __set_wc_funcs(__global_locale.id[LC_CTYPE], &__global_locale.wctomb, &__global_locale.mbtowc);
+#ifdef _MB_EXTENDED_CHARSETS_ANY
+    __set_ctype(__global_locale.id[LC_CTYPE], &__global_locale.ctype);
+#endif
+#endif
+    return (char *) __locale_name(id);
+}

--- a/newlib/libc/tinylocale/setlocale.h
+++ b/newlib/libc/tinylocale/setlocale.h
@@ -1,0 +1,1 @@
+#include "locale_private.h"

--- a/newlib/libc/tinylocale/setwcfuncs.c
+++ b/newlib/libc/tinylocale/setwcfuncs.c
@@ -1,0 +1,175 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2025 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _DEFAULT_SOURCE
+#include "locale_private.h"
+#include "../stdlib/local.h"
+
+#ifdef _MB_CAPABLE
+#ifdef _MB_EXTENDED_CHARSETS_ISO
+static uint8_t iso_val[] = {
+    [locale_ISO_8859_1- locale_ISO_8859_1] = 1,
+    [locale_ISO_8859_2- locale_ISO_8859_1] = 2,
+    [locale_ISO_8859_3- locale_ISO_8859_1] = 3,
+    [locale_ISO_8859_4- locale_ISO_8859_1] = 4,
+    [locale_ISO_8859_5- locale_ISO_8859_1] = 5,
+    [locale_ISO_8859_6- locale_ISO_8859_1] = 6,
+    [locale_ISO_8859_7- locale_ISO_8859_1] = 7,
+    [locale_ISO_8859_8- locale_ISO_8859_1] = 8,
+    [locale_ISO_8859_9- locale_ISO_8859_1] = 9,
+    [locale_ISO_8859_10- locale_ISO_8859_1] = 10,
+    [locale_ISO_8859_11- locale_ISO_8859_1] = 11,
+    [locale_ISO_8859_13- locale_ISO_8859_1] = 13,
+    [locale_ISO_8859_14- locale_ISO_8859_1] = 14,
+    [locale_ISO_8859_15- locale_ISO_8859_1] = 15,
+    [locale_ISO_8859_16- locale_ISO_8859_1] = 16,
+};
+#endif
+#ifdef _MB_EXTENDED_CHARSETS_WINDOWS
+static uint16_t cp_val[] = {
+    [locale_CP437 - locale_CP437] = 437,
+    [locale_CP720 - locale_CP437] = 720,
+    [locale_CP737 - locale_CP437] = 737,
+    [locale_CP775 - locale_CP437] = 775,
+    [locale_CP850 - locale_CP437] = 850,
+    [locale_CP852 - locale_CP437] = 852,
+    [locale_CP855 - locale_CP437] = 855,
+    [locale_CP857 - locale_CP437] = 857,
+    [locale_CP858 - locale_CP437] = 858,
+    [locale_CP862 - locale_CP437] = 862,
+    [locale_CP866 - locale_CP437] = 866,
+    [locale_CP874 - locale_CP437] = 874,
+    [locale_CP1125 - locale_CP437] = 1125,
+    [locale_CP1250 - locale_CP437] = 1250,
+    [locale_CP1251 - locale_CP437] = 1251,
+    [locale_CP1252 - locale_CP437] = 1252,
+    [locale_CP1253 - locale_CP437] = 1253,
+    [locale_CP1254 - locale_CP437] = 1254,
+    [locale_CP1255 - locale_CP437] = 1255,
+    [locale_CP1256 - locale_CP437] = 1256,
+    [locale_CP1257 - locale_CP437] = 1257,
+    [locale_CP1258 - locale_CP437] = 1258,
+    [locale_KOI8_R - locale_CP437] = 20866,
+    [locale_KOI8_U - locale_CP437] = 21866,
+    [locale_GEORGIAN_PS - locale_CP437] = 101,
+    [locale_PT154 - locale_CP437] = 102,
+    [locale_KOI8_T - locale_CP437] = 103,
+};
+#endif
+
+void
+__set_wc_funcs(enum locale_id id,
+               wctomb_t *wctomb,
+               mbtowc_t *mbtowc)
+{
+    switch (id) {
+    default:
+        *wctomb = __ascii_wctomb;
+        *mbtowc = __ascii_mbtowc;
+        break;
+    case locale_UTF_8:
+        *wctomb = __utf8_wctomb;
+        *mbtowc = __utf8_mbtowc;
+        break;
+#ifdef _MB_EXTENDED_CHARSETS_ISO
+    case locale_ISO_8859_1:
+    case locale_ISO_8859_2:
+    case locale_ISO_8859_3:
+    case locale_ISO_8859_4:
+    case locale_ISO_8859_5:
+    case locale_ISO_8859_6:
+    case locale_ISO_8859_7:
+    case locale_ISO_8859_8:
+    case locale_ISO_8859_9:
+    case locale_ISO_8859_10:
+    case locale_ISO_8859_11:
+    case locale_ISO_8859_13:
+    case locale_ISO_8859_14:
+    case locale_ISO_8859_15:
+    case locale_ISO_8859_16:
+        *wctomb = __iso_wctomb (iso_val[id - locale_ISO_8859_1]);
+        *mbtowc = __iso_mbtowc (iso_val[id - locale_ISO_8859_1]);
+        break;
+#endif
+#ifdef _MB_EXTENDED_CHARSETS_WINDOWS
+    case locale_CP437:
+    case locale_CP720:
+    case locale_CP737:
+    case locale_CP775:
+    case locale_CP850:
+    case locale_CP852:
+    case locale_CP855:
+    case locale_CP857:
+    case locale_CP858:
+    case locale_CP862:
+    case locale_CP866:
+    case locale_CP874:
+    case locale_CP1125:
+    case locale_CP1250:
+    case locale_CP1251:
+    case locale_CP1252:
+    case locale_CP1253:
+    case locale_CP1254:
+    case locale_CP1255:
+    case locale_CP1256:
+    case locale_CP1257:
+    case locale_CP1258:
+    case locale_KOI8_R:
+    case locale_KOI8_U:
+    case locale_GEORGIAN_PS:
+    case locale_PT154:
+    case locale_KOI8_T:
+        *wctomb = __cp_wctomb (cp_val[id - locale_CP437]);
+        *mbtowc = __cp_mbtowc (cp_val[id - locale_CP437]);
+        break;
+#endif
+#ifdef _MB_EXTENDED_CHARSETS_JIS
+    case locale_JIS:
+        *wctomb = __jis_wctomb;
+        *mbtowc = __jis_mbtowc;
+        break;
+    case locale_EUCJP:
+        *wctomb = __eucjp_wctomb;
+        *mbtowc = __eucjp_mbtowc;
+        break;
+    case locale_SJIS:
+        *wctomb = __sjis_wctomb;
+        *mbtowc = __sjis_mbtowc;
+        break;
+#endif
+    }
+}
+
+#endif /* _MB_CAPABLE */

--- a/newlib/libc/tinylocale/timedata.c
+++ b/newlib/libc/tinylocale/timedata.c
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2025 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _DEFAULT_SOURCE
+#include "locale_private.h"
+
+const char *const __time_wday[7] = {
+    "Sun", "Mon", "Tue", "Wed",
+    "Thu", "Fri", "Sat"
+};
+
+const char *const __time_weekday[7] = {
+    "Sunday", "Monday", "Tuesday", "Wednesday",
+    "Thursday", "Friday", "Saturday"
+};
+
+const char *const __time_mon[12] = {
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+};
+
+const char *const __time_month[12] = {
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December"
+};
+
+const char *const __time_am_pm[2] = {
+    "AM", "PM"
+};
+
+const wchar_t *const __wtime_wday[7] = {
+    L"Sun", L"Mon", L"Tue", L"Wed",
+    L"Thu", L"Fri", L"Sat"
+};
+
+const wchar_t *const __wtime_weekday[7] = {
+    L"Sunday", L"Monday", L"Tuesday", L"Wednesday",
+    L"Thursday", L"Friday", L"Saturday"
+};
+
+const wchar_t *const __wtime_mon[12] = {
+    L"Jan", L"Feb", L"Mar", L"Apr", L"May", L"Jun",
+    L"Jul", L"Aug", L"Sep", L"Oct", L"Nov", L"Dec"
+};
+
+const wchar_t *const __wtime_month[12] = {
+    L"January", L"February", L"March", L"April", L"May", L"June",
+    L"July", L"August", L"September", L"October", L"November", L"December"
+};
+
+const wchar_t *const __wtime_am_pm[2] = {
+    L"AM", L"PM"
+};

--- a/newlib/libc/tinylocale/uselocale.c
+++ b/newlib/libc/tinylocale/uselocale.c
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2025 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _DEFAULT_SOURCE
+#include "locale_private.h"
+#include "../ctype/ctype_.h"
+
+#ifdef _HAVE_POSIX_LOCALE_API
+
+locale_t
+uselocale (locale_t locale)
+{
+    locale_t current = _locale;
+
+    if (current == NULL)
+        current = LC_GLOBAL_LOCALE;
+
+    if (locale == LC_GLOBAL_LOCALE)
+        locale = NULL;
+    _locale = locale;
+
+    return current;
+}
+
+#endif

--- a/newlib/libc/tinystdio/vfscanf.c
+++ b/newlib/libc/tinystdio/vfscanf.c
@@ -35,6 +35,7 @@
 #include "stdio_private.h"
 #include <wctype.h>
 #include "scanf_private.h"
+#include "../stdlib/local.h"
 
 /*
  * Compute which features are required
@@ -146,7 +147,7 @@ getmb(FILE *stream, scanf_context_t *context, mbstate_t *ps, uint16_t flags)
         wchar_t     ch;
         char        mb[MB_LEN_MAX];
         size_t      n = 0;
-        size_t      s;
+        int         s;
         mbstate_t   save;
 
         while (n < MB_LEN_MAX) {
@@ -155,11 +156,11 @@ getmb(FILE *stream, scanf_context_t *context, mbstate_t *ps, uint16_t flags)
                 return WEOF;
             mb[n++] = (char) i;
             save = *ps;
-            s = mbrtowc(&ch, mb, n, ps);
+            s = __MBTOWC(&ch, mb, n, ps);
             switch (s) {
-            case (size_t) -1:
+            case -1:
                 return WEOF;
-            case (size_t) -2:
+            case -2:
                 *ps = save;
                 break;
             default:
@@ -186,9 +187,9 @@ _putmb(void *addr, wint_t wi, mbstate_t *ps, uint16_t flags)
         *(wchar_t *) addr = (wchar_t) wi;
         addr = (wchar_t *) addr + 1;
     } else {
-        size_t  s;
-        s = wcrtomb((char *) addr, (wchar_t) wi, ps);
-        if (s == (size_t) -1)
+        int  s;
+        s = __WCTOMB((char *) addr, (wchar_t) wi, ps);
+        if (s == -1)
             return NULL;
         addr = (char *) addr + s;
     }

--- a/picolibc.h.in
+++ b/picolibc.h.in
@@ -44,6 +44,9 @@
 /* Use tiny stdio from gcc avr */
 #cmakedefine TINY_STDIO
 
+/* Use tiny locale */
+#cmakedefine _TINY_LOCALE
+
 #cmakedefine _ATEXIT_DYNAMIC_ALLOC
 
 #cmakedefine _PICOLIBC_ATOMIC_SIGNAL
@@ -374,6 +377,14 @@
 #cmakedefine _LITE_EXIT
 
 #cmakedefine _MB_CAPABLE
+
+#cmakedefine _MB_EXTENDED_CHARSETS_ALL
+
+#cmakedefine _MB_EXTENDED_CHARSETS_ISO
+
+#cmakedefine _MB_EXTENDED_CHARSETS_WINDOWS
+
+#cmakedefine _MB_EXTENDED_CHARSETS_JIS
 
 #cmakedefine _NANO_FORMATTED_IO
 

--- a/scripts/do-cmake-clang-thumbv6m-configure
+++ b/scripts/do-cmake-clang-thumbv6m-configure
@@ -1,2 +1,2 @@
 #!/bin/sh
-cmake -G Ninja -DTESTS=ON -DCMAKE_TOOLCHAIN_FILE="$(dirname $0)/../cmake/TC-clang-thumbv6m.cmake" "$(dirname $0)/.." "$@"
+cmake -G Ninja -DTESTS=ON --toolchain "$(dirname $0)/../cmake/TC-clang-thumbv6m.cmake" "$(dirname $0)/.." "$@"

--- a/scripts/do-cmake-clang-thumbv7m-configure
+++ b/scripts/do-cmake-clang-thumbv7m-configure
@@ -1,2 +1,2 @@
 #!/bin/sh
-cmake -G Ninja -DTESTS=ON -DCMAKE_TOOLCHAIN_FILE="$(dirname $0)/../cmake/TC-clang-thumbv7m.cmake" "$(dirname $0)/.." "$@"
+cmake -G Ninja -DTESTS=ON --toolchain "$(dirname $0)/../cmake/TC-clang-thumbv7m.cmake" "$(dirname $0)/.." "$@"

--- a/scripts/do-cmake-thumbv6m-configure
+++ b/scripts/do-cmake-thumbv6m-configure
@@ -1,2 +1,2 @@
 #!/bin/sh
-cmake -G Ninja -DTESTS=ON -DCMAKE_TOOLCHAIN_FILE="$(dirname $0)/../cmake/TC-thumbv6m.cmake" "$(dirname $0)/.." "$@"
+cmake -G Ninja -DTESTS=ON --toolchain "$(dirname $0)/../cmake/TC-thumbv6m.cmake" "$(dirname $0)/.." "$@"

--- a/scripts/do-cmake-thumbv7m-configure
+++ b/scripts/do-cmake-thumbv7m-configure
@@ -1,2 +1,2 @@
 #!/bin/sh
-cmake -G Ninja -DTESTS=ON -DCMAKE_TOOLCHAIN_FILE="$(dirname $0)/../cmake/TC-thumbv7m.cmake" "$(dirname $0)/.." "$@"
+cmake -G Ninja -DTESTS=ON --toolchain "$(dirname $0)/../cmake/TC-thumbv7m.cmake" "$(dirname $0)/.." "$@"

--- a/test/meson.build
+++ b/test/meson.build
@@ -43,6 +43,7 @@ plain_tests_common = ['regex', 'ungetc',
                       'test-sprintf-percent-n',
                       'test-ctype',
                       'test-uchar',
+                      'time-tests',
 	      ]
 
 math_tests_common = [
@@ -101,7 +102,6 @@ plain_tests = plain_tests_common
 
 plain_tests += math_tests + [
   'test-funopen',
-  'time-tests',
   'tls',  
 ]
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -618,9 +618,9 @@ if enable_native_tests
                        'CP874', 'CP1125', 'CP1250', 'CP1251', 'CP1252', 'CP1253',
                        'CP1254', 'CP1256', 'CP1257', 'KOI8-R', 'KOI8-U',
 
-                       'SJIS', 'EUC-JP']
+                       'SHIFT-JIS', 'EUC-JP']
         locale = 'C.' + ctype
-        if ctype == 'SJIS'
+        if ctype == 'SHIFT-JIS'
           ctype = 'SHIFT_JIS'
         elif ctype == 'CP437'
           ctype = 'IBM437'

--- a/test/test-ctype.c
+++ b/test/test-ctype.c
@@ -103,7 +103,8 @@ static const char *locales[] = {
     "C.CP1254", "C.CP1256", "C.CP1257", "C.KOI8-R", "C.KOI8-U",
 #endif
 #ifdef HAVE_JIS_CHARSETS
-    "C.SJIS",
+    "C.SHIFT-JIS",
+    "C.EUC-JP",
 #endif
 };
 

--- a/test/test-encode.c
+++ b/test/test-encode.c
@@ -71,7 +71,7 @@ static const char *locales[] = {
 #ifdef HAVE_JIS_CHARSETS
 #define JIS_START       (NUM_LOCALE-2)
     "C.EUC-JP",
-    "C.SJIS",
+    "C.SHIFT-JIS",
 #endif
 };
 

--- a/test/test-wctype.c
+++ b/test/test-wctype.c
@@ -111,7 +111,7 @@ static const char *locales[] = {
     "C.CP1254", "C.CP1256", "C.CP1257", "C.KOI8-R", "C.KOI8-U",
 #endif
 #ifdef HAVE_JIS_CHARSETS
-    "C.SJIS",
+    "C.SHIFT-JIS",
     "C.EUC-JP",
 #endif
 };

--- a/test/time-tests.c
+++ b/test/time-tests.c
@@ -37,7 +37,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <time.h>
-
+#include <string.h>
 
 #define TIME_TM_YEAR_BASE 1900
 
@@ -45,34 +45,37 @@
 static void
 init_struct_tm ( struct tm * stm )
 {
-  if ( sizeof( struct tm ) != 9 * sizeof( int ) )
-  {
-    puts("Error: struct tm has changed, so these tests probably need adjusting.");
-    exit(1);
-  }
-
-  stm->tm_sec   = 0;
-  stm->tm_min   = 0;
-  stm->tm_hour  = 0;
-  stm->tm_mday  = 0;
-  stm->tm_mon   = 0;
-  stm->tm_year  = 0;
-  stm->tm_wday  = 0;
-  stm->tm_yday  = 0;
-  stm->tm_isdst = 0;
+  memset(stm, 0, sizeof *stm);
 }
 
+static int
+test_strftime(int line, const struct tm *tm, const char *fmt, const char *expect)
+{
+  char  strbuf[128];
+  size_t len;
+  size_t expect_len = strlen(expect);
+
+  len = strftime(strbuf, sizeof(strbuf), fmt, tm);
+  if (strcmp(strbuf, expect) != 0 || len != strlen(expect)) {
+    printf("%s:%d: strftime(%s) = '%s'(%zd) expect '%s'(%zd)\n",
+           __FILE__, line,
+           fmt, strbuf, len, expect, expect_len);
+    return 0;
+  }
+  return 1;
+}
 
 int
 main(void)
 {
+  int ret = 0;
   // Time zone ART3 is America/Buenos_Aires.
   // There is no daylight saving time (aka sommer time).
 
   if ( 0 != setenv( "TZ", "ART3", 1 ) )
   {
     puts("Error calling setenv().");
-    exit(1);
+    return 1;
   }
 
   tzset();
@@ -96,8 +99,11 @@ main(void)
        dtForTimegm1.tm_wday != 2 )  // 2 means Tuesday.
   {
     puts("Test t1 failed.");
-    exit(1);
+    ret = 1;
   }
+
+  if (!test_strftime(__LINE__, &dtForTimegm1, "%a %b %d %Y %H:%M:%S", "Tue Feb 03 1970 00:00:00"))
+    ret = 1;
 
   // mktime() is affected by the time zone. Check that the offset is the expected one.
 
@@ -107,9 +113,11 @@ main(void)
        dtForMktime2.tm_wday != 2 )
   {
     puts("Test t2 failed.");
-    exit(1);
+    ret = 1;
   }
 
+  if (!test_strftime(__LINE__, &dtForMktime2, "%A %B %d %Y %H:%M:%S", "Tuesday February 03 1970 00:00:00"))
+    ret = 1;
 
   // The European Central Time goes the other direction (negative)
   // and has a daylight saving time (aka sommer time).
@@ -117,7 +125,7 @@ main(void)
   if ( 0 != setenv( "TZ", "CET-1CEST,M3.5.0,M10.5.0/3", 1 ) )
   {
     puts("Error calling setenv().");
-    exit(1);
+    ret = 1;
   }
 
   tzset();
@@ -141,8 +149,11 @@ main(void)
        dtForTimegm3.tm_isdst != 0  )  // timegm() should reset the daylight saving time flag.
   {
     puts("Test t3 failed.");
-    exit(1);
+    ret = 1;
   }
+
+  if (!test_strftime(__LINE__, &dtForTimegm3, "%U %u %Y %H:%M:%S", "17 6 2021 00:00:00"))
+    ret = 1;
 
   time_t t4 = mktime( &dtForMktime4 );
 
@@ -152,9 +163,11 @@ main(void)
        dtForMktime4.tm_isdst != 1  )  // mktime() should leave the daylight saving time flag set.
   {
     puts("Test t4 failed.");
-    exit(1);
+    ret = 1;
   }
 
+  if (!test_strftime(__LINE__, &dtForMktime4, "%V %u %a %b %d %Y %H:%M:%S", "17 6 Sat May 01 2021 00:00:00"))
+    ret = 1;
 
   // Test the first non-negative time_t value of 0,
   // which is the "UNIX Epoch time" of 1st Januar 1970 00:00:00.
@@ -174,9 +187,11 @@ main(void)
        dtForTimegm5.tm_isdst != 0  )
   {
     puts("Test t5 failed.");
-    exit(1);
+    ret = 1;
   }
 
+  if (!test_strftime(__LINE__, &dtForTimegm5, "%W %w %a %b %d %Y %H:%M:%S", "00 4 Thu Jan 01 1970 00:00:00"))
+    ret = 1;
 
   // Test the last time_t value of 0x7FFFFFFF before the 32-bit signed integer overflow,
   // aka "year 2038 problem". That corresponds to 2038-01-19 03:14:07.
@@ -202,9 +217,11 @@ main(void)
        dtForTimegm6.tm_isdst != 0   )
   {
     puts("Test t6 failed.");
-    exit(1);
+    ret = 1;
   }
 
+  if (!test_strftime(__LINE__, &dtForTimegm6, "%a %b %d %Y %R", "Tue Jan 19 2038 03:14"))
+    ret = 1;
 
   // Test the next time_t value of 0x80000000 right after
   // the 32-bit signed integer overflow, aka "year 2038 problem".
@@ -219,9 +236,11 @@ main(void)
        dtForTimegm7.tm_isdst != 0   )
   {
     puts("Test t7 failed.");
-    exit(1);
+    ret = 1;
   }
 
+  if (!test_strftime(__LINE__, &dtForTimegm7, "%a %b %d %Y %I:%M:%S %p", "Tue Jan 19 2038 03:14:08 AM"))
+    ret = 1;
 
   // Test the 29th of February in a leap year far in the future.
 
@@ -239,9 +258,11 @@ main(void)
        dtForTimegm8.tm_yday != 59  )
   {
     puts("Test t8 failed.");
-    exit(1);
+    ret = 1;
   }
 
+  if (!test_strftime(__LINE__, &dtForTimegm8, "%a %b %d %Y %H:%M:%S", "Fri Feb 29 2104 00:00:00"))
+    ret = 1;
 
-  return 0;
+  return ret;
 }


### PR DESCRIPTION
This should provide most of the same functionality as the original locale code as available in embedded systems where there aren't any locale data files available. It is missing is the ability to construct an LC_ALL locale string which specifies multiple locale categories, but as the only useful category is LC_CTYPE, that doesn't seem terrible useful (and is not required by C).