### PR TITLE
Bug fix: ensure library built with given 'stack-protector-guard' setting

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -420,6 +420,7 @@ endif
 tls_stack_guard = prefer_tls_stack_guard and have_tls_stack_guard
 if tls_stack_guard
   stack_guard_spec = '%{!mstack-protector-guard:-mstack-protector-guard=tls}'
+  c_args += c_stack_guard_tls_flags
 else
   if stack_guard_option == 'tls'
     if not thread_local_storage
@@ -431,6 +432,7 @@ else
   c_stack_guard_global_flags = cc.get_supported_arguments(['-mstack-protector-guard=global'])
   if c_stack_guard_global_flags != []
     stack_guard_spec = '%{!mstack-protector-guard:-mstack-protector-guard=global}'
+    c_args += c_stack_guard_global_flags
   endif
 endif
 


### PR DESCRIPTION
This fixes a bug in f440a10467ef713d3d78bc31413726755986df42 which I triggered when trying to add TLS support for x86, due to differences in stack guard handling on different types of x86 host platforms.