### PR TITLE
Ensure AEABI aliases are preserved during LTO

### DIFF
--- a/newlib/libc/machine/arm/aeabi_memset.c
+++ b/newlib/libc/machine/arm/aeabi_memset.c
@@ -34,10 +34,10 @@
 /* Support the alias for the __aeabi_memset which may
    assume memory alignment.  */
 void __aeabi_memset4 (void *dest, size_t n, int c)
-	_ATTRIBUTE ((alias ("__aeabi_memset"), weak));
+	_ATTRIBUTE ((alias ("__aeabi_memset"), weak, used));
 
 void __aeabi_memset8 (void *dest, size_t n, int c)
-	_ATTRIBUTE ((alias ("__aeabi_memset"), weak));
+	_ATTRIBUTE ((alias ("__aeabi_memset"), weak, used));
 
 /* Support the routine __aeabi_memset.  Can't alias to memset
    because the arguments are in a different order */

--- a/newlib/libc/machine/arm/bzero.c
+++ b/newlib/libc/machine/arm/bzero.c
@@ -34,10 +34,10 @@
    assume memory alignment.  */
 
 void __aeabi_memclr4 (void *dest, size_t n)
-	_ATTRIBUTE ((alias ("bzero"), weak));
+	_ATTRIBUTE ((alias ("bzero"), weak, used));
 
 void __aeabi_memclr8 (void *dest, size_t n)
-	_ATTRIBUTE ((alias ("bzero"), weak));
+	_ATTRIBUTE ((alias ("bzero"), weak, used));
 
 void __aeabi_memclr (void *dest, size_t n)
-	_ATTRIBUTE ((alias ("bzero"), weak));
+	_ATTRIBUTE ((alias ("bzero"), weak, used));

--- a/newlib/libc/machine/arm/memcpy.c
+++ b/newlib/libc/machine/arm/memcpy.c
@@ -46,12 +46,12 @@
 # include "../../string/memcpy.c"
 
 void *__aeabi_memcpy4 (void *__restrict dest, const void * __restrict source, size_t n)
-	_ATTRIBUTE ((alias ("memcpy"), weak));
+	_ATTRIBUTE ((alias ("memcpy"), weak, used));
 
 void *__aeabi_memcpy8 (void * __restrict dest, const void * __restrict source, size_t n)
-	_ATTRIBUTE ((alias ("memcpy"), weak));
+	_ATTRIBUTE ((alias ("memcpy"), weak, used));
 
 void *__aeabi_memcpy (void * __restrict dest, const void * __restrict source, size_t n)
-	_ATTRIBUTE ((alias ("memcpy"), weak));
+	_ATTRIBUTE ((alias ("memcpy"), weak, used));
 
 #endif

--- a/newlib/libc/machine/arm/memmove.c
+++ b/newlib/libc/machine/arm/memmove.c
@@ -40,10 +40,10 @@
 /* Support the alias for the __aeabi_memmove which may
    assume memory alignment.  */
 void *__aeabi_memmove4 (void *__restrict dest, const void *source, size_t n)
-	_ATTRIBUTE ((alias ("memmove"), weak));
+	_ATTRIBUTE ((alias ("memmove"), weak, used));
 
 void *__aeabi_memmove8 (void *dest, const void *source, size_t n)
-	_ATTRIBUTE ((alias ("memmove"), weak));
+	_ATTRIBUTE ((alias ("memmove"), weak, used));
 
 void *__aeabi_memmove (void *dest, const void *source, size_t n)
-	_ATTRIBUTE ((alias ("memmove"), weak));
+	_ATTRIBUTE ((alias ("memmove"), weak, used));


### PR DESCRIPTION
When LLD runs in Link Time Optimization mode, it decides which symbols could be needed in the final binary long before final machine code is generated. Unfortunately, the instruction selection pass can reintroduce references to `__aeabi_*` symbols at a late stage of LTO during lowering of certain LLVM intrinsics. Unless `__aeabi_*` symbols are annotated with the 'used' attribute, LLD may not realize they are needed, resulting in an undefined symbol error.

`__aeabi_memset` is already annotated, but the other `__aeabi_*` symbols provided by picolibc are not. This PR proposes to add the 'used' attribute to the other symbols, allowing picolibc to be compiled with LTO under a wider range of circumstances. My testing indicates that this is necessary even though these other symbols are aliases and not definitions of their own.