### PR TITLE
libm/math: Update log1p FE_INEXACT code

### DIFF
--- a/newlib/libm/common/s_log1p.c
+++ b/newlib/libm/common/s_log1p.c
@@ -120,7 +120,6 @@ Interface Definition (Issue 2).
 static const __float64
 ln2_hi  =  _F_64(6.93147180369123816490e-01),	/* 3fe62e42 fee00000 */
 ln2_lo  =  _F_64(1.90821492927058770002e-10),	/* 3dea39ef 35793c76 */
-two54   =  _F_64(1.80143985094819840000e+16),  /* 43500000 00000000 */
 Lp1 = _F_64(6.666666666666735130e-01),  /* 3FE55555 55555593 */
 Lp2 = _F_64(3.999999999940941908e-01),  /* 3FD99999 9997FA04 */
 Lp3 = _F_64(2.857142874366239149e-01),  /* 3FD24924 94229359 */
@@ -149,11 +148,10 @@ log1p64(__float64 x)
 		    return __math_invalid (x);	/* log1p(x<-1)=NaN */
 	    }
 	    if(ax<0x3e200000) {			/* |x| < 2**-29 */
-		if(two54+x>zero			/* raise inexact */
-	            &&ax<0x3c900000) 		/* |x| < 2**-54 */
-		    return x;
+		if(ax<0x3c900000) 		/* |x| < 2**-54 */
+		    return __math_inexact64(x);
 		else
-		    return x - x*x*_F_64(0.5);
+		    return __math_inexact64(x - x*x*_F_64(0.5));
 	    }
 	    if(hx>0||hx<=((__int32_t)0xbfd2bec3)) {
 		k=0;f=x;hu=1;}	/* -0.2929<x<0.41422 */

--- a/newlib/libm/common/sf_log1p.c
+++ b/newlib/libm/common/sf_log1p.c
@@ -19,7 +19,6 @@
 static const float
 ln2_hi =   6.9313812256e-01,	/* 0x3f317180 */
 ln2_lo =   9.0580006145e-06,	/* 0x3717f7d1 */
-two25 =    3.355443200e+07,	/* 0x4c000000 */
 Lp1 = 6.6666668653e-01,	/* 3F2AAAAB */
 Lp2 = 4.0000000596e-01,	/* 3ECCCCCD */
 Lp3 = 2.8571429849e-01, /* 3E924925 */
@@ -49,11 +48,10 @@ log1pf(float x)
 		    return __math_invalidf (x);	/* log1p(x<-1)=NaN */
 	    }
 	    if(ax<0x31000000) {			/* |x| < 2**-29 */
-		if(two25+x>zero			/* raise inexact */
-	            &&ax<0x24800000) 		/* |x| < 2**-54 */
-		    return x;
+		if(ax<0x24800000) 		/* |x| < 2**-54 */
+		    return __math_inexactf(x);
 		else
-		    return x - x*x*(float)0.5;
+		    return __math_inexactf(x - x*x*(float)0.5);
 	    }
 	    if(hx>0||hx<=((__int32_t)0xbe95f61f)) {
 		k=0;f=x;hu=1;}	/* -0.2929<x<0.41422 */


### PR DESCRIPTION
Replace the code that is there to generate FE_INEXACT with __math_inexact.