### PR TITLE
Make test-except work in AArch32 big endian

### DIFF
--- a/test/test-except.c
+++ b/test/test-except.c
@@ -49,7 +49,7 @@ main(void)
 #ifdef __thumb__
     __asm__(".inst.n 0xde00");
 #else
-    __asm__(".word 0xe7f000f0");
+    __asm__(".inst 0xe7f000f0");
 #endif
 
 #elif defined(__riscv)


### PR DESCRIPTION
`.inst` ensures that endianness is taken care of.