### PR TITLE
Handle riscv large model and vector extension. Fix riscv extension stuff for qemu

### DIFF
--- a/picocrt/machine/riscv/crt0.c
+++ b/picocrt/machine/riscv/crt0.c
@@ -221,6 +221,13 @@ _start(void)
                 "csrw	mstatus, t0\n"
                 "csrwi	fcsr, 0");
 #endif
+#ifdef __riscv_vector
+	__asm__("csrr	t0, mstatus\n"
+                "li	t1, 512\n"     	        // 1 << 9 = 512
+                "or	t0, t1, t0\n"
+                "csrw	mstatus, t0\n"
+                "csrwi	vxrm, 1");
+#endif
 #ifdef CRT0_SEMIHOST
 #ifdef __riscv_cmodel_large
         __asm__("ld     t0,.start_trap");

--- a/scripts/cross-coreboot-arm-eabi.txt
+++ b/scripts/cross-coreboot-arm-eabi.txt
@@ -3,8 +3,8 @@
 # so we have to add -nostdlib to the compiler configuration itself or
 # early compiler tests will fail. This can be removed when picolibc
 # requires at least version 0.54.2 of meson.
-c = ['ccache', 'arm-eabi-gcc', '-nostdlib', '-mabi=aapcs', '-mfp16-format=ieee', '-mno-unaligned-access', '-mthumb', '-mcpu=cortex-m4']
-cpp = ['ccache', 'arm-eabi-g++', '-nostdlib', '-mabi=aapcs', '-mfp16-format=ieee', '-mno-unaligned-access', '-mthumb', '-mcpu=cortex-m4']
+c = ['ccache', 'arm-eabi-gcc', '-nostdlib', '-mabi=aapcs', '-mfp16-format=ieee', '-mno-unaligned-access' ]
+cpp = ['ccache', 'arm-eabi-g++', '-nostdlib', '-mabi=aapcs', '-mfp16-format=ieee', '-mno-unaligned-access' ]
 ar = 'arm-eabi-ar'
 as = 'arm-eabi-as'
 nm = 'arm-eabi-nm'

--- a/scripts/cross-riscv64-zephyr-elf.txt
+++ b/scripts/cross-riscv64-zephyr-elf.txt
@@ -24,3 +24,11 @@ default_flash_addr = '0x80000000'
 default_flash_size = '0x00400000'
 default_ram_addr   = '0x80400000'
 default_ram_size   = '0x00200000'
+
+custom_mem_config_rv64imafdc_zicsr_zifencei_lp64d_large = 'large'
+custom_mem_config_rv64imafdcv_zicsr_zifencei_lp64d_large = 'large'
+
+default_flash_addr_large = '0x80000000'
+default_flash_size_large = '0x04000000'
+default_ram_addr_large   = '0xfc000000'
+default_ram_size_large   = '0x03000000'

--- a/scripts/do-coreboot-arm-eabi-configure
+++ b/scripts/do-coreboot-arm-eabi-configure
@@ -31,5 +31,4 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-exec "$(dirname "$0")"/do-configure coreboot-arm-eabi -Dtests=true "$@" \
-     -Dmultilib=false "$@"
+exec "$(dirname "$0")"/do-configure coreboot-arm-eabi -Dtests=true "$@"

--- a/scripts/run-arm
+++ b/scripts/run-arm
@@ -48,11 +48,11 @@ memory=
 # Map ELF information to required core type
 #
 
-cpu_arch=`arm-none-eabi-readelf -A "$elf" | awk '/Tag_CPU_arch:/ { print $2 }'`
-cpu_profile=`arm-none-eabi-readelf -A "$elf" | awk '/Tag_CPU_arch_profile:/ { print $2 }'`
-fp_arch=`arm-none-eabi-readelf -A "$elf" | awk '/Tag_FP_arch/ { print $2 }'`
-fp_use=`arm-none-eabi-readelf -A "$elf" | awk '/Tag_ABI_HardFP_use/ { print $2 }'`
-ram_addr=`arm-none-eabi-readelf -l "$elf" | awk '/LOAD.*RW/ { if (min_va == 0 || $3 < min_va) min_va = $3; } END { print(min_va); }'`
+cpu_arch=`readelf -A "$elf" | awk '/Tag_CPU_arch:/ { print $2 }'`
+cpu_profile=`readelf -A "$elf" | awk '/Tag_CPU_arch_profile:/ { print $2 }'`
+fp_arch=`readelf -A "$elf" | awk '/Tag_FP_arch/ { print $2 }'`
+fp_use=`readelf -A "$elf" | awk '/Tag_ABI_HardFP_use/ { print $2 }'`
+ram_addr=`readelf -l "$elf" | awk '/LOAD.*RW/ { if (min_va == 0 || $3 < min_va) min_va = $3; } END { print(min_va); }'`
 
 case "$cpu_arch"/"$cpu_profile" in
     v4T/)

