### PR TITLE
meson: Don't install picolibc if picolib is a subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -45,6 +45,12 @@ project('picolibc', 'c',
 	version: '1.8.10'
        )
 
+# When picolibc is embedded as a subproject you probably don't expect
+# installing of the outter project cause picolibc to get installed.
+# However, the user can force install even if picolibc is a subproject
+# via the force-install option.
+really_install = get_option('force-install') or not meson.is_subproject()
+
 fs = import('fs')
 
 cc = meson.get_compiler('c')
@@ -771,7 +777,7 @@ picolibc_specs = configure_file(input: 'picolibc.specs.in',
 				output: 'picolibc.specs',
 				configuration: specs_c_data,
 				install_dir: specs_dir,
-				install: specs_install)
+				install: specs_install and really_install)
 
 picolibc_specs_name = 'picolibc.specs'
 
@@ -779,7 +785,7 @@ picolibcpp_specs = configure_file(input: 'picolibc.specs.in',
 				  output: 'picolibcpp.specs',
 				  configuration: specs_cpp_data,
 				  install_dir: specs_dir,
-				  install: specs_install)
+				  install: specs_install and really_install)
 
 # Not all compilers necessarily support all warnings; only use these which are:
 common_warnings = [
@@ -1213,7 +1219,7 @@ foreach params : [default_target] + targets
                    configure_file(input: 'picolibc.ld.in',
                                   output: picolibc_ld_file,
                                   configuration: picolibc_ld_data,
-                                  install: picolibc_ld_install,
+                                  install: picolibc_ld_install and really_install,
                                   install_dir: lib_dir))
     endif
 
@@ -1232,7 +1238,7 @@ foreach params : [default_target] + targets
                  configure_file(input: 'picolibc.ld.in',
                                 output: picolibcpp_ld_file,
                                 configuration: picolibcpp_ld_data,
-                                install: picolibc_ld_install,
+                                install: picolibc_ld_install and really_install,
                                 install_dir: lib_dir))
     endif
                    
@@ -1642,7 +1648,8 @@ conf_data.set('__IEEEFP_FUNCS', ieeefp_funcs, description: 'IEEE fp funcs availa
 
 configure_file(output : 'picolibc.h',
 	       configuration: conf_data,
-	       install_dir: include_dir)
+	       install_dir: include_dir,
+	       install: really_install)
 
 # Usage as an embedded subproject:
 # If picolibc is embedded into the source as a subproject,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -74,6 +74,8 @@ option('sysroot-install-skip-checks', type: 'boolean', value: false,
        description: 'Skip sysroot path checks during config')
 option('system-libc', type: 'boolean', value: false,
        description: 'Install as system C library')
+option('force-install', type: 'boolean', value: false,
+       description: 'If picolibc is a subproject its targets will not be installed by default, setting this to true forces installation')
 
 #
 # Testing options

--- a/newlib/libc/include/arpa/meson.build
+++ b/newlib/libc/include/arpa/meson.build
@@ -37,8 +37,10 @@ inc_arpa_headers = [
   'inet.h'
 ]
 
-install_headers(inc_arpa_headers,
-		install_dir: include_dir / 'arpa')
+if really_install
+  install_headers(inc_arpa_headers,
+                  install_dir: include_dir / 'arpa')
+endif
 
 if enable_cdefs_tests
   ignore_headers = []

--- a/newlib/libc/include/machine/meson.build
+++ b/newlib/libc/include/machine/meson.build
@@ -63,7 +63,9 @@ foreach file : inc_machine_headers_all
   endif
 endforeach
 
-install_headers(
-  inc_machine_headers,
-  install_dir: include_dir / 'machine'
-)
+if really_install
+  install_headers(
+    inc_machine_headers,
+    install_dir: include_dir / 'machine'
+  )
+endif

--- a/newlib/libc/include/meson.build
+++ b/newlib/libc/include/meson.build
@@ -104,12 +104,16 @@ endif
 
 inc_headers += ['picotls.h']
 
