### PR TITLE
Don't run exhaustive math tests by default

### DIFF
--- a/.github/do-native
+++ b/.github/do-native
@@ -1,5 +1,5 @@
 #!/bin/sh
 set -e
 HERE=`dirname "$0"`
-"$HERE"/do-test-noopt native "$@"
-"$HERE"/do-test-noopt native-m32 "$@"
+"$HERE"/do-test-noopt native -Dexhaustive-math-tests=true "$@"
+"$HERE"/do-test-noopt native-m32 -Dexhaustive-math-tests=true "$@"

--- a/.github/do-test
+++ b/.github/do-test
@@ -55,7 +55,7 @@ case "$*" in
 	;;
 esac
 
-OPTIONS="$SANITIZER"
+OPTIONS="$SANITIZER -Dexhaustive-math-tests=native"
 
 (mkdir "$DIR" || exit 1
  cd "$DIR" || exit 2

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -109,7 +109,7 @@ option('native-tests', type: 'boolean', value: false,
        description: 'Run some tests against native libc too')
 option('native-math-tests', type: 'boolean', value: true,
        description: 'Run math tests against native libm when native-tests is enabled')
-option('exhaustive-math-tests', type: 'combo', choices: ['true', 'false', 'native'], value: 'native',
+option('exhaustive-math-tests', type: 'combo', choices: ['true', 'false', 'native'], value: 'false',
        description: 'Run exhaustive binary32 math tests. If set to native, enable when native tests are enabled')
 option('use-stdlib', type: 'boolean', value: false,
        description: 'Do not bypass the standard system library with -nostdlib (useful for native testing)')


### PR DESCRIPTION
Only run these when requested; they take a very long time.