### PR TITLE
TLS support for RP2350

### DIFF
--- a/newlib/libc/picolib/machine/arm/arm_tls.h
+++ b/newlib/libc/picolib/machine/arm/arm_tls.h
@@ -38,7 +38,7 @@
 #endif
 
 /* Switch cortex-m0 to use RP2040 CPUID register if requested */
-#if __ARM_ARCH >= 6 && __ARM_ARCH_PROFILE == 'M' && defined(__THREAD_LOCAL_STORAGE_RP2040)
+#ifdef __THREAD_LOCAL_STORAGE_RP2040
 #define ARM_RP2040
 #endif
 


### PR DESCRIPTION
The RP2350 has the same TLS support as the RP2040, (i.e., an array of tls structs indexed by the cpuid register which is at the same base address), however it doesn't get compiled in because of this #ifdef since it's a different ARM arch level. To fix this, I relax the condition on the __ARM_ARCH check. Arguably though the ARM arch level check doesn't help much as __THREAD_LOCAL_STORAGE_RP2040 seems to be the ground truth on whether you want this feature, and more MCUs could exist in the future with this feature regardless of their ARM arch level.