### PR TITLE
scripts: Prune sample lm32 multi-lib list to just two options

### DIFF
--- a/scripts/do-lm32-unknown-elf-configure
+++ b/scripts/do-lm32-unknown-elf-configure
@@ -38,4 +38,5 @@ exec "$(dirname "$0")"/do-configure lm32-unknown-elf \
   -Dfortify-source=none \
   -Dposix-console=true \
   -Dtests=true \
+  -Dmultilib-list=".,mbarrel-shift-enabled/mmultiply-enabled/mdivide-enabled/msign-extend-enabled"
   "$@"


### PR DESCRIPTION
Don't build every combination, just build with no options and with all the options. This should reduce testing time.