### PR TITLE
stdlib: Use lots of uintptr_t casts to avoid sanitizer in malloc

### DIFF
--- a/newlib/libc/picolib/picosbrk.c
+++ b/newlib/libc/picolib/picosbrk.c
@@ -35,6 +35,7 @@
 
 #include <unistd.h>
 #include <errno.h>
+#include <stdint.h>
 
 extern char __heap_start[];
 extern char __heap_end[];
@@ -44,17 +45,17 @@ static char *__brk = __heap_start;
 void *sbrk(ptrdiff_t incr)
 {
 	if (incr < 0) {
-                if ((size_t) (__brk - __heap_start) < (size_t) (-incr)) {
+                if ((size_t) ((uintptr_t)__brk - (uintptr_t)__heap_start) < (size_t) (-incr)) {
                     errno = ENOMEM;
                     return (void *) -1;
             }
 	} else {
-                if ((size_t) (__heap_end - __brk) < (size_t) incr) {
+                if ((size_t) ((uintptr_t)__heap_end - (uintptr_t)__brk) < (size_t) incr) {
                         errno = ENOMEM;
 			return (void *) -1;
                 }
 	}
 	void *ret = __brk;
-	__brk += incr;
+	__brk = (char *) ((uintptr_t) __brk + incr);
 	return ret;
 }

--- a/newlib/libc/stdlib/nano-malloc.c
+++ b/newlib/libc/stdlib/nano-malloc.c
@@ -66,13 +66,13 @@ __malloc_sbrk_aligned(size_t s)
     if (p == (void *)-1)
         return p;
 
-    __malloc_sbrk_top = p + s;
+    __malloc_sbrk_top = (char *) ((uintptr_t) p + s);
 
     /* Adjust returned space so that the storage area
      * is MALLOC_CHUNK_ALIGN aligned and the head is
      * MALLOC_HEAD_ALIGN aligned.
      */
-    align_p = __align_up(p + MALLOC_HEAD, MALLOC_CHUNK_ALIGN) - MALLOC_HEAD;
+    align_p = (char *) (__align_up((uintptr_t) p + MALLOC_HEAD, MALLOC_CHUNK_ALIGN) - MALLOC_HEAD);
 
     if (align_p != p)
     {
@@ -84,7 +84,7 @@ __malloc_sbrk_aligned(size_t s)
 	 */
 	intptr_t adjust = align_p - p;
         char *extra = sbrk(adjust);
-        if (extra != p + s)
+        if (extra != (char *) ((uintptr_t) p + s))
             return (void *) -1;
 	__malloc_sbrk_top = extra + adjust;
     }


### PR DESCRIPTION
Much of mallocs work confuses the address sanitizer as the pointers don't appear to point into the same object, even though they all come from sbrk. Spam the code with enough uintptr_t casts to avoid the sanitizer's wrath.