### PR TITLE
Have linker script spot .text.sorted.* sections, & sort them

### DIFF
--- a/picolibc.ld.in
+++ b/picolibc.ld.in
@@ -67,6 +67,7 @@ SECTIONS
 		/* code */
 		*(.literal.unlikely .text.unlikely .literal.unlikely.* .text.unlikely.*)
 		*(.literal.startup .text.startup .literal.startup.* .text.startup.*)
+		*(SORT(.text.sorted.*))
 		*(.literal .text .literal.* .text.* .opd .opd.* .branch_lt .branch_lt.* @EXTRA_TEXT_SECTIONS@)
 		*(.gnu.linkonce.t.*)
 		KEEP (*(.fini .fini.*))


### PR DESCRIPTION
Sorted `.text.*` subsections were added to GNU `ld`'s default linker script & supporting code, around 2019 (https://sourceware.org/pipermail/binutils/2019-September/108181.html). They were introduced to aid link-time optimisation, & may also have other uses.