### PR TITLE
Rename the __format macro from cdefs.h

### DIFF
--- a/newlib/libc/include/ssp/stdio.h
+++ b/newlib/libc/include/ssp/stdio.h
@@ -36,16 +36,16 @@
 _BEGIN_STD_C
 
 int __sprintf_chk(char *__restrict, int, size_t, const char *__restrict, ...)
-    __format(__printf__, 4, 5);
+    __picolibc_format(__printf__, 4, 5);
 int __vsprintf_chk(char *__restrict, int, size_t, const char *__restrict,
     __gnuc_va_list)
-    __format(__printf__, 4, 0);
+    __picolibc_format(__printf__, 4, 0);
 int __snprintf_chk(char *__restrict, size_t, int, size_t,
     const char *__restrict, ...)
-    __format(__printf__, 5, 6);
+    __picolibc_format(__printf__, 5, 6);
 int __vsnprintf_chk(char *__restrict, size_t, int, size_t,
      const char *__restrict, __gnuc_va_list)
-    __format(__printf__, 5, 0);
+    __picolibc_format(__printf__, 5, 0);
 char *__gets_chk(char *, size_t);
 
 #if __SSP_FORTIFY_LEVEL > 0

--- a/newlib/libc/include/sys/cdefs.h
+++ b/newlib/libc/include/sys/cdefs.h
@@ -96,9 +96,9 @@
 #endif
 
 #if __has_attribute(__format__)
-# define __format(a,b,c) __attribute__((__format__(a,b,c)))
+# define __picolibc_format(a,b,c) __attribute__((__format__(a,b,c)))
 #else
-# define __format(a,b,c)
+# define __picolibc_format(a,b,c)
 #endif
 
 #if __has_attribute(__nonnull__)

--- a/newlib/libc/tinystdio/stdio.h
+++ b/newlib/libc/tinystdio/stdio.h
@@ -253,9 +253,9 @@ int	fflush(FILE *stream);
 #ifdef __GNUCLIKE_PRAGMA_DIAGNOSTIC
 #pragma GCC diagnostic ignored "-Wformat"
 #endif
-#define __FORMAT_ATTRIBUTE__(__a, __s, __f) __format(__a, __s, 0)
+#define __FORMAT_ATTRIBUTE__(__a, __s, __f) __picolibc_format(__a, __s, 0)
 #else
-#define __FORMAT_ATTRIBUTE__(__a, __s, __f) __format(__a, __s, __f)
+#define __FORMAT_ATTRIBUTE__(__a, __s, __f) __picolibc_format(__a, __s, __f)
 #endif
 
 #define __PRINTF_ATTRIBUTE__(__s, __f) __FORMAT_ATTRIBUTE__(printf, __s, __f)

--- a/newlib/libc/xdr/xdr_private.h
+++ b/newlib/libc/xdr/xdr_private.h
@@ -34,10 +34,10 @@ typedef void (*xdr_vprintf_t) (const char *, va_list);
 xdr_vprintf_t xdr_set_vprintf (xdr_vprintf_t);
 
 void xdr_vwarnx (const char *, va_list)
-    __format(__printf__, 1, 0);
+    __picolibc_format(__printf__, 1, 0);
 
 void xdr_warnx (const char *, ...)
-    __format(__printf__, 1, 2);
+    __picolibc_format(__printf__, 1, 2);
 
 /* endian issues */
 #include <machine/endian.h>


### PR DESCRIPTION
The `locale` header from LLVM libcxx has a function whose name is `__format`, therefore building libcxx with picolibc doesn't work anymore since the macro name renaming that happened in https://github.com/picolibc/picolibc/pull/968

This patch renames the macro to use a picolibc prefix, thus solving the naming clash between picolic and LLVM libcxx.