### PR TITLE
ctype: Fixup for C++ compatibility, remove _Thread from uchar statics

### DIFF
--- a/newlib/libc/include/ctype.h
+++ b/newlib/libc/include/ctype.h
@@ -225,8 +225,6 @@ extern const short      _ctype_wide[];
 
 #define _ctype_ (_ctype_b + _CTYPE_OFFSET)
 
-#ifndef __cplusplus
-
 #define	_U	0x001    /* upper */
 #define	_L	0x002    /* lower */
 #define	_N	0x004    /* digit */
@@ -244,6 +242,8 @@ const char *__locale_ctype_ptr (void);
 #else
 #define __CTYPE_PTR	_ctype_
 #endif
+
+#ifndef __cplusplus
 
 #define __ctype_lookup(__c) (__CTYPE_PTR + 1)[(int) (__c)]
 

--- a/newlib/libc/uchar/c16rtomb.c
+++ b/newlib/libc/uchar/c16rtomb.c
@@ -38,7 +38,7 @@
 size_t
 c16rtomb (char *s, char16_t c16, mbstate_t *ps)
 {
-    static NEWLIB_THREAD_LOCAL mbstate_t local_state;
+    static mbstate_t local_state;
 
     if (ps == NULL)
         ps = &local_state;

--- a/newlib/libc/uchar/c32rtomb.c
+++ b/newlib/libc/uchar/c32rtomb.c
@@ -38,7 +38,7 @@
 size_t
 c32rtomb (char *s, char32_t c32, mbstate_t *ps)
 {
-    static NEWLIB_THREAD_LOCAL mbstate_t local_state;
+    static mbstate_t local_state;
 
     if (ps == NULL)
         ps = &local_state;

--- a/newlib/libc/uchar/c8rtomb.c
+++ b/newlib/libc/uchar/c8rtomb.c
@@ -38,7 +38,7 @@
 size_t
 c8rtomb (char *s, char8_t c8, mbstate_t *ps)
 {
-    static NEWLIB_THREAD_LOCAL mbstate_t _state;
+    static mbstate_t _state;
     char32_t    c32;
     int count;
 

--- a/newlib/libc/uchar/mbrtoc16.c
+++ b/newlib/libc/uchar/mbrtoc16.c
@@ -39,7 +39,7 @@ size_t
 mbrtoc16(char16_t * __restrict pc16, const char * __restrict s, size_t n,
          _mbstate_t * __restrict ps)
 {
-    static NEWLIB_THREAD_LOCAL mbstate_t local_state;
+    static mbstate_t local_state;
 
     if (ps == NULL)
         ps = &local_state;

--- a/newlib/libc/uchar/mbrtoc32.c
+++ b/newlib/libc/uchar/mbrtoc32.c
@@ -38,7 +38,7 @@
 size_t mbrtoc32(char32_t * __restrict pc32, const char * __restrict s, size_t n,
                 _mbstate_t * __restrict ps)
 {
-    static NEWLIB_THREAD_LOCAL mbstate_t local_state;
+    static mbstate_t local_state;
 
     if (ps == NULL)
         ps = &local_state;

--- a/newlib/libc/uchar/mbrtoc8.c
+++ b/newlib/libc/uchar/mbrtoc8.c
@@ -39,7 +39,7 @@ size_t
 mbrtoc8(char8_t * __restrict pc8, const char * __restrict s, size_t n,
         mbstate_t * __restrict ps)
 {
-    static NEWLIB_THREAD_LOCAL mbstate_t local_state;
+    static mbstate_t local_state;
 
     if (ps == NULL)
         ps = &local_state;


### PR DESCRIPTION
libstdc++ uses `_ctype_` and the various ctype bitmasks, so we need to make those visible when compiling with C++.

The spec doesn't require that uchar static mbstate_t values be thread local, and that wastes memory for applications using them as intended.