### PR TITLE
linux: Allow NULL new settings in sigprocmask

### DIFF
--- a/libos/linux/sigprocmask.c
+++ b/libos/linux/sigprocmask.c
@@ -38,7 +38,7 @@
 int
 sigprocmask(int how, const sigset_t *set, sigset_t *oldset)
 {
-    __kernel_sigset_t kset = {}, koldset, *poldset = NULL;
+    __kernel_sigset_t kset = {}, *pset = NULL, koldset, *poldset = NULL;
     int               ret;
 
     switch (how) {
@@ -55,10 +55,13 @@ sigprocmask(int how, const sigset_t *set, sigset_t *oldset)
         errno = EINVAL;
         return -1;
     }
-    _sigmask_to_linux(&kset, set);
+    if (set) {
+        _sigmask_to_linux(&kset, set);
+        pset = &kset;
+    }
     if (oldset)
         poldset = &koldset;
-    ret = syscall(LINUX_SYS_rt_sigprocmask, how, &kset, poldset, __KERNEL_NSIG_BYTES);
+    ret = syscall(LINUX_SYS_rt_sigprocmask, how, pset, poldset, __KERNEL_NSIG_BYTES);
     if (ret < 0)
         return ret;
     if (oldset)

--- a/scripts/do-x86_64-linux-full
+++ b/scripts/do-x86_64-linux-full
@@ -4,12 +4,13 @@
 # to eleven
 #
 exec "$(dirname "$0")"/do-x86_64-linux-gnu-configure \
-	-Dio-long-double=true \
-	-Dmb-capable=true \
-	-Dio-percent-b=true \
-	-Dfast-bufio=true \
-	-Dstdio-exit-flush=true \
-	-Dio-wchar=true \
-	-Dstdio-locking=true \
-	-Dmalloc-small-bucket=1024 \
-	-Dwant-math-errno=true "$@"
+     --prefix=/usr/local \
+     -Dio-long-double=true \
+     -Dmb-capable=true \
+     -Dio-percent-b=true \
+     -Dfast-bufio=true \
+     -Dstdio-exit-flush=true \
+     -Dio-wchar=true \
+     -Dstdio-locking=true \
+     -Dmalloc-small-bucket=1024 \
+     -Dwant-math-errno=true "$@"


### PR DESCRIPTION
This is used to fetch the current settings without changing anything.