### PR TITLE
semihost/x86: add TLS support for semihosting Intel i386 and x86-64

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -387,7 +387,7 @@ endif
 tls_model_spec = ''
 thread_local_storage = false
 thread_local_storage_option = get_option('thread-local-storage')
-have_picolibc_tls_api = fs.is_file('newlib/libc/picolib/machine' / host_cpu_family / 'tls.c')
+have_picolibc_tls_api = enable_picolib and fs.is_file('newlib/libc/picolib/machine' / host_cpu_family / 'tls.c')
 if thread_local_storage_option == 'auto' or thread_local_storage_option == 'picolibc'
   # We assume that _set_tls() is defined in the arch specific tls.c
   if thread_local_storage_option == 'auto' or have_picolibc_tls_api

--- a/newlib/libc/machine/x86/machine/_ssp_tls.h
+++ b/newlib/libc/machine/x86/machine/_ssp_tls.h
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2025 TK Chia
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _MACHINE__SSP_TLS_H_
+#define _MACHINE__SSP_TLS_H_
+
+#include <sys/param.h>
+
+#ifndef __THREAD_LOCAL_STORAGE_STACK_GUARD
+#error
+#endif
+
+#include "machine/_tls.h"
+
+extern _Thread_local __tcb_head_t __x86_tls_tcb;
+#define __stack_chk_guard (__x86_tls_tcb.__stack_guard)
+
+#endif

--- a/newlib/libc/machine/x86/machine/_tls.h
+++ b/newlib/libc/machine/x86/machine/_tls.h
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2025 TK Chia
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _MACHINE__TLS_H_
+#define _MACHINE__TLS_H_
+
+#include <stdint.h>
+#include <sys/param.h>
+
+#if !defined(__i386__) && !defined(__x86_64)
+#error
+#endif
+
+typedef struct
+{
+	/* Self-pointer per ABI (https://akkadia.org/drepper/tls.pdf). */
+	void *__tcb;
+#ifdef __THREAD_LOCAL_STORAGE_STACK_GUARD
+	/*
+	 * If we are configured to use a TLS stack protection canary, then
+	 * GCC expects the canary to be located at the same offset into the
+	 * TCB as implemented in GNU libc's Native POSIX Thread Library
+	 * (NPTL) component.  So declare some additional NPTL-compatible TCB
+	 * fields here.
+	 */
+	void *__dtv;
+	void *__self;
+	int32_t __multiple_threads;
+#ifdef __x86_64
+	int32_t __gscope_flag;
+#endif
+	uintptr_t __sysinfo;
+	uintptr_t __stack_guard;
+#endif
+} __tcb_head_t;
+
+#endif

--- a/newlib/libc/picolib/machine/x86/CMakeLists.txt
+++ b/newlib/libc/picolib/machine/x86/CMakeLists.txt
@@ -1,0 +1,41 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2022 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+if(${__THREAD_LOCAL_STORAGE_API})
+  picolibc_sources(
+    tls.c
+    tcb.S
+    )
+endif()

--- a/newlib/libc/picolib/machine/x86/meson.build
+++ b/newlib/libc/picolib/machine/x86/meson.build
@@ -1,0 +1,41 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2021 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+if thread_local_storage
+  src_picolib += files([
+    'tls.c',
+    'tcb.S'
+  ])
+endif

--- a/newlib/libc/picolib/machine/x86/tcb-32.S
+++ b/newlib/libc/picolib/machine/x86/tcb-32.S
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2025 TK Chia
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <picolibc.h>
+
+	.text
+	.weak	__set_tcb
+	.type	__set_tcb, @function
+__set_tcb:
+	/*
+	 * Assume that the %gs selector value refers to a slot in the GDT
+	 * dedicated to thread local storage; modify the GDT slot's base
+	 *
+	 * NOTE: this procedure only works if our program is running in
+	 * kernel mode (ring 0) and can directly write to the GDT
+	 *
+	 * If we are running unprivileged, then a syscall is likely needed
+	 * (e.g. set_thread_area on Linux/x86)
+	 */
+	push	%edx
+	push	%edx
+	sgdt	2(%esp)			# read GDTR to get pointer to GDT
+	pop	%edx
+	pop	%edx
+	xor	%ecx, %ecx
+	mov	%gs, %cx		# get index into GDT
+	shr	$3, %ecx
+	jbe	9f
+	lea	(%edx, %ecx, 8), %ecx	# compute pointer to GDT entry
+	mov	4(%esp), %eax		# get TCB base
+	mov	%eax, (%eax)		# fill in self-pointer
+	shld	$8, %eax, %edx		# split TCB address into two parts
+	shl	$8, %eax
+	mov	$0xff, %al		# update GDT entry
+	mov	%eax, 1(%ecx)
+	mov	%dl, 7(%ecx)
+	mov	%gs, %ecx		# reload %gs descriptor cache
+	mov	%ecx, %gs
+	ret
+9:
+	ud2
+	.size	__set_tcb, . - __set_tcb
+
+#if defined(__linux__) && defined(__ELF__)
+	.section .note.GNU-stack, "", @progbits
+#endif

