### PR TITLE
ctype: Rename bit definitions to avoid application symbols

### DIFF
--- a/newlib/libc/ctype/ctype_.h
+++ b/newlib/libc/ctype/ctype_.h
@@ -17,6 +17,16 @@ __get_ctype(enum locale_id id)
 
 #endif
 
+#define _U __CTYPE_UPPER
+#define _L __CTYPE_LOWER
+#define _N __CTYPE_DIGIT
+#define _S __CTYPE_SPACE
+#define _P __CTYPE_PUNCT
+#define _C __CTYPE_CNTRL
+#define _X __CTYPE_HEX
+#define _B __CTYPE_BLANK
+#define _T __CTYPE_TAB
+
 #define _CTYPE_DATA_0_127 \
 	_C,	_C,	_C,	_C,	_C,	_C,	_C,	_C, \
 	_C,	_C|_S, _C|_S, _C|_S,	_C|_S,	_C|_S,	_C,	_C, \

--- a/newlib/libc/ctype/isalnum.c
+++ b/newlib/libc/ctype/isalnum.c
@@ -75,6 +75,6 @@ isalnum (int c)
 #if _PICOLIBC_CTYPE_SMALL
     return isalpha(c) || isdigit(c);
 #else
-    return __CTYPE_PTR[c+1] & (_U|_L|_N);
+    return __CTYPE_PTR[c+1] & (__CTYPE_UPPER|__CTYPE_LOWER|__CTYPE_DIGIT);
 #endif
 }

--- a/newlib/libc/ctype/isalnum_l.c
+++ b/newlib/libc/ctype/isalnum_l.c
@@ -13,6 +13,6 @@ isalnum_l (int c, locale_t locale)
     (void) locale;
     return isalnum(c);
 #else
-    return __CTYPE_PTR_L (locale)[c+1] & (_U|_L|_N);
+    return __CTYPE_PTR_L (locale)[c+1] & (__CTYPE_UPPER|__CTYPE_LOWER|__CTYPE_DIGIT);
 #endif
 }

--- a/newlib/libc/ctype/isalpha.c
+++ b/newlib/libc/ctype/isalpha.c
@@ -75,6 +75,6 @@ isalpha (int c)
 #if _PICOLIBC_CTYPE_SMALL
     return isupper(c) || islower(c);
 #else
-    return __CTYPE_PTR[c+1] & (_U|_L);
+    return __CTYPE_PTR[c+1] & (__CTYPE_UPPER|__CTYPE_LOWER);
 #endif
 }

--- a/newlib/libc/ctype/isalpha_l.c
+++ b/newlib/libc/ctype/isalpha_l.c
@@ -13,6 +13,6 @@ isalpha_l (int c, locale_t locale)
     (void) locale;
     return isalpha(c);
 #else
-    return __CTYPE_PTR_L (locale)[c+1] & (_U|_L);
+    return __CTYPE_PTR_L (locale)[c+1] & (__CTYPE_UPPER|__CTYPE_LOWER);
 #endif
 }

--- a/newlib/libc/ctype/isblank.c
+++ b/newlib/libc/ctype/isblank.c
@@ -45,6 +45,6 @@ isblank (int c)
 #if _PICOLIBC_CTYPE_SMALL
     return c == ' ' || c == '\t';
 #else
-    return(__CTYPE_PTR[c+1] & _B) || c == '\t';
+    return(__CTYPE_PTR[c+1] & __CTYPE_BLANK) || c == '\t';
 #endif
 }

--- a/newlib/libc/ctype/isblank_l.c
+++ b/newlib/libc/ctype/isblank_l.c
@@ -13,6 +13,6 @@ isblank_l (int c, locale_t locale)
     (void) locale;
     return isblank(c);
 #else
-    return (__CTYPE_PTR_L (locale)[c+1] & _B) || (c == '\t');
+    return (__CTYPE_PTR_L (locale)[c+1] & __CTYPE_BLANK) || (c == '\t');
 #endif
 }

--- a/newlib/libc/ctype/iscntrl.c
+++ b/newlib/libc/ctype/iscntrl.c
@@ -76,6 +76,6 @@ iscntrl (int c)
 #if _PICOLIBC_CTYPE_SMALL
     return (0x00 <= c && c <= 0x1f) || c == 0x7f;
 #else
-    return(__CTYPE_PTR[c+1] & _C);
+    return(__CTYPE_PTR[c+1] & __CTYPE_CNTRL);
 #endif
 }

