### PR TITLE
[complex] Modify casin/casinh functions for better accuracy

### DIFF
--- a/newlib/libm/complex/casin.c
+++ b/newlib/libm/complex/casin.c
@@ -85,81 +85,22 @@ __weak_alias(casin, _casin)
 double complex
 casin(double complex z)
 {
-	double complex w;
-	double complex ca, ct, zz, z2;
-	double x, y;
+	double x = creal(z);
+	double y = cimag(z);
+	double complex res;
 
-	x = creal(z);
-	y = cimag(z);
+	if (x == 0.0 && y == 0.0) return z;
 
-#if 0 /* MD: test is incorrect, casin(>1) is defined */
-	if (y == 0.0) {
-		if (fabs(x) > 1.0) {
-			w = M_PI_2 + 0.0 * (double complex) I;
-#if 0
-			mtherr ("casin", DOMAIN);
-#endif
-		} else {
-			w = asin(x) + 0.0 * (double complex) I;
-		}
-		return w;
-	}
-#endif
+        if (isnan(x) || isnan(y)) {
+                if (isinf(x) || isinf(y)) {
+                        return NAN + copysign(INFINITY, y) * I;
+                }
+                return NAN + NAN * I;
+        }
 
-/* Power series expansion */
-/*
-b = cabs(z);
-if( b < 0.125 )
-{
-z2.r = (x - y) * (x + y);
-z2.i = 2.0 * x * y;
+	double complex iz = CMPLX(-y,x);
+	double complex w = casinh(iz);
+	res = cimag(w) - creal(w) * I;
 
-cn = 1.0;
-n = 1.0;
-ca.r = x;
-ca.i = y;
-sum.r = x;
-sum.i = y;
-do
-	{
-	ct.r = z2.r * ca.r  -  z2.i * ca.i;
-	ct.i = z2.r * ca.i  +  z2.i * ca.r;
-	ca.r = ct.r;
-	ca.i = ct.i;
-
-	cn *= n;
-	n += 1.0;
-	cn /= n;
-	n += 1.0;
-	b = cn/n;
-
-	ct.r *= b;
-	ct.i *= b;
-	sum.r += ct.r;
-	sum.i += ct.i;
-	b = fabs(ct.r) + fabs(ct.i);
-	}
-while( b > MACHEP );
-w->r = sum.r;
-w->i = sum.i;
-return;
-}
-*/
-
-
-	ca = x + y * (double complex) I;
-	ct = ca * (double complex) I;
-	/* sqrt( 1 - z*z) */
-	/* cmul( &ca, &ca, &zz ) */
-	/*x * x  -  y * y */
-	zz = (x - y) * (x + y) + (2.0 * x * y) * (double complex) I;
-
-	zz = 1.0 - creal(zz) - cimag(zz) * (double complex) I;
-	z2 = csqrt(zz);
-
-	zz = ct + z2;
-	zz = clog(zz);
-	/* multiply by 1/i = -i */
-	w = zz * (-1.0 * (double complex) I);
-	return w;
+	return res;
 }

--- a/newlib/libm/complex/casinf.c
+++ b/newlib/libm/complex/casinf.c
@@ -42,81 +42,22 @@ __weak_alias(casinf, _casinf)
 float complex
 casinf(float complex z)
 {
-	float complex w;
-	float complex ca, ct, zz, z2;
-	float x, y;
+	float x = crealf(z);
+	float y = cimagf(z);
+	float complex res;
 
-	x = crealf(z);
-	y = cimagf(z);
+	if (x == 0.0f && y == 0.0f) return z;
 
-#if 0 /* MD: test is incorrect, casin(>1) is defined */
-	if (y == 0.0f) {
-		if (fabsf(x) > 1.0) {
-			w = M_PI_2 + 0.0f * I;
-#if 0
-			mtherr ("casin", DOMAIN);
-#endif
-		} else {
-			w = asinf(x) + 0.0f * I;
-		}
-		return w;
-	}
-#endif
+        if (isnanf(x) || isnanf(y)) {
+                if (isinff(x) || isinff(y)) {
+                        return NAN + copysignf(INFINITY, y) * I;
+                }
+                return NAN + NAN * I;
+        }
 
-/* Power series expansion */
-/*
-b = cabsf(z);
-if( b < 0.125 )
-{
-z2.r = (x - y) * (x + y);
-z2.i = 2.0 * x * y;
+	float complex iz = CMPLXF(-y,x);
+	float complex w = casinhf(iz);
+	res = cimagf(w) - crealf(w) * I;
 
-cn = 1.0;
-n = 1.0;
-ca.r = x;
-ca.i = y;
-sum.r = x;
-sum.i = y;
-do
-	{
-	ct.r = z2.r * ca.r  -  z2.i * ca.i;
-	ct.i = z2.r * ca.i  +  z2.i * ca.r;
-	ca.r = ct.r;
-	ca.i = ct.i;
-
-	cn *= n;
-	n += 1.0;
-	cn /= n;
-	n += 1.0;
-	b = cn/n;
-
-	ct.r *= b;
-	ct.i *= b;
-	sum.r += ct.r;
-	sum.i += ct.i;
-	b = fabsf(ct.r) + fabsf(ct.i);
-	}
-while( b > MACHEP );
-w->r = sum.r;
-w->i = sum.i;
-return;
-}
-*/
-
-
-	ca = x + y * I;
-	ct = ca * I;
-	/* sqrt( 1 - z*z) */
-	/* cmul( &ca, &ca, &zz ) */
-	/*x * x  -  y * y */
-	zz = (x - y) * (x + y) + (2.0f * x * y) * I;
-
-	zz = 1.0f - crealf(zz) - cimagf(zz) * I;
-	z2 = csqrtf(zz);
-
-	zz = ct + z2;
-	zz = clogf(zz);
-	/* multiply by 1/i = -i */
-	w = zz * (-1.0f * I);
-	return w;
+	return res;
 }

