### PR TITLE
Fixes to make AArch32 A-profile work better in Thumb state

### DIFF
--- a/newlib/libc/machine/arm/arm_asm.h
+++ b/newlib/libc/machine/arm/arm_asm.h
@@ -531,6 +531,12 @@
 #endif
 .endm
 
+.macro	ASM_ALIAS_ARM_STATE new old
+	.global	\new
+	.type	\new, %function
+	.set	\new, \old
+.endm
+
 #endif /* __ASSEMBLER__ */
 
 #endif /* ARM_ASM__H */

--- a/newlib/libc/machine/arm/arm_asm.h
+++ b/newlib/libc/machine/arm/arm_asm.h
@@ -521,14 +521,10 @@
 	.endif
 .endm
 
-.macro	ASM_ALIAS new old
+.macro	ASM_ALIAS_THUMB_STATE new old
 	.global	\new
 	.type	\new, %function
-#if defined (__thumb__)
 	.thumb_set	\new, \old
-#else
-	.set	\new, \old
-#endif
 .endm
 
 .macro	ASM_ALIAS_ARM_STATE new old

--- a/newlib/libc/machine/arm/memcpy-armv7a.S
+++ b/newlib/libc/machine/arm/memcpy-armv7a.S
@@ -157,9 +157,9 @@
 	.endm
 
 def_fn memcpy p2align=6
-	ASM_ALIAS __aeabi_memcpy, memcpy
-	ASM_ALIAS __aeabi_memcpy4, memcpy
-	ASM_ALIAS __aeabi_memcpy8, memcpy
+	ASM_ALIAS_ARM_STATE __aeabi_memcpy, memcpy
+	ASM_ALIAS_ARM_STATE __aeabi_memcpy4, memcpy
+	ASM_ALIAS_ARM_STATE __aeabi_memcpy8, memcpy
 
 	mov	dst, dstin	/* Preserve dstin, we need to return it.  */
 	cmp	count, #64

--- a/newlib/libc/machine/arm/memcpy-armv7m.S
+++ b/newlib/libc/machine/arm/memcpy-armv7m.S
@@ -93,9 +93,9 @@
 	.cfi_sections .debug_frame
 	.cfi_startproc
 	.type	memcpy, %function
-	ASM_ALIAS __aeabi_memcpy, memcpy
-	ASM_ALIAS __aeabi_memcpy4, memcpy
-	ASM_ALIAS __aeabi_memcpy8, memcpy
+	ASM_ALIAS_THUMB_STATE __aeabi_memcpy, memcpy
+	ASM_ALIAS_THUMB_STATE __aeabi_memcpy4, memcpy
+	ASM_ALIAS_THUMB_STATE __aeabi_memcpy8, memcpy
 memcpy:
 	// r0: dst
 	// r1: src

--- a/newlib/libc/picolib/machine/arm/interrupt.c
+++ b/newlib/libc/picolib/machine/arm/interrupt.c
@@ -137,7 +137,7 @@ __weak_vector_table(void)
 	 * Exception vector that lives at the
 	 * start of program text (usually 0x0)
 	 */
-#if __thumb2__ && __ARM_ARCH_PROFILE != 'A'
+#ifdef __thumb2__
 	/* Thumb 2 processors start in thumb mode */
 	__asm__(".thumb\n"
                 ".syntax unified\n"

--- a/picocrt/machine/arm/crt0.c
+++ b/picocrt/machine/arm/crt0.c
@@ -243,7 +243,7 @@ _cstart(void)
         _set_stacks();
 #endif
 
-#if __thumb2__ && __ARM_ARCH_PROFILE != 'A'
+#ifdef __thumb2__
 	/* Make exceptions run in Thumb mode */
 	uint32_t sctlr;
 	__asm__("mrc p15, 0, %0, c1, c0, 0" : "=r" (sctlr));
@@ -308,7 +308,7 @@ _cstart(void)
 
                 /* Enable caches, branch prediction and the MMU. Disable TRE */
                 uint32_t sctlr;
-                __asm__("mrc p15, 0, %0, c1, c0, 0" : "=r" (sctlr));
+                __asm__ __volatile__("mrc p15, 0, %0, c1, c0, 0" : "=r" (sctlr));
                 sctlr |= SCTLR_ICACHE | SCTLR_BRANCH_PRED | SCTLR_DATA_L2 | SCTLR_MMU;
                 #ifndef __ARM_FEATURE_UNALIGNED
                     sctlr |= SCTLR_A;


### PR DESCRIPTION
 - Make Armv7-A memcpy work in Thumb state

The implementation of Armv7-A's `memcpy` requires Arm state, therefore callers from Thumb state must perform an interworking call by the use of `BLX`.

Before this patch, the alias declaration for `__aeabi_memcpy(4|8)?` used a macro (`ASM_ALIAS`) that, when targeting Thumb, used the directive `.thumb_set`.  This directive, in this specific case, wrongly marked the alias as a Thumb entry point.

This patch defines a new macro to define an alias unconditionally for the Arm state, and uses this new macro to define the aliases to `memcpy`.

 - AArch32 A-profile using Thumb state must stay at it on exception entry

On exception entry, the architecture may switch ISA depending on the TE bit of the SCTLR register.

Before this patch, the startup code was overprescriptive and set the TE bit only if the target is Thumb but not A-profile. This last condition isn't correct: A-profile architectures may run on Thumb state too.

This change fixes the preprocessor conditional to test only `__thumb2__`.

Moreover, the second read of SCTLR needs to be marked as volatile in inline assembly to prevent the compiler from optimizing it away. Without this mark, the compiler presumes that the second read is redundant because it isn't aware of the write that happens in between.

 - AArch32 A-profile interrupt vectors in Thumb2 mode should use Thumb2 instructions

This code assumes that A-profile can't run in Thumb mode. As a consequence, code that does run in it faults if exceptions are taken.

This patch changes the conditional to check only for Thumb mode.