### PR TITLE
[complex] Fix catan() functions with pure imaginary inputs

### DIFF
--- a/newlib/libm/complex/catan.c
+++ b/newlib/libm/complex/catan.c
@@ -100,8 +100,17 @@ catan(double complex z)
 	x = creal(z);
 	y = cimag(z);
 
-	if ((x == 0.0) && (y > 1.0))
-		goto ovrf;
+        if (x == 0.0) {
+                if (y > 1.0) {
+                        return CMPLX(M_PI_2, 0.5 * log((1.0 + y)/(y - 1.0)));
+                }
+                if (y < -1.0) {
+                        return CMPLX(-M_PI_2, 0.5 * log((1.0 - y)/(-y - 1.0)));
+                }
+                if (fabs(y) <= 1.0) {
+                        return CMPLX(0.0, atanh(y));
+                }
+        }
 
 	x2 = x * x;
 	a = 1.0 - x2 - (y * y);

--- a/newlib/libm/complex/catanf.c
+++ b/newlib/libm/complex/catanf.c
@@ -49,8 +49,17 @@ catanf(float complex z)
 	x = crealf(z);
 	y = cimagf(z);
 
-	if ((x == 0.0f) && (y > 1.0f))
-		goto ovrf;
+	if (x == 0.0f) {
+		if (y > 1.0f) {
+				return CMPLXF((float)M_PI_2, 0.5f * logf((1.0f + y)/(y - 1.0f)));
+		}
+		if (y < -1.0) {
+				return CMPLXF((float)-M_PI_2, 0.5f * logf((1.0f - y)/(-y - 1.0f)));
+		}
+		if (fabsf(y) <= 1.0f) {
+				return CMPLXF(0.0f, atanhf(y));
+		}
+	}
 
 	x2 = x * x;
 	a = 1.0f - x2 - (y * y);

--- a/newlib/libm/complex/catanl.c
+++ b/newlib/libm/complex/catanl.c
@@ -48,8 +48,17 @@ catanl(long double complex z)
 	x = creall(z);
 	y = cimagl(z);
 
-	if ((x == 0.0L) && (y > 1.0L))
-		goto ovrf;
+	if (x == 0.0L) {
+		if (y > 1.0L) {
+			return CMPLXL(_M_PI_2L, 0.5L * logl((1.0L + y)/(y - 1.0L)));
+		}
+		if (y < -1.0L) {
+			return CMPLXL(-_M_PI_2L, 0.5L * logl((1.0L - y)/(-y - 1.0L)));
+		}
+		if (fabsl(y) <= 1.0L) {
+			return CMPLXL(0.0L, atanhl(y));
+		}
+	}
 
 	x2 = x * x;
 	a = 1.0L - x2 - (y * y);


### PR DESCRIPTION
catan() functions needed special case handling for pure imaginary inputs instead of triggering the overflow case when it shouldn't