### PR TITLE
locale: setlocale() function should return NULL with invalid locale

### DIFF
--- a/newlib/libc/locale/locale_names.c
+++ b/newlib/libc/locale/locale_names.c
@@ -183,7 +183,7 @@ __find_charset(const char *charset)
 enum locale_id
 __find_locale(const char *name)
 {
-    enum locale_id     id = LOCALE_DEFAULT;
+    enum locale_id     id = locale_INVALID;
     const char          *lang_end;
 
     if (!*name)


### PR DESCRIPTION
locale: setlocale() function should return NULL with invalid locale

Before this change, setlocale() function can only return NULL if the return value from __find_locale() function is locale_INVALID. however, __find_locale() function doesn't set locale_INVALID in any scenario.