--- a/newlib/libc/picolib/machine/x86/tcb-64.S
+++ b/newlib/libc/picolib/machine/x86/tcb-64.S
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2025 TK Chia
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <picolibc.h>
+
+#define MSR_FS_BASE	0xc0000100
+
+	.text
+	.weak	__set_tcb
+	.type	__set_tcb, @function
+__set_tcb:
+	/* Assume that MSR_FS_BASE is present and that we can write to it */
+	xchg	%rdi, %rax
+	mov	%rax, (%rax)		# fill in self-pointer
+	shld	$32, %rax, %rdx		# write %fs segment base
+	mov	$MSR_FS_BASE, %ecx
+	wrmsr
+	ret
+	.size	__set_tcb, . - __set_tcb
+
+#if defined(__linux__) && defined(__ELF__)
+	.section .note.GNU-stack, "", @progbits
+#endif

--- a/newlib/libc/picolib/machine/x86/tcb.S
+++ b/newlib/libc/picolib/machine/x86/tcb.S
@@ -1,0 +1,7 @@
+#include <picolibc.h>
+
+#ifdef __x86_64
+#include "tcb-64.S"
+#else
+#include "tcb-32.S"
+#endif

--- a/newlib/libc/picolib/machine/x86/tls.c
+++ b/newlib/libc/picolib/machine/x86/tls.c
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2025 TK Chia
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <picotls.h>
+#include <stdlib.h>
+#include "machine/_tls.h"
+
+extern void __set_tcb(void *);
+extern char __x86_tls_tcb_offset[];
+#define TP_OFFSET ((size_t)&__x86_tls_tcb_offset)
+
+void
+_set_tls(void *tls)
+{
+	__set_tcb((char *)tls + TP_OFFSET);
+}
+
+/* Reserve space for a TCB. */
+__attribute__((__section__(".tls_tail_extra"), __aligned__(1), __used__))
+static char __tcb_space[sizeof(__tcb_head_t)];

--- a/picocrt/machine/x86/crt0-32.S
+++ b/picocrt/machine/x86/crt0-32.S
@@ -42,11 +42,11 @@
 	.text
 	.section	.text.init.enter
 	.globl	_start
-	.type	start, @function
+	.type	_start, @function
 _start:
 	.code16
 	cs
-	lgdtl gdt_desc - _start + 0x10
+	lgdtl gdt_desc - _start + 0x10	# use copy of GDT in read-only memory
 	mov $1, %eax
 	mov %eax, %cr0
 	ljmpl $0x10,$_start32
@@ -59,6 +59,9 @@ _start32:
 	mov	%eax, %ss
 	mov	%eax, %ds
 	mov	%eax, %fs
+#ifdef __THREAD_LOCAL_STORAGE
+	mov	$0x20, %eax		# selector for thread local storage
+#endif
 	mov	%eax, %gs
 	fninit				# initialize x87 FPU
 
@@ -89,6 +92,10 @@ _start32:
 	addl	$12, %esp
 
 #ifdef __THREAD_LOCAL_STORAGE
+	// switch to copy of GDT in writable memory, so we can modify TLS
+	// segment base (in case machine lacks MSR_GS_BASE register)
+	lgdtl	gdt2_desc
+
 	// call to _set_tls(__tls_base)
 	pushl	$__tls_base
 	call	_set_tls
@@ -112,16 +119,37 @@ _start32:
 1:
 	jmp	1b
 #endif
-	
-gdt_desc:
-	.word gdt_end - gdt - 1
-	.long gdt
 
-gdt:
+	gdt_size = gdt_end - __x86_gdt
+
+	.balign	2
+gdt_desc:
+	.word gdt_size - 1
+	.long __x86_gdt_ro
+
+	// if GDT will not be modified, place it in read-only memory
+	// otherwise place it in writable memory, and arrange to first use
+	// the read-only copy at early startup
+	// linker script computes address of __x86_gdt_ro in that case
+#ifndef __THREAD_LOCAL_STORAGE
+	.globl 	__x86_gdt_ro
+__x86_gdt_ro:
+#else
+gdt2_desc:
+	.word gdt_size - 1
+	.long __x86_gdt
+
+	.data
+#endif
+	.globl 	__x86_gdt
+__x86_gdt:
 	.quad 0x0000000000000000	# unused (null selector)
 	.quad 0x0000000000000000	# 0x08: space for Task State Segment
 	.quad 0x00CF9B000000FFFF        # 0x10: ring 0 32-bit code segment
 	.quad 0x00CF93000000FFFF        # 0x18: ring 0 data segment
+#ifdef __THREAD_LOCAL_STORAGE
+	.quad 0x00CF93000000FFFF	# 0x20: thread local storage
+#endif
 gdt_end:
 
 #if defined(__linux__) && defined(__ELF__)

--- a/picolibc.ld.in
+++ b/picolibc.ld.in
@@ -220,6 +220,7 @@ SECTIONS
 	} >ram AT>flash :ram_init
 	PROVIDE(@PREFIX@__data_start = ADDR(.data));
 	PROVIDE(@PREFIX@__data_source = LOADADDR(.data));
