### PR TITLE
include/sys: Remove <float.h> from config.h

### DIFF
--- a/newlib/libc/include/machine/ieeefp.h
+++ b/newlib/libc/include/machine/ieeefp.h
@@ -89,18 +89,6 @@ warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 # endif
 #endif
 
-#if __SIZEOF_DOUBLE__ == __SIZEOF_FLOAT__
-# define _DBL_EQ_FLT
-#endif
-
-#if __SIZEOF_LONG_DOUBLE == __SIZEOF_DOUBLE__
-# define LDBL_EQ_DBL
-#endif
-
-#if __SIZEOF_DOUBLE__ == 4
-# define _DOUBLE_IS_32BITS
-#endif
-
 #if (defined(__arm__) || defined(__thumb__)) && !defined(__MAVERICK__)
 /* arm with hard fp and soft dp cannot use new float code */
 # if (__ARM_FP & 4) && !(__ARM_FP & 8)
@@ -601,6 +589,29 @@ warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #else
 #define __IEEE_LITTLE_ENDIAN
 #endif
+#endif
+
+/* Figure out if long double is the same size as double. If the system
+ * doesn't provide long double, then those values will be undefined
+ * and cpp will substitute 0 for them in the test
+ */
+
+#if __LDBL_MANT_DIG__ == __DBL_MANT_DIG__ && __LDBL_MIN_EXP__ == __DBL_MIN_EXP__ &&     \
+    __LDBL_MAX_EXP__ == __DBL_MAX_EXP__
+#define _LDBL_EQ_DBL
+#endif
+
+#if __SIZEOF_DOUBLE__ == 4
+# define _DOUBLE_IS_32BITS
+#endif
+
+/*
+ * long double is supported for binary128 and 80-bit extended
+ * precision for x86 and m68k. Targets with binary64 long double
+ * are supported by al
+ */
+#if defined (_LDBL_EQ_DBL) || defined (__CYGWIN__) || (defined(__HAVE_LONG_DOUBLE) && __SIZEOF_LONG_DOUBLE__ <= 8) || (__LDBL_MANT_DIG__ == 64 || __LDBL_MANT_DIG__ == 113)
+#define __HAVE_LONG_DOUBLE_MATH
 #endif
 
 /* New math code requires 64-bit doubles */

--- a/newlib/libc/include/sys/config.h
+++ b/newlib/libc/include/sys/config.h
@@ -31,7 +31,6 @@
 
 #include <machine/ieeefp.h>  /* floating point macros */
 #include <sys/features.h>	/* POSIX defs */
-#include <float.h>
 
 #ifdef __aarch64__
 #define MALLOC_ALIGNMENT 16
@@ -273,22 +272,12 @@
 #define __HAVE_LONG_DOUBLE
 #endif
 
-/* Figure out if long double is the same size as double. If the system
- * doesn't provide long double, then those values will be undefined
- * and cpp will substitute 0 for them in the test
- */
-
-#if LDBL_MANT_DIG == DBL_MANT_DIG && LDBL_MIN_EXP == DBL_MIN_EXP &&     \
-    LDBL_MAX_EXP == DBL_MAX_EXP
-#define _LDBL_EQ_DBL
-#endif
-
 /* Newlib doesn't fully support long double math functions so far.
    On platforms where long double equals double the long double functions
    simply call the double functions.  On Cygwin the long double functions
    are implemented independently from newlib to be able to use optimized
    assembler functions despite using the Microsoft x86_64 ABI. */
-#if defined (_LDBL_EQ_DBL) || defined (__CYGWIN__) || (defined(__HAVE_LONG_DOUBLE) && __SIZEOF_LONG_DOUBLE__ <= 8) || (LDBL_MANT_DIG == 64 || LDBL_MANT_DIG == 113)
+#if defined (_LDBL_EQ_DBL) || defined (__CYGWIN__) || (defined(__HAVE_LONG_DOUBLE) && __SIZEOF_LONG_DOUBLE__ <= 8) || (__LDBL_MANT_DIG__ == 64 || __LDBL_MANT_DIG__ == 113)
 #define __HAVE_LONG_DOUBLE_MATH
 #endif
 

--- a/newlib/libc/machine/loongarch/machine/fenv-fp.h
+++ b/newlib/libc/machine/loongarch/machine/fenv-fp.h
@@ -213,8 +213,8 @@ __declare_fenv_inline(int) feraiseexcept(int excepts)
 {
   const float fp_zero = 0.0f;
   const float fp_one = 1.0f;
-  const float fp_max = FLT_MAX;
-  const float fp_min = FLT_MIN;
+  const float fp_max = __FLT_MAX__;
+  const float fp_min = __FLT_MIN__;
   const float fp_1e32 = 1.0e32f;
   const float fp_two = 2.0f;
   const float fp_three = 3.0f;

--- a/newlib/libm/common/math_config.h
+++ b/newlib/libm/common/math_config.h
@@ -33,6 +33,7 @@
 #include <stdint.h>
 #include <errno.h>
 #include <fenv.h>
+#include <float.h>
 
 #ifndef WANT_ROUNDING
 /* Correct special case results in non-nearest rounding modes.  */

--- a/newlib/libm/ld/math_ld.h
+++ b/newlib/libm/ld/math_ld.h
@@ -35,6 +35,7 @@
 
 #include "fdlibm.h"
 #include <math.h>
+#include <float.h>
 
 #if defined(__HAVE_LONG_DOUBLE_MATH) && defined(_NEED_FLOAT_HUGE)
 #define __HAVE_LD_SUPPORT


### PR DESCRIPTION
Don't expose the symbols in this public file to every library user. Move all of the float symbol settings to ieeefp.h