### PR TITLE
empty-libs: Fix builds for a default target

### DIFF
--- a/empty-libs/meson.build
+++ b/empty-libs/meson.build
@@ -56,6 +56,7 @@ foreach params : targets
                      c_args: target_c_args + c_args,
 		     objects : [])
     else
+      target_lib_prefix = params['lib_prefix']
       static_library(join_paths(target_dir, target_lib_prefix + lib_name),
 		     ['empty.c'],
 		     install : really_install,


### PR DESCRIPTION
Meson installs lim, libg and libnosys to liblibm.a, liblibg.a and liblibnosys.a for a default target. Define target_lib_prefix variable to fix it.