### PR TITLE
AArch32 A-profile interrupt vectors in Thumb2 mode should use Thumb2 instructions

### DIFF
--- a/newlib/libc/picolib/machine/arm/interrupt.c
+++ b/newlib/libc/picolib/machine/arm/interrupt.c
@@ -137,7 +137,7 @@ __weak_vector_table(void)
 	 * Exception vector that lives at the
 	 * start of program text (usually 0x0)
 	 */
-#if __thumb2__ && __ARM_ARCH_PROFILE != 'A'
+#ifdef __thumb2__
 	/* Thumb 2 processors start in thumb mode */
 	__asm__(".thumb\n"
                 ".syntax unified\n"


### PR DESCRIPTION
This code assumes that A-profile can't run in Thumb mode. As a consequence, code that does run in it faults if exceptions are taken.

This patch changes the conditional to check only for Thumb mode.