### PR TITLE
linux: Edit state in tcsetattr rather than replace

### DIFF
--- a/libos/linux/tcsetattr.c
+++ b/libos/linux/tcsetattr.c
@@ -72,6 +72,9 @@ tcsetattr(int fd, int actions, const struct termios *termios)
     struct __kernel_termios2 ktermios = {};
     long                     cmd;
 
+    if (syscall(LINUX_SYS_ioctl, fd, LINUX_TCGETS2, &ktermios) == -1)
+        return -1;
+
     switch (actions) {
     case TCSANOW:
         cmd = LINUX_TCSETS2;


### PR DESCRIPTION
The picolibc struct termios doesn't hold the entire linux state. Fetch the current state and only change the bits we know about so that other settings don't get mangled.