-install_headers(inc_headers,
-		install_dir: include_dir)
-
+if really_install
+  install_headers(inc_headers,
+                  install_dir: include_dir)
+endif
 # For compatibility with libc++'s __mbstate_t.h:
-install_headers(['bits/types/mbstate_t.h'],
-		install_dir: include_dir / 'bits/types')
+
+if really_install
+  install_headers(['bits/types/mbstate_t.h'],
+                  install_dir: include_dir / 'bits/types')
+endif
 
 if enable_cdefs_tests
 

--- a/newlib/libc/include/rpc/meson.build
+++ b/newlib/libc/include/rpc/meson.build
@@ -38,8 +38,10 @@ inc_rpc_headers = [
   'xdr.h',
 ]
 
-install_headers(inc_rpc_headers,
-		install_dir: include_dir / 'rpc')
+if really_install
+  install_headers(inc_rpc_headers,
+                  install_dir: include_dir / 'rpc')
+endif
 
 if enable_cdefs_tests
   ignore_headers = []

--- a/newlib/libc/include/ssp/meson.build
+++ b/newlib/libc/include/ssp/meson.build
@@ -43,5 +43,7 @@ inc_ssp_headers = [
     'wchar.h',
 ]
 
-install_headers(inc_ssp_headers,
-		install_dir: include_dir / 'ssp')
+if really_install
+  install_headers(inc_ssp_headers,
+                  install_dir: include_dir / 'ssp')
+endif

--- a/newlib/libc/include/sys/meson.build
+++ b/newlib/libc/include/sys/meson.build
@@ -85,8 +85,10 @@ foreach file : inc_sys_headers_all
   endif
 endforeach
 
-install_headers(inc_sys_headers,
-		install_dir: include_dir / 'sys')
+if really_install
+  install_headers(inc_sys_headers,
+                  install_dir: include_dir / 'sys')
+endif
 
 if enable_cdefs_tests
   ignore_headers = ['config.h', 'features.h', 'string.h', 'custom_file.h', 'dirent.h']

--- a/newlib/libc/machine/aarch64/machine/meson.build
+++ b/newlib/libc/machine/aarch64/machine/meson.build
@@ -39,5 +39,7 @@ inc_machine_headers_machine = [
   'math.h',
 ]
 
-install_headers(inc_machine_headers_machine,
-		install_dir: include_dir / 'machine')
+if really_install
+  install_headers(inc_machine_headers_machine,
+                  install_dir: include_dir / 'machine')
+endif

--- a/newlib/libc/machine/arm/machine/meson.build
+++ b/newlib/libc/machine/arm/machine/meson.build
@@ -41,5 +41,7 @@ inc_machine_headers_machine = [
   'param.h',
 ]
 
-install_headers(inc_machine_headers_machine,
-		install_dir: include_dir / 'machine')
+if really_install
+  install_headers(inc_machine_headers_machine,
+                  install_dir: include_dir / 'machine')
+endif

--- a/newlib/libc/machine/loongarch/machine/meson.build
+++ b/newlib/libc/machine/loongarch/machine/meson.build
@@ -39,5 +39,7 @@ inc_machine_headers_machine = [
   'math.h'
 ]
 
-install_headers(inc_machine_headers_machine,
-		install_dir: include_dir / 'machine')
+if really_install
+  install_headers(inc_machine_headers_machine,
+                  install_dir: include_dir / 'machine')
+endif

--- a/newlib/libc/machine/m68k/machine/meson.build
+++ b/newlib/libc/machine/m68k/machine/meson.build
@@ -37,5 +37,7 @@ inc_sys_headers_machine = [
   'fenv-fp.h'
 ]
 
-install_headers(inc_sys_headers_machine,
-		install_dir: include_dir / 'machine')
+if really_install
+  install_headers(inc_sys_headers_machine,
+                  install_dir: include_dir / 'machine')
+endif

