### PR TITLE
Promote `off_t` type when `long->4-bytes` and `size_t->8-bytes`

### DIFF
--- a/newlib/libc/include/sys/_types.h
+++ b/newlib/libc/include/sys/_types.h
@@ -78,7 +78,11 @@ typedef __uint32_t __fsfilcnt_t;
 #endif
 
 #ifndef __machine_off_t_defined
+#if __SIZEOF_SIZE_T__ == 8 && __SIZEOF_LONG__ < 8
+typedef __uint64_t _off_t;
+#else
 typedef long _off_t;
+#endif
 #endif
 
 #if defined(__XMK__)


### PR DESCRIPTION
To guarantee that `off_t >= size_t` 

As required to build  fmemopen.c line [117](https://github.com/picolibc/picolibc/blame/d44fa19886bad821f6004583c75bfc202cd4b156/newlib/libc/tinystdio/fmemopen.c#L117C14-L117C14):
` _Static_assert(sizeof(off_t) >= sizeof(size_t), "must avoid truncation");` 

Also to comply with the assumption in [your disccusions](https://github.com/picolibc/picolibc/pull/634#discussion_r1376668351)

The problem is in 64-bit systems `long` type can be configured to be 4-bytes and `long long` to be 8-bytes then `off_t` and `size_t w` will be mapped as follows:

- `size_t` -> `__SIZE_TYPE__` -> `long long` -> **8**-bytes.  Note that `__SIZE_TYPE__` is compiler predefined macro
- `off_t`  -> `long` -> **4**-bytes

which results in library failing to build in such environment.

