### PR TITLE
stdio: Make legacy nano printf code at least compile

### DIFF
--- a/newlib/libc/stdio/nano-vfprintf.c
+++ b/newlib/libc/stdio/nano-vfprintf.c
@@ -617,7 +617,7 @@ VFPRINTF (
 	      n = 0;
 	    }
 	  else
-            n = _printf_float (data, &prt_data, fp, pfunc, &ap_copy);
+            n = _printf_float (&prt_data, fp, pfunc, &ap_copy);
 	}
       else
 #endif

--- a/newlib/libc/stdio/nano-vfprintf_float.c
+++ b/newlib/libc/stdio/nano-vfprintf_float.c
@@ -63,13 +63,14 @@ int __exponent (char *p0, int exp, int fmtch);
    [aAeEfFgG]; if it is [aA], then the return string lives in BUF,
    otherwise the return value shares the mprec reentrant storage.  */
 char *
-__cvt (struct _reent *data, _PRINTF_FLOAT_TYPE value, int ndigits, int flags,
+__cvt (_PRINTF_FLOAT_TYPE value, int ndigits, int flags,
        char *sign, int *decpt, int ch, int *length, char *buf)
 {
   int mode, dsgn;
   char *digits, *bp, *rve;
   union double_union tmp;
 
+  (void) buf;
   tmp.d = value;
   /* This will check for "< 0" and "-0.0".  */
   if (word0 (tmp) & Sign_bit)
@@ -160,10 +161,9 @@ __exponent (char *p0, int exp, int fmtch)
 
 /* Decode and print floating point number specified by "eEfgG".  */
 int
-_printf_float (struct _reent *data,
-	       struct _prt_data_t *pdata,
+_printf_float (struct _prt_data_t *pdata,
 	       FILE * fp,
-	       int (*pfunc) (struct _reent *, FILE *, const char *,
+	       int (*pfunc) (FILE *, const char *,
 			     size_t len), va_list * ap)
 {
 #define _fpvalue (pdata->_double_)
@@ -178,8 +178,7 @@ _printf_float (struct _reent *data,
   int expsize = 0;
   /* Actual number of digits returned by cvt.  */
   int ndig = 0;
-  char *cp;
-  int n;
+  char *cp = NULL;
   /* Field size expanded by dprec(not for _printf_float).  */
   int realsz;
   char code = pdata->code;
@@ -234,7 +233,7 @@ _printf_float (struct _reent *data,
 
   pdata->flags |= FPT;
 
-  cp = __cvt (data, _fpvalue, pdata->prec, pdata->flags, &softsign,
+  cp = __cvt (_fpvalue, pdata->prec, pdata->flags, &softsign,
 	      &expt, code, &ndig, cp);
 
   if (code == 'g' || code == 'G')
@@ -285,7 +284,7 @@ _printf_float (struct _reent *data,
   if (softsign)
     pdata->l_buf[0] = '-';
 print_float:
-  if (_printf_common (data, pdata, &realsz, fp, pfunc) == -1)
+  if (_printf_common (pdata, &realsz, fp, pfunc) == -1)
     goto error;
 
   if ((pdata->flags & FPT) == 0)

--- a/newlib/libc/stdio/nano-vfscanf.c
+++ b/newlib/libc/stdio/nano-vfscanf.c
@@ -397,7 +397,7 @@ _SVFSCANF (
 	ret = _scanf_i (&scan_data, fp, &ap_copy);
 #ifdef __IO_FLOATING_POINT
       else if (_scanf_float)
-	ret = _scanf_float (rptr, &scan_data, fp, &ap_copy);
+	ret = _scanf_float (&scan_data, fp, &ap_copy);
 #endif
 
       if (ret == MATCH_FAILURE)

--- a/newlib/libc/stdio/nano-vfscanf_float.c
+++ b/newlib/libc/stdio/nano-vfscanf_float.c
@@ -32,8 +32,7 @@
 
 #ifdef __IO_FLOATING_POINT
 int
-_scanf_float (struct _reent *rptr,
-	      struct _scan_data_t *pdata,
+_scanf_float (struct _scan_data_t *pdata,
 	      FILE *fp, va_list *ap)
 {
   int c;
@@ -84,7 +83,7 @@ _scanf_float (struct _reent *rptr,
 		}
 	      goto fskip;
 	    }
-	/* Fall through.  */
+          __fallthrough;
 	case '1':
 	case '2':
 	case '3':
@@ -212,7 +211,7 @@ fskip:
       ++pdata->nread;
       if (--fp->_r > 0)
 	fp->_p++;
-      else if (pdata->pfn_refill (rptr, fp))
+      else if (pdata->pfn_refill (fp))
 	/* "EOF".  */
 	break;
     }
@@ -234,7 +233,7 @@ fskip:
 	 guarantee that in all implementations of ungetc.  */
       while (p > pdata->buf)
 	{
-	  pdata->pfn_ungetc (rptr, *--p, fp); /* "[-+nNaA]".  */
+	  pdata->pfn_ungetc (*--p, fp); /* "[-+nNaA]".  */
 	  --pdata->nread;
 	}
       return MATCH_FAILURE;
@@ -248,14 +247,14 @@ fskip:
       if (infcount >= 3) /* valid 'inf', but short of 'infinity'.  */
 	while (infcount-- > 3)
 	  {
-	    pdata->pfn_ungetc (rptr, *--p, fp); /* "[iInNtT]".  */
+	    pdata->pfn_ungetc (*--p, fp); /* "[iInNtT]".  */
 	    --pdata->nread;
 	  }
       else
         {
 	  while (p > pdata->buf)
 	    {
-	      pdata->pfn_ungetc (rptr, *--p, fp); /* "[-+iInN]".  */
+	      pdata->pfn_ungetc (*--p, fp); /* "[-+iInN]".  */
 	      --pdata->nread;
 	    }
 	  return MATCH_FAILURE;
@@ -271,7 +270,7 @@ fskip:
 	  /* No digits at all.  */
 	  while (p > pdata->buf)
 	    {
-	      pdata->pfn_ungetc (rptr, *--p, fp); /* "[-+.]".  */
+	      pdata->pfn_ungetc (*--p, fp); /* "[-+.]".  */
 	      --pdata->nread;
 	    }
 	  return MATCH_FAILURE;
@@ -281,11 +280,11 @@ fskip:
       --pdata->nread;
       if (c != 'e' && c != 'E')
 	{
-	  pdata->pfn_ungetc (rptr, c, fp); /* "[-+]".  */
+	  pdata->pfn_ungetc (c, fp); /* "[-+]".  */
 	  c = *--p;
 	  --pdata->nread;
 	}
-      pdata->pfn_ungetc (rptr, c, fp); /* "[eE]".  */
+      pdata->pfn_ungetc (c, fp); /* "[eE]".  */
     }
   if ((pdata->flags & SUPPRESS) == 0)
     {

--- a/newlib/libc/stdio/stdio.h
+++ b/newlib/libc/stdio/stdio.h
@@ -446,7 +446,7 @@ int	siprintf (char *, const char *, ...)
                __picolibc_format(__printf__, 2, 3) __nothrow;
 #define __i_sprintf siprintf
 int	siscanf (const char *, const char *, ...)
-               __picolibc_format(__scanf__,  2, 3);
+               __picolibc_format(__scanf__,  2, 3) __nothrow;
 int	sniprintf (char *, size_t, const char *, ...)
                __picolibc_format(__printf__, 3, 4) __nothrow;
 #define  __i_snprintf sniprintf
@@ -467,9 +467,9 @@ int	viprintf (const char *, va_list)
 int	viscanf (const char *, va_list)
                __picolibc_format(__scanf__,  1, 0);
 int	vsiprintf (char *, const char *, va_list)
-               __picolibc_format(__printf__, 2, 0);
+               __picolibc_format(__printf__, 2, 0) __nothrow;
 int	vsiscanf (const char *, const char *, va_list)
-               __picolibc_format(__scanf__,  2, 0);
+               __picolibc_format(__scanf__,  2, 0) __nothrow;
 int	vsniprintf (char *, size_t, const char *, va_list)
                __picolibc_format(__printf__, 3, 0) __nothrow;
 #endif /* __MISC_VISIBLE */


### PR DESCRIPTION
Remove 'struct _reent' dregs. Add __nothrow as needed to stdio.h. Clean up some simple compiler warnings about undefined behavior.

There are many gaps in standards conformance with this; making it pass the test suite would be a significant effort. But, at least it builds again.