### PR TITLE
Locale and iconv fixes found by glibc test suite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,7 +269,11 @@ if(NOT DEFINED _MB_CAPABLE)
 endif()
 
 if(NOT DEFINED _MB_EXTENDED_CHARSETS_ALL)
-  option(_MB_EXTENDED_CHARSETS_ALL "Enable ISO, Windows and JIS multibyte encodings" OFF)
+  option(_MB_EXTENDED_CHARSETS_ALL "Enable UCS, ISO, Windows and JIS multibyte encodings" OFF)
+endif()
+
+if(NOT DEFINED _MB_EXTENDED_CHARSETS_UCS)
+  option(_MB_EXTENDED_CHARSETS_UCS "Enable UCS encodings" OFF)
 endif()
 
 if(NOT DEFINED _MB_EXTENDED_CHARSETS_ISO)

--- a/meson.build
+++ b/meson.build
@@ -243,6 +243,11 @@ fast_strcmp = get_option('fast-strcmp')
 
 mb_capable = get_option('mb-capable') or get_option('newlib-mb')
 mb_extended_charsets = mb_capable and get_option('mb-extended-charsets')
+if get_option('mb-ucs-charsets') == 'auto'
+  mb_ucs_charsets = mb_extended_charsets
+else
+  mb_ucs_charsets = mb_capable and get_option('mb-ucs-charsets') == 'true'
+endif
 if get_option('mb-iso-charsets') == 'auto'
   mb_iso_charsets = mb_extended_charsets
 else
@@ -1381,6 +1386,7 @@ if not tinystdio
 endif
 conf_data.set('_WANT_REENT_SMALL', get_option('newlib-reent-small'))
 conf_data.set('_MB_CAPABLE', mb_capable)
+conf_data.set('_MB_EXTENDED_CHARSETS_UCS', mb_ucs_charsets)
 conf_data.set('_MB_EXTENDED_CHARSETS_ISO', mb_iso_charsets)
 conf_data.set('_MB_EXTENDED_CHARSETS_WINDOWS', mb_windows_charsets)
 conf_data.set('_MB_EXTENDED_CHARSETS_JIS', mb_jis_charsets)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -221,14 +221,17 @@ option('mb-capable', type: 'boolean', value: false,
        description: 'enable multibyte support for UTF-8 charset')
 option('mb-extended-charsets', type: 'boolean', value: false,
        description: 'enable additional ISO, Windows and JIS charsets')
+option('mb-ucs-charsets', type: 'combo', choices: ['true', 'false', 'auto'], value: 'auto',
+       description: 'enable additional UCS encodings')
 option('mb-iso-charsets', type: 'combo', choices: ['true', 'false', 'auto'], value: 'auto',
-       description: 'enable additional ISO multibyte encodings')
+       description: 'enable ISO-8859 encodings')
 option('mb-jis-charsets', type: 'combo', choices: ['true', 'false', 'auto'], value: 'auto',
        description: 'enable additional JIS multibyte encodings')
 option('mb-windows-charsets', type: 'combo', choices: ['true', 'false', 'auto'], value: 'auto',
-       description: 'enable additional Windows multibyte encodings')
+       description: 'enable additional Windows encodings')
+
 option('newlib-mb', type: 'boolean', value: false,
-       description: 'enable multibyte support')
+       description: 'enable multibyte support [deprecated, use mb-capable]')
 
 #
 # Startup/shutdown options

--- a/newlib/libc/ctype/ctype_.c
+++ b/newlib/libc/ctype/ctype_.c
@@ -54,7 +54,7 @@ const char _ctype_[1 + 256] = {
 
 #endif	/* !ALLOW_NEGATIVE_CTYPE_INDEX */
 
-#ifdef _MB_EXTENDED_CHARSETS_ANY
+#ifdef _MB_EXTENDED_CHARSETS_NON_UNICODE
 
 #include "ctype_extended.h"
 
@@ -132,4 +132,4 @@ const char __ctype[locale_END - locale_EXTENDED_BASE][CTYPE_OFFSET + 1 + 256] = 
 #endif
 };
 