--- a/newlib/libc/ctype/iscntrl_l.c
+++ b/newlib/libc/ctype/iscntrl_l.c
@@ -13,6 +13,6 @@ iscntrl_l (int c, locale_t locale)
 #if _PICOLIBC_CTYPE_SMALL
     return (0x00 <= c && c <= 0x1f) || c == 0x7f;
 #else
-    return __CTYPE_PTR_L (locale)[c+1] & _C;
+    return __CTYPE_PTR_L (locale)[c+1] & __CTYPE_CNTRL;
 #endif
 }

--- a/newlib/libc/ctype/isdigit.c
+++ b/newlib/libc/ctype/isdigit.c
@@ -76,6 +76,6 @@ isdigit (int c)
 #if _PICOLIBC_CTYPE_SMALL
     return '0' <= c && c <= '9';
 #else
-    return __CTYPE_PTR[c+1] & _N;
+    return __CTYPE_PTR[c+1] & __CTYPE_DIGIT;
 #endif
 }

--- a/newlib/libc/ctype/isdigit_l.c
+++ b/newlib/libc/ctype/isdigit_l.c
@@ -13,6 +13,6 @@ isdigit_l (int c, locale_t locale)
     (void) locale;
     return isdigit(c);
 #else
-    return __CTYPE_PTR_L (locale)[c+1] & _N;
+    return __CTYPE_PTR_L (locale)[c+1] & __CTYPE_DIGIT;
 #endif
 }

--- a/newlib/libc/ctype/isgraph.c
+++ b/newlib/libc/ctype/isgraph.c
@@ -75,6 +75,6 @@ isgraph (int c)
 #if _PICOLIBC_CTYPE_SMALL
     return '!' <= c && c <= '~';
 #else
-    return __CTYPE_PTR[c+1]&(_P|_U|_L|_N);
+    return __CTYPE_PTR[c+1]&(__CTYPE_PUNCT|__CTYPE_UPPER|__CTYPE_LOWER|__CTYPE_DIGIT);
 #endif
 }

--- a/newlib/libc/ctype/isgraph_l.c
+++ b/newlib/libc/ctype/isgraph_l.c
@@ -14,6 +14,6 @@ isgraph_l (int c, locale_t locale)
     (void) locale;
     return isgraph(c);
 #else
-    return __CTYPE_PTR_L (locale)[c+1] & (_P|_U|_L|_N);
+    return __CTYPE_PTR_L (locale)[c+1] & (__CTYPE_PUNCT|__CTYPE_UPPER|__CTYPE_LOWER|__CTYPE_DIGIT);
 #endif
 }

--- a/newlib/libc/ctype/islower.c
+++ b/newlib/libc/ctype/islower.c
@@ -75,6 +75,6 @@ islower (int c)
 #if _PICOLIBC_CTYPE_SMALL
     return 'a' <= c && c <= 'z';
 #else
-    return ((__CTYPE_PTR[c+1] & (_U|_L)) == _L);
+    return ((__CTYPE_PTR[c+1] & (__CTYPE_UPPER|__CTYPE_LOWER)) == __CTYPE_LOWER);
 #endif
 }

--- a/newlib/libc/ctype/islower_l.c
+++ b/newlib/libc/ctype/islower_l.c
@@ -13,6 +13,6 @@ islower_l (int c, locale_t locale)
     (void) locale;
     return islower(c);
 #else
-    return (__CTYPE_PTR_L (locale)[c+1] & (_U|_L)) == _L;
+    return (__CTYPE_PTR_L (locale)[c+1] & (__CTYPE_UPPER|__CTYPE_LOWER)) == __CTYPE_LOWER;
 #endif
 }

--- a/newlib/libc/ctype/isprint.c
+++ b/newlib/libc/ctype/isprint.c
@@ -89,6 +89,6 @@ isprint (int c)
 #if _PICOLIBC_CTYPE_SMALL
     return ' ' <= c && c <= '~';
 #else
-    return __CTYPE_PTR[c+1] & (_P|_U|_L|_N|_B);
+    return __CTYPE_PTR[c+1] & (__CTYPE_PUNCT|__CTYPE_UPPER|__CTYPE_LOWER|__CTYPE_DIGIT|__CTYPE_BLANK);
 #endif
 }

--- a/newlib/libc/ctype/isprint_l.c
+++ b/newlib/libc/ctype/isprint_l.c
@@ -14,6 +14,6 @@ isprint_l (int c, locale_t locale)
     (void) locale;
     return isprint(c);
 #else
