### PR TITLE
Clean up constant data marked read-write

### DIFF
--- a/doc/locking.md
+++ b/doc/locking.md
@@ -1,11 +1,9 @@
 # Locking in Picolibc
 
-When newlib-multithread and newlib-retargetable-locking are enabled,
-Picolibc uses the following locking API. Picolibc provides stubs for
-all of these functions that do not actually perform any locking, so
-that a single-threaded application can still use a Picolibc compiled
-with locking enabled. An application needing locking must provide a
-real implementation of the locking API.
+Picolibc uses locking and atomics to protect global state between
+re-entrant calls. The amount of global state protected by locks has
+been minimized so that applications can avoid needing them for
+most common operations.
 
 ## Where Picolibc uses locking
 
@@ -15,39 +13,45 @@ data. That includes:
  * malloc family
  * onexit/atexit
  * arc4random
+ * getenv/setenv
  * functions using timezones (localtime, et al)
- * legacy stdio struct reent globals
+ * legacy stdio globals
 
 Tinystdio (the default stdio) uses per-file locks for the buffered
 POSIX file backend, but it doesn't require any locks for the bulk of
-the implementation. It uses atomic exchanges to handle the one
-reentrancy issue related to ungetc/getc.
+the implementation. You can enable POSIX-compliant locking in
+tinystdio with -Dstdio-locking-true. That will prevent I/O from stdio
+operations from interleaving between threads.
 
 The legacy stdio implementation is full of locking, and has per-file
 locks for every operation.
 
+## Where Picolibc uses atomics
+
+Picolibc also uses atomics to protect other data structures while
+avoiding the need for locking:
+
+ * getc/ungetc in tinystdio
+ * signal handling
+
 ## Configuration options controlling locking
 
-There are two configuration options related to locking:
+There is only one configuration option related to locking:
 
- * newlib-retargetable-locking. When 'true', locking operations are
-   enabled and performed by the retargetable locking API described below.
+ * single-thread. When 'true', all locking operations are elided from
+   the library. Re-entrant usage of the library will result in
+   undefined behavior.
 
- * newlib-multithread. When 'true', the library is built with
-   multithreading support enabled and uses the locking operations.
-
-Picolibc inherits these options from newlib, and they're so
-interrelated as to make them effectively co-dependent, so users must
-set them to the same value.
+Atomics will still be used as defined above, so disabling locking
+will still allow safe re-entrancy for those parts of the library.
 
 ## Retargetable locking API
 
-When newlib-multithread and newlib-retargetable-locking are enabled
-enabled, Picolibc uses the following interface. Picolibc provides
-stubs for all of these functions that do not perform locking, so a
-single threaded application can still use a library compiled to enable
-locking. An application needing locking would provide a real
-implementation of the API.
+When -Dsingle-thread is not selected, Picolibc uses the following
+interface. Picolibc provides stubs for all of these functions that do
+not perform locking, so a single threaded application can still use a
+library compiled to enable locking. An application needing locking
+would provide a real implementation of the API.
 
 This API requires recursive mutexes; if the underlying implementation
 only provides non-recursive mutexes, a suitable wrapper implementing
@@ -56,6 +60,11 @@ involving recursive mutexes contain `recursive` in their names.
 
 In this section, *the locking implementation* refers to the external
 implementation of this API.
+
+When implementing this API every function and variable must be
+defined. If not, the application will fail to link as the default
+implementation will be used to satisfy any missing symbol and other
+symbols will collide with the application versions.
 
 ### `struct __lock; typedef struct __lock *_LOCK_T;`
 

--- a/newlib/libc/machine/x86/machine/fenv.h
+++ b/newlib/libc/machine/x86/machine/fenv.h
@@ -147,7 +147,7 @@ typedef __uint32_t fexcept_t;
    represents an environment where every exception raised causes a trap
    to occur. You can test for this macro using #ifdef. It is only defined
    if _GNU_SOURCE is defined.  */
-extern const fenv_t *_fe_nomask_env;
+extern const fenv_t *const _fe_nomask_env;
 #define FE_NOMASK_ENV (_fe_nomask_env)
 #endif
 