--- a/newlib/libm/complex/casinh.c
+++ b/newlib/libm/complex/casinh.c
@@ -86,12 +86,62 @@ QUICKREF
 
 
 #include <complex.h>
+#include <math.h>
+#include <float.h>
 
 double complex
 casinh(double complex z)
 {
-	double complex w;
 
-	w = -1.0 * (double complex) I * casin(z * (double complex) I);
-	return w;
+    double x = fabs(creal(z));
+    double y = fabs(cimag(z));
+    double complex res;
+    double complex w;
+
+    const double eps = DBL_EPSILON;
+
+    if (y == 0.0) {
+        if (isnan(x)) {
+            res = NAN + copysign(0.0, cimag(z)) * I;
+        }
+        else if (isinf(x)) {
+            res = x + copysign(0.0, cimag(z)) * I;
+        }
+        else {
+            res = asinh(x) + copysign(0.0, cimag(z)) * I;
+        }
+    }
+    /* Handle large values */
+    else if (x >= 1.0/eps || y >= 1.0/eps) {
+        res = clog(x + y * I);
+        res = creal(res) + M_LN2 + cimag(res) * I;
+
+    }
+
+    /* Case where real part >= 0.5 and imag part very samll */
+    else if (x >= 0.5 && y < eps/8.0) {
+        double s = hypot(1.0, x);
+        res = log(x + s) + atan2(y, s) * I;
+    }
+
+    /* Case Where real part very small and imag part >= 1.5 */
+    else if (x < eps/8.0 && y >= 1.5) {
+        double s = sqrt((y + 1.0) * (y - 1.0));
+        res = log(y + s) + atan2(s, x) * I;
+    }
+
+    else {
+        /* General case */
+        w = (x - y) * (x + y) + 1.0 + (2.0 * x * y) * I;
+        w = csqrt(w);
+
+        w = (x + creal(w)) + (y + cimag(w)) * I;
+        res = clog(w);
+    }
+
+    /* Apply correct signs */
+    res = copysign(creal(res), creal(z)) +
+          copysign(cimag(res), cimag(z)) * I;
+
+    return res;
 }

--- a/newlib/libm/complex/casinhf.c
+++ b/newlib/libm/complex/casinhf.c
@@ -33,12 +33,62 @@
  */
 
 #include <complex.h>
