### PR TITLE
ctype: Define `_T` for `__CTYPE_TAB` under C++ guard

### DIFF
--- a/newlib/libc/include/ctype.h
+++ b/newlib/libc/include/ctype.h
@@ -245,6 +245,7 @@ extern const short      _ctype_wide[];
 #define _C __CTYPE_CNTRL
 #define _X __CTYPE_HEX
 #define _B __CTYPE_BLANK
+#define _T __CTYPE_TAB
 #endif
 
 #ifdef __MB_EXTENDED_CHARSETS_NON_UNICODE


### PR DESCRIPTION
Add `T` as an alias for `__CTYPE_TAB` in `ctype.h`, similar to the existing legacy definitions (`_U`, `_L`, etc). This is needed to maintain consistency and provide C++ code (e.g., libstdc++) access to the tab classification macro.