### PR TITLE
libm/math: Update expm1 FE_INEXACT code

### DIFF
--- a/newlib/libm/common/s_expm1.c
+++ b/newlib/libm/common/s_expm1.c
@@ -185,10 +185,8 @@ _NAME_64(expm1)(__float64 x)
 	        }
 	        if(x > o_threshold) return __math_oflow (0); /* overflow */
 	    }
-	    if(xsb!=0) { /* x < -56*ln2, return -1.0 with inexact */
-		if(x+tiny<_F_64(0.0))		/* raise inexact */
-		return tiny-one;	/* return -1 */
-	    }
+	    if(xsb!=0) /* x < -56*ln2, return -1.0 with inexact */
+		return __math_inexact64(tiny-one);	/* return -1 */
 	}
 
     /* argument reduction */

--- a/newlib/libm/common/sf_expm1.c
+++ b/newlib/libm/common/sf_expm1.c
@@ -53,10 +53,8 @@ float expm1f(float x)
 		return (xsb==0)? x:-1.0f;/* exp(+-inf)={inf,-1} */
 	    if(xsb == 0 && hx > FLT_UWORD_LOG_MAX) /* if x>=o_threshold */
 		return __math_oflowf (0); /* overflow */
-	    if(xsb!=0) { /* x < -27*ln2, return -1.0 with inexact */
-		if(x+tiny<0.0f)	/* raise inexact */
-		return tiny-one;	/* return -1 */
-	    }
+	    if(xsb!=0) /* x < -27*ln2, return -1.0 with inexact */
+		return __math_inexactf(tiny-one);	/* return -1 */
 	}
 
     /* argument reduction */


### PR DESCRIPTION
Replace the code that is there to generate FE_INEXACT with __math_inexact.