+#include <math.h>
+#include <float.h>
 
 float complex
 casinhf(float complex z)
 {
-	float complex w;
 
-	w = -1.0f * I * casinf(z * I);
-	return w;
+    float x = fabsf(crealf(z));
+    float y = fabsf(cimagf(z));
+    float complex res;
+    float complex w;
+
+    const float eps = FLT_EPSILON;
+
+    if (y == 0.0f) {
+        if (isnanf(x)) {
+            res = NAN + copysignf(0.0, cimagf(z)) * I;
+        }
+        else if (isinff(x)) {
+            res = x + copysignf(0.0, cimagf(z)) * I;
+        }
+        else {
+            res = asinhf(x) + copysignf(0.0, cimagf(z)) * I;
+        }
+    }
+    /* Handle large values */
+    else if (x >= 1.0f/eps || y >= 1.0f/eps) {
+        res = clogf(x + y * I);
+        res = crealf(res) + M_LN2 + cimagf(res) * I;
+
+    }
+
+    /* Case where real part >= 0.5 and imag part very samll */
+    else if (x >= 0.5f && y < eps/8.0f) {
+        float s = hypotf(1.0f, x);
+        res = logf(x + s) + atan2f(y, s) * I;
+    }
+
+    /* Case Where real part very small and imag part >= 1.5 */
+    else if (x < eps/8.0f && y >= 1.5f) {
+        float s = sqrtf((y + 1.0f) * (y - 1.0f));
+        res = logf(y + s) + atan2f(s, x) * I;
+    }
+
+    else {
+        /* General case */
+        w = (x - y) * (x + y) + 1.0f + (2.0f * x * y) * I;
+        w = csqrtf(w);
+
+        w = (x + crealf(w)) + (y + cimagf(w)) * I;
+        res = clogf(w);
+    }
+
+    /* Apply correct signs */
+    res = copysignf(crealf(res), crealf(z)) +
+          copysignf(cimagf(res), cimagf(z)) * I;
+
+    return res;
 }

--- a/newlib/libm/complex/casinl.c
+++ b/newlib/libm/complex/casinl.c
@@ -30,6 +30,7 @@
  */
 
 #include <complex.h>
+#include <math.h>
 
 #ifdef __HAVE_LONG_DOUBLE_MATH
 
@@ -40,83 +41,24 @@ __weak_alias(casinl, _casinl)
 long double complex
 casinl(long double complex z)
 {
-	long double complex w;
-	long double complex ca, ct, zz, z2;
-	long double x, y;
+	long double x = creall(z);
+	long double y = cimagl(z);
+	long double complex res;
 
-	x = creall(z);
-	y = cimagl(z);
+	if (x == 0.0L && y == 0.0L) return z;
 
-#if 0 /* MD: test is incorrect, casin(>1) is defined */
-	if (y == 0.0L) {
-		if (fabsl(x) > 1.0L) {
-			w = M_PI_2L + 0.0L * (double complex) I;
-#if 0
-			mtherr ("casinl", DOMAIN);
-#endif
-		} else {
-			w = asinl(x) + 0.0L * (double complex) I;
-		}
-		return w;
-	}
-#endif
+        if (isnanl(x) || isnanl(y)) {
+                if (isinfl(x) || isinfl(y)) {
+                        return NAN + copysignl(INFINITY, y) * I;
+                }
+                return NAN + NAN * I;
+        }
 
-/* Power series expansion */
-/*
-b = cabsl(z);
-if( b < 0.125L )
-{
-z2.r = (x - y) * (x + y);
-z2.i = 2.0L * x * y;
+	long double complex iz = CMPLXL(-y,x);
+	long double complex w = casinhl(iz);
+	res = cimagl(w) - creall(w) * I;
 
-cn = 1.0L;
-n = 1.0L;
-ca.r = x;
-ca.i = y;
-sum.r = x;
-sum.i = y;
-do
-	{
-	ct.r = z2.r * ca.r  -  z2.i * ca.i;
-	ct.i = z2.r * ca.i  +  z2.i * ca.r;
-	ca.r = ct.r;
-	ca.i = ct.i;
-
-	cn *= n;
-	n += 1.0;
-	cn /= n;
-	n += 1.0;
-	b = cn/n;
-
-	ct.r *= b;
-	ct.i *= b;
-	sum.r += ct.r;
-	sum.i += ct.i;
-	b = fabsl(ct.r) + fabsl(ct.i);
-	}
-while( b > MACHEPL );
-w->r = sum.r;
-w->i = sum.i;
-return;
-}
-*/
-
-
-	ca = x + y * (long double complex) I;
-	ct = ca * (long double complex) I;
-	/* sqrtl( 1 - z*z) */
-	/* cmull( &ca, &ca, &zz ) */
-	/*x * x  -  y * y */
-	zz = (x - y) * (x + y) + (2.0L * x * y) * (long double complex) I;
-
-	zz = 1.0L - creall(zz) - cimagl(zz) * (long double complex) I;
-	z2 = csqrtl(zz);
-
-	zz = ct + z2;
-	zz = clogl(zz);
-	/* multiply by 1/i = -i */
-	w = zz * (-1.0L * (long double complex) I);
-	return w;
+	return res;
 }
 
 #endif


### PR DESCRIPTION
re-implement casin/casinh functions to match the standard relationship between these functions which is casin(z) = -i * casinh(i*z) this is numerically more stable with less cancelation errors avoiding the direct sqrt(1 - z^2) problematic calculation leading to more accurate results.