### PR TITLE
machine/arc: strncpy fails as __strncpy_bzero passes target addr in r3, not r0

### DIFF
--- a/newlib/libc/machine/arc/memset-bs.S
+++ b/newlib/libc/machine/arc/memset-bs.S
@@ -81,7 +81,7 @@ ENTRY (memset)
 	brls	r2,SMALL,.Ltiny
 #endif
 .Lnot_tiny:
-	add_s	r12,r2,r0
+	add_s	r12,r2,r3
 	stb	r1,[r12,-1]
 	bclr_l	r12,r12,0
 	stw	r1,[r12,-2]

--- a/newlib/libc/machine/arc/strncpy.S
+++ b/newlib/libc/machine/arc/strncpy.S
@@ -72,13 +72,13 @@ ENTRY (strncpy)
 	sub	r12,r3,r8
 	bic_s	r12,r12,r3
 	BRand	(r12,r11,.Lr3z2)
-	st.ab	r3,[r10,8]
+	st.ab	r3,[r10,4]
 	sub	r12,r4,r8
 	bic	r12,r12,r4
 	BRand	(r12,r11,.Lr4z)
 	ld.a	r3,[r1,4]
 	brlo.d	r10,r6,1b
-	st	r4,[r10,-4]
+	st.ab	r4,[r10,4]
 .Loop_end:
 	add	r6,r6,4
 	brhs	r10,r6,.Lastword

--- a/test/meson.build
+++ b/test/meson.build
@@ -45,6 +45,7 @@ plain_tests_common = ['regex', 'ungetc',
                       'test-uchar',
                       'test-wctomb',
                       'test-scmpu',
+                      'test-strncpy',
                       'time-tests',
 	      ]
 

--- a/test/test-strncpy.c
+++ b/test/test-strncpy.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025 Fredrik Gihl
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+static int testStr(char *dest, const char *src)
+{
+    char* tempStr = dest;
+    size_t str_len;
+    int ret = 1;
+
+    strncpy(tempStr, src, 49);
+    if(strcmp(tempStr, src) != 0)
+    {
+        printf("strncpy failed(len=%zd). String: %s, expected: %s\n",
+               strlen(src),
+               tempStr,
+               src);
+        ret = 0;
+    }
+    str_len = strlen(src);
+    if (str_len > 49)
+    {
+        printf("strncpy wrote %zd to buffer 49 bytes long\n", str_len);
+        ret = 0;
+    }
+    while (str_len < 49)
+    {
+        if (tempStr[str_len] != '\0')
+        {
+            printf("strncpy didn't clear byte at %zd\n", str_len);
+            ret = 0;
+        }
+        str_len++;
+    }
+    return ret;
+}
+
+static char *fillStr(size_t len, char *src, char val)
+{
+    for (size_t i = 0; i < len; i++)
+    {
+        src[i] = val + (i % 10);
+    }
+    src[len] = '\0';
+    return (char*)src;
+}
+
+// This function test the strncpy function so it copy a string correct.
+// We copy string from 5 bytes to 40bytes, and verify that the string is copied correct.
+static int test_strncpy(void)
+{
+    char str[100];
+    int ret = 1;
+
+    char src[49];
+
+    for (size_t strLen = 9; strLen < 40; strLen++)
+    {
+        fillStr(99, str, 'a');
+        if (!testStr(str, fillStr(strLen, src, '0')))
+            ret = 0;
+    }
+    return ret;
+}
+
+
+int main(void)
+{
+    if (!test_strncpy())
+        return 1;
+    return 0;
+}


### PR DESCRIPTION
The memset code has a special entry point used to clear space beyond the destination in strncpy. To make it work, the destination is passed in r3 instead of r0 (as r0 must hold the final return value).
    
However, the code to clear the unaligned end of the string was mistakenly computing the end address using r0 instead of r3. If the number of bytes to erase was smaller than the copied string, that would end up smashing bytes in the middle of the result instead of clearing bytes at the end.
