### PR TITLE
[complex] Fix cacoshf() function for pure real inputs

### DIFF
--- a/newlib/libm/complex/cacoshf.c
+++ b/newlib/libm/complex/cacoshf.c
@@ -33,11 +33,19 @@
  */
 
 #include <complex.h>
+#include <math.h>
 
 float complex
 cacoshf(float complex z)
 {
 	float complex w;
+	float x = crealf(z);
+	float y = cimagf(z);
+
+	if (y == 0.0f && x >= 1.0f) {
+		float w = acoshf(x);
+		return CMPLXF(w, 0.0f);
+	}
 
 #if 0 /* does not give the principal value */
 	w = I * cacosf(z);


### PR DESCRIPTION
Special handling for purely real inputs where x >= 1 to use the real acoshf() function which is more accurate for these cases and use the complex formula for other cases