+	PROVIDE(@PREFIX@__x86_gdt_ro = DEFINED(@PREFIX@__x86_gdt) ? @PREFIX@__x86_gdt - @PREFIX@__data_start + @PREFIX@__data_source : 0);
 
 	/* Thread local initialized data. This gets
 	 * space allocated as it is expected to be placed
@@ -263,13 +264,15 @@ SECTIONS
 	PROVIDE( @PREFIX@__tbss_start = ADDR(.tbss));
 	PROVIDE( @PREFIX@__tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
 	PROVIDE( @PREFIX@__tbss_size = SIZEOF(.tbss) );
-	PROVIDE( @PREFIX@__tls_size = @PREFIX@__tls_end - @PREFIX@__tls_base );
 	PROVIDE( @PREFIX@__tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+	PROVIDE( @PREFIX@__tls_size = (@PREFIX@__tls_tail_extra_size ? ALIGN(@PREFIX@__tls_end, @PREFIX@__tls_align) + @PREFIX@__tls_tail_extra_size : @PREFIX@__tls_end) - @PREFIX@__tls_base );
 	PROVIDE( @PREFIX@__tls_size_align = (@PREFIX@__tls_size + @PREFIX@__tls_align - 1) & ~(@PREFIX@__tls_align - 1));
 	PROVIDE( @PREFIX@__arm32_tls_tcb_offset = MAX(8, @PREFIX@__tls_align) );
 	PROVIDE( @PREFIX@__arm64_tls_tcb_offset = MAX(16, @PREFIX@__tls_align) );
 	PROVIDE( @PREFIX@__or1k_tls_tcb_offset = MAX(16, @PREFIX@__tls_align) );
 	PROVIDE( @PREFIX@__sh32_tls_tcb_offset = MAX(8, @PREFIX@__tls_align) );
+	PROVIDE( @PREFIX@__x86_tls_tcb = ALIGN(@PREFIX@__tls_end, @PREFIX@__tls_align) );
+	PROVIDE( @PREFIX@__x86_tls_tcb_offset = @PREFIX@__x86_tls_tcb - @PREFIX@__tls_base );
 
 	/*
 	 * Unlike ld.lld, ld.bfd does not advance the location counter for
@@ -284,6 +287,25 @@ SECTIONS
 	} >ram AT>ram :ram
 	@BFD_END@
 	.bss (NOLOAD) : {
+		/*
+		 * For the x86-32 and x86-64, we must further allocate extra
+		 * space for the thread control block -- at a minimum, the
+		 * TCB needs to contain a pointer to itself
+		 * (https://akkadia.org/drepper/tls.pdf).  Unlike the
+		 * PowerPC case, the x86 TCB appears after the thread local
+		 * variables.
+		 * On the x86, the precise procedure to set the TCB pointer
+		 * depends on the operating system.  The system library
+		 * should implement a __set_tcb() function to set this
+		 * pointer (similar to OpenBSD's, https://man.openbsd.org/
+		 *__get_tcb.2).  __set_tcb() will be called by _set_tls().
+		 */
+		. = ALIGN(@PREFIX@__tls_align);
+		PROVIDE( @PREFIX@__tls_tail_extra_start = . );
+		KEEP (*(.tls_tail_extra .tls_tail_extra.*))
+		PROVIDE( @PREFIX@__tls_tail_extra_end = . );
+
+		PROVIDE( @PREFIX@__non_tls_bss_start = . );
 		*(.sbss* @EXTRA_SBSS_SECTIONS@)
 		*(.gnu.linkonce.sb.*)
 		*(.bss .bss.* @EXTRA_BSS_SECTIONS@)
@@ -294,7 +316,7 @@ SECTIONS
 		. = ALIGN(@DEFAULT_ALIGNMENT@);
 		@PREFIX@__bss_end = .;
 	} >ram AT>ram :ram
-	PROVIDE( @PREFIX@__non_tls_bss_start = ADDR(.bss) );
+	PROVIDE( @PREFIX@__tls_tail_extra_size = @PREFIX@__tls_tail_extra_end - @PREFIX@__tls_tail_extra_start );
 	PROVIDE( @PREFIX@__end = @PREFIX@__bss_end );
 	@PREFIX@_end = @PREFIX@__bss_end;
 	PROVIDE( @PREFIX@end = @PREFIX@__bss_end );


### PR DESCRIPTION
On the x86, the precise procedure for setting the current TCB pointer -- the `%gs` segment base (for i386) or the `%fs` base (for x86-64) -- is unfortunately OS-specific, since it generally involves privileged operations.

The current proposed arrangement is to have an OS-indepedent `_set_tls()` routine calculate the TCB address from the TLS base -- by adding the needed offset -- and then simply hand over to a lower layer `__set_tcb()` routine to actually set the TCB pointer.

(The `__set_tcb()` interface follows that of OpenBSD: see https://man.openbsd.org/__get_tcb.2 .)

The linker script was also modified to allocate space for the thread control block, which on the x86 appears _after_ the TLS variables (https://akkadia.org/drepper/tls.pdf).