### PR TITLE
Define _NEWLIB_VERSION for the use of picolibc with LLVM libcxx

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1405,6 +1405,8 @@ conf_data.set('__PICOLIBC_MINOR__', version_array[1], description: 'The Picolibc
 conf_data.set('__PICOLIBC_PATCHLEVEL__', picolibc_patch_level, description: 'The Picolibc patch level.')
 
 conf_data.set('__NEWLIB_VERSION__', '"@0@"'.format(NEWLIB_VERSION), description: 'The newlib version in string format.')
+# The macro below is used in the LLVM's libcxx code base, so we define it for compatibility
+conf_data.set('_NEWLIB_VERSION', '"@0@"'.format(NEWLIB_VERSION), description: 'The newlib version in string format.')
 conf_data.set('__NEWLIB__', NEWLIB_MAJOR_VERSION, description: 'The newlib major version number.')
 conf_data.set('__NEWLIB_MINOR__', NEWLIB_MINOR_VERSION, description: 'The newlib minor version number.')
 conf_data.set('__NEWLIB_PATCHLEVEL__', NEWLIB_PATCHLEVEL_VERSION, description: 'The newlib patch level.')


### PR DESCRIPTION
The LLVM libcxx library uses `_NEWLIB_VERSION` across its codebase. The recent renaming broke the build of libcxx because of this.

This patch reintroduces the macro definition for compatibility with LLVM libcxx.