### PR TITLE
Fix __INIT_FINI_FUNCS usage and cmake default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,7 @@ set(__IEEEFP_FUNCS 0)
 set(__INIT_FINI_ARRAY 1)
 
 # Support _init() and _fini() functions
-set(__INIT_FINI_FUNCS 1)
+set(__INIT_FINI_FUNCS 0)
 
 # Enable MMU in pico crt startup
 set(__PICOCRT_ENABLE_MMU 1)

--- a/newlib/libc/misc/init.c
+++ b/newlib/libc/misc/init.c
@@ -33,7 +33,7 @@ __libc_init_array (void)
         _init ();
 
     fn = __init_array_start;
-    fn_end = __preinit_array_end;
+    fn_end = __init_array_end;
     while (fn != fn_end)
         (*fn++) ();
 #else


### PR DESCRIPTION
When __INIT_FINI_FUNCS is set, use the correct symbol for the end of the init funcs.

Change cmake default for __INIT_FINI_FUNCS to match meson, which is to disable them.

Closes: #1012 