### PR TITLE
semihost: Provide alternate aarch64 semihosting with raw serial port

### DIFF
--- a/picocrt/machine/aarch64/crt0.c
+++ b/picocrt/machine/aarch64/crt0.c
@@ -195,7 +195,6 @@ void _cstart(void)
  * Trap faults, print message and exit when running under semihost
  */
 
-#include <semihost.h>
 #include <unistd.h>
 #include <stdio.h>
 

--- a/scripts/run-aarch64
+++ b/scripts/run-aarch64
@@ -34,6 +34,8 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+dir="$(dirname "$0")"
+
 qemu="qemu-system-aarch64"
 
 # select the program
@@ -77,12 +79,24 @@ done
 
 semi=enable=on,chardev=stdio0,arg="$cmdline"
 
-# Disable monitor
-
-mon=none
-
-# Point serial port at new chardev
-
-serial=none
-
-echo "$input" | $qemu -chardev $chardev -semihosting-config "$semi" -monitor "$mon" -serial "$serial" -M virt -cpu cortex-a57 -nographic -kernel "$elf" "$@" -nic none
+if nm "$elf" | grep -q aarch64_putc; then
+    "$dir"/monitor-e9 $qemu \
+        -chardev stdio,id=con,mux=on \
+        -mon chardev=con,mode=readline \
+        -serial chardev:con \
+        -M virt \
+        -cpu max \
+        -nic none \
+        -nographic \
+        -kernel "$elf" "$@"
+else
+    echo "$input" | $qemu -chardev $chardev \
+                          -semihosting-config "$semi" \
+                          -monitor none \
+                          -serial none \
+                          -M virt \
+                          -cpu cortex-a57 \
+                          -nic none \
+                          -nographic \
+                          -kernel "$elf" "$@"
+fi

--- a/semihost/machine/aarch64/aarch64-semihost.h
+++ b/semihost/machine/aarch64/aarch64-semihost.h
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2023 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _AARCH64_SEMIHOST_H_
+#define _AARCH64_SEMIHOST_H_
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+int
+aarch64_putc(char c, FILE *file);
+
+#endif /* _AARCH64_SEMIHOST_H_ */

--- a/semihost/machine/aarch64/aarch64_exit.c
+++ b/semihost/machine/aarch64/aarch64_exit.c
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2021 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "aarch64-semihost.h"
+
+__noreturn void
+_exit(int code)
+{
+        char buf[15];
+        int n;
+        /* Can't use printf because stdout has already been cleaned up */
+        n = snprintf(buf, sizeof(buf), "%cexit %d\n", 0xe9, code);
+        write(1, buf, n);
+	while(1);
+}

--- a/semihost/machine/aarch64/aarch64_iob.c
+++ b/semihost/machine/aarch64/aarch64_iob.c
@@ -1,0 +1,151 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2023 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "aarch64-semihost.h"
+
+typedef volatile uint8_t vuint8_t;
+typedef volatile uint32_t vuint32_t;
+
+struct pl011 {
+    vuint32_t   dr;
+    vuint32_t   rsr;
+    vuint32_t   fr;
+    vuint32_t   iplr;
+    vuint32_t   ibrd;
+    vuint32_t   fbrd;
+    vuint32_t   lcrh;
+    vuint32_t   cr;
+    vuint32_t   ifls;
+    vuint32_t   imsc;
+    vuint32_t   ris;
+    vuint32_t   mis;
+    vuint32_t   icr;
+    vuint32_t   dmacr;
+};
+
+#ifdef __GNUCLIKE_PRAGMA_DIAGNOSTIC
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
+/* 'bsize' is used directly with malloc/realloc which confuses -fanalyzer */
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
+
+/* pl011 serial port */
+#define uart    (*((struct pl011 *) 0x09000000))
+
+/* Flag Register, UARTFR */
+#define PL011_FLAG_RI   0x100
+#define PL011_FLAG_TXFE 0x80
+#define PL011_FLAG_RXFF 0x40
+#define PL011_FLAG_TXFF 0x20
+#define PL011_FLAG_RXFE 0x10
+#define PL011_FLAG_DCD  0x04
+#define PL011_FLAG_DSR  0x02
+#define PL011_FLAG_CTS  0x01
+
+/* Data Register, UARTDR */
+#define DR_BE   (1 << 10)
+
+/* Interrupt status bits in UARTRIS, UARTMIS, UARTIMSC */
+#define INT_OE (1 << 10)
+#define INT_BE (1 << 9)
+#define INT_PE (1 << 8)
+#define INT_FE (1 << 7)
+#define INT_RT (1 << 6)
+#define INT_TX (1 << 5)
+#define INT_RX (1 << 4)
+#define INT_DSR (1 << 3)
+#define INT_DCD (1 << 2)
+#define INT_CTS (1 << 1)
+#define INT_RI (1 << 0)
+#define INT_E (INT_OE | INT_BE | INT_PE | INT_FE)
+#define INT_MS (INT_RI | INT_DSR | INT_DCD | INT_CTS)
+
+/* Line Control Register, UARTLCR_H */
+#define LCR_FEN     (1 << 4)
+#define LCR_BRK     (1 << 0)
+
+/* Control Register, UARTCR */
+#define CR_OUT2     (1 << 13)
+#define CR_OUT1     (1 << 12)
+#define CR_RTS      (1 << 11)
+#define CR_DTR      (1 << 10)
+#define CR_RXE      (1 << 9)
+#define CR_TXE      (1 << 8)
+#define CR_LBE      (1 << 7)
+#define CR_UARTEN   (1 << 0)
+
+/* Integer Baud Rate Divider, UARTIBRD */
+#define IBRD_MASK 0xffff
+
+/* Fractional Baud Rate Divider, UARTFBRD */
+#define FBRD_MASK 0x3f
+
+int
+aarch64_putc(char c, FILE *file)
+{
+	(void) file;
+        uart.cr |= CR_TXE|CR_UARTEN;
+        while ((uart.fr & PL011_FLAG_TXFF) != 0)
+               ;
+        uart.dr = (uint8_t) c;
+	return (unsigned char) c;
+}
+
+#ifdef __TINY_STDIO
+
+static int
+aarch64_getc(FILE *file)
+{
+	(void) file;
+        uart.cr |= CR_RXE|CR_UARTEN;
+        while ((uart.cr & PL011_FLAG_RXFE) == 0)
+            ;
+        return (unsigned char) uart.dr;
+}
+
+static FILE __stdio = FDEV_SETUP_STREAM(aarch64_putc, aarch64_getc, NULL, _FDEV_SETUP_RW);
+
+#ifdef __strong_reference
+#define STDIO_ALIAS(x) __strong_reference(stdin, x);
+#else
+#define STDIO_ALIAS(x) FILE *const x = &__stdio;
+#endif
+
+FILE *const stdin = &__stdio;
+STDIO_ALIAS(stdout);
+STDIO_ALIAS(stderr);
+
+#endif

