### PR TITLE
uchar: Fixes in mb/wc conversion functions

### DIFF
--- a/newlib/libc/uchar/c32rtomb.c
+++ b/newlib/libc/uchar/c32rtomb.c
@@ -47,8 +47,9 @@ c32rtomb (char *s, char32_t c32, mbstate_t *ps)
         errno = EILSEQ;
         return (size_t) -1;
     }
+
 #if __SIZEOF_WCHAR_T__ == 2
-    if (char32_needs_surrogates(c32)) {
+    if (char32_needs_surrogates(c32) && s != NULL) {
         const wchar_t wc[2] = {
             [0] = ((c32 - 0x10000) >> 10) + HIGH_SURROGATE_FIRST,
             [1] = (c32 & 0x3ff) + LOW_SURROGATE_FIRST,

--- a/newlib/libc/uchar/mbrtoc32.c
+++ b/newlib/libc/uchar/mbrtoc32.c
@@ -121,7 +121,8 @@ size_t mbrtoc32(char32_t * __restrict pc32, const char * __restrict s, size_t n,
         return (size_t) -1;
     }
 
-    *pc32 = c32;
+    /* Ignore parameter pc32 if s is a null pointer */
+    if(s != NULL) *pc32 = c32;
 
     return ret;
 


### PR DESCRIPTION
Fixes in mb/wc conversion functions:
1- mbrtoc32() should ignore parameter pc32 if s is a null pointer
2- c32rtomb() Explicitly handle s = NULL in c32rtomb() function
3- __utf8_wctomb() should store nothing if the conversion is inclomplete yet.