### PR TITLE
sys/types.h: include <sys/_pthreadtypes.h>

### DIFF
--- a/newlib/libc/include/sys/types.h
+++ b/newlib/libc/include/sys/types.h
@@ -254,6 +254,7 @@ typedef	__int64_t	sbintime_t;
 #endif
 
 #include <sys/features.h>
+#include <sys/_pthreadtypes.h>
 #include <machine/types.h>
 
 #endif  /* !__need_inttypes */


### PR DESCRIPTION
It seems that some essential types are not defined when using

```cpp
#include <pthread.h>
```

Indeed, when comparing `sys/types.h` with [the Newlib variant](https://github.com/bminor/newlib/blob/63dc988ac7454b701ee923590f18df4103587994/newlib/libc/include/sys/types.h#L221), we see that `sys/_pthreadtypes.h` is missing in Picolibc.

Include the missing file in `sys/types.h` to get access to other essential posix types.