### PR TITLE
picolibc.ld: Allow for non-default stack size

### DIFF
--- a/picolibc.ld.in
+++ b/picolibc.ld.in
@@ -405,7 +405,7 @@ SECTIONS
 		. += (DEFINED(@PREFIX@__heap_size_min) ? @PREFIX@__heap_size_min : 0);
 	} >ram :ram
 
-@LINUX@	PROVIDE ( @PREFIX@__stack_bottom = ORIGIN(ram) + LENGTH(ram) - (DEFINED(__stack_size) ? __stack_size : 0x00001000) );
+@LINUX@	PROVIDE ( @PREFIX@__stack_bottom = ORIGIN(ram) + LENGTH(ram) - (DEFINED(@PREFIX@@STACK@_size) ? @PREFIX@@STACK@_size : @DEFAULT_STACK_SIZE@) );
 @LINUX@
 @LINUX@	/* Define a stack region to make sure it fits in memory */
 @LINUX@	.stack @PREFIX@__stack_bottom (NOLOAD) : {


### PR DESCRIPTION
When calculating the bottom of the stack, a hard-coded value for the default stack size was used instead of the configurable variable. This caused overflow errors when trying to link with non-default stack sizes.