### PR TITLE
picocrt/riscv: Build crt0 functions with Zicsr extension

### DIFF
--- a/picocrt/machine/riscv/crt0.c
+++ b/picocrt/machine/riscv/crt0.c
@@ -94,6 +94,7 @@ _ctrap(struct fault *fault)
 #define PASTE(r)  _PASTE(r)
 
 void __naked __section(".init") __used __attribute((aligned(4)))
+__attribute__((target("arch=+zicsr")))
 _trap(void)
 {
 #ifndef __clang__
@@ -190,7 +191,7 @@ _trap(void)
 }
 #endif
 
-void __naked __section(".text.init.enter") __used
+void __naked __section(".text.init.enter") __used __attribute__((target("arch=+zicsr")))
 _start(void)
 {
 

--- a/picocrt/machine/riscv/meson.build
+++ b/picocrt/machine/riscv/meson.build
@@ -33,29 +33,3 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 src_picocrt += files('crt0.c')
-
-if cc.compiles('int i;', args: core_c_args + ['-march=rv32imac_zicsr', '-mabi=ilp32'])
-  picocrt_march_add='_zicsr'
-  new_targets = []
-  foreach params : targets
-    target = params['name']
-    target_dir = params['dir']
-    target_c_args = params['c_args']
-    target_lib_prefix = params['lib_prefix']
-    new_c_args = []
-    foreach c_arg : target_c_args
-      if c_arg.startswith('-march') and not c_arg.contains(picocrt_march_add)
-	c_arg = c_arg + picocrt_march_add
-      endif
-      new_c_args += c_arg
-    endforeach
-    target_c_args = new_c_args
-    new_targets += {
-                  'name': target,
-                  'dir': target_dir,
-                  'c_args': target_c_args,
-                  'lib_prefix': target_lib_prefix,
-                }
-  endforeach
-  targets = new_targets
-endif


### PR DESCRIPTION
If a default march does not contain Zicsr then Picolibc build system cannot add _zicsr to -march as it does with other multilib configurations.