### PR TITLE
meson: Rename cross compile property 'libgcc' to 'librt'

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,10 @@ use Picolibc:
 
  * Test exception handling on m68k
 
+ * Rename cross compile property 'libgcc' to 'librt' since we can now
+   specify either libgcc or compiler-rt as run-time library. However,
+   'libgcc' is still supported for backward compatibility.
+
 ### Picolibc release 1.8.10
 
  * Add missing POSIX constants to limits.h.

--- a/meson.build
+++ b/meson.build
@@ -337,25 +337,25 @@ endif
 
 # Find the compiler support library
 
-lib_gcc = [meson.get_cross_property('libgcc', false)]
+runtime_lib = [meson.get_cross_property('librt', meson.get_cross_property('libgcc', false))]
 
-if lib_gcc == [false]
-  lib_gcc = []
-  foreach lg : ['-lgcc', '-lclang_rt.builtins']
-    if cc.has_multi_link_arguments(link_test_args + [lg])
-      lib_gcc = [lg]
+if runtime_lib == [false]
+  runtime_lib = []
+  foreach lrt : ['-lgcc', '-lclang_rt.builtins']
+    if cc.has_multi_link_arguments(link_test_args + [lrt])
+      runtime_lib = [lrt]
       break
     endif
   endforeach
 endif
 
-# Add libgcc for use in future linking tests
+# Add run-time library for use in future linking tests
 
-link_test_args += lib_gcc
+link_test_args += runtime_lib
 
 # Get additional flags used for linking tests.
 
-test_link_args_base = lib_gcc
+test_link_args_base = runtime_lib
 
 foreach ld : ['-Wl,--gc-sections', '-Wl,--no-warn-rwx-segments']
   if cc.has_multi_link_arguments(link_test_args + [ld])

--- a/scripts/cross-clang-aarch64-none-elf-fvp.txt
+++ b/scripts/cross-clang-aarch64-none-elf-fvp.txt
@@ -22,7 +22,7 @@ endian = 'little'
 
 [properties]
 skip_sanity_check = true
-libgcc='-lclang_rt.builtins'
+librt='-lclang_rt.builtins'
 default_flash_addr = '0x80000000'
 default_flash_size = '0x01000000'
 default_ram_addr   = '0x81000000'

--- a/scripts/cross-clang-aarch64-none-elf.txt
+++ b/scripts/cross-clang-aarch64-none-elf.txt
@@ -20,7 +20,7 @@ endian = 'little'
 
 [properties]
 skip_sanity_check = true
-libgcc='-lclang_rt.builtins'
+librt='-lclang_rt.builtins'
 default_flash_addr = '0x40000000'
 default_flash_size = '0x00400000'
 default_ram_addr   = '0x40400000'

--- a/scripts/cross-clang-arm-none-eabi.txt
+++ b/scripts/cross-clang-arm-none-eabi.txt
@@ -19,7 +19,7 @@ endian = 'little'
 
 [properties]
 skip_sanity_check = true
-libgcc='-lclang_rt.builtins'
+librt='-lclang_rt.builtins'
 default_flash_addr = '0x00000000'
 default_flash_size = '0x00400000'
 default_ram_addr   = '0x20000000'

--- a/scripts/cross-clang-cortex-r82.txt
+++ b/scripts/cross-clang-cortex-r82.txt
@@ -20,7 +20,7 @@ endian = 'little'
 
 [properties]
 skip_sanity_check = true
-libgcc='-lclang_rt.builtins-aarch64'
+librt='-lclang_rt.builtins-aarch64'
 default_flash_addr = '0x40000000'
 default_flash_size = '0x00400000'
 default_ram_addr   = '0x40400000'

--- a/scripts/cross-clang-hexagon.txt
+++ b/scripts/cross-clang-hexagon.txt
@@ -57,7 +57,7 @@ endian='little'
 # hardcode runtime library, otherwise meson build configuration will add '-lgcc'
 # use -Dc_link_args=-L$(clang -print-resource-dir)/lib/hexagon-unknown-none-elf flag while calling hexagon configure script
 # so that clang can find builtins library
-libgcc = '-lclang_rt.builtins'
+librt = '-lclang_rt.builtins'
 skip_sanity_check = true
 needs_exe_wrapper = true
 link_spec = '--build-id=none'

--- a/scripts/cross-msp430-unknown-elf.txt
+++ b/scripts/cross-msp430-unknown-elf.txt
@@ -19,7 +19,7 @@ endian = 'little'
 
 [properties]
 skip_sanity_check = true
-libgcc = ['-lmul_none', '-lgcc']
+librt = ['-lmul_none', '-lgcc']
 default_alignment = 2
 default_flash_addr  = '0x00010000'
 default_flash_size  = '0x000e0000'

--- a/scripts/cross-msp430.txt
+++ b/scripts/cross-msp430.txt
@@ -18,5 +18,5 @@ endian = 'little'
 
 [properties]
 skip_sanity_check = true
-libgcc = ['-lmul_none', '-lgcc']
+librt = ['-lmul_none', '-lgcc']
 default_alignment = 2


### PR DESCRIPTION
Rename cross compile property 'libgcc' to 'librt' as it can be used to specify either libgcc or compiler-rt as run-time library.
    
Updated the in-tree example cross scripts to use 'librt'. However, 'libgcc' is still supported for backward compatibility and out-of-tree cross scripts.