### PR TITLE
math: add faster soft float sqrtf implementation, add rsqrtf

### DIFF
--- a/newlib/libc/include/math.h
+++ b/newlib/libc/include/math.h
@@ -513,6 +513,9 @@ extern float logf (float);
 extern float log10f (float);
 extern float powf (float, float);
 extern float sqrtf (float);
+#if !(__ARM_FP & 0x4) 
+extern float rsqrtf (float);
+#endif
 extern float fmodf (float, float);
 
 /* Other single precision functions.  */

--- a/newlib/libm/machine/arm/Csqrt.c
+++ b/newlib/libm/machine/arm/Csqrt.c
@@ -1,0 +1,235 @@
+//Copyright (C) 2025 Dominik Kurz
+
+//This program is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 3 of the License, or (at your option) any later version.
+
+//This program is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+
+//You should have received a copy of the GNU Lesser General Public License
+//along with this program; if not, write to the Free Software Foundation,
+//Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+#include <stdint.h>
+#define QUIET_NAN ((255 << 23) | ((1 << 22) | 1))
+#define INF (0xFF << 23)
+#define NEGATIVE_INF (1u<<31)|(0xFF << 23)
+
+# define likely(x) __builtin_expect (!!(x), 1)
+# define unlikely(x) __builtin_expect ((x), 0)
+
+uint32_t __mantissa_sqrt_asm(uint32_t x);
+uint32_t __mantissa_rsqrt_asm(uint32_t x);
+
+#if  !defined(__ARM_ARCH) || defined(__OPTIMIZE_SIZE__)
+static uint32_t sqrt_core(uint32_t x, uint32_t y)
+{
+    x<<=6;
+    uint32_t t=x+(x>>1);
+    if (t < (1u<<31)){ //first iteration is special cased
+        t+=t>>1;
+        if (t < (1u<<31)) {
+            x=t;
+            y+=y>>1;
+        }
+    }
+    #ifndef __OPTIMIZE_SIZE__
+    #pragma GCC unroll 12 
+    #endif
+    for (uint32_t i =2; i<14; i+=1){
+        uint32_t t=x+(x>>i);
+        t+=t>>i;
+        if (t < (1u<<31)) {
+            x=t;
+            y+=y>>i;
+        }
+    }
+    uint32_t hi = ((uint64_t)(x)*(y)  )>>32;
+    y+=y>>1; //this can overflow
+    return ((y)-(hi) ); //but then this underflows so they cancel
+}
+
+static uint32_t mantissa_sqrt(uint32_t x)
+{
+    uint32_t new_mantissa=sqrt_core(x,x<<7 )>>8;
+    //we could stop here but we want infinitely precise rounding
+    int64_t msquared=(int64_t)new_mantissa*new_mantissa;
+    int64_t x0=x;
+    x0<<=23;
+    int64_t residual=x0-msquared;
+    if (residual>new_mantissa)
+    {
+            new_mantissa+=1;
+    }  
+    return new_mantissa; 
+}
+
+static uint32_t mantissa_rsqrt(uint32_t x)
+{
+    uint32_t Y=x;
+    uint32_t U=sqrt_core(x,1u<<30 )>>6;
+    //we could return (U+1)>>1 and be 90 % accurate 
+    //but we want infinitely precise rounding
+    U |=1;
+    uint32_t A_hi= ((uint64_t) U*U)>>32;
+    uint32_t A_lo= U*U;
+    uint32_t B_hi = ((uint64_t) Y*A_lo)>>32;
+    uint64_t C= (uint64_t) Y*A_hi;
+    uint64_t S=B_hi+C;
+    uint32_t P=S>>32;
+    uint32_t Q=1u<<(9);
+    if (P >= Q)
+    { 
+       return  U>>1;
+    } else 
+    {
+       return (U+1)>>1;
+    }
+}
+#else
+static inline uint32_t mantissa_sqrt(uint32_t x)
+{
+    return __mantissa_sqrt_asm(x);
+}
+
+static inline uint32_t mantissa_rsqrt(uint32_t x)
+{
+    return __mantissa_rsqrt_asm(x);
+}
+#endif
+
+float sqrtf(float x)
+{
+    union
+    {
+        float f;
+        uint32_t i;
+    } xu;
+    xu.f = x;
+    int32_t exponent= (int32_t )xu.i >>23;
+    // check if exponent is 0
+    if (likely(exponent>0) )
+    {
+        if (unlikely( exponent==255 ) ) //check if negative or NaN
+        {
+            // Expected behavior:
+            // sqrt(-f)=+qNaN, sqrt(-NaN)=+qNaN,sqrt(-Inf)=+qNaN
+            xu.i = (xu.i == INF) ? INF : QUIET_NAN;
+            return xu.f;
+        } else 
+        {
+            uint32_t mantissa = xu.i &~ ((uint32_t)exponent << 23);
+            exponent = exponent - (127);
+            mantissa += 1 << 23; // adds implicit bit to mantissa.
+            mantissa <<= (exponent & 1);
+
+            exponent >>= 1;
+            // This is meant to be a floor division
+            // meaning -1/2= -0.5 should map to -1
+            exponent = (exponent + (126 ));
+
+            uint32_t new_mantissa=mantissa_sqrt(mantissa);
+            xu.i = (exponent<<23) + new_mantissa;
+            return xu.f;
+        }
+    }
+    else
+    {
+        if (likely(exponent == 0))  
+        {   
+            if (likely (xu.i !=0) )
+            {
+
+                uint32_t mantissa = xu.i &~ ((uint32_t)exponent << 23);
+                int32_t shift=__builtin_clz(mantissa)- (31-23);
+                mantissa<<=shift; // normalize subnormal
+                int32_t exponent =  - (126)-shift;
+                mantissa <<= (exponent & 1);
+                uint32_t new_mantissa=mantissa_sqrt(mantissa); 
+
+                exponent >>= 1;
+                exponent = (exponent + (126));
+                xu.i = (exponent<<23) + new_mantissa;
+                return xu.f;            
+            } else //sqrt(+0)=+0
+            {
+                xu.i = 0; 
+                return xu.f;
+            }
+
+        } else if (xu.i == (1u<<31))
+        {
+            xu.i= (1u<<31); //sqrt(-0)=-0
+            return xu.f;             
+        } else {
+            xu.i=QUIET_NAN;  //sqrt(negative)=qNaN
+            return xu.f;        
+        }
+
+    }
+}
+
+float rsqrtf(float x)
+{
+    union
+    {
+        float f;
+        uint32_t i;
+    } xu;
+    xu.f = x;
+    int32_t exp = (int32_t)xu.i >> 23; //must compile to arithmetic shift
+                                       //otherwise undef. behavior
+    if(likely(exp > 0 ))
+    {
+        if(unlikely(exp == 255))
+        {
+            // 1 / sqrt(+Inf) = +0
+            // 1 / sqrt(NaN) = qNaN
+            xu.i = (xu.i == INF) ? 0 : QUIET_NAN;
+            return xu.f;
+        } else //normal case 
+        {
+            uint32_t mantissa = xu.i &~ ((uint32_t)exp << 23);
+            mantissa += 1u << 23;
+            mantissa<<= !(exp & 1) ; 
+            uint32_t newMantissa=mantissa_rsqrt(mantissa);
+            int32_t newExp = -((exp - 127) >> 1) + 127 -2;
+            xu.i = newMantissa + ((uint32_t)newExp << 23);
+            return xu.f;
+        }
+    } else //exp<=0
+    {
+        if(likely(exp == 0 ))
+        {
+            if (likely (xu.i!=0 )) //subnormal
+            {
+                //printf("subnormal branch!\n");
+                uint32_t mantissa = xu.i;
+                int32_t shift=__builtin_clz(mantissa)- (31-23);
+                mantissa<<=shift; // normalize subnormal
+                shift=- 126-shift;
+                mantissa <<= shift & 1 ;
+                int32_t newExp = (-((shift)>>1)) +127-2;
+
+                uint32_t new_mantissa=mantissa_rsqrt(mantissa); 
+                xu.i = new_mantissa + ((uint32_t)newExp << 23);
+                return xu.f;
+            } else //rsqrt(+0)=+INF
+            {
+                xu.i = INF; 
+                return xu.f;
+            }
+        } else if (xu.i == (1u<<31))
+        {
+            xu.i= NEGATIVE_INF; //rsqrt(-0)=-INF
+            return xu.f;             
+        } else {
+            xu.i=QUIET_NAN;  //rsqrt(negative)=qNaN
+            return xu.f;        
+        }
+    }
+}

