### PR TITLE
include: Move use of _intsup.h from stdint.h to inttypes.h

### DIFF
--- a/newlib/libc/include/inttypes.h
+++ b/newlib/libc/include/inttypes.h
@@ -15,6 +15,7 @@
 
 #include <sys/cdefs.h>
 #include <stdint.h>
+#include <sys/_intsup.h>
 
 _BEGIN_STD_C
 

--- a/newlib/libc/include/stdint.h
+++ b/newlib/libc/include/stdint.h
@@ -11,8 +11,8 @@
 
 #include <sys/cdefs.h>
 #include <machine/_default_types.h>
-#include <sys/_intsup.h>
 #include <sys/_stdint.h>
+#include <sys/_intsup.h>
 
 _BEGIN_STD_C
 


### PR DESCRIPTION
The values computed in _intsup.h are only used in inttypes.h, so move the include of that file from stdint.h to inttypes.h. This fixes gcc installations which override our stdint.h with the gcc version that doesn't include this file.