### PR TITLE
scripts: Modify run-riscv script to get elf filename error

### DIFF
--- a/scripts/run-riscv
+++ b/scripts/run-riscv
@@ -119,7 +119,7 @@ chardev=stdio,mux=on,id=stdio0
 
 # Point the semihosting driver at our new chardev
 
-cmdline="program-name"
+cmdline="$elf" 
 input=""
 done=0
 


### PR DESCRIPTION
The default name of “cmdline” is “program-name”, which does not show the correct elf file name.

expect
```
 ./scripts/run-riscv  a.out 1 2 3
argc = 4
argv =  a.out 2 2 3 
```
in fact
```
 ./scripts/run-riscv  a.out 1 2 3
argc = 4
argv = program-name 2 2 3 
```
