### PR TITLE
doc: Update testing.md with new scripts path

### DIFF
--- a/doc/testing.md
+++ b/doc/testing.md
@@ -26,7 +26,7 @@ Again, create a directory and build there:
 
     $ mkdir build-native
     $ cd build-native
-    $ ../do-native-configure
+    $ ../scripts/do-native-configure
     $ ninja
 
 This will also build a test case for printf and scanf in the


### PR DESCRIPTION
The build scripts were moved to the scripts/ directory in commit 7710d760ccff. Update testing.md to match.