--- a/newlib/libm/machine/arm/sf_sqrt.c
+++ b/newlib/libm/machine/arm/sf_sqrt.c
@@ -46,5 +46,5 @@ sqrtf(float x)
 }
 
 #else
-#include "../../math/sf_sqrt.c"
+#include "Csqrt.c"
 #endif

--- a/newlib/libm/machine/arm/sqrtcore-small.s
+++ b/newlib/libm/machine/arm/sqrtcore-small.s
@@ -1,0 +1,77 @@
+//Copyright (C) 2025 Dominik Kurz
+
+//This program is free software; you can redistribute it and/or
+//modify it under the terms of the GNU Lesser General Public
+//License as published by the Free Software Foundation; either
+//version 3 of the License, or (at your option) any later version.
+
+//This program is distributed in the hope that it will be useful,
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//Lesser General Public License for more details.
+
+//You should have received a copy of the GNU Lesser General Public License
+//along with this program; if not, write to the Free Software Foundation,
+//Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+.syntax  unified
+.arm
+
+.text
+.balign 4
+.global __mantissa_sqrt_asm
+.type   __mantissa_sqrt_asm, %function
+__mantissa_sqrt_asm:
+    lsl    r1, r0, #7
+    mov    r3, r0
+    mov    r12, lr
+    bl     __sqrt_core_asm
+    lsr    r0, r0, #8
+    lsl    r1, r3, #23
+    umull  lr, r2, r0, r0
+    subs   r1, r1, lr
+    rsc    r2, r2, r3, lsr #9
+    cmp    r0, r1
+    mov    r1, #0
+    sbcs   r1, r1, r2
+    addlt  r0, r0, #1
+    bx     r12
+
+.arm
+.text
+.balign 4
+.global __sqrt_core_asm
+.type   __sqrt_core_asm, %function
+__sqrt_core_asm: 
+    //calculates rsqrt of 9.23 fixed point number in the range [1,4)
+    lsls r0, r0, #7      
+    .irp x,1,2,3,4,5,6,7,8,9,10,11,12,13 //seems to be enough
+    adds   r2,r0,r0,lsr #\x  
+    addscc r2,r2,r2,lsr #\x
+    movcc  r0,r2
+    addcc  r1, r1,r1,lsr #\x
+    .endr 
+    umull  r2,r0, r1, r0
+    adds r1, r1,r1, lsr #1
+    subs r0, r1, r0, lsr #1
+    bx lr
+
+.arm
+.balign    4
+.global __mantissa_rsqrt_asm
+.type   __mantissa_rsqrt_asm, %function
+__mantissa_rsqrt_asm:
+    mov    r12, lr
+    mov    r1, #1073741824
+    mov    r3, r0 
+    bl     __sqrt_core_asm
+    lsr    r1, r0, #6
+    orr    r1, r1, #1
+    umull  r0, lr, r1, r1
+    umull  r2, r0, r3, r0
+    mov    r2, #0
+    umlal  r0, r2, lr, r3
+    cmp    r2, #512
+    addcc  r1, r1, #1
+    lsr    r0, r1, #1
+    bx     r12


### PR DESCRIPTION
I still need to figure out how to run pico-libc's tests, so please don't flog me if you find a bug with it and in particular you'd probably want to add some tests for rsqrtf elsewhere. The pure-C version might also provide a speed benefit on non-arm architectures, but someone should test that more thoroughly to make decisions about when to unroll etc.