### PR TITLE
stdlib: mbtowc() should return -1 with invalid multibyte sequence

### DIFF
--- a/newlib/libc/stdlib/mbtowc.c
+++ b/newlib/libc/stdlib/mbtowc.c
@@ -69,6 +69,7 @@ mbtowc (wchar_t *__restrict pwc,
                 _mbtowc_state.__count = 0;
 #endif
                 errno = EILSEQ;
+                retval = -1;
         }
         return retval;
 }


### PR DESCRIPTION
Enhancement over this PR: https://github.com/picolibc/picolibc/pull/947 it missed setting the retval to -1 if the input points to an invalid multibyte sequence.