--- a/newlib/libc/machine/mips/machine/meson.build
+++ b/newlib/libc/machine/mips/machine/meson.build
@@ -39,5 +39,7 @@ inc_machine_headers_machine = [
   'regdef.h',
 ]
 
-install_headers(inc_machine_headers_machine,
-		install_dir: include_dir / 'machine')
+if really_install
+  install_headers(inc_machine_headers_machine,
+                  install_dir: include_dir / 'machine')
+endif

--- a/newlib/libc/machine/powerpc/machine/meson.build
+++ b/newlib/libc/machine/powerpc/machine/meson.build
@@ -37,5 +37,7 @@ inc_machine_headers_machine = [
   'fenv-fp.h',
 ]
 
-install_headers(inc_machine_headers_machine,
-		install_dir: include_dir / 'machine')
+if really_install
+  install_headers(inc_machine_headers_machine,
+                  install_dir: include_dir / 'machine')
+endif

--- a/newlib/libc/machine/riscv/machine/meson.build
+++ b/newlib/libc/machine/riscv/machine/meson.build
@@ -38,5 +38,7 @@ inc_machine_headers_machine = [
   'math.h'
 ]
 
-install_headers(inc_machine_headers_machine,
-		install_dir: include_dir / 'machine')
+if really_install
+  install_headers(inc_machine_headers_machine,
+                  install_dir: include_dir / 'machine')
+endif

--- a/newlib/libc/machine/sh/machine/meson.build
+++ b/newlib/libc/machine/sh/machine/meson.build
@@ -37,5 +37,7 @@ inc_machine_headers_machine = [
   'fenv-fp.h',
 ]
 
-install_headers(inc_machine_headers_machine,
-		install_dir: include_dir / 'machine')
+if really_install
+  install_headers(inc_machine_headers_machine,
+                  install_dir: include_dir / 'machine')
+endif

--- a/newlib/libc/machine/sparc/machine/meson.build
+++ b/newlib/libc/machine/sparc/machine/meson.build
@@ -38,5 +38,7 @@ inc_machine_headers_machine = [
   'sparclet.h',
 ]
 
-install_headers(inc_machine_headers_machine,
-		install_dir: include_dir / 'machine')
+if really_install
+  install_headers(inc_machine_headers_machine,
+                  install_dir: include_dir / 'machine')
+endif

--- a/newlib/libc/machine/x86/machine/meson.build
+++ b/newlib/libc/machine/x86/machine/meson.build
@@ -37,5 +37,7 @@ inc_machine_headers_machine = [
   'fastmath.h'
 ]
 
-install_headers(inc_machine_headers_machine,
-		install_dir: include_dir / 'machine')
+if really_install
+  install_headers(inc_machine_headers_machine,
+                  install_dir: include_dir / 'machine')
+endif

--- a/newlib/libc/machine/xtensa/machine/meson.build
+++ b/newlib/libc/machine/xtensa/machine/meson.build
@@ -38,5 +38,7 @@ inc_machine_headers_machine = [
   'fenv-fp.h'
 ]
 
-install_headers(inc_machine_headers_machine,
-		install_dir: include_dir / 'machine')
+if really_install
+  install_headers(inc_machine_headers_machine,
+                  install_dir: include_dir / 'machine')
+endif

--- a/newlib/libc/stdio/meson.build
+++ b/newlib/libc/stdio/meson.build
@@ -34,8 +34,10 @@
 #
 subdir('sys')
 inc_headers = ['stdio.h']
