### PR TITLE
stdlib: use unsigned arithmetic in rand() to fix overflow

### DIFF
--- a/newlib/libc/stdlib/random.c
+++ b/newlib/libc/stdlib/random.c
@@ -54,8 +54,9 @@ algorithm as <<rand>>.
 
 #define _DEFAULT_SOURCE
 #include <stdlib.h>
+#include <stdint.h>
 
-__THREAD_LOCAL long long _rand_next = 1;
+__THREAD_LOCAL uint64_t _rand_next = 1;
 
 long int
 random (void)
@@ -63,6 +64,6 @@ random (void)
   /* This multiplier was obtained from Knuth, D.E., "The Art of
      Computer Programming," Vol 2, Seminumerical Algorithms, Third
      Edition, Addison-Wesley, 1998, p. 106 (line 26) & p. 108 */
-  _rand_next = _rand_next * __extension__ 6364136223846793005LL + 1;
+  _rand_next = _rand_next * 6364136223846793005ULL + 1;
   return (long int)((_rand_next >> 32) & RAND_MAX);
 }


### PR DESCRIPTION
Closes #988

I checked newlib's source code and found that they use `unsigned long long`, which is what I changed the previous `long long` to here.