-    return __CTYPE_PTR_L (locale)[c+1] & (_P|_U|_L|_N|_B);
+    return __CTYPE_PTR_L (locale)[c+1] & (__CTYPE_PUNCT|__CTYPE_UPPER|__CTYPE_LOWER|__CTYPE_DIGIT|__CTYPE_BLANK);
 #endif
 }

--- a/newlib/libc/ctype/ispunct.c
+++ b/newlib/libc/ctype/ispunct.c
@@ -79,6 +79,6 @@ ispunct (int c)
             ('[' <= c && c <= '`') ||
             ('{' <= c && c <= '~'));
 #else
-    return(__CTYPE_PTR[c+1] & _P);
+    return(__CTYPE_PTR[c+1] & __CTYPE_PUNCT);
 #endif
 }

--- a/newlib/libc/ctype/ispunct_l.c
+++ b/newlib/libc/ctype/ispunct_l.c
@@ -13,7 +13,7 @@ ispunct_l (int c, locale_t locale)
     (void) locale;
     return ispunct(c);
 #else
-    return __CTYPE_PTR_L (locale)[c+1] & _P;
+    return __CTYPE_PTR_L (locale)[c+1] & __CTYPE_PUNCT;
 #endif
 }
 

--- a/newlib/libc/ctype/isspace.c
+++ b/newlib/libc/ctype/isspace.c
@@ -75,6 +75,6 @@ isspace (int c)
 #if _PICOLIBC_CTYPE_SMALL
     return c == ' ' || ('\t' <= c && c <= '\r');
 #else
-    return(__CTYPE_PTR[c+1] & _S);
+    return(__CTYPE_PTR[c+1] & __CTYPE_SPACE);
 #endif
 }

--- a/newlib/libc/ctype/isspace_l.c
+++ b/newlib/libc/ctype/isspace_l.c
@@ -13,7 +13,7 @@ isspace_l (int c, locale_t locale)
 #if _PICOLIBC_CTYPE_SMALL
     return isspace(c);
 #else
-    return __CTYPE_PTR_L (locale)[c+1] & _S;
+    return __CTYPE_PTR_L (locale)[c+1] & __CTYPE_SPACE;
 #endif
 }
 

--- a/newlib/libc/ctype/isupper.c
+++ b/newlib/libc/ctype/isupper.c
@@ -73,6 +73,6 @@ isupper (int c)
 #if _PICOLIBC_CTYPE_SMALL
     return 'A' <= c && c <= 'Z';
 #else
-    return ((__CTYPE_PTR[c+1] & (_U|_L)) == _U);
+    return ((__CTYPE_PTR[c+1] & (__CTYPE_UPPER|__CTYPE_LOWER)) == __CTYPE_UPPER);
 #endif
 }

--- a/newlib/libc/ctype/isupper_l.c
+++ b/newlib/libc/ctype/isupper_l.c
@@ -13,7 +13,7 @@ isupper_l (int c, locale_t locale)
     (void) locale;
     return isupper(c);
 #else
-    return (__CTYPE_PTR_L (locale)[c+1] & (_U|_L)) == _U;
+    return (__CTYPE_PTR_L (locale)[c+1] & (__CTYPE_UPPER|__CTYPE_LOWER)) == __CTYPE_UPPER;
 #endif
 }
 

--- a/newlib/libc/ctype/isxdigit.c
+++ b/newlib/libc/ctype/isxdigit.c
@@ -77,6 +77,6 @@ isxdigit (int c)
             ('A' <= c && c <= 'F') ||
             ('a' <= c && c <= 'f'));
 #else
-    return __CTYPE_PTR[c+1] & ((_X)|(_N));
+    return __CTYPE_PTR[c+1] & ((__CTYPE_HEX)|(__CTYPE_DIGIT));
 #endif
 }

--- a/newlib/libc/ctype/isxdigit_l.c
+++ b/newlib/libc/ctype/isxdigit_l.c
@@ -14,7 +14,7 @@ isxdigit_l (int c, locale_t locale)
 #if _PICOLIBC_CTYPE_SMALL
     return isxdigit(c);
 #else
-    return __CTYPE_PTR_L (locale)[c+1] & ((_X)|(_N));
+    return __CTYPE_PTR_L (locale)[c+1] & ((__CTYPE_HEX)|(__CTYPE_DIGIT));
 #endif
 }
 

