### PR TITLE
Preserve LR across semihosting SVC to prevent LR corruption on Hardware Targets.

### DIFF
--- a/libos/semihost/machine/arm/semihost-arm.S
+++ b/libos/semihost/machine/arm/semihost-arm.S
@@ -47,12 +47,22 @@
 sys_semihost:
 #if __ARM_ARCH_PROFILE == 'M'
 	bkpt #0xab
-#else
-#ifdef __thumb__
-	svc #0xab
-#else
-	svc #0x123456
-#endif
-#endif
 	bx lr
+#else
+        push  {lr}
+  #if defined(__ARM_SEMIHOST_USE_HLT) && __ARM_ARCH >= 8
+    #ifdef __thumb__
+        hlt #0x3c
+    #else
+        hlt #0xf000
+    #endif
+  #else
+    #ifdef __thumb__
+        svc #0xab
+    #else
+        svc #0x123456
+    #endif
+  #endif
+        pop {pc}
+#endif
 	.size sys_semihost, . - sys_semihost

--- a/meson.build
+++ b/meson.build
@@ -149,6 +149,11 @@ tests_enable_stack_protector = get_option('tests-enable-stack-protector')
 tests_enable_full_malloc_stress = get_option('tests-enable-full-malloc-stress')
 tests_enable_posix_io = get_option('tests-enable-posix-io')
 
+use_hlt_semihosting = false
+if get_option('use-hlt-semihosting')
+  use_hlt_semihosting = true
+endif
+
 # C++ is only used in tests, so only check for it when tests are enabled
 if enable_tests
   have_cplusplus = add_languages('cpp', required: false, native: false)
@@ -1683,6 +1688,7 @@ endif
 
 conf_data.set('__SEMIHOST', has_semihost, description: 'Semihost APIs supported')
 conf_data.set('__ARM_SEMIHOST', has_arm_semihost, description: 'ARM Semihost APIs supported')
+conf_data.set('__ARM_SEMIHOST_USE_HLT', use_hlt_semihosting, description: 'ARM semihost uses hlt on ARMv8 targets')
 
 # By default, tests don't require any special arguments
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -61,6 +61,8 @@ option('fast-strcmp', type: 'boolean', value: true,
        description: 'Always optimize strcmp for performance')
 option('sanitize', type: 'string', value: 'none',
        description: 'Code sanitizer to use')
+option('use-hlt-semihosting', type: 'boolean', value: 'false',
+        description: 'Enable HLT Semihosting (only valid for Armv8)')
 
 #
 # Installation options


### PR DESCRIPTION
This patch updates the sys_semihost assembly to explictly save and restore LR around the SVC and HLT instruction used for semihosting operations.

According to ARM AAPCS, LR is a caller saved register, it may be overwritten across any call like boundary such as an SVC based semihosting trap.

Also it provides a meson build option(-Duse-hlt-semihosting) which selects the trap instruction to use based on the preprocessor macro sets by the user via -D at configure time. It uses HLT semihosting only when the user enables it via -Duse-hlt-semihosting at configure time and the target architecture defines __ARM_ARCH >= 8, otherwise it defaults back to SVC.
https://github.com/ARM-software/abi-aa/blob/main/semihosting/semihosting.rst#the-semihosting-interface