### PR TITLE
Semihost: open sys call doesn't handle "rb+" mode

### DIFF
--- a/semihost/open.c
+++ b/semihost/open.c
@@ -69,8 +69,10 @@ open(const char *pathname, int flags, ...)
 	default:
 		if (flags & O_TRUNC)
 			semiflags = SH_OPEN_W_PLUS_B;	/* 'wb+' */
-		else
+		else if (flags & O_APPEND)
 			semiflags = SH_OPEN_A_PLUS_B;	/* 'ab+' */
+		else
+			semiflags = SH_OPEN_R_PLUS_B;	/* 'rb+' */
 		break;
 	}
 


### PR DESCRIPTION
### According to the ISO/IEC_9899_1999, section:7.19.5.3

- Opening file with read mode ('r' as the first character in the mode argument) fails if the file does not exist.
In case of `r+`, `r+b`, `rb+` Semihost system call "open" implemented in `open.c` does not handle those update modes ("+" is update mode) only handles `wb+` and `ab+` which results in 2 issues:
1. Opening a non-existing file using mentioned modes creates the file which is not the correct behavior according to the standard.
2. Opening a file using the mentioned modes then write into it, it appends as it is `ab+` mode because it is the "else" case.

### Test Case (Reproduces the Issue)
```c
#include <stdio.h>
#include <stdlib.h>

int main() {
    // Open a non-existent file to update (read+write), should fail according to ISO C
    FILE *res = fopen("this_file_does_not_exist.dat", "rb+");

    if (res == NULL) {
        printf("[PASS] fopen() failed as expected for non-existent file\n");
    } else {
        printf("[FAIL] fopen() unexpectedly succeeded (file should not be created)\n");
        fclose(res);
        return 1;
    }

    return 0;
}

```
This test fails before the fix and passes after the fix — verifying that `fopen("rb+")` does not create a file if it does not exist, as per the ISO standard.
