### PR TITLE
picolib/arm: Split 'tls' variable out of read_tp asm code

### DIFF
--- a/newlib/libc/picolib/machine/arm/CMakeLists.txt
+++ b/newlib/libc/picolib/machine/arm/CMakeLists.txt
@@ -38,6 +38,7 @@ picolibc_sources(interrupt.c)
 if(${_HAVE_PICOLIBC_TLS_API})
   picolibc_sources(
     tls.c
+    set_tls.c
     read_tp.S
     )
 endif()

--- a/newlib/libc/picolib/machine/arm/meson.build
+++ b/newlib/libc/picolib/machine/arm/meson.build
@@ -35,5 +35,5 @@
 
 src_picolib += files('interrupt.c')
 if thread_local_storage
-  src_picolib += files('tls.c', 'read_tp.S')
+  src_picolib += files('tls.c', 'set_tls.c', 'read_tp.S')
 endif

--- a/newlib/libc/picolib/machine/arm/read_tp.S
+++ b/newlib/libc/picolib/machine/arm/read_tp.S
@@ -35,6 +35,7 @@
  */
 #include <picolibc.h>
 
+#define _IN_ASM
 #include "arm_tls.h"
 /*
  * This cannot be a C ABI function as the compiler assumes that it
@@ -90,14 +91,3 @@ __aeabi_read_tp:
 #endif
 
 	.cfi_endproc
-
-#ifndef ARM_TLS_CP15
-	.global __tls
-	.bss
-	.align 4
-	.type __tls, %object
-	.size __tls, TLS_SIZE
-__tls:
-	.space TLS_SIZE
-
-#endif

--- a/newlib/libc/picolib/machine/arm/tls.c
+++ b/newlib/libc/picolib/machine/arm/tls.c
@@ -43,32 +43,5 @@
  * refer to it in an asm statement
  */
 #ifndef ARM_TLS_CP15
-extern void *__tls[];
+void *__tls[ARM_TLS_COUNT];
 #endif
-
-/* The size of the thread control block.
- * TLS relocations are generated relative to
- * a location this far *before* the first thread
- * variable (!)
- * NB: The actual size before tp also includes padding
- * to align up to the alignment of .tdata/.tbss.
- */
-#define TCB_SIZE	8
-extern char __arm32_tls_tcb_offset;
-#define TP_OFFSET ((size_t)&__arm32_tls_tcb_offset)
-
-void
-_set_tls(void *tls)
-{
-        tls = (uint8_t *) tls - TP_OFFSET;
-#ifdef ARM_TLS_CP15
-	__asm__("mcr p15, 0, %0, cr13, cr0, 3" : : "r" (tls));
-#else
-#ifdef ARM_RP2040
-        uint32_t cpuid = *(uint32_t *)0xd0000000;
-        __tls[cpuid] = tls;
-#else
-	__tls[0] = tls;
-#endif
-#endif
-}


### PR DESCRIPTION
Apps using the standard crt0 will write this value, but if they don't use any thread-local variables, they won't need the reading function.