### PR TITLE
scripts/aarch64: in clang/llvm toolchain, llvm-as is not the assemble…

### DIFF
--- a/scripts/cross-clang-aarch64-none-elf-fvp.txt
+++ b/scripts/cross-clang-aarch64-none-elf-fvp.txt
@@ -8,7 +8,7 @@
 c = ['clang', '-target', 'aarch64-none-elf', '-nostdlib']
 cpp = ['clang', '-target', 'aarch64-none-elf', '-nostdlib']
 ar = 'llvm-ar'
-as = 'llvm-as'
+as = 'clang'
 nm = 'llvm-nm'
 strip = 'llvm-strip'
 # only needed to run tests

--- a/scripts/cross-clang-aarch64-none-elf.txt
+++ b/scripts/cross-clang-aarch64-none-elf.txt
@@ -6,7 +6,7 @@
 c = ['clang', '-target', 'aarch64-none-elf', '-nostdlib']
 cpp = ['clang', '-target', 'aarch64-none-elf', '-nostdlib']
 ar = 'llvm-ar'
-as = 'llvm-as'
+as = 'clang'
 nm = 'llvm-nm'
 strip = 'llvm-strip'
 # only needed to run tests


### PR DESCRIPTION
…r tool

In clang/llvm compiler toolchain, 'llvm-as' is the assembler for LLVM IR (Intermediate Representation) files and not for the regular assembly files. Changing it to 'clang'.