### PR TITLE
test: Avoid -Wunused-result warnings

### DIFF
--- a/test/malloc.c
+++ b/test/malloc.c
@@ -244,11 +244,15 @@ main(void)
     //        printf("big %p\n", big);
     if (big) {
         memset(big, '1', 1024);
-        void *small = malloc(128);
+        char *small = malloc(128);
         //                printf("small %p\n", small);
         if (small) {
             memset(small, '2', 128);
-            (void)atoi(small);
+            small[127] = '\0';
+            if (atoi(small) == 0) {
+                printf("atoi of '2' string returned 0\n");
+                ++result;
+            }
             free(big);
             char *med = realloc(small, 1024);
             if (med) {

--- a/test/test-stdio/test-tmpnam.c
+++ b/test/test-stdio/test-tmpnam.c
@@ -41,8 +41,14 @@ main(void)
     char generate[2][L_tmpnam];
 
     // Generate two temporary files
-    tmpnam(generate[0]);
-    tmpnam(generate[1]);
+    if (tmpnam(generate[0]) == NULL) {
+        printf("tmpnam(generate[0]) failed\n");
+        return -1;
+    }
+    if (tmpnam(generate[1]) == NULL) {
+        printf("tmpnam(generate[1]) failed\n");
+        return -1;
+    }
 
     // Check if the two file names are the same
     if (strcmp(tmpnam(generate[0]), generate[1]) == 0) {


### PR DESCRIPTION
The atoi() call was unterminated (and also didn't check the result). Similarly, the tmpnam results weren't checked. Fix both to silence Ubuntu build warnings:

[2263/3550] Compiling C object test/malloc-native.p/malloc.c.o ../test/malloc.c: In function 'main':
../test/malloc.c:251:19: warning: ignoring return value of 'atoi' declared with attribute 'warn_unused_result' [-Wunused-result]
  251 |             (void)atoi(small);
      |                   ^~~~~~~~~~~                                                                                                           [2644/3550] Compiling C object test/test-stdio/test-tmpnam-native.p/test-tmpnam.c.o
../test/test-stdio/test-tmpnam.c: In function 'main':
../test/test-stdio/test-tmpnam.c:44:5: warning: ignoring return value of 'tmpnam' declared with attribute 'warn_unused_result' [-Wunused-result]
   44 |     tmpnam(generate[0]);                                                                                                                      |     ^~~~~~~~~~~~~~~~~~~
../test/test-stdio/test-tmpnam.c:45:5: warning: ignoring return value of 'tmpnam' declared with attribute 'warn_unused_result' [-Wunused-result]
   45 |     tmpnam(generate[1]);
      |     ^~~~~~~~~~~~~~~~~~~