### PR TITLE
libm: use the WANT_ROUNDING macro in #if directives

### DIFF
--- a/newlib/libm/common/exp.c
+++ b/newlib/libm/common/exp.c
@@ -81,8 +81,10 @@ specialcase (double_t tmp, uint64_t sbits, uint64_t ki)
       lo = 1.0 - hi + y + lo;
       y = eval_as_double (hi + lo) - 1.0;
       /* Avoid -0.0 with downward rounding.  */
-      if (WANT_ROUNDING && y == 0.0)
+#if WANT_ROUNDING
+      if (y == 0.0)
 	y = 0.0;
+#endif
       /* The underflow exception needs to be signaled explicitly.  */
       force_eval_double (opt_barrier_double (0x1p-1022) * 0x1p-1022);
     }
@@ -111,7 +113,11 @@ exp (double x)
       if (abstop - top12 (0x1p-54) >= 0x80000000)
 	/* Avoid spurious underflow for tiny x.  */
 	/* Note: 0 is common input.  */
-	return WANT_ROUNDING ? 1.0 + x : 1.0;
+#if WANT_ROUNDING
+	return 1.0 + x;
+#else
+	return 1.0;
+#endif
       if (abstop >= top12 (1024.0))
 	{
 	  if (asuint64 (x) == asuint64 ((double) -INFINITY))

--- a/newlib/libm/common/exp2.c
+++ b/newlib/libm/common/exp2.c
@@ -79,8 +79,10 @@ specialcase (double_t tmp, uint64_t sbits, uint64_t ki)
       lo = 1.0 - hi + y + lo;
       y = eval_as_double (hi + lo) - 1.0;
       /* Avoid -0.0 with downward rounding.  */
-      if (WANT_ROUNDING && y == 0.0)
+#if WANT_ROUNDING
+      if (y == 0.0)
 	y = 0.0;
+#endif
       /* The underflow exception needs to be signaled explicitly.  */
       force_eval_double (opt_barrier_double (0x1p-1022) * 0x1p-1022);
     }
@@ -109,7 +111,11 @@ exp2 (double x)
       if (abstop - top12 (0x1p-54) >= 0x80000000)
 	/* Avoid spurious underflow for tiny x.  */
 	/* Note: 0 is common input.  */
-	return WANT_ROUNDING ? 1.0 + x : 1.0;
+#if WANT_ROUNDING
+	return 1.0 + x;
+#else
+	return 1.0;
+#endif
       if (abstop >= top12 (1024.0))
 	{
 	  if (asuint64 (x) == asuint64 ((double) -INFINITY))

--- a/newlib/libm/common/log.c
+++ b/newlib/libm/common/log.c
@@ -72,8 +72,10 @@ log (double x)
     {
       /* Handle close to 1.0 inputs separately.  */
       /* Fix sign of zero with downward rounding when x==1.  */
-      if (WANT_ROUNDING && unlikely (ix == asuint64 (1.0)))
+#if WANT_ROUNDING
+      if (unlikely (ix == asuint64 (1.0)))
 	return 0;
+#endif
       r = x - 1.0;
       r2 = r * r;
       r3 = r * r2;

--- a/newlib/libm/common/log2.c
+++ b/newlib/libm/common/log2.c
@@ -69,8 +69,10 @@ double
     {
       /* Handle close to 1.0 inputs separately.  */
       /* Fix sign of zero with downward rounding when x==1.  */
-      if (WANT_ROUNDING && unlikely (ix == asuint64 (1.0)))
+#if WANT_ROUNDING
+      if (unlikely (ix == asuint64 (1.0)))
 	return 0;
+#endif
       r = x - 1.0;
 #if __HAVE_FAST_FMA
       hi = r * InvLn2hi;

--- a/newlib/libm/common/pow.c
+++ b/newlib/libm/common/pow.c
@@ -211,7 +211,11 @@ exp_inline (double x, double xtail, uint32_t sign_bias)
 	{
 	  /* Avoid spurious underflow for tiny x.  */
 	  /* Note: 0 is common input.  */
-	  double_t one = WANT_ROUNDING ? 1.0 + x : 1.0;
+#if WANT_ROUNDING
+	  double_t one = 1.0 + x;
+#else
+	  double_t one = 1.0;
+#endif
 	  return sign_bias ? -one : one;
 	}
       if (abstop >= top12 (1024.0))
@@ -363,10 +367,11 @@ pow (double x, double y)
 	  if ((topy & 0x7ff) < 0x3be)
 	    {
 	      /* |y| < 2^-65, x^y ~= 1 + y*log(x).  */
-	      if (WANT_ROUNDING)
+#if WANT_ROUNDING
 		return ix > asuint64 (1.0) ? 1.0 + y : 1.0 - y;
-	      else
+#else
 		return 1.0;
+#endif
 	    }
 	  return (ix > asuint64 (1.0)) == (topy < 0x800) ? __math_oflow (0)
 							 : __math_uflow (0);

--- a/newlib/libm/common/sf_pow.c
+++ b/newlib/libm/common/sf_pow.c
@@ -224,8 +224,8 @@ powf (float x, float y)
       if (ylogx > 0x1.fffffffd1d571p+6 * POWF_SCALE)
 	/* |x^y| > 0x1.ffffffp127.  */
 	return __math_oflowf (sign_bias);
-      if (WANT_ROUNDING && WANT_ERRNO
-	  && ylogx > 0x1.fffffffa3aae2p+6 * POWF_SCALE)
+#if WANT_ROUNDING && WANT_ERRNO
+      if (ylogx > 0x1.fffffffa3aae2p+6 * POWF_SCALE)
 	/* |x^y| > 0x1.fffffep127, check if we round away from 0.  */
 	if ((!sign_bias
 	     && eval_as_float (1.0f + opt_barrier_float (0x1p-25f)) != 1.0f)
@@ -233,6 +233,7 @@ powf (float x, float y)
 		&& eval_as_float (-1.0f - opt_barrier_float (0x1p-25f))
 		     != -1.0f))
 	  return __math_oflowf (sign_bias);
+#endif
       if (ylogx <= -150.0 * POWF_SCALE)
 	return __math_uflowf (sign_bias);
 #if WANT_ERRNO_UFLOW


### PR DESCRIPTION
Use preprocessor directives instead of using the macro in if statements.