### PR TITLE
rv_strcpy: move checking the 4th byte in case of 32-bit to 64-bit

### DIFF
--- a/newlib/libc/machine/riscv/rv_strcpy.h
+++ b/newlib/libc/machine/riscv/rv_strcpy.h
@@ -97,8 +97,8 @@ char *__libc_strcpy(char *dst, const char *src, bool ret_start)
           if (!(*dst++ = src[0])) return dst0;
           if (!(*dst++ = src[1])) return dst0;
           if (!(*dst++ = src[2])) return dst0;
-          if (!(*dst++ = src[3])) return dst0;
           #if __riscv_xlen == 64
+            if (!(*dst++ = src[3])) return dst0;
             if (!(*dst++ = src[4])) return dst0;
             if (!(*dst++ = src[5])) return dst0;
             if (!(*dst++ = src[6])) return dst0;
@@ -109,8 +109,8 @@ char *__libc_strcpy(char *dst, const char *src, bool ret_start)
           if (!(*dst++ = src[0])) return dst - 1;
           if (!(*dst++ = src[1])) return dst - 1;
           if (!(*dst++ = src[2])) return dst - 1;
-          if (!(*dst++ = src[3])) return dst - 1;
           #if __riscv_xlen == 64
+            if (!(*dst++ = src[3])) return dst - 1;
             if (!(*dst++ = src[4])) return dst - 1;
             if (!(*dst++ = src[5])) return dst - 1;
             if (!(*dst++ = src[6])) return dst - 1;


### PR DESCRIPTION
This check is not needed in case of `_riscv_xlen=32` at all as it's checking the last byte which is supposed to be `NULL` (by standard `strcpy` input is null terminated string)

Also it causes function to set 0 to out of boundary address in case of `_riscv_xlen=32`

Reducing assembly instructions of `strcpy` in case of `_riscv_xlen=32`