### PR TITLE
[riscv/math] Make `lrint` function aliases for correct types

### DIFF
--- a/newlib/libm/machine/riscv/s_lrint.c
+++ b/newlib/libm/machine/riscv/s_lrint.c
@@ -36,6 +36,8 @@
 #include <math.h>
 
 #if defined(__RISCV_HARD_FLOAT) && __RISCV_HARD_FLOAT >= 64
+#include "math_config.h"
+
 long int
 lrint (double x)
 {
@@ -51,6 +53,9 @@ lrint (double x)
        "\t%0, %1" : "=r"(result) : "f"(x));
   return result;
 }
+
+_MATH_ALIAS_j_d(lrint)
+
 #else
 #include "../../common/s_lrint.c"
 #endif


### PR DESCRIPTION
Make `lrint` function aliases for correct types if `double` and `long double` are the same size, then alias double function to the long double name.

Before this change: building picolibc on RISCV with `-Zd` or `-Zdinx`  that calls `lrintl()` function; the application will fail compilation as `lrintl` is an undefined symbol in this case.

inclusion of `math_config.h` is added in order to get `_MATH_ALIAS_j_d` symbol definition.

Similar to https://github.com/picolibc/picolibc/pull/926