### PR TITLE
machine/riscv: Support compilers without riscv_bitmanip.h

### DIFF
--- a/newlib/libc/machine/riscv/rv_string.h
+++ b/newlib/libc/machine/riscv/rv_string.h
@@ -17,24 +17,34 @@
 #include "xlenint.h"
 
 #if __riscv_zbb
-  #include <riscv_bitmanip.h>
-
   // Determine which intrinsics to use based on XLEN and endianness
   #if __riscv_xlen == 64
-    #define __LIBC_RISCV_ZBB_ORC_B(x)       __riscv_orc_b_64(x)
+    #if __has_builtin(__builtin_riscv_orc_b_64)
+      #define __LIBC_RISCV_ZBB_ORC_B(x)       __builtin_riscv_orc_b_64 (x)
+    #endif
 
     #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-      #define __LIBC_RISCV_ZBB_CNT_Z(x)     __riscv_ctz_64(x)
+      #if __has_builtin(__builtin_riscv_ctz_64)
+        #define __LIBC_RISCV_ZBB_CNT_Z(x)     __builtin_riscv_ctz_64(x)
+      #endif
     #else
-      #define __LIBC_RISCV_ZBB_CNT_Z(x)     __riscv_clz_64(x)
+      #if __has_builtin(__builtin_riscv_clz_64)
+        #define __LIBC_RISCV_ZBB_CNT_Z(x)     __builtin_riscv_clz_64(x)
+      #endif
     #endif
   #else
-    #define __LIBC_RISCV_ZBB_ORC_B(x)       __riscv_orc_b_32(x)
+    #if __has_builtin(__builtin_riscv_orc_b_32)
+      #define __LIBC_RISCV_ZBB_ORC_B(x)       __builtin_riscv_orc_b_32(x)
+    #endif
 
     #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-      #define __LIBC_RISCV_ZBB_CNT_Z(x)     __riscv_ctz_32(x)
+      #if __has_builtin(__builtin_riscv_ctz_32)
+        #define __LIBC_RISCV_ZBB_CNT_Z(x)     __builtin_riscv_ctz_32(x)
+      #endif
     #else
-      #define __LIBC_RISCV_ZBB_CNT_Z(x)     __riscv_clz_32(x)
+      #if __has_builtin(__builtin_riscv_clz_32)
+        #define __LIBC_RISCV_ZBB_CNT_Z(x)     __builtin_riscv_clz_32(x)
+      #endif
     #endif
   #endif
 #endif
@@ -42,7 +52,7 @@
 
 static __inline uintxlen_t __libc_detect_null(uintxlen_t w)
 {
-#if __riscv_zbb
+#ifdef __LIBC_RISCV_ZBB_ORC_B
   /*
     If there are any zeros in each byte of the register, all bits will
     be unset for that byte value, otherwise, all bits will be set.

--- a/newlib/libc/machine/riscv/strlen.c
+++ b/newlib/libc/machine/riscv/strlen.c
@@ -42,7 +42,7 @@ size_t strlen(const char *str)
   str = (const char *)ps;
   size_t ret = str - start, sp = sizeof (*ps);
 
-  #if __riscv_zbb
+  #if defined(__LIBC_RISCV_ZBB_ORC_B) && defined(__LIBC_RISCV_ZBB_CNT_Z)
     psval = ~__LIBC_RISCV_ZBB_ORC_B(psval);
     psval = __LIBC_RISCV_ZBB_CNT_Z(psval);
 


### PR DESCRIPTION
This header just wraps builtins in inline functions, so instead of relying on it at all, just use the builtins directly. To deal with compilers that might not have them, use __has_builtin.

This avoids any compiler version checks.