### PR TITLE
stdlib: mbtowc() function can't return -2

### DIFF
--- a/newlib/libc/stdlib/mbtowc.c
+++ b/newlib/libc/stdlib/mbtowc.c
@@ -64,7 +64,7 @@ mbtowc (wchar_t *__restrict pwc,
         int retval;
 
         retval = __MBTOWC (pwc, s, n, ps);
-        if (retval == -1) {
+        if (retval < 0) {
 #ifdef _MB_CAPABLE
                 _mbtowc_state.__count = 0;
 #endif


### PR DESCRIPTION
mbtowc() function can only return the number of bytes consumed to convert a valid multibyte character or 0 if the input points to a null character or -1 if the input points to an invalid multibyte sequence.

before this change, if _MBTOWC call is __ascii_mbtowc() and n = 0 it will return -2 in retval and the mbtowc return the retval as it is which is non-standard it should return -1 if the conversion is invalid which is the case with n = 0