### PR TITLE
cdefs: Add __returns_twice and use with setjmp

### DIFF
--- a/newlib/libc/include/setjmp.h
+++ b/newlib/libc/include/setjmp.h
@@ -45,9 +45,8 @@ SUCH DAMAGE.
 _BEGIN_STD_C
 
 __noreturn void	longjmp (jmp_buf __jmpb, int __retval);
-int	setjmp (jmp_buf __jmpb);
+__returns_twice int setjmp (jmp_buf __jmpb);
 
 _END_STD_C
 
 #endif /* _SETJMP_H_ */
-

--- a/newlib/libc/include/sys/cdefs.h
+++ b/newlib/libc/include/sys/cdefs.h
@@ -283,6 +283,12 @@
 # endif
 #endif
 
+#if __has_attribute(__returns_twice__)
+# define __returns_twice __attribute__((__returns_twice__))
+#else
+# define __returns_twice
+#endif
+
 /*
  * Builtins.
  *


### PR DESCRIPTION
This lets the compiler know how setjmp works and makes sure all register contents are dead across the call.