### PR TITLE
meson: add -D_LIBC cflag for proper build

### DIFF
--- a/newlib/libc/machine/xtensa/meson.build
+++ b/newlib/libc/machine/xtensa/meson.build
@@ -44,7 +44,7 @@ srcs_machine = [
 ]
 
 conf_data.set('_XTENSA_HAVE_CONFIG_CORE_ISA_H',
-	      cc.check_header('xtensa/config/core-isa.h'),
+	      cc.check_header('xtensa/config/core-isa.h', args: '-D_LIBC'),
 	      description: 'Xtensa toolchain includes core-isa.h')
 
 subdir('machine')

--- a/picocrt/meson.build
+++ b/picocrt/meson.build
@@ -126,7 +126,7 @@ endif
 foreach params : targets
   target = params['name']
   target_dir = params['dir']
-  target_c_args = params['c_args'] + stack_c_args
+  target_c_args = params['c_args'] + stack_c_args + '-D_LIBC'
 
   instdir = join_paths(lib_dir, target_dir)
 


### PR DESCRIPTION
Meson build system cannot simply add global CFLAGS. It handles `c_args` differently for native and cross builds (yet another reason to dislike meson). These changes fixed my Xtensa builds.

I think other cases need to be revised.