### PR TITLE
cdefs: Create separate __deprecated_m that takes a message

### DIFF
--- a/newlib/libc/include/stdlib.h
+++ b/newlib/libc/include/stdlib.h
@@ -198,7 +198,7 @@ int	mkstemp (char *);
 int	mkstemps (char *, int);
 #endif
 #if __BSD_VISIBLE || (__XSI_VISIBLE >= 4 && __POSIX_VISIBLE < 200112)
-char *	mktemp (char *) __deprecated("the use of `mktemp' is dangerous; use `mkstemp' instead");
+char *	mktemp (char *) __deprecated_m("the use of `mktemp' is dangerous; use `mkstemp' instead");
 #endif
 #if __SVID_VISIBLE || __XSI_VISIBLE
 long   mrand48 (void);

--- a/newlib/libc/include/sys/cdefs.h
+++ b/newlib/libc/include/sys/cdefs.h
@@ -209,12 +209,14 @@
 
 #if __has_attribute(__deprecated__)
 # if __GNUC_PREREQ__(4,5) || defined(__clang__)
-#  define __deprecated(m) __attribute__((__deprecated__(m)))
+#  define __deprecated_m(m) __attribute__((__deprecated__(m)))
 # else
-#  define __deprecated(m) __attribute__((__deprecated__))
+#  define __deprecated_m(m) __attribute__((__deprecated__))
 # endif
+# define __deprecated __attribute__((__deprecated__))
 #else
-# define __deprecated(m)
+# define __deprecated_m(m)
+# define __deprecated
 #endif
 
 #if __has_attribute(__no_builtin__)


### PR DESCRIPTION
GCC supports two forms of the deprecated attribute, one with no argument that prints a generic message and another with a string argument that is displayed as part of the warning. Zephyr uses only the argument-free version and calls that __deprecated.

To avoid conflicting with that, replicate that behavior in picolibc and then create another macro, __deprecated_m(s), which takes the message and can be used in the one place in picolibc headers which expose a deprecated function (mktemp).