--- a/semihost/machine/aarch64/aarch64_stub.c
+++ b/semihost/machine/aarch64/aarch64_stub.c
@@ -1,0 +1,108 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2021 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _GNU_SOURCE
+#include "aarch64-semihost.h"
+
+ssize_t
+read(int fd, void *buf, size_t count)
+{
+        (void) fd;
+        (void) buf;
+        (void) count;
+	return 0;
+}
+
+ssize_t
+write(int fd, const void *buf, size_t count)
+{
+	const char *b = buf;
+	size_t c = count;
+
+        (void) fd;
+	while (c--)
+                aarch64_putc(*b++, NULL);
+	return count;
+}
+
+int
+open(const char *pathname, int flags, ...)
+{
+        (void) pathname;
+        (void) flags;
+	return -1;
+}
+
+int
+close(int fd)
+{
+        (void) fd;
+	return 0;
+}
+
+off_t lseek(int fd, off_t offset, int whence)
+{
+        (void) fd;
+        (void) offset;
+        (void) whence;
+	return (off_t) -1;
+}
+
+_off64_t lseek64(int fd, _off64_t offset, int whence)
+{
+	return (_off64_t) lseek(fd, (off_t) offset, whence);
+}
+
+int
+unlink(const char *pathname)
+{
+        (void) pathname;
+	return 0;
+}
+
+int
+fstat (int fd, struct stat *sbuf)
+{
+        (void) fd;
+        (void) sbuf;
+	return -1;
+}
+
+int
+isatty (int fd)
+{
+        (void) fd;
+	return 1;
+}

--- a/semihost/machine/aarch64/meson.build
+++ b/semihost/machine/aarch64/meson.build
@@ -33,3 +33,34 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 src_semihost += files('semihost-aarch64.S')
+
+lib_semihost_raw_srcs = [
+  'aarch64_stub.c',
+  'aarch64_exit.c',
+  'aarch64_iob.c',
+  ]
+
+has_semihost = true
+
+foreach params : targets
+  target = params['name']
+  target_dir = params['dir']
+  target_c_args = params['c_args']
+  target_lib_prefix = params['lib_prefix']
+
+  instdir = join_paths(lib_dir, target_dir)
+
+  libsemihost_raw_name = 'semihost_raw'
+
+  local_lib_semihost_raw_target = static_library(join_paths(target_dir, target_lib_prefix + libsemihost_raw_name),
+				       lib_semihost_raw_srcs,
+				       install : really_install,
+				       install_dir : instdir,
+				       include_directories : inc,
+				       c_args : target_c_args + c_args,
+				       pic: false)
+
+  set_variable('lib_semihost_raw' + target, local_lib_semihost_raw_target)
+
+endforeach
+

--- a/test/meson.build
+++ b/test/meson.build
@@ -427,6 +427,41 @@ foreach params : targets
        timeout: 90,
       )
 
+  if is_variable('lib_semihost_raw' + target) and test_machine == 'qemu'
+
+    _libs_raw = [get_variable('lib_c' + target)]
+    _libs_raw += [get_variable('lib_semihost_raw' + target)]
+    
+    _lib_raw_files=[]
+    foreach _lib_raw : _libs_raw
+      _lib_raw_files += _lib_raw.full_path()
+    endforeach
+
+    _link_raw_args = target_c_args + _lib_raw_files + get_variable('test_link_args' + target, test_link_args)
+    _link_raw_depends = get_variable('test_link_depends' + target, test_link_depends) + _libs_raw
+
+    if is_variable('crt0_hosted' + target)
+      _objs_raw = [get_variable('crt0_hosted' + target)]
+    else
+      _objs_raw = []
+    endif
+
+    t1 = 'test-hello-raw'
+    t1_src = 'test-hello.c'
+    test(t1 + target,
+         executable(t1 + target, t1_src,
+		    c_args: printf_compile_args_d + _c_args,
+		    link_args: printf_link_args_d + _link_raw_args,
+		    objects: _objs_raw,
+		    link_depends:  _link_raw_depends,
+		    include_directories: inc),
+         depends: bios_bin,
+         suite: 'test',
+         env: test_env,
+         timeout: 90,
+        )
+  endif
+
   if get_option('test-stdin')
     t1 = 'test-gets'
     t1_src = 'test-gets.c'


### PR DESCRIPTION
Add a --oslib=semihost-raw option which uses a serial port at the standard QEMU address. This allows use of qemu with KVM enabled.