### PR TITLE
AArch32 A-profile using Thumb state must stay at it on exception entry

### DIFF
--- a/picocrt/machine/arm/crt0.c
+++ b/picocrt/machine/arm/crt0.c
@@ -243,7 +243,7 @@ _cstart(void)
         _set_stacks();
 #endif
 
-#if __thumb2__ && __ARM_ARCH_PROFILE != 'A'
+#ifdef __thumb2__
 	/* Make exceptions run in Thumb mode */
 	uint32_t sctlr;
 	__asm__("mrc p15, 0, %0, c1, c0, 0" : "=r" (sctlr));
@@ -308,7 +308,7 @@ _cstart(void)
 
                 /* Enable caches, branch prediction and the MMU. Disable TRE */
                 uint32_t sctlr;
-                __asm__("mrc p15, 0, %0, c1, c0, 0" : "=r" (sctlr));
+                __asm__ __volatile__("mrc p15, 0, %0, c1, c0, 0" : "=r" (sctlr));
                 sctlr |= SCTLR_ICACHE | SCTLR_BRANCH_PRED | SCTLR_DATA_L2 | SCTLR_MMU;
                 #ifndef __ARM_FEATURE_UNALIGNED
                     sctlr |= SCTLR_A;


### PR DESCRIPTION
On exception entry, the architecture may switch ISA depending on the TE bit of the SCTLR register.

Before this patch, the startup code was overprescriptive and set the TE bit only if the target is Thumb but not A-profile. This last condition isn't correct: A-profile architectures may run on Thumb state too.

This change fixes the preprocessor conditional to test only `__thumb2__`.

Moreover, the second read of SCTLR needs to be marked as volatile in inline assembly to prevent the compiler from optimizing it away. Without this mark, the compiler presumes that the second read is redundant because it isn't aware of the write that happens in between.