### PR TITLE
machine/arm: Disable exception tables in ARM string asm code

### DIFF
--- a/newlib/libc/machine/arm/arm_asm.h
+++ b/newlib/libc/machine/arm/arm_asm.h
@@ -151,6 +151,28 @@
 *
 ******************************************************************************/
 
+
+/* Don't emit unwind or exception table entries */
+
+        .macro fnstart
+#ifdef __INCLUDE_EXIDX
+        .fnstart
+#endif
+        .endm
+
+        .macro cantunwind
+#ifdef __INCLUDE_EXIDX
+        .cantunwind
+#endif
+        .endm
+
+        .macro fnend
+#ifdef __INCLUDE_EXIDX
+        .fnend
+#endif
+        .endm
+
+
 /* Emit .cfi_restore directives for a consecutive sequence of registers.  */
 	.macro cfirestorelist first, last
 	.cfi_restore \last

--- a/newlib/libc/machine/arm/memchr.S
+++ b/newlib/libc/machine/arm/memchr.S
@@ -293,7 +293,7 @@ memchr:
 	.p2align 4,,15
 	.global memchr
 	.type memchr,%function
-	.fnstart
+	fnstart
 	.cfi_sections .debug_frame
 	.cfi_startproc
 memchr:
@@ -419,8 +419,8 @@ memchr:
 	subs	r0,r0,#1
 	epilogue
 	.cfi_endproc
-	.cantunwind
-	.fnend
+	cantunwind
+	fnend
 #else
   /* Defined in memchr.c.  */
 #endif

--- a/newlib/libc/machine/arm/memcpy-armv7m.S
+++ b/newlib/libc/machine/arm/memcpy-armv7m.S
@@ -89,7 +89,7 @@
 	.global	memcpy
 	.thumb
 	.thumb_func
-	.fnstart
+	fnstart
 	.cfi_sections .debug_frame
 	.cfi_startproc
 	.type	memcpy, %function
@@ -345,6 +345,6 @@ memcpy:
 	epilogue 0 push_ip=HAVE_PAC_LEAF
 #endif /* __ARM_FEATURE_UNALIGNED */
 	.cfi_endproc
-	.cantunwind
-	.fnend
+	cantunwind
+	fnend
 	.size	memcpy, .-memcpy

--- a/newlib/libc/machine/arm/memset-thumb.S
+++ b/newlib/libc/machine/arm/memset-thumb.S
@@ -36,7 +36,7 @@
 	.type	memset, %function
 	.p2align 1
 memset:
-	.fnstart
+	fnstart
 	.cfi_sections .debug_frame
 	.cfi_startproc
 	prologue 4 6 push_ip=HAVE_PAC_LEAF
@@ -125,6 +125,6 @@ memset:
 	movs	r4, r2
 	b	3b
 	.cfi_endproc
-	.cantunwind
-	.fnend
+	cantunwind
+	fnend
 	.size memset, . - memset

--- a/newlib/libc/machine/arm/memset-thumb2.S
+++ b/newlib/libc/machine/arm/memset-thumb2.S
@@ -36,7 +36,7 @@
 	.type	memset, %function
 	.p2align 1
 memset:
-	.fnstart
+	fnstart
 	.cfi_sections .debug_frame
 	.cfi_startproc
 	prologue 4 6 push_ip=HAVE_PAC_LEAF
@@ -112,8 +112,8 @@ memset:
 	mov	r3, r0
 	b	3b
 	.cfi_endproc
-	.cantunwind
-	.fnend
+	cantunwind
+	fnend
 	.size memset, . - memset
 
 #if defined(__linux__) && defined(__ELF__)

--- a/newlib/libc/machine/arm/strcmp-arm-tiny.S
+++ b/newlib/libc/machine/arm/strcmp-arm-tiny.S
@@ -35,7 +35,7 @@
 
 	.syntax unified
 def_fn strcmp
-	.fnstart
+	fnstart
 	.cfi_sections .debug_frame
 	.cfi_startproc
 	prologue
@@ -50,6 +50,6 @@ def_fn strcmp
 	subs	r0, r2, r3
 	epilogue
 	.cfi_endproc
