### PR TITLE
Remove duplicate unguarded declarations of `isinf` and `isnan` in `<math.h>`

### DIFF
--- a/newlib/libc/include/math.h
+++ b/newlib/libc/include/math.h
@@ -138,9 +138,7 @@ extern double fmod (double, double);
 #if __MISC_VISIBLE
 extern int finite (double);
 extern int finitef (float);
-extern int isinf (double);
 extern int isinff (float);
-extern int isnan (double);
 extern int isnanf (float);
 #if defined(__HAVE_LONG_DOUBLE)
 extern int finitel (long double);


### PR DESCRIPTION
This PR removes the unguarded declarations of `isinf(double)` and `isnan(double)` that were introduced in [commit 407b3d8](https://github.com/picolibc/picolibc/commit/407b3d8e8b407a1eb8e2a630abd5bac2a3fcc6a3), which conflict with C++11 and later.

These functions were already added (correctly) under C++ version guards in [commit 722e363](https://github.com/picolibc/picolibc/commit/722e363c4de410e67f24d0da3129c446074716bc).

The duplicate, unguarded declarations cause ambiguity when including `<math.h>` or `<cmath>` in C++11+, since those functions are also provided as built-ins.

This PR keeps only the guarded declarations to maintain compatibility with both C and modern C++.

Closes:#[163](https://github.com/picolibc/picolibc/issues/1063)