### PR TITLE
Avoid integer overflow with large dates in gmtime_r

### DIFF
--- a/newlib/libc/time/gmtime_r.c
+++ b/newlib/libc/time/gmtime_r.c
@@ -65,7 +65,8 @@ struct tm *
 gmtime_r (const time_t *__restrict tim_p,
 	struct tm *__restrict res)
 {
-  long days, rem;
+  long rem;
+  time_t days;
   const time_t lcltime = *tim_p;
   int era, weekday, year;
   unsigned erayear, yearday, month, day;


### PR DESCRIPTION
days calculation overflows LONG_MIN/LONG_MAX for large 64-bit timestamps (where time_t is 64 bit)