--- a/newlib/libc/include/ctype.h
+++ b/newlib/libc/include/ctype.h
@@ -225,16 +225,27 @@ extern const short      _ctype_wide[];
 
 #define _ctype_ (_ctype_b + _CTYPE_OFFSET)
 
-#define	_U	0x001    /* upper */
-#define	_L	0x002    /* lower */
-#define	_N	0x004    /* digit */
-#define	_S	0x008    /* space */
-#define _P	0x010    /* punct */
-#define _C	0x020    /* control */
-#define _X	0x040    /* hex */
-#define	_B	0x080    /* blank (but not tab) */
-/* _T used for _ctype_wide table */
-#define _T      0x100    /* tab */
+#define	__CTYPE_UPPER	0x001    /* upper */
+#define	__CTYPE_LOWER	0x002    /* lower */
+#define	__CTYPE_DIGIT	0x004    /* digit */
+#define	__CTYPE_SPACE	0x008    /* space */
+#define __CTYPE_PUNCT	0x010    /* punct */
+#define __CTYPE_CNTRL	0x020    /* control */
+#define __CTYPE_HEX	0x040    /* hex */
+#define	__CTYPE_BLANK	0x080    /* blank (but not tab) */
+#define __CTYPE_TAB     0x100    /* tab (only in wide table) */
+
+#ifdef __cplusplus
+/* We need these legacy symbols to build libstdc++ */
+#define _U __CTYPE_UPPER
+#define _L __CTYPE_LOWER
+#define _N __CTYPE_DIGIT
+#define _S __CTYPE_SPACE
+#define _P __CTYPE_PUNCT
+#define _C __CTYPE_CNTRL
+#define _X __CTYPE_HEX
+#define _B __CTYPE_BLANK
+#endif
 
 #ifdef __MB_EXTENDED_CHARSETS_NON_UNICODE
 const char *__locale_ctype_ptr (void);
@@ -247,21 +258,21 @@ const char *__locale_ctype_ptr (void);
 
 #define __ctype_lookup(__c) (__CTYPE_PTR + 1)[(int) (__c)]
 
-#define	isalpha(__c)	(__ctype_lookup(__c)&(_U|_L))
-#define	isupper(__c)	((__ctype_lookup(__c)&(_U|_L))==_U)
-#define	islower(__c)	((__ctype_lookup(__c)&(_U|_L))==_L)
-#define	isdigit(__c)	(__ctype_lookup(__c)&_N)
-#define	isxdigit(__c)	(__ctype_lookup(__c)&(_X|_N))
-#define	isspace(__c)	(__ctype_lookup(__c)&_S)
-#define ispunct(__c)	(__ctype_lookup(__c)&_P)
-#define isalnum(__c)	(__ctype_lookup(__c)&(_U|_L|_N))
-#define isprint(__c)	(__ctype_lookup(__c)&(_P|_U|_L|_N|_B))
-#define	isgraph(__c)	(__ctype_lookup(__c)&(_P|_U|_L|_N))
-#define iscntrl(__c)	(__ctype_lookup(__c)&_C)
+#define	isalpha(__c)	(__ctype_lookup(__c)&(__CTYPE_UPPER|__CTYPE_LOWER))
+#define	isupper(__c)	((__ctype_lookup(__c)&(__CTYPE_UPPER|__CTYPE_LOWER))==__CTYPE_UPPER)
+#define	islower(__c)	((__ctype_lookup(__c)&(__CTYPE_UPPER|__CTYPE_LOWER))==__CTYPE_LOWER)
+#define	isdigit(__c)	(__ctype_lookup(__c)&__CTYPE_DIGIT)
+#define	isxdigit(__c)	(__ctype_lookup(__c)&(__CTYPE_HEX|__CTYPE_DIGIT))
+#define	isspace(__c)	(__ctype_lookup(__c)&__CTYPE_SPACE)
+#define ispunct(__c)	(__ctype_lookup(__c)&__CTYPE_PUNCT)
+#define isalnum(__c)	(__ctype_lookup(__c)&(__CTYPE_UPPER|__CTYPE_LOWER|__CTYPE_DIGIT))
+#define isprint(__c)	(__ctype_lookup(__c)&(__CTYPE_PUNCT|__CTYPE_UPPER|__CTYPE_LOWER|__CTYPE_DIGIT|__CTYPE_BLANK))
+#define	isgraph(__c)	(__ctype_lookup(__c)&(__CTYPE_PUNCT|__CTYPE_UPPER|__CTYPE_LOWER|__CTYPE_DIGIT))
+#define iscntrl(__c)	(__ctype_lookup(__c)&__CTYPE_CNTRL)
 
 #if __ISO_C_VISIBLE >= 1999 && defined(__declare_extern_inline)
 __declare_extern_inline(int) isblank(int c) {
-    return c == '\t' || __ctype_lookup(c) & _B;
+    return c == '\t' || __ctype_lookup(c) & __CTYPE_BLANK;
 }
 #endif
 