-	.cantunwind
-	.fnend
+	cantunwind
+	fnend
 	.size	strcmp, . - strcmp

--- a/newlib/libc/machine/arm/strcmp-armv7.S
+++ b/newlib/libc/machine/arm/strcmp-armv7.S
@@ -127,7 +127,7 @@
 	.text
 	.p2align	5
 def_fn	strcmp
-	.fnstart
+	fnstart
 	.cfi_sections .debug_frame
 	.cfi_startproc
 	prologue push_ip=HAVE_PAC_LEAF
@@ -479,6 +479,6 @@ def_fn	strcmp
 	sub	result, result, data2, lsr #24
 	epilogue push_ip=HAVE_PAC_LEAF
 	.cfi_endproc
-	.cantunwind
-	.fnend
+	cantunwind
+	fnend
 	.size strcmp, . - strcmp

--- a/newlib/libc/machine/arm/strcmp-armv7m.S
+++ b/newlib/libc/machine/arm/strcmp-armv7m.S
@@ -48,7 +48,7 @@
 	.thumb
 	.syntax unified
 def_fn strcmp
-	.fnstart
+	fnstart
 	.cfi_sections .debug_frame
 	.cfi_startproc
 	prologue push_ip=HAVE_PAC_LEAF
@@ -385,6 +385,6 @@ def_fn strcmp
 	.cfi_adjust_cfa_offset -4
 	epilogue push_ip=HAVE_PAC_LEAF
 	.cfi_endproc
-	.cantunwind
-	.fnend
+	cantunwind
+	fnend
 	.size strcmp, . - strcmp

--- a/newlib/libc/machine/arm/strcpy.S
+++ b/newlib/libc/machine/arm/strcpy.S
@@ -46,7 +46,7 @@
 	.global strcpy
 	.type strcpy, %function
 strcpy:
-	.fnstart
+	fnstart
 	.cfi_sections .debug_frame
 	.cfi_startproc
 	prologue push_ip=HAVE_PAC_LEAF
@@ -180,8 +180,8 @@ strcpy:
 #endif
 	epilogue push_ip=HAVE_PAC_LEAF
 	.cfi_endproc
-	.cantunwind
-	.fnend
+	cantunwind
+	fnend
 	.size strcpy, . - strcpy
 
 #if defined(__linux__) && defined(__ELF__)

--- a/newlib/libc/machine/arm/strlen-armv7.S
+++ b/newlib/libc/machine/arm/strlen-armv7.S
@@ -106,7 +106,7 @@
 #define tmp2		r5
 
 def_fn	strlen p2align=6
-	.fnstart
+	fnstart
 	.cfi_sections .debug_frame
 	.cfi_startproc
 	prologue 4 5 push_ip=HAVE_PAC_LEAF
@@ -188,8 +188,8 @@ def_fn	strlen p2align=6
 	mov	const_0, #0
 	b	.Lstart_realigned
 	.cfi_endproc
-	.cantunwind
-	.fnend
+	cantunwind
+	fnend
 	.size	strlen, . - strlen
 
 #if defined(__linux__) && defined(__ELF__)

--- a/newlib/libc/machine/arm/strlen-thumb2-Os.S
+++ b/newlib/libc/machine/arm/strlen-thumb2-Os.S
@@ -47,7 +47,7 @@
 	.syntax unified
 
 def_fn	strlen p2align=1
-	.fnstart
+	fnstart
 	.cfi_sections .debug_frame
 	.cfi_startproc
 	prologue
@@ -59,8 +59,8 @@ def_fn	strlen p2align=1
 	subs    r0, #1
 	epilogue
 	.cfi_endproc
-	.cantunwind
-	.fnend
+	cantunwind
+	fnend
 	.size	strlen, . - strlen
 
 #if defined(__linux__) && defined(__ELF__)


### PR DESCRIPTION
A bunch of arm string code was generating exception table information even though they are all leaf functions and raise no exceptions. Disable these by creating empty macros in case they need to be re-enable in the future.

Fixes issue identified in #1024 