### PR TITLE
empty-libs: Fix build and install of these libraries

### DIFF
--- a/empty-libs/meson.build
+++ b/empty-libs/meson.build
@@ -43,6 +43,7 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
+  instdir = join_paths(lib_dir, target_dir)
 
   foreach lib_name : empty_lib_names
     if meson.version().version_compare('>=1.10')

--- a/meson.build
+++ b/meson.build
@@ -1872,9 +1872,6 @@ foreach params : targets
   instdir = join_paths(lib_dir, target_dir)
 
   libc_name = 'c'
-  libg_name = 'g'
-  libm_name = 'm'
-  libnosys_name = 'nosys'
 
   if meson.version().version_compare('>=1.10')
     local_lib_c_target = static_library(libc_name,


### PR DESCRIPTION
The install directory wasn't getting set correctly so the libraries all got installed in the last place the previous library target installed things to.