-#endif /* _MB_EXTENDED_CHARSETS_ANY */
+#endif /* _MB_EXTENDED_CHARSETS_NON_UNICODE */

--- a/newlib/libc/ctype/ctype_.h
+++ b/newlib/libc/ctype/ctype_.h
@@ -5,7 +5,7 @@
 
 # define DEFAULT_CTYPE_PTR	((char *) _ctype_)
 
-#ifdef _MB_EXTENDED_CHARSETS_ANY
+#ifdef _MB_EXTENDED_CHARSETS_NON_UNICODE
 
 #if defined(ALLOW_NEGATIVE_CTYPE_INDEX)
 #define CTYPE_OFFSET    127

--- a/newlib/libc/iconv/iconv.c
+++ b/newlib/libc/iconv/iconv.c
@@ -40,6 +40,11 @@ iconv (iconv_t ic,
        char **__restrict inbuf, size_t *__restrict inbytesleft,
        char **__restrict outbuf, size_t *__restrict outbytesleft)
 {
+    if (ic == (iconv_t) -1) {
+        errno = EINVAL;
+        return (size_t) -1;
+    }
+
     if (!inbuf || !inbytesleft)
         return 0;
 
@@ -68,6 +73,11 @@ iconv (iconv_t ic,
         } else if (inbytes && ic->buf_len == 0) {
             ret = ic->in_mbtowc(&wc, in, inbytes, &ic->in_state);
             switch (ret) {
+            case 0:
+                wc = L'\0';
+                in += inbytes;
+                inbytes = 0;
+                break;
             case -1:
                 goto fail;
             case -2:

--- a/newlib/libc/iconv/iconv_close.c
+++ b/newlib/libc/iconv/iconv_close.c
@@ -38,10 +38,12 @@
 int
 iconv_close (iconv_t ic)
 {
+    if (ic == (iconv_t) -1) {
+        errno = EINVAL;
+        return -1;
+    }
 #ifdef _MB_CAPABLE
     free(ic);
-#else
-    (void) ic;
 #endif
     return 0;
 }

--- a/newlib/libc/include/ctype.h
+++ b/newlib/libc/include/ctype.h
@@ -46,7 +46,7 @@ _BEGIN_STD_C
  * The small ctype code does not support extended character sets. It also breaks
  * libstdc++'s ctype implementation, so just skip it for c++
  */
-#if defined(_MB_EXTENDED_CHARSETS_ANY) || defined (__cplusplus)
+#if defined(_MB_EXTENDED_CHARSETS_NON_UNICODE) || defined (__cplusplus)
 #undef _PICOLIBC_CTYPE_SMALL
 #define _PICOLIBC_CTYPE_SMALL 0
 #endif
@@ -242,7 +242,7 @@ extern const char	_ctype_[];
 
 extern const short _ctype_wide[];
 
-#ifdef _MB_EXTENDED_CHARSETS_ANY
+#ifdef _MB_EXTENDED_CHARSETS_NON_UNICODE
 const char *__locale_ctype_ptr (void);
 #else
 #define __locale_ctype_ptr()	_ctype_
@@ -274,7 +274,7 @@ static __inline char __ctype_lookup(int c) { return (__CTYPE_PTR + 1)[c]; }
 #endif
 
 #if __POSIX_VISIBLE >= 200809
-#ifdef _MB_EXTENDED_CHARSETS_ANY
+#ifdef _MB_EXTENDED_CHARSETS_NON_UNICODE
 const char *__locale_ctype_ptr_l (locale_t);
 #else
 static __inline const char *
@@ -313,14 +313,14 @@ static __inline char __ctype_lookup_l(int c, locale_t l) {
    slightly slower.  These macros are not NLS-aware so they are
    disabled if the system supports the extended character sets. */
 # if defined(__GNUC__)
-#  ifndef _MB_EXTENDED_CHARSETS_ANY
+#  ifndef _MB_EXTENDED_CHARSETS_NON_UNICODE
 #   define toupper(__c) \
   __extension__ ({ __typeof__ (__c) __x = (__c);	\
       islower (__x) ? (int) __x - 'a' + 'A' : (int) __x;})
 #   define tolower(__c) \
   __extension__ ({ __typeof__ (__c) __x = (__c);	\
       isupper (__x) ? (int) __x - 'A' + 'a' : (int) __x;})
-#  else /* _MB_EXTENDED_CHARSETS_ANY */
+#  else /* _MB_EXTENDED_CHARSETS_NON_UNICODE */
 /* Allow a gcc warning if the user passed 'char', but defer to the
    function.  */
 #   define toupper(__c) \
@@ -329,7 +329,7 @@ static __inline char __ctype_lookup_l(int c, locale_t l) {
 #   define tolower(__c) \
   __extension__ ({ __typeof__ (__c) __x = (__c);	\
       (void) __CTYPE_PTR[(int) __x]; (tolower) (__x);})
-#  endif /* _MB_EXTENDED_CHARSETS_ANY */
+#  endif /* _MB_EXTENDED_CHARSETS_NON_UNICODE */
 # endif /* __GNUC__ */
 
 #endif /* !__cplusplus */

--- a/newlib/libc/include/sys/_types.h
+++ b/newlib/libc/include/sys/_types.h
@@ -210,6 +210,7 @@ typedef struct
     wint_t __wch;
     unsigned char __wchb[4];
     __uint32_t __ucs;
+    __uint16_t __ucs2;
   } __value;		/* Value so far.  */
 } _mbstate_t;
 #endif

--- a/newlib/libc/include/sys/config.h
+++ b/newlib/libc/include/sys/config.h
@@ -317,6 +317,7 @@ SUCH DAMAGE.
 /* Make sure all of these are disabled if multi-byte is disabled*/
 #undef _MB_EXTENDED_CHARSETS_ALL
 #undef _MB_EXTENDED_CHARSETS_ANY
+#undef _MB_EXTENDED_CHARSETS_UCS
 #undef _MB_EXTENDED_CHARSETS_ISO
 #undef _MB_EXTENDED_CHARSETS_WINDOWS
 #undef _MB_EXTENDED_CHARSETS_JIS
@@ -326,14 +327,20 @@ SUCH DAMAGE.
    charsets.  The extended charsets add a few functions and a couple
    of tables of a few K each. */
 #ifdef _MB_EXTENDED_CHARSETS_ALL
+#define _MB_EXTENDED_CHARSETS_UCS 1
 #define _MB_EXTENDED_CHARSETS_ISO 1
 #define _MB_EXTENDED_CHARSETS_WINDOWS 1
 #define _MB_EXTENDED_CHARSETS_JIS 1
 #endif
 
-#if defined(_MB_EXTENDED_CHARSETS_ISO) || \
+#if defined(_MB_EXTENDED_CHARSETS_ISO) ||     \
     defined(_MB_EXTENDED_CHARSETS_WINDOWS) || \
     defined(_MB_EXTENDED_CHARSETS_JIS)
+#define _MB_EXTENDED_CHARSETS_NON_UNICODE
+#endif
+
+#if defined(_MB_EXTENDED_CHARSETS_UCS) ||       \
+    defined(_MB_EXTENDED_CHARSETS_NON_UNICODE)
 #define _MB_EXTENDED_CHARSETS_ANY
 #endif
 

--- a/newlib/libc/locale/locale_ctype_ptr.c
+++ b/newlib/libc/locale/locale_ctype_ptr.c
@@ -37,7 +37,7 @@
 #include "locale_private.h"
 #include "../ctype/ctype_.h"
 
-#ifdef _MB_EXTENDED_CHARSETS_ANY
+#ifdef _MB_EXTENDED_CHARSETS_NON_UNICODE
 
 const char *
 __locale_ctype_ptr(void)

--- a/newlib/libc/locale/locale_ctype_ptr.c
+++ b/newlib/libc/locale/locale_ctype_ptr.c
@@ -42,7 +42,7 @@
 const char *
 __locale_ctype_ptr(void)
 {
-    return __get_current_locale()->ctype;
+    return __get_ctype(__get_current_locale()->id[LC_CTYPE]);
 }
 
 #endif

--- a/newlib/libc/locale/locale_ctype_ptr_l.c
+++ b/newlib/libc/locale/locale_ctype_ptr_l.c
@@ -35,13 +35,14 @@
 
 #define _DEFAULT_SOURCE
 #include "locale_private.h"
+#include "../ctype/ctype_.h"
 
 #ifdef _MB_EXTENDED_CHARSETS_ANY
 
 const char *
 __locale_ctype_ptr_l(locale_t locale)
 {
-    return locale->ctype;
+    return __get_ctype(locale->id[LC_CTYPE]);
 }
 
 #endif

--- a/newlib/libc/locale/locale_ctype_ptr_l.c
+++ b/newlib/libc/locale/locale_ctype_ptr_l.c
@@ -37,7 +37,7 @@
 #include "locale_private.h"
 #include "../ctype/ctype_.h"
 
-#ifdef _MB_EXTENDED_CHARSETS_ANY
+#ifdef _MB_EXTENDED_CHARSETS_NON_UNICODE
 
 const char *
 __locale_ctype_ptr_l(locale_t locale)

--- a/newlib/libc/locale/locale_names.c
+++ b/newlib/libc/locale/locale_names.c
@@ -39,6 +39,12 @@ const char * const __locale_names[] = {
     [locale_C] = "C",
 #ifdef _MB_CAPABLE
     [locale_UTF_8] = "C.UTF-8",
+    [locale_UCS_2] = "C.UCS-2",
+    [locale_UCS_2LE] = "C.UCS-2LE",
+    [locale_UCS_2BE] = "C.UCS-2BE",
+    [locale_UCS_4] = "C.UCS-4",
+    [locale_UCS_4LE] = "C.UCS-4LE",
+    [locale_UCS_4BE] = "C.UCS-4BE",
 #ifdef _MB_EXTENDED_CHARSETS_ISO
     [locale_ISO_8859_1] = "C.ISO-8859-1",
     [locale_ISO_8859_2] = "C.ISO-8859-2",

--- a/newlib/libc/locale/locale_private.h
+++ b/newlib/libc/locale/locale_private.h
@@ -141,13 +141,6 @@ typedef mbtowc_f        *mbtowc_p;
 
 struct __locale_t {
     enum locale_id id[NUMCAT];
-#ifdef _MB_CAPABLE
-    wctomb_p    wctomb;
-    mbtowc_p    mbtowc;
-#ifdef _MB_EXTENDED_CHARSETS_ANY
-    const char *ctype;
-#endif
-#endif
 };
 
 #ifndef _DEFAULT_LOCALE
@@ -163,12 +156,15 @@ extern NEWLIB_THREAD_LOCAL struct __locale_t    *_locale;
 
 #ifdef _MB_CAPABLE
 
+extern const wctomb_p __wctomb[locale_END];
+extern const mbtowc_p __mbtowc[locale_END];
+
 #define __get_wctomb(id)        __wctomb[id]
 #define __get_mbtowc(id)        __mbtowc[id]
 
 #ifdef _HAVE_POSIX_LOCALE_API
-#define __WCTOMB_L(l)   ((l)->wctomb)
-#define __MBTOWC_L(l)   ((l)->mbtowc)
+#define __WCTOMB_L(l)   (__get_wctomb(l->id[LC_CTYPE]))
+#define __MBTOWC_L(l)   (__get_mbtowc(l->id[LC_CTYPE]))
 #define __WCTOMB        (__WCTOMB_L(__get_current_locale()))
 #define __MBTOWC        (__MBTOWC_L(__get_current_locale()))
 #else

--- a/newlib/libc/locale/locale_private.h
+++ b/newlib/libc/locale/locale_private.h
@@ -60,6 +60,12 @@ enum locale_id {
     locale_C,
 #ifdef _MB_CAPABLE
     locale_UTF_8,
+    locale_UCS_2,
+    locale_UCS_2LE,
+    locale_UCS_2BE,
+    locale_UCS_4,
+    locale_UCS_4LE,
+    locale_UCS_4BE,
 #ifdef _MB_EXTENDED_CHARSETS_ISO
     locale_ISO_BASE,
     locale_EXTENDED_BASE = locale_ISO_BASE,

--- a/newlib/libc/locale/localedata.c
+++ b/newlib/libc/locale/localedata.c
@@ -37,14 +37,4 @@
 #include "../ctype/ctype_.h"
 #include "../stdlib/local.h"
 
-struct __locale_t       __global_locale
-#ifdef _MB_CAPABLE
-= {
-    .wctomb = __ascii_wctomb,
-    .mbtowc = __ascii_mbtowc,
-#ifdef _MB_EXTENDED_CHARSETS_ANY
-    .ctype = _ctype_,
-#endif
-}
-#endif
-;
+struct __locale_t       __global_locale;

--- a/newlib/libc/locale/newlocale.c
+++ b/newlib/libc/locale/newlocale.c
@@ -69,14 +69,6 @@ newlocale (int category_mask, const char *locale, locale_t base)
         if (category_mask & (1 << category))
             base->id[category] = id;
 
-#ifdef _MB_CAPABLE
-    base->wctomb = __get_wctomb(base->id[LC_CTYPE]);
-    base->mbtowc = __get_mbtowc(base->id[LC_CTYPE]);
-#ifdef _MB_EXTENDED_CHARSETS_ANY
-    base->ctype = __get_ctype(base->id[LC_CTYPE]);
-#endif
-#endif
-
     return base;
 }
 

--- a/newlib/libc/locale/setlocale.c
+++ b/newlib/libc/locale/setlocale.c
@@ -63,12 +63,5 @@ setlocale(int category, const char *locale)
         for (category = LC_ALL + 1; category < _LC_LAST; category++)
             __global_locale.id[category] = id;
     }
-#ifdef _MB_CAPABLE
-    __global_locale.wctomb = __get_wctomb(__global_locale.id[LC_CTYPE]);
-    __global_locale.mbtowc = __get_mbtowc(__global_locale.id[LC_CTYPE]);
-#ifdef _MB_EXTENDED_CHARSETS_ANY
-    __global_locale.ctype = __get_ctype(__global_locale.id[LC_CTYPE]);
-#endif
-#endif
     return (char *) __locale_name(id);
 }

--- a/newlib/libc/stdlib/local.h
+++ b/newlib/libc/stdlib/local.h
@@ -24,8 +24,6 @@ wctomb_f __ascii_wctomb;
 
 mbtowc_f __utf8_mbtowc;
 wctomb_f __utf8_wctomb;
-extern const wctomb_p __wctomb[locale_END];
-extern const mbtowc_p __mbtowc[locale_END];
 
 #ifdef _MB_EXTENDED_CHARSETS_ISO
 extern const uint16_t __iso_8859_conv[14][0x60];

--- a/picolibc.h.in
+++ b/picolibc.h.in
@@ -175,6 +175,8 @@
 
 #cmakedefine _MB_EXTENDED_CHARSETS_ALL
 
+#cmakedefine _MB_EXTENDED_CHARSETS_UCS
+
 #cmakedefine _MB_EXTENDED_CHARSETS_ISO
 
 #cmakedefine _MB_EXTENDED_CHARSETS_WINDOWS

--- a/test/meson.build
+++ b/test/meson.build
@@ -152,7 +152,7 @@ foreach params : targets
 
   _c_args = target_c_args + get_variable('test_c_args' + target, test_c_args)
   _link_args = target_c_args + _lib_files + get_variable('test_link_args' + target, test_link_args)
-  _link_depends = get_variable('test_link_depends' + target, test_link_depends)
+  _link_depends = get_variable('test_link_depends' + target, test_link_depends) + _libs
   if have_cplusplus
     _cpp_args = target_c_args + get_variable('test_cpp_args_' + target, test_cpp_args)
   endif


### PR DESCRIPTION
Adds ucs-2 and ucs-4 locales so that iconv can support those. Adds error checking for iconv and iconv_close in case applications pass the (iconv_t) -1 along.