### PR TITLE
stdlib: Add enable-malloc/ENABLE_MALLOC config option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,11 @@ if(NOT DEFINED __THREAD_LOCAL_STORAGE_STACK_GUARD)
   option(__THREAD_LOCAL_STORAGE_STACK_GUARD "use thread local storage for stack protection canary" OFF)
 endif()
 
+# enable malloc code
+if(NOT DEFINED ENABLE_MALLOC)
+  option(ENABLE_MALLOC "provide malloc family of functions based on sbrk" ON)
+endif()
+
 option(POSIX_CONSOLE "Use POSIX I/O for stdin/stdout/stderr" OFF)
 
 # Optimize for space over speed

--- a/meson.build
+++ b/meson.build
@@ -162,6 +162,7 @@ else
 endif
 
 newlib_atexit_dynamic_alloc = get_option('newlib-atexit-dynamic-alloc')
+enable_malloc = get_option('enable-malloc')
 newlib_nano_malloc = get_option('newlib-nano-malloc')
 nano_malloc_clear_freed = get_option('nano-malloc-clear-freed')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -232,6 +232,8 @@ option('newlib-register-fini', type: 'boolean', value: false,
 # Malloc options
 #
 
+option('enable-malloc', type: 'boolean', value: true,
+       description: 'provide malloc family of functions based on sbrk')
 option('newlib-nano-malloc', type: 'boolean', value: true,
        description: 'use small-footprint nano-malloc implementation')
 option('nano-malloc-clear-freed', type: 'boolean', value: false,

--- a/newlib/libc/stdlib/CMakeLists.txt
+++ b/newlib/libc/stdlib/CMakeLists.txt
@@ -112,18 +112,20 @@ picolibc_sources(
   ignore_handler_s.c
   )
 
-picolibc_sources_flags("-fno-builtin-malloc;-fno-builtin-free"
-  nano-calloc.c
-  nano-free.c
-  nano-getpagesize.c
-  nano-mallinfo.c
-  nano-malloc.c
-  nano-malloc-stats.c
-  nano-malloc-usable-size.c
-  nano-mallopt.c
-  nano-memalign.c
-  nano-posix-memalign.c
-  nano-pvalloc.c
-  nano-realloc.c
-  nano-valloc.c
-  )
+if(ENABLE_MALLOC)
+  picolibc_sources_flags("-fno-builtin-malloc;-fno-builtin-free"
+    nano-calloc.c
+    nano-free.c
+    nano-getpagesize.c
+    nano-mallinfo.c
+    nano-malloc.c
+    nano-malloc-stats.c
+    nano-malloc-usable-size.c
+    nano-mallopt.c
+    nano-memalign.c
+    nano-posix-memalign.c
+    nano-pvalloc.c
+    nano-realloc.c
+    nano-valloc.c
+    )
+endif()

--- a/newlib/libc/stdlib/meson.build
+++ b/newlib/libc/stdlib/meson.build
@@ -190,23 +190,6 @@ if not tinystdio
   srcs_stdlib += srcs_stdlib_stdio
 endif
 
-# Work around compiler optimizing calls involving malloc/free
-
-c_args_malloc = []
-if cc.has_argument('-fno-builtin-malloc')
-  c_args_malloc += ['-fno-builtin-malloc']
-endif
-
-if cc.has_argument('-fno-builtin-free')
-  c_args_malloc += ['-fno-builtin-free']
-endif
-
-if newlib_nano_malloc
-  srcs_stdlib_malloc = nano_malloc_srcs_stdlib
-else
-  srcs_stdlib_malloc = std_malloc_srcs_stdlib
-endif
-
 if picoexit
   srcs_stdlib += pico_exit_srcs_stdlib
 else
@@ -238,32 +221,51 @@ foreach file : srcs_stdlib
   endif
 endforeach
 
-srcs_stdlib_malloc_use = []
-foreach file : srcs_stdlib_malloc
-  s_file = fs.replace_suffix(file, '.S')
-  if file in srcs_machine
-    message('libc/stdlib/' + file + ': machine overrides generic')
-  elif s_file in srcs_machine
-    message('libc/stdlib/' + s_file + ': machine overrides generic')
-  else
-    srcs_stdlib_malloc_use += file
-  endif
-endforeach
-
 src_stdlib = files(srcs_stdlib_use)
 
-foreach params : targets
-  target = params['name']
-  target_dir = params['dir']
-  target_c_args = params['c_args']
-  target_lib_prefix = params['lib_prefix']
+if enable_malloc
+  # Work around compiler optimizing calls involving malloc/free
 
-  # Have to build a sub-library to get custom c_args for malloc
-  set_variable('lib_stdlib' + target,
-	       static_library('stdlib_malloc' + target,
-			      srcs_stdlib_malloc_use,
-			      pic: false,
-			      include_directories: inc,
-			      c_args: target_c_args + c_args + c_args_malloc))
+  c_args_malloc = []
+  if cc.has_argument('-fno-builtin-malloc')
+    c_args_malloc += ['-fno-builtin-malloc']
+  endif
 
-endforeach
+  if cc.has_argument('-fno-builtin-free')
+    c_args_malloc += ['-fno-builtin-free']
+  endif
+
+  if newlib_nano_malloc
+    srcs_stdlib_malloc = nano_malloc_srcs_stdlib
+  else
+    srcs_stdlib_malloc = std_malloc_srcs_stdlib
+  endif
+
+  srcs_stdlib_malloc_use = []
+  foreach file : srcs_stdlib_malloc
+    s_file = fs.replace_suffix(file, '.S')
+    if file in srcs_machine
+      message('libc/stdlib/' + file + ': machine overrides generic')
+    elif s_file in srcs_machine
+      message('libc/stdlib/' + s_file + ': machine overrides generic')
+    else
+      srcs_stdlib_malloc_use += file
+    endif
+  endforeach
+
+  foreach params : targets
+    target = params['name']
+    target_dir = params['dir']
+    target_c_args = params['c_args']
+    target_lib_prefix = params['lib_prefix']
+
+    # Have to build a sub-library to get custom c_args for malloc
+    set_variable('lib_stdlib' + target,
+	         static_library('stdlib_malloc' + target,
+			        srcs_stdlib_malloc_use,
+			        pic: false,
+			        include_directories: inc,
+			        c_args: target_c_args + c_args + c_args_malloc))
+
+  endforeach
+endif

--- a/zephyr/zephyr.cmake
+++ b/zephyr/zephyr.cmake
@@ -101,6 +101,9 @@ if(CONFIG_PICOLIBC_USE_MODULE)
     set(__PICOLIBC_ERRNO_FUNCTION z_errno_wrap)
   endif()
 
+  # Disable malloc functions
+  set(ENABLE_MALLOC 0)
+
   # Fetch zephyr compile flags from interface
   get_property(PICOLIBC_EXTRA_COMPILE_OPTIONS TARGET zephyr_interface PROPERTY INTERFACE_COMPILE_OPTIONS)
 


### PR DESCRIPTION
This new option (enable-malloc in meson, ENABLE_MALLOC in cmake) controls whether the library includes an implementation of the malloc functions:

 * malloc
 * calloc
 * aligned_alloc
 * memalign
 * posix_memalign
 * pvalloc
 * valloc
 * realloc
 * free
 * cfree
 * malloc_usable_size
 * getpagesize
 * mallinfo
 * malloc_stats

The option is enabled by default, although the Zephyr configuration disables it as Zephyr always uses their own internal malloc implementation.