-install_headers(inc_headers,
-		install_dir: include_dir)
+if really_install
+  install_headers(inc_headers,
+                  install_dir: include_dir)
+endif
 
 general_srcs_stdio = [
   'clearerr.c',

--- a/newlib/libc/stdio/sys/meson.build
+++ b/newlib/libc/stdio/sys/meson.build
@@ -46,8 +46,10 @@ foreach file : inc_stdio_sys_headers_all
   endif
 endforeach
 
-install_headers(inc_stdio_sys_headers,
-		install_dir: include_dir / 'sys')
+if really_install
+  install_headers(inc_stdio_sys_headers,
+                  install_dir: include_dir / 'sys')
+endif
 
 if enable_cdefs_tests
   foreach header : inc_stdio_sys_headers

--- a/newlib/libc/tinystdio/meson.build
+++ b/newlib/libc/tinystdio/meson.build
@@ -242,9 +242,10 @@ if posix_console
 endif
 
 inc_headers = ['stdio.h', 'stdio-bufio.h']
-install_headers(inc_headers,
-		install_dir: include_dir
-	       )
+if really_install
+  install_headers(inc_headers,
+                  install_dir: include_dir)
+endif
 
 srcs_tinystdio_use = []
 foreach file : srcs_tinystdio

--- a/newlib/meson.build
+++ b/newlib/meson.build
@@ -68,7 +68,7 @@ foreach params : targets
 
   local_lib_c_target = static_library(join_paths(target_dir, target_lib_prefix + libc_name),
 				      libsrcs_target,
-				      install : true,
+				      install : really_install,
 				      install_dir : instdir,
 				      pic: false,
 				      objects : libobjs,
@@ -77,21 +77,21 @@ foreach params : targets
 
   static_library(join_paths(target_dir, target_lib_prefix + libm_name),
 		 ['empty.c'],
-		 install : true,
+		 install : really_install,
 		 install_dir : instdir,
 		 pic: false,
                  c_args: target_c_args + c_args,
 		 objects : [])
   static_library(join_paths(target_dir, target_lib_prefix + libg_name),
 		 ['empty.c'],
-		 install : true,
+		 install : really_install,
 		 install_dir : instdir,
 		 pic: false,
                  c_args: target_c_args + c_args,
 		 objects : [])
   static_library(join_paths(target_dir, target_lib_prefix + libnosys_name),
 		 ['empty.c'],
-		 install : true,
+		 install : really_install,
 		 install_dir : instdir,
 		 pic: false,
                  c_args: target_c_args + c_args,

--- a/picocrt/meson.build
+++ b/picocrt/meson.build
@@ -132,7 +132,7 @@ foreach params : targets
       _crt = executable(join_paths(target_dir, crt_name),
                         _src,
                         include_directories : inc,
-                        install : true,
+                        install : really_install,
                         install_dir : instdir,
                         c_args : _c_args,
                         link_args : _link_args)
@@ -147,7 +147,7 @@ foreach params : targets
         static_library(join_paths(target_dir, target_lib_prefix + libcrt_name),
                        [],
                        include_directories : inc,
-                       install : true,
+                       install : really_install,
                        install_dir : instdir,
                        c_args : _c_args,
                        objects: _crt.extract_objects(_src),

--- a/semihost/fake/meson.build
+++ b/semihost/fake/meson.build
@@ -57,7 +57,7 @@ foreach params : targets
 
   local_lib_semihost_target = static_library(join_paths(target_dir, target_lib_prefix + libsemihost_name),
 				       lib_semihost_srcs,
-				       install : true,
+				       install : really_install,
 				       install_dir : instdir,
 				       include_directories : inc,
 				       c_args : target_c_args + c_args,

--- a/semihost/machine/arc/meson.build
+++ b/semihost/machine/arc/meson.build
@@ -60,7 +60,7 @@ foreach params : targets
 
   local_lib_semihost_target = static_library(join_paths(target_dir, target_lib_prefix + libsemihost_name),
 				       lib_semihost_srcs,
-				       install : true,
+				       install : really_install,
 				       install_dir : instdir,
 				       include_directories : inc,
 				       c_args : target_c_args + c_args,

--- a/semihost/machine/arc64/meson.build
+++ b/semihost/machine/arc64/meson.build
@@ -60,7 +60,7 @@ foreach params : targets
 
   local_lib_semihost_target = static_library(join_paths(target_dir, target_lib_prefix + libsemihost_name),
 				       lib_semihost_srcs,
-				       install : true,
+				       install : really_install,
 				       install_dir : instdir,
 				       include_directories : inc,
 				       c_args : target_c_args + c_args,

--- a/semihost/machine/lm32/meson.build
+++ b/semihost/machine/lm32/meson.build
@@ -60,7 +60,7 @@ foreach params : targets
 
   local_lib_semihost_target = static_library(join_paths(target_dir, target_lib_prefix + libsemihost_name),
 				       lib_semihost_srcs,
-				       install : true,
+				       install : really_install,
 				       install_dir : instdir,
 				       include_directories : inc,
 				       c_args : target_c_args + c_args,

--- a/semihost/machine/m68k/meson.build
+++ b/semihost/machine/m68k/meson.build
@@ -61,7 +61,7 @@ foreach params : targets
 
   local_lib_semihost_target = static_library(join_paths(target_dir, target_lib_prefix + libsemihost_name),
 				       lib_semihost_srcs,
-				       install : true,
+				       install : really_install,
 				       install_dir : instdir,
 				       include_directories : inc,
 				       c_args : target_c_args + c_args,

--- a/semihost/machine/mips/meson.build
+++ b/semihost/machine/mips/meson.build
@@ -59,7 +59,7 @@ foreach params : targets
 
   local_lib_semihost_target = static_library(join_paths(target_dir, target_lib_prefix + libsemihost_name),
 				       lib_semihost_srcs,
-				       install : true,
+				       install : really_install,
 				       install_dir : instdir,
 				       include_directories : inc,
 				       c_args : target_c_args + c_args,

--- a/semihost/machine/msp430/meson.build
+++ b/semihost/machine/msp430/meson.build
@@ -53,7 +53,7 @@ foreach params : targets
 
   local_lib_semihost_target = static_library(join_paths(target_dir, target_lib_prefix + libsemihost_name),
 				       lib_semihost_srcs,
-				       install : true,
+				       install : really_install,
 				       install_dir : instdir,
 				       include_directories : inc,
 				       c_args : target_c_args + c_args,

--- a/semihost/machine/nios2/meson.build
+++ b/semihost/machine/nios2/meson.build
@@ -61,7 +61,7 @@ foreach params : targets
 
   local_lib_semihost_target = static_library(join_paths(target_dir, target_lib_prefix + libsemihost_name),
 				       lib_semihost_srcs,
-				       install : true,
+				       install : really_install,
 				       install_dir : instdir,
 				       include_directories : inc,
 				       c_args : target_c_args + c_args,

--- a/semihost/machine/or1k/meson.build
+++ b/semihost/machine/or1k/meson.build
@@ -53,7 +53,7 @@ foreach params : targets
 
   local_lib_semihost_target = static_library(join_paths(target_dir, target_lib_prefix + libsemihost_name),
 				       lib_semihost_srcs,
-				       install : true,
+				       install : really_install,
 				       install_dir : instdir,
 				       include_directories : inc,
 				       c_args : target_c_args + c_args,

--- a/semihost/machine/powerpc/meson.build
+++ b/semihost/machine/powerpc/meson.build
@@ -75,7 +75,7 @@ if cc.get_define('_CALL_ELF') == '1'
 
       local_lib_semihost_target = static_library(join_paths(target_dir, target_lib_prefix + libsemihost_name),
 						 lib_semihost_srcs,
-						 install : true,
+						 install : really_install,
 						 install_dir : instdir,
 						 include_directories : inc,
 						 c_args : target_c_args + c_args,

--- a/semihost/machine/rx/meson.build
+++ b/semihost/machine/rx/meson.build
@@ -53,7 +53,7 @@ foreach params : targets
 
   local_lib_semihost_target = static_library(join_paths(target_dir, target_lib_prefix + libsemihost_name),
 				       lib_semihost_srcs,
-				       install : true,
+				       install : really_install,
 				       install_dir : instdir,
 				       include_directories : inc,
 				       c_args : target_c_args + c_args,

--- a/semihost/machine/sh/meson.build
+++ b/semihost/machine/sh/meson.build
@@ -54,7 +54,7 @@ foreach params : targets
 
   local_lib_semihost_target = static_library(join_paths(target_dir, target_lib_prefix + libsemihost_name),
 				       lib_semihost_srcs,
-				       install : true,
+				       install : really_install,
 				       install_dir : instdir,
 				       include_directories : inc,
 				       c_args : target_c_args + c_args,

--- a/semihost/machine/sparc/meson.build
+++ b/semihost/machine/sparc/meson.build
@@ -53,7 +53,7 @@ foreach params : targets
 
   local_lib_semihost_target = static_library(join_paths(target_dir, target_lib_prefix + libsemihost_name),
 				       lib_semihost_srcs,
-				       install : true,
+				       install : really_install,
 				       install_dir : instdir,
 				       include_directories : inc,
 				       c_args : target_c_args + c_args,

--- a/semihost/machine/x86/meson.build
+++ b/semihost/machine/x86/meson.build
@@ -59,7 +59,7 @@ foreach params : targets
 
   local_lib_semihost_target = static_library(join_paths(target_dir, target_lib_prefix + libsemihost_name),
 				       lib_semihost_srcs,
-				       install : true,
+				       install : really_install,
 				       install_dir : instdir,
 				       include_directories : inc,
 				       c_args : target_c_args + c_args,
@@ -90,7 +90,7 @@ if objcopy.found()
   bios_bin = custom_target('bios.bin',
 		           build_by_default: true,
 		           input: bios,
-		           install: true,
+		           install: really_install,
 		           install_dir: instdir,
 		           output: 'bios.bin',
 		           command: [objcopy, '-O', 'binary', '--only-section=.text', '@INPUT@', '@OUTPUT@'])

--- a/semihost/machine/xtensa/meson.build
+++ b/semihost/machine/xtensa/meson.build
@@ -60,7 +60,7 @@ foreach params : targets
 
   local_lib_semihost_target = static_library(join_paths(target_dir, target_lib_prefix + libsemihost_name),
 				       lib_semihost_srcs,
-				       install : true,
+				       install : really_install,
 				       install_dir : instdir,
 				       include_directories : inc,
 				       c_args : target_c_args + c_args,

--- a/semihost/meson.build
+++ b/semihost/meson.build
@@ -96,9 +96,10 @@ if src_semihost != []
   endif
 
   inc_headers = ['semihost.h']
-  install_headers(inc_headers,
-		  install_dir: include_dir
-		 )
+  if really_install
+    install_headers(inc_headers,
+                    install_dir: include_dir)
+  endif
 
   inc = [inc, include_directories('.')]
   inc_args += '-I' + meson.current_source_dir()
@@ -122,7 +123,7 @@ if src_semihost != []
     set_variable('lib_semihost' + target,
 		 static_library(join_paths(target_dir, target_lib_prefix + libsemihost_name),
 				src_semihost,
-				install : true,
+				install : really_install,
 				install_dir : instdir,
 				include_directories : inc,
 				c_args : target_c_args + c_args))


### PR DESCRIPTION
Currently if picolibc is used as a subproject triggering install on the outter project will cause all of the targets that picolibc provides that are installable will also get installed.

This is probably undesirable as it'll replace whatever picolibc the user has already installed, the picolibc configured in the subproject is probably explictly for the use of the outter project, picolibc is probably statically linked into the output of the outter project so there is no need to install anything from picolibc etc etc etc.

Unfortunately, meson doesn't have a good way of disabling installation of subproject targets from the outter project so we need to check if picolibc is a subproject and remove the install flag/not define the target for everything.