--- a/scripts/run-riscv
+++ b/scripts/run-riscv
@@ -67,14 +67,9 @@ else
     echo "Unknown architecture for $elf: $archstring" >&2
     exit 1
 fi
-# The I extension is always required, and since it's the first one there is
-# no preceding _ to match on. Just assume it's always there
-options="i"
-test "${archstring#*_m}" != "$archstring" && options="$options m"
-test "${archstring#*_a}" != "$archstring" && options="$options a"
-test "${archstring#*_f}" != "$archstring" && options="$options f"
-test "${archstring#*_d}" != "$archstring" && options="$options d"
-test "${archstring#*_c}" != "$archstring" && options="$options c"
+options="$(echo "$archstring" | sed 's/rv[36][24]//' | sed 's/_/ /g' | sed 's/[0-9]p[0-9]\>//g')"
+
+qemu_version="$("$qemu" --version | grep version | sed 's/.*version \([0-9][0-9.]*\).*/\1/')"
 
 cpu="$cpu,mmu=false,pmp=false"
 
@@ -82,32 +77,57 @@ if [ -z "$options" ]; then
     options="$(echo "$elf" | sed 's/.*rv[36][24]\([a-z]*\)_.*$/\1/' | sed 's/\(.\)/\1 /g')"
 fi
 
-all_options="i e g m a f d c s u"
-
-if $qemu --version | grep -q 'version \(7\|8\|9\|10\)'; then
-    all_options="h $all_options"
-fi
-
-if $qemu --version | grep -q 'version \(8\|9\|10\)'; then
-    if $qemu --version | grep -q 'version 8.1'; then
-        all_options="Zawrs $all_options"
-    else
-        all_options="zawrs $all_options"
-    fi
-fi
-
-if $qemu --version | grep -q 'version \(8.[1-9]\|9\|10\)'; then
-    all_options="zfa $all_options"
-fi
-
-for o in $all_options; do
-    if echo "$options" | grep -q "$o"; then
-	value=true
-    else
-	value=false
-    fi
-    cpu="$cpu,$o=$value"
+for o in $options; do
+    # Old versions of qemu don't have new extension subsets
+    case "$qemu_version" in
+        8*|7*)
+            case "$o" in
+                zmmul)
+                    o=m
+                    ;;
+                zaamo|zalrsc|zawrs)
+                    o=a
+                    ;;
+            esac
+            ;;
+    esac
+    case "$o" in
+        zvl*)
+            # qemu doesn't list zvl extensions
+            ;;
+        *)
+            cpu="$cpu,$o=true"
+            ;;
+    esac
 done
+
+# qemu enables some options by defualt; we need to explicitly
+# disable them when not selected
+enabled_options="i h e g m a f d c s u v zifencei zihintpause"
+
+# Add default enabled options for newer qemu versions
+case "$qemu_version" in
+    8.[01]*|7*)
+        ;;
+    *)
+        enabled_options="$enabled_options zawrs zfa zihintntl"
+        ;;
+esac
+
+for enabled in $enabled_options; do
+    if echo "$options" | grep -q -w $enabled; then
+        :
+    else
+        cpu="$cpu,$enabled=false"
+    fi
+done
+
+# Map lower case options to upper case for qemu version 8.1 and earlier
+case "$qemu_version" in
+    8.[01]*|7*)
+        cpu="$(echo "$cpu" | sed 's/\<z/Z/g')"
+        ;;
+esac
 
 # Set the target machine
 machine=virt,accel=tcg

--- a/scripts/run-riscv
+++ b/scripts/run-riscv
@@ -177,4 +177,4 @@ mon=none
 
 serial=none
 
-echo "$input" | $qemu -chardev $chardev -semihosting-config "$semi" -monitor "$mon" -serial "$serial" -machine "$machine" -cpu "$cpu" -kernel "$elf" -nographic "$@" -bios none
+echo "$input" | $qemu -chardev $chardev -semihosting-config "$semi" -monitor "$mon" -serial "$serial" -machine "$machine" -cpu "$cpu" -kernel "$elf" -nographic "$@" -bios none -m 2G


### PR DESCRIPTION
There were a couple non-large model addressing operations in crt0, and the vector unit wasn't getting enabled.

The run-riscv script wasn't enabling all required extensions; parse the readelf output and map those to qemu command line options.