### PR TITLE
libm: Remove duplicate FE_DFL_ENV definitions

### DIFF
--- a/newlib/libc/machine/mips/machine/fenv.h
+++ b/newlib/libc/machine/mips/machine/fenv.h
@@ -62,10 +62,6 @@ typedef int fexcept_t;
 #define	_ROUND_MASK	(FE_TONEAREST | FE_DOWNWARD | \
 			 FE_UPWARD | FE_TOWARDZERO)
 
-/* Default floating-point environment */
-extern fenv_t		_fe_dfl_env;
-#define	FE_DFL_ENV	((const fenv_t *) &_fe_dfl_env)
-
 /* We need to be able to map status flag positions to mask flag positions */
 #define	_FCSR_ENABLE_SHIFT	5
 #define	_FCSR_ENABLE_MASK	(FE_ALL_EXCEPT << _FCSR_ENABLE_SHIFT)

--- a/newlib/libc/machine/powerpc/machine/fenv.h
+++ b/newlib/libc/machine/powerpc/machine/fenv.h
@@ -75,12 +75,6 @@ typedef	int	fexcept_t;
 #define	_ROUND_MASK	(FE_TONEAREST | FE_DOWNWARD | \
 			 FE_UPWARD | FE_TOWARDZERO)
 
-
-
-/* Default floating-point environment */
-extern fenv_t		_fe_dfl_env;
-#define	FE_DFL_ENV	((const fenv_t *) &_fe_dfl_env)
-
 /* We need to be able to map status flag positions to mask flag positions */
 #define	_FPUSW_SHIFT	22
 #define	_ENABLE_MASK	((FE_DIVBYZERO | FE_INEXACT | FE_INVALID | \

--- a/newlib/libc/machine/spu/machine/fenv.h
+++ b/newlib/libc/machine/spu/machine/fenv.h
@@ -142,9 +142,6 @@ _BEGIN_STD_C
 typedef unsigned int fexcept_t;
 typedef unsigned int fenv_t;
 
-extern fenv_t _fe_dfl_env;
-#define FE_DFL_ENV	((const fenv_t *) &_fe_dfl_env)
-
 _END_STD_C
 
 #endif /* fenv.h */


### PR DESCRIPTION
Several machine-specific fenv.h files included redundant definitions of _fe_dfl_env and FE_DFL_ENV. Remove them as the common fenv.h already has the required definitions.