--- a/newlib/libc/picolib/dso_handle.c
+++ b/newlib/libc/picolib/dso_handle.c
@@ -37,4 +37,4 @@
  * destruction. We don't have shared objects, so this is just a stub
  * to let C++ programs link
  */
-void *__dso_handle;
+const void *const __dso_handle;

--- a/newlib/libc/stdlib/environ.c
+++ b/newlib/libc/stdlib/environ.c
@@ -29,8 +29,8 @@
 
 /* Provide a definition of `environ' if crt0.o doesn't.  */
 
-static char *initial_env[] = { 0 };
+static const char *const initial_env[] = { 0 };
 
 /* Posix says `environ' is a pointer to a null terminated list of pointers.
    Hence `environ' itself is never NULL.  */
-char **environ = &initial_env[0];
+char **environ = (char **) &initial_env[0];

--- a/newlib/libc/xdr/xdr.c
+++ b/newlib/libc/xdr/xdr.c
@@ -595,7 +595,7 @@ xdr_opaque (XDR * xdrs,
 	u_int cnt)
 {
   u_int rndup;
-  static char crud[BYTES_PER_XDR_UNIT];
+  char crud[BYTES_PER_XDR_UNIT];
 
   /*
    * if no data we are done

--- a/newlib/libm/ld/ld128/e_expl.c
+++ b/newlib/libm/ld/ld128/e_expl.c
@@ -78,14 +78,14 @@
    Theoretical peak relative error = 2.2e-37,
    relative peak error spread = 9.2e-38
  */
-static long double P[5] = {
+static const long double P[5] = {
  3.279723985560247033712687707263393506266E-10L,
  6.141506007208645008909088812338454698548E-7L,
  2.708775201978218837374512615596512792224E-4L,
  3.508710990737834361215404761139478627390E-2L,
  9.999999999999999999999999999999999998502E-1L
 };
-static long double Q[6] = {
+static const long double Q[6] = {
  2.980756652081995192255342779918052538681E-12L,
  1.771372078166251484503904874657985291164E-8L,
  1.504792651814944826817779302637284053660E-5L,
@@ -104,7 +104,7 @@ static const long double huge = 0x1p10000L;
 #if 0 /* XXX Prevent gcc from erroneously constant folding this. */
 static const long double twom10000 = 0x1p-10000L;
 #else
-static volatile long double twom10000 = 0x1p-10000L;
+static const volatile long double twom10000 = 0x1p-10000L;
 #endif
 
 long double

--- a/newlib/libm/ld/ld128/e_tgammal.c
+++ b/newlib/libm/ld/ld128/e_tgammal.c
@@ -17,16 +17,14 @@
  */
 
 
-volatile long double _x, _y, _z, _w;
 
 long double
 tgammal(long double x)
 {
 	int64_t i0,i1;
         int sign;
-        long double y;
+        long double y, z;
 
-        _x = x;
 	GET_LDOUBLE_WORDS64(i0,i1,x);
 	if (((i0&0x7fffffffffffffffLL)|i1) == 0)
                 return __math_divzerol(i0 < 0);
@@ -38,9 +36,8 @@ tgammal(long double x)
 		return __math_invalidl(x);
 
         y = lgammal_r(x, &sign);
-        _y = y;
-        _z = expl(y);
-        _w = (long double) sign;
-        return _z * _w;
-//	return expl(y) * (long double) sign;
+        z = expl(y);
+        if (sign < 0)
+            z = -z;
+        return z;
 }

--- a/newlib/libm/ld/ld128/s_exp2l.c
+++ b/newlib/libm/ld/ld128/s_exp2l.c
@@ -36,7 +36,7 @@
 #if 0 /* XXX Prevent gcc from erroneously constant folding this. */
 static const long double twom10000 = 0x1p-10000L;
 #else
-static volatile long double twom10000 = 0x1p-10000L;
+static const volatile long double twom10000 = 0x1p-10000L;
 #endif
 
 static const long double

--- a/newlib/libm/ld/ld80/e_expl.c
+++ b/newlib/libm/ld/ld80/e_expl.c
@@ -74,12 +74,12 @@
 
 
 
-static long double P[3] = {
+static const long double P[3] = {
  1.2617719307481059087798E-4L,
  3.0299440770744196129956E-2L,
  9.9999999999999999991025E-1L,
 };
-static long double Q[4] = {
+static const long double Q[4] = {
  3.0019850513866445504159E-6L,
  2.5244834034968410419224E-3L,
  2.2726554820815502876593E-1L,

--- a/newlib/libm/ld/ld80/e_log10l.c
+++ b/newlib/libm/ld/ld80/e_log10l.c
@@ -69,7 +69,7 @@
  * 1/sqrt(2) <= x < sqrt(2)
  * Theoretical peak relative error = 6.2e-22
  */
-static long double P[] = {
+static const long double P[] = {
  4.9962495940332550844739E-1L,
  1.0767376367209449010438E1L,
  7.7671073698359539859595E1L,
@@ -78,7 +78,7 @@ static long double P[] = {
  3.4258224542413922935104E2L,
  1.0747524399916215149070E2L,
 };
-static long double Q[] = {
+static const long double Q[] = {
 /* 1.0000000000000000000000E0,*/
  2.3479774160285863271658E1L,
  1.9444210022760132894510E2L,
@@ -95,13 +95,13 @@ static long double Q[] = {
  * Theoretical peak relative error = 6.16e-22
  */
 
-static long double R[4] = {
+static const long double R[4] = {
  1.9757429581415468984296E-3L,
 -7.1990767473014147232598E-1L,
  1.0777257190312272158094E1L,
 -3.5717684488096787370998E1L,
 };
-static long double S[4] = {
+static const long double S[4] = {
 /* 1.00000000000000000000E0L,*/
 -2.6201045551331104417768E1L,
  1.9361891836232102174846E2L,

--- a/newlib/libm/ld/ld80/e_log2l.c
+++ b/newlib/libm/ld/ld80/e_log2l.c
@@ -69,7 +69,7 @@
  * 1/sqrt(2) <= x < sqrt(2)
  * Theoretical peak relative error = 6.2e-22
  */
-static long double P[] = {
+static const long double P[] = {
  4.9962495940332550844739E-1L,
  1.0767376367209449010438E1L,
  7.7671073698359539859595E1L,
@@ -78,7 +78,7 @@ static long double P[] = {
  3.4258224542413922935104E2L,
  1.0747524399916215149070E2L,
 };
-static long double Q[] = {
+static const long double Q[] = {
 /* 1.0000000000000000000000E0,*/
  2.3479774160285863271658E1L,
  1.9444210022760132894510E2L,
@@ -94,13 +94,13 @@ static long double Q[] = {
  * 1/sqrt(2) <= x < sqrt(2)
  * Theoretical peak relative error = 6.16e-22
  */
-static long double R[4] = {
+static const long double R[4] = {
  1.9757429581415468984296E-3L,
 -7.1990767473014147232598E-1L,
  1.0777257190312272158094E1L,
 -3.5717684488096787370998E1L,
 };
-static long double S[4] = {
+static const long double S[4] = {
 /* 1.00000000000000000000E0L,*/
 -2.6201045551331104417768E1L,
  1.9361891836232102174846E2L,

--- a/newlib/libm/ld/ld80/e_logl.c
+++ b/newlib/libm/ld/ld80/e_logl.c
@@ -69,7 +69,7 @@
  * 1/sqrt(2) <= x < sqrt(2)
  * Theoretical peak relative error = 2.32e-20
  */
-static long double P[] = {
+static const long double P[] = {
  4.5270000862445199635215E-5L,
  4.9854102823193375972212E-1L,
  6.5787325942061044846969E0L,
@@ -78,7 +78,7 @@ static long double P[] = {
  5.7112963590585538103336E1L,
  2.0039553499201281259648E1L,
 };
-static long double Q[] = {
+static const long double Q[] = {
 /* 1.0000000000000000000000E0,*/
  1.5062909083469192043167E1L,
  8.3047565967967209469434E1L,
@@ -94,13 +94,13 @@ static long double Q[] = {
  * Theoretical peak relative error = 6.16e-22
  */
 
-static long double R[4] = {
+static const long double R[4] = {
  1.9757429581415468984296E-3L,
 -7.1990767473014147232598E-1L,
  1.0777257190312272158094E1L,
 -3.5717684488096787370998E1L,
 };
-static long double S[4] = {
+static const long double S[4] = {
 /* 1.00000000000000000000E0L,*/
 -2.6201045551331104417768E1L,
  1.9361891836232102174846E2L,

--- a/newlib/libm/ld/ld80/e_tgammal.c
+++ b/newlib/libm/ld/ld80/e_tgammal.c
@@ -65,7 +65,7 @@ Peak error =  1.83e-20
 Relative error spread =  8.4e-23
 */
 
-static long double P[8] = {
+static const long double P[8] = {
  4.212760487471622013093E-5L,
  4.542931960608009155600E-4L,
  4.092666828394035500949E-3L,
@@ -75,7 +75,7 @@ static long double P[8] = {
  8.378004301573126728826E-1L,
  1.000000000000000000009E0L,
 };
-static long double Q[9] = {
+static const long double Q[9] = {
 -1.397148517476170440917E-5L,
  2.346584059160635244282E-4L,
 -1.237799246653152231188E-3L,
@@ -88,7 +88,7 @@ static long double Q[9] = {
 };
 
 /*
-static long double P[] = {
+static const long double P[] = {
 -3.01525602666895735709e0L,
 -3.25157411956062339893e1L,
 -2.92929976820724030353e2L,
@@ -98,7 +98,7 @@ static long double P[] = {
 -5.99650230220855581642e4L,
 -7.15743521530849602425e4L
 };
-static long double Q[] = {
+static const long double Q[] = {
  1.00000000000000000000e0L,
 -1.67955233807178858919e1L,
  8.85946791747759881659e1L,
@@ -123,7 +123,7 @@ Peak error =  9.44e-21
 Relative error spread =  8.8e-4
 */
 
-static long double STIR[9] = {
+static const long double STIR[9] = {
  7.147391378143610789273E-4L,
 -2.363848809501759061727E-5L,
 -5.950237554056330156018E-4L,
@@ -144,7 +144,7 @@ static const long double SQTPI = 2.50662827463100050242E0L;
  * Peak relative error 4.2e-23
  */
 
-static long double S[9] = {
+static const long double S[9] = {
 -1.193945051381510095614E-3L,
  7.220599478036909672331E-3L,
 -9.622023360406271645744E-3L,
@@ -163,7 +163,7 @@ static long double S[9] = {
  * Relative error spread =  2.5e-24
  */
 
-static long double SN[9] = {
+static const long double SN[9] = {
  1.133374167243894382010E-3L,
  7.220837261893170325704E-3L,
  9.621911155035976733706E-3L,

--- a/newlib/libm/ld/ld80/s_exp2l.c
+++ b/newlib/libm/ld/ld80/s_exp2l.c
@@ -36,7 +36,7 @@ static const long double huge = 0x1p10000L;
 #if 0 /* XXX Prevent gcc from erroneously constant folding this. */
 static const long double twom10000 = 0x1p-10000L;
 #else
-static volatile long double twom10000 = 0x1p-10000L;
+static const volatile long double twom10000 = 0x1p-10000L;
 #endif
 
 static const double

--- a/newlib/libm/ld/ld80/s_log1pl.c
+++ b/newlib/libm/ld/ld80/s_log1pl.c
@@ -66,7 +66,7 @@
  * Theoretical peak relative error = 2.32e-20
  */
 
-static long double P[] = {
+static const long double P[] = {
  4.5270000862445199635215E-5L,
  4.9854102823193375972212E-1L,
  6.5787325942061044846969E0L,
@@ -75,7 +75,7 @@ static long double P[] = {
  5.7112963590585538103336E1L,
  2.0039553499201281259648E1L,
 };
-static long double Q[] = {
+static const long double Q[] = {
 /* 1.0000000000000000000000E0,*/
  1.5062909083469192043167E1L,
  8.3047565967967209469434E1L,
@@ -91,13 +91,13 @@ static long double Q[] = {
  * Theoretical peak relative error = 6.16e-22
  */
 
-static long double R[4] = {
+static const long double R[4] = {
  1.9757429581415468984296E-3L,
 -7.1990767473014147232598E-1L,
  1.0777257190312272158094E1L,
 -3.5717684488096787370998E1L,
 };
-static long double S[4] = {
+static const long double S[4] = {
 /* 1.00000000000000000000E0L,*/
 -2.6201045551331104417768E1L,
  1.9361891836232102174846E2L,

--- a/newlib/libm/machine/x86/fenv.c
+++ b/newlib/libm/machine/x86/fenv.c
@@ -44,7 +44,7 @@
 static fenv_t fe_nomask_env;
 
 /* These pointers provide the outside world with read-only access to them.  */
-const fenv_t *_fe_nomask_env = &fe_nomask_env;
+const fenv_t *const _fe_nomask_env = &fe_nomask_env;
 
 /* Assume i686 or above (hence SSE available) these days, with the
    compiler feels free to use it (depending on compile- time flags of

--- a/scripts/do-native-configure
+++ b/scripts/do-native-configure
@@ -38,6 +38,7 @@ meson setup \
         --buildtype debug \
 	--fatal-meson-warnings \
         -Dtls-model=global-dynamic \
+	-Dthread-local-storage=true \
 	-Derrno-function=auto \
         -Dmultilib=false \
         -Dpicolib=false \

--- a/test/tls.c
+++ b/test/tls.c
@@ -61,7 +61,7 @@ volatile int32_t *volatile overaligned_data_addr;
 volatile int32_t *volatile bss_addr;
 volatile int32_t *volatile overaligned_bss_addr;
 
-#ifdef __THREAD_LOCAL_STORAGE
+#ifdef __THREAD_LOCAL_STORAGE_API
 extern char __tdata_start[], __tdata_end[];
 extern char __tdata_source[], __tdata_source_end[];
 extern char __data_start[], __data_source[];
@@ -89,7 +89,7 @@ check_tls(char *where, bool check_addr, void *tls_region)
 
 	printf("tls check %s %p %p %p %p\n", where, &data_var,
 	       &overaligned_data_var, &bss_var, &overaligned_bss_var);
-#ifdef __THREAD_LOCAL_STORAGE
+#ifdef __THREAD_LOCAL_STORAGE_API
         if (_tls_align() & (OVERALIGN_DATA-1)) {
                 printf("TLS alignment too small for data (need %ld, got %ld)\n",
                        (unsigned long) OVERALIGN_DATA,
@@ -203,7 +203,7 @@ check_tls(char *where, bool check_addr, void *tls_region)
 			result++;
 		}
 	}
-#ifdef __THREAD_LOCAL_STORAGE
+#ifdef __THREAD_LOCAL_STORAGE_API
 	check_inside_tls_region(&data_var, tls_region);
 	check_inside_tls_region(&overaligned_data_var, tls_region);
 	check_inside_tls_region(&bss_var, tls_region);
@@ -230,7 +230,7 @@ check_tls(char *where, bool check_addr, void *tls_region)
 	return result;
 }
 
-#ifdef __THREAD_LOCAL_STORAGE
+#ifdef __THREAD_LOCAL_STORAGE_API
 static void
 hexdump(const void *ptr, int length, const char *hdr)
 {
@@ -260,7 +260,7 @@ main(void)
 	bss_addr = &bss_var;
         overaligned_bss_addr = &overaligned_bss_var;
 
-#ifdef __THREAD_LOCAL_STORAGE
+#ifdef __THREAD_LOCAL_STORAGE_API
         printf("TLS region: %p-%p (%zd bytes)\n", __tdata_start,
 	       __tdata_start + _tls_size(), _tls_size());
 	size_t tdata_source_size = __tdata_source_end - __tdata_source;


### PR DESCRIPTION
A bunch of data (especially in the long-double code) was missing `const` annotation. Fix that, along with updating the locking document.