### PR TITLE
libc: Compile builtin funtions with '-fno-lto'

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1497,6 +1497,11 @@ if cc.has_argument('-fno-builtin')
   arg_fnobuiltin = ['-fno-builtin']
 endif
 
+arg_fnolto = []
+if cc.has_argument('-fno-lto')
+  arg_fnolto = ['-fno-lto']
+endif
+
 version_array = meson.project_version().split('.')
 
 if version_array.length() > 2

--- a/newlib/libc/machine/arm/meson.build
+++ b/newlib/libc/machine/arm/meson.build
@@ -60,5 +60,5 @@ foreach params : targets
 			srcs_machine,
 			pic: false,
 			include_directories: inc,
-			c_args: target_c_args + c_args + arg_fnobuiltin))
+			c_args: target_c_args + c_args + arg_fnobuiltin + arg_fnolto))
 endforeach


### PR DESCRIPTION
This is necessary to let LTO consistently work with GCC 15. Otherwise the symbols may get accidentally get optimized out when linking. E.g.:

   snprintf.c:(.text.snprintf+0x20): undefined reference to `memset'

The benefit of compiling Picolib with "-flto" is not very big. But very small bare metal systems can still profit.