### PR TITLE
stdlib: Add ignore_handler_s.c to CMakeLists.txt and meson.build

### DIFF
--- a/newlib/libc/stdlib/CMakeLists.txt
+++ b/newlib/libc/stdlib/CMakeLists.txt
@@ -117,6 +117,7 @@ picolibc_sources(
   pico-onexit.c
   pico-cxa-atexit.c
   set_constraint_handler_s.c
+  ignore_handler_s.c
   )
 
 picolibc_sources_flags("-fno-builtin-malloc;-fno-builtin-free"

--- a/newlib/libc/stdlib/meson.build
+++ b/newlib/libc/stdlib/meson.build
@@ -163,6 +163,7 @@ srcs_stdlib = [
     'wctomb.c',
     'wctomb_r.c',
     'set_constraint_handler_s.c',
+    'ignore_handler_s.c',
 ]
 
 srcs_stdlib_stdio = [


### PR DESCRIPTION
The file `ignore_handler_s.c` was not included in the `stdlib` CMakeLists.txt and meson.build, causing it to be omitted from the build. This PR adds it to both build systems to ensure it is compiled and linked correctly.