### PR TITLE
picocrt/m68k: Add exception reporting when semihosting

### DIFF
--- a/picocrt/machine/m68k/crt0.c
+++ b/picocrt/machine/m68k/crt0.c
@@ -40,6 +40,9 @@ extern char __stack[];
 void __section(".init") __used
 _start(void)
 {
+	/* Generate a reference to __exception_vector so we get one loaded */
+	__asm__(".equ __my_exception_vector, __exception_vector");
+
 	/* Initialize stack pointer */
 	__asm__("lea %0,%%sp" : : "m" (__stack));
 
@@ -51,12 +54,88 @@ _start(void)
 #endif
 
 	/* Branch to C code */
-	__asm__("jmp _cstart");
-}
-
-static void __used __section(".init")
-_cstart(void)
-{
 	__start();
 }
 
+#ifdef CRT0_SEMIHOST
+
+/*
+ * Trap faults, print message and exit when running under semihost
+ */
+
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+
+struct fault {
+    uint32_t    d[8];
+    uint32_t    a[8];
+    uint16_t    ccr;    /* pushed by processor */
+    uint16_t    pc_hi;  /* pushed by processor */
+    uint16_t    pc_lo;  /* pushed by processor */
+};
+
+void
+m68k_fault(struct fault *fault, char *reason)
+{
+    size_t      i;
+    printf("M68k fault: %s\n", reason);
+    for (i = 0; i < 8; i++)
+        printf("D%ld: 0x%08lx\n", i, fault->d[i]);
+    for (i = 0; i < 8; i++)
+        printf("A%ld: 0x%08lx\n", i, fault->a[i]);
+    printf("PC: 0x%08lx\n", ((uint32_t) fault->pc_hi << 16) | (uint32_t) fault->pc_lo);
+    printf("SR: 0x%04x\n", fault->ccr);
+    _exit(1);
+}
+
+#if 0
+#define ISR_COMMON                              \
+    struct fault *sp;                           \
+    __asm__("move.l %%a7,-(%%sp);"              \
+            "move.l %%a6,-(%%sp);"              \
+            "move.l %%a5,-(%%sp);"              \
+            "move.l %%a4,-(%%sp);"              \
+            "move.l %%a3,-(%%sp);"              \
+            "move.l %%a2,-(%%sp);"              \
+            "move.l %%a1,-(%%sp);"              \
+            "move.l %%a0,-(%%sp);"              \
+            "move.l %%d7,-(%%sp);"              \
+            "move.l %%d6,-(%%sp);"              \
+            "move.l %%d5,-(%%sp);"              \
+            "move.l %%d4,-(%%sp);"              \
+            "move.l %%d3,-(%%sp);"              \
+            "move.l %%d2,-(%%sp);"              \
+            "move.l %%d1,-(%%sp);"              \
+            "move.l %%d0,-(%%sp);"              \
+            "move.l %%sp,%0" : "=d" (sp));
+#endif
+#define ISR_COMMON                              \
+    struct fault *sp;                           \
+    __asm__("move.l %%a7,-(%%sp);"              \
+            "suba.l #60,%%sp;"                  \
+            "movem.l #0x7fff,(%%sp);"           \
+            "move.l %%sp,%0" : "=d" (sp));
+
+#define _isr_name(name) m68k_ ## name ## _isr
+#define isr_name(name) _isr_name(name)
+#define isr(name) void isr_name(name)(void) { ISR_COMMON; m68k_fault(sp, #name); }
+
+isr(access_fault)
+isr(address_error)
+isr(illegal_instruction)
+isr(divide_by_zero)
+isr(chk)
+isr(trap)
+
+isr(fp_branch_uc)
+isr(fp_inexact)
+isr(fp_divide_by_zero)
+isr(fp_underflow)
+
+isr(fp_operand_error)
+isr(fp_overflow)
+isr(fp_signaling_nan)
+isr(fp_unimplemented_data)
+
+#endif

--- a/test/test-except.c
+++ b/test/test-except.c
@@ -68,6 +68,11 @@ main(void)
 
     __asm__("ud2");
 
+#elif defined(__m68k__)
+
+    /* 0x4afc is reserved for customer use to take an illegal instruction trap */
+    __asm__(".word 0x4afc");
+
 #else
 
 #define NO_INVALID


### PR DESCRIPTION
Register ISR handlers for all vectors which dump register state and call _exit(1). Add m68k to test/test-except now.