### PR TITLE
stdlib: Allow aligned_alloc to build in c99 mode too

### DIFF
--- a/newlib/libc/include/stdlib.h
+++ b/newlib/libc/include/stdlib.h
@@ -106,7 +106,7 @@ long    a64l (const char *__input);
 #endif
 __noreturn void	abort (void);
 int	abs (int);
-#if __ISO_C_VISIBLE >= 2011
+#if __ISO_C_VISIBLE >= 2011 || __GNU_VISIBLE
 void   *aligned_alloc(size_t, size_t) __malloc_like __alloc_align(1)
                          __alloc_size(2) __warn_unused_result __nothrow;
 #endif

--- a/newlib/libc/stdlib/nano-memalign.c
+++ b/newlib/libc/stdlib/nano-memalign.c
@@ -26,6 +26,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#define _GNU_SOURCE
 #include "nano-malloc.h"
 
 /*


### PR DESCRIPTION
We need to provide a way for aligned_alloc to be built even using an older compiler. Add it to the GNU_VISIBLE class so that stdlib.h will declare it, even for pre-C11 compilers.