### PR TITLE
fdopen: fix fd close issue

### DIFF
--- a/newlib/libc/stdio/fdopen.c
+++ b/newlib/libc/stdio/fdopen.c
@@ -50,10 +50,9 @@ fdopen(int fd, const char *mode)
 	/* Allocate file structure and necessary buffers */
 	bf = calloc(1, sizeof(struct __file_bufio) + BUFSIZ);
 
-	if (bf == NULL) {
-		close(fd);
+	if (bf == NULL)
 		return NULL;
-	}
+
         buf = (char *) (bf + 1);
 
         *bf = (struct __file_bufio)

--- a/newlib/libc/stdio/fopen.c
+++ b/newlib/libc/stdio/fopen.c
@@ -38,6 +38,7 @@
 FILE *
 fopen(const char *pathname, const char *mode)
 {
+	FILE *ret;
 	int fd;
 	int stdio_flags;
 	int open_flags;
@@ -50,5 +51,9 @@ fopen(const char *pathname, const char *mode)
 	if (fd < 0)
 		return NULL;
 
-	return fdopen(fd, mode);
+	ret = fdopen(fd, mode);
+	if (ret == NULL)
+		close(fd);
+
+	return ret;
 }


### PR DESCRIPTION
I could not find in C standard that fdopen should close the fd on failure