### PR TITLE
machine/riscv: Refactor machine specific memmove overriding mechanism

### DIFF
--- a/newlib/libc/machine/riscv/CMakeLists.txt
+++ b/newlib/libc/machine/riscv/CMakeLists.txt
@@ -40,7 +40,7 @@ picolibc_sources_flags("-fno-builtin"
   memcpy-asm.S
   memcpy.c
   memmove.S
-  memmove-stub.c
+  memmove.c
   memset.S
   setjmp.S
   stpcpy.c

--- a/newlib/libc/machine/riscv/memmove.S
+++ b/newlib/libc/machine/riscv/memmove.S
@@ -9,9 +9,9 @@
    http://www.opensource.org/licenses.
 */
 
-#include <picolibc.h>
+#include "rv_memmove.h"
 
-#if defined(__PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
+#ifdef _MACHINE_RISCV_MEMMOVE_ASM_
 .section .text.memmove
 .global memmove
 .type	memmove, @function
@@ -39,4 +39,4 @@ memmove:
   ret
 
   .size	memmove, .-memmove
-#endif
+#endif /* _MACHINE_RISCV_MEMMOVE_ASM_ */

--- a/newlib/libc/machine/riscv/memmove.c
+++ b/newlib/libc/machine/riscv/memmove.c
@@ -9,8 +9,8 @@
    http://www.opensource.org/licenses.
 */
 
-#include <picolibc.h>
+#include "rv_memmove.h"
 
-#if !defined(__PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__)
+#ifdef _MACHINE_RISCV_MEMMOVE_GENERIC_
 #include "../../string/memmove.c"
 #endif

--- a/newlib/libc/machine/riscv/meson.build
+++ b/newlib/libc/machine/riscv/meson.build
@@ -37,7 +37,7 @@ srcs_machine = [
   'memcpy-asm.S',
   'memcpy.c',
   'memmove.S',
-  'memmove-stub.c',
+  'memmove.c',
   'memset.S',
   'setjmp.S',
   'stpcpy.c',

--- a/newlib/libc/machine/riscv/rv_memmove.h
+++ b/newlib/libc/machine/riscv/rv_memmove.h
@@ -1,0 +1,12 @@
+#ifndef _RV_MEMMOVE_H_
+#define _RV_MEMMOVE_H_
+
+#include <picolibc.h>
+
+#if !defined(__PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__)
+# define _MACHINE_RISCV_MEMMOVE_GENERIC_
+#else
+# define _MACHINE_RISCV_MEMMOVE_ASM_
+#endif
+
+#endif /* _RV_MEMMOVE_H_ */


### PR DESCRIPTION
For RISC-V, it is possible to have several optimized implementations of library routines depending on which hardware extensions are enabled and the current mechanism to choose the appropriate implementation will quickly become messy when dealing with many implementations.

With this change, the idea is 'newlib/libc/machine/riscv/memmove.c' will override the generic 'newlib/libc/string/memmove.c' through the 'srcs_machine' scheme and conditions in 'newlib/libc/machine/riscv/memmove.c' will decide which implementation gets compiled and used for a given scenario.

I think this mechanism is simple and scalable.

The remaining RISC-V specific library implementations are either only assembly or only C. Probably we don't need to change those at this moment.