### PR TITLE
Make Armv7-A memcpy work in Thumb state

### DIFF
--- a/newlib/libc/machine/arm/arm_asm.h
+++ b/newlib/libc/machine/arm/arm_asm.h
@@ -531,6 +531,12 @@
 #endif
 .endm
 
+.macro	ASM_ALIAS_ARM_STATE new old
+	.global	\new
+	.type	\new, %function
+	.set	\new, \old
+.endm
+
 #endif /* __ASSEMBLER__ */
 
 #endif /* ARM_ASM__H */

--- a/newlib/libc/machine/arm/memcpy-armv7a.S
+++ b/newlib/libc/machine/arm/memcpy-armv7a.S
@@ -157,9 +157,9 @@
 	.endm
 
 def_fn memcpy p2align=6
-	ASM_ALIAS __aeabi_memcpy, memcpy
-	ASM_ALIAS __aeabi_memcpy4, memcpy
-	ASM_ALIAS __aeabi_memcpy8, memcpy
+	ASM_ALIAS_ARM_STATE __aeabi_memcpy, memcpy
+	ASM_ALIAS_ARM_STATE __aeabi_memcpy4, memcpy
+	ASM_ALIAS_ARM_STATE __aeabi_memcpy8, memcpy
 
 	mov	dst, dstin	/* Preserve dstin, we need to return it.  */
 	cmp	count, #64


### PR DESCRIPTION
The implementation of Armv7-A's `memcpy` requires Arm state, therefore callers from Thumb state must perform an interworking call by the use of `BLX`.

Before this patch, the alias declaration for `__aeabi_memcpy(4|8)?` used a macro (`ASM_ALIAS`) that, when targeting Thumb, used the directive `.thumb_set`.  This directive, in this specific case, wrongly marked the alias as a Thumb entry point.

This patch defines a new macro to define an alias unconditionally for the Arm state, and uses this new macro to define the aliases to `memcpy`.