### PR TITLE
Stdlib: Bug fix in nano-free.c 

### DIFF
--- a/newlib/libc/stdlib/nano-free.c
+++ b/newlib/libc/stdlib/nano-free.c
@@ -44,8 +44,9 @@ free (void * free_p)
     chunk_t     **p, *r;
 
     if (free_p == NULL) return;
-
-    p_to_free = ptr_to_chunk(free_p);
+    
+    r = chunk_to_blob(free_p);
+    p_to_free = ptr_to_chunk(r);
 
 #ifdef __NANO_MALLOC_CLEAR_FREED
     memset(p_to_free, 0, chunk_usable(p_to_free));


### PR DESCRIPTION
Problem: 
The `p_to_free` pointer was incorrectly pointing to user data instead of the chunk header.

Cause:
As a result, the statement `p_to_free->next = NULL;` overwrote the user's data instead of the `next` field in the chunk header structure.

Solution:
Adjust `p_to_free` to correctly reference the chunk header before modifying the `next` pointer. Fixed an issue where the p_to_free pointer was incorrectly pointing to the user data rather than the chunk header. As a result, the statement `p_to_free->next = NULL` overwrote the user’s data instead of the next field within the chunk header structure.