### PR TITLE
AArch32 crt0: don't write to VBAR on Armv7-R systems.

### DIFF
--- a/picocrt/machine/arm/crt0.c
+++ b/picocrt/machine/arm/crt0.c
@@ -259,7 +259,7 @@ _cstart(void)
 
 /* Set up exception table base address (register VBAR_ELx).
    Architectures earlier than v7 have the base address fixed. */
-#if __ARM_ARCH >= 7
+#if __ARM_ARCH >= 7 && __ARM_ARCH_PROFILE != 'R'
     __asm__("mcr p15, #0, %0, c12, c0, 0" : : "r"(__vector_table) :);
 #endif
 


### PR DESCRIPTION
This CP15 register, which controls the exception vector table base address, is part of the Security Extensions, which are not available in Armv7-R. So the MCR instruction which writes to them will provoke an UNDEF exception on an Armv7-R CPU.

This MCR instruction was already conditionally compiled: if you're compiling crt0.c for a platform without it, you just have to make sure your ld script puts the exception vectors in the default place. This patch tightens the existing condition to exclude Armv7-R.