### PR TITLE
Define `__STDC_LIB_EXT1__` in headers that provide Annex K functions

### DIFF
--- a/newlib/libc/include/errno.h
+++ b/newlib/libc/include/errno.h
@@ -37,6 +37,10 @@ SUCH DAMAGE.
 #include <sys/cdefs.h>
 
 #if __STDC_WANT_LIB_EXT1__ == 1
+#ifndef __STDC_LIB_EXT1__
+#define __STDC_LIB_EXT1__ 1
+#endif
+
 #include <sys/_types.h>
 
 #ifndef _ERRNO_T_DEFINED

--- a/newlib/libc/include/stdint.h
+++ b/newlib/libc/include/stdint.h
@@ -462,6 +462,10 @@ typedef __uint_least64_t uint_least64_t;
 #endif
 
 #if __STDC_WANT_LIB_EXT1__ == 1
+#ifndef __STDC_LIB_EXT1__
+#define __STDC_LIB_EXT1__ 1
+#endif
+
   // could be defined by the user
 #ifndef RSIZE_MAX
 #define RSIZE_MAX SIZE_MAX

--- a/newlib/libc/include/stdlib.h
+++ b/newlib/libc/include/stdlib.h
@@ -409,6 +409,10 @@ void	__eprintf (const char *, const char *, unsigned int, const char *);
 #endif
 
 #if __STDC_WANT_LIB_EXT1__ == 1
+#ifndef __STDC_LIB_EXT1__
+#define __STDC_LIB_EXT1__ 1
+#endif
+
 #include <sys/_types.h>
 
 #ifndef _ERRNO_T_DEFINED

--- a/newlib/libc/include/string.h
+++ b/newlib/libc/include/string.h
@@ -208,6 +208,10 @@ int	 timingsafe_memcmp (const void *, const void *, size_t);
 #endif
 
 #if __STDC_WANT_LIB_EXT1__ == 1
+#ifndef __STDC_LIB_EXT1__
+#define __STDC_LIB_EXT1__ 1
+#endif
+
 #include <sys/_types.h>
 
 #ifndef _ERRNO_T_DEFINED

--- a/newlib/libc/include/sys/_types.h
+++ b/newlib/libc/include/sys/_types.h
@@ -270,6 +270,10 @@ typedef	unsigned long	__useconds_t;	/* microseconds (unsigned) */
 #endif
 
 #if __STDC_WANT_LIB_EXT1__ == 1
+#ifndef __STDC_LIB_EXT1__
+#define __STDC_LIB_EXT1__ 1
+#endif
+
 typedef size_t __rsize_t;
 typedef int __errno_t;
 #endif

--- a/newlib/libc/include/time.h
+++ b/newlib/libc/include/time.h
@@ -301,6 +301,10 @@ int        timer_settime (timer_t timerid, int flags,
 void       tzset (void);
 
 #if __STDC_WANT_LIB_EXT1__ == 1
+#ifndef __STDC_LIB_EXT1__
+#define __STDC_LIB_EXT1__ 1
+#endif
+
 #include <sys/_types.h>
 
 #ifndef _ERRNO_T_DEFINED

--- a/newlib/libc/include/wchar.h
+++ b/newlib/libc/include/wchar.h
@@ -302,6 +302,10 @@ int      wscanf (const wchar_t *__restrict, ...);
 #endif
 
 #if __STDC_WANT_LIB_EXT1__ == 1
+#ifndef __STDC_LIB_EXT1__
+#define __STDC_LIB_EXT1__ 1
+#endif
+
 #include <sys/_types.h>
 
 #ifndef _ERRNO_T_DEFINED

--- a/newlib/libc/stdio/stdio.h
+++ b/newlib/libc/stdio/stdio.h
@@ -780,6 +780,10 @@ _putchar_unlocked(int _c)
 #endif /* !__CUSTOM_FILE_IO__ */
 
 #if __STDC_WANT_LIB_EXT1__ == 1
+#ifndef __STDC_LIB_EXT1__
+#define __STDC_LIB_EXT1__ 1
+#endif
+
 #include <sys/_types.h>
 
 #ifndef _ERRNO_T_DEFINED

--- a/newlib/libc/stdlib/local_s.h
+++ b/newlib/libc/stdlib/local_s.h
@@ -37,6 +37,10 @@
 #define _LOCAL_S_H_
 
 #if __STDC_WANT_LIB_EXT1__ == 1
+#ifndef __STDC_LIB_EXT1__
+#define __STDC_LIB_EXT1__ 1
+#endif
+
 #include <stdint.h>
 #include <stdlib.h>
 

--- a/newlib/libc/tinystdio/stdio.h
+++ b/newlib/libc/tinystdio/stdio.h
@@ -451,6 +451,10 @@ int	putchar_unlocked (int);
 #endif
 
 #if __STDC_WANT_LIB_EXT1__ == 1
+#ifndef __STDC_LIB_EXT1__
+#define __STDC_LIB_EXT1__ 1
+#endif
+
 #include <sys/_types.h>
 #include <stdarg.h>
 


### PR DESCRIPTION
Picolibc implements the optional bounds-checking interfaces from C11 Annex K (e.g., `sprintf_s`, `memcpy_s`), but currently does not define the macro `__STDC_LIB_EXT1__`.

Reference: ISO/IEC 9899:2011 (C11), Annex K:
```
An implementation that defines __STDC_LIB_EXT1__ shall conform to the specifications in this annex.
Implementations that do not define __STDC_LIB_EXT1__ are not required to conform to these specifications.
```

So, defining this macro when Annex K features are exposed signals compliance with the standard and allows conformance tests and portable code to detect support for these interfaces.

This change adds:
```c
#define __STDC_LIB_EXT1__ 1
```
inside the conditional blocks guarded by `__STDC_WANT_LIB_EXT1__ == 1` in all headers.