### PR TITLE
newlib: include: time.h: declare pid_t to be conformant

### DIFF
--- a/newlib/libc/include/time.h
+++ b/newlib/libc/include/time.h
@@ -109,6 +109,11 @@ typedef	__timer_t	timer_t;
 #define	_TIMER_T_DECLARED
 #endif
 
+#ifndef _PID_T_DECLARED
+typedef	__pid_t	pid_t;
+#define	_PID_T_DECLARED
+#endif
+
 /*
  * Structure defined by POSIX.1b to be like a itimerval, but with
  * timespecs. Used in the timer_*() system calls.


### PR DESCRIPTION
According to POSIX, the time.h header must declare pid_t as declared in sys/types.h.

https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/time.h.html

It would appear that the corresponding newlib time.h pulls in sys/types.h rather than sys/_types.h, which would ensure that pid_t is defined correctly.