@@ -276,21 +287,21 @@ const char *__locale_ctype_ptr_l (locale_t);
 
 #define __ctype_lookup_l(__c, __l) ((__CTYPE_PTR_L(__l)+1)[(int)(__c)])
 
-#define	isalpha_l(__c,__l)	(__ctype_lookup_l(__c,__l)&(_U|_L))
-#define	isupper_l(__c,__l)	((__ctype_lookup_l(__c,__l)&(_U|_L))==_U)
-#define	islower_l(__c,__l)	((__ctype_lookup_l(__c,__l)&(_U|_L))==_L)
-#define	isdigit_l(__c,__l)	(__ctype_lookup_l(__c,__l)&_N)
-#define	isxdigit_l(__c,__l)	(__ctype_lookup_l(__c,__l)&(_X|_N))
-#define	isspace_l(__c,__l)	(__ctype_lookup_l(__c,__l)&_S)
-#define ispunct_l(__c,__l)	(__ctype_lookup_l(__c,__l)&_P)
-#define isalnum_l(__c,__l)	(__ctype_lookup_l(__c,__l)&(_U|_L|_N))
-#define isprint_l(__c,__l)	(__ctype_lookup_l(__c,__l)&(_P|_U|_L|_N|_B))
-#define	isgraph_l(__c,__l)	(__ctype_lookup_l(__c,__l)&(_P|_U|_L|_N))
-#define iscntrl_l(__c,__l)	(__ctype_lookup_l(__c,__l)&_C)
+#define	isalpha_l(__c,__l)	(__ctype_lookup_l(__c,__l)&(__CTYPE_UPPER|__CTYPE_LOWER))
+#define	isupper_l(__c,__l)	((__ctype_lookup_l(__c,__l)&(__CTYPE_UPPER|__CTYPE_LOWER))==__CTYPE_UPPER)
+#define	islower_l(__c,__l)	((__ctype_lookup_l(__c,__l)&(__CTYPE_UPPER|__CTYPE_LOWER))==__CTYPE_LOWER)
+#define	isdigit_l(__c,__l)	(__ctype_lookup_l(__c,__l)&__CTYPE_DIGIT)
+#define	isxdigit_l(__c,__l)	(__ctype_lookup_l(__c,__l)&(__CTYPE_HEX|__CTYPE_DIGIT))
+#define	isspace_l(__c,__l)	(__ctype_lookup_l(__c,__l)&__CTYPE_SPACE)
+#define ispunct_l(__c,__l)	(__ctype_lookup_l(__c,__l)&__CTYPE_PUNCT)
+#define isalnum_l(__c,__l)	(__ctype_lookup_l(__c,__l)&(__CTYPE_UPPER|__CTYPE_LOWER|__CTYPE_DIGIT))
+#define isprint_l(__c,__l)	(__ctype_lookup_l(__c,__l)&(__CTYPE_PUNCT|__CTYPE_UPPER|__CTYPE_LOWER|__CTYPE_DIGIT|__CTYPE_BLANK))
+#define	isgraph_l(__c,__l)	(__ctype_lookup_l(__c,__l)&(__CTYPE_PUNCT|__CTYPE_UPPER|__CTYPE_LOWER|__CTYPE_DIGIT))
+#define iscntrl_l(__c,__l)	(__ctype_lookup_l(__c,__l)&__CTYPE_CNTRL)
 
 #ifdef __declare_extern_inline
 __declare_extern_inline(int) isblank_l(int c, locale_t l) {
-    return c == '\t' || (__ctype_lookup_l(c, l) & _B);
+    return c == '\t' || (__ctype_lookup_l(c, l) & __CTYPE_BLANK);
 }
 #endif
 


### PR DESCRIPTION
Using _U et al makes these symbols far more likely to collide with application usage. Avoid that by making the names all start with __CTYPE along with a longer description of their function.

To avoid breaking libstdc++, expose the old symbols for C++. As that didn't used to include the tab bit, don't include it now.