### PR TITLE
meson: add shared-library option to build libc.so

### DIFF
--- a/libc/machine/aarch64/meson.build
+++ b/libc/machine/aarch64/meson.build
@@ -83,7 +83,7 @@ foreach params : targets
     set_variable('lib_machine' + target,
         static_library('machine' + target,
             srcs_machine,
-            pic: false,
+            pic: use_pic,
             include_directories: inc,
             c_args: target_c_args + c_args + arg_fnobuiltin + arg_fnolto))
 endforeach

--- a/libc/machine/arc/meson.build
+++ b/libc/machine/arc/meson.build
@@ -71,7 +71,7 @@ foreach params : targets
   set_variable('lib_machine' + target,
 	       static_library('machine' + target,
 			      srcs_machine,
-			      pic: false,
+			      pic: use_pic,
 			      include_directories: inc,
 			      c_args: target_c_args + c_args + arg_fnobuiltin + arg_fnolto))
 endforeach

--- a/libc/machine/arc64/meson.build
+++ b/libc/machine/arc64/meson.build
@@ -59,7 +59,7 @@ foreach params : targets
   set_variable('lib_machine' + target,
 	       static_library('machine' + target,
 			      srcs_machine,
-			      pic: false,
+			      pic: use_pic,
 			      include_directories: inc,
 			      c_args: target_c_args + c_args + arg_fnobuiltin))
 endforeach

--- a/libc/machine/arm/meson.build
+++ b/libc/machine/arm/meson.build
@@ -63,7 +63,7 @@ foreach params : targets
 	set_variable('lib_machine' + target,
 		static_library('machine' + target,
 			srcs_machine,
-			pic: false,
+			pic: use_pic,
 			include_directories: inc,
 			c_args: target_c_args + c_args + arg_fnobuiltin + arg_fnolto))
 endforeach

--- a/libc/machine/hexagon/meson.build
+++ b/libc/machine/hexagon/meson.build
@@ -44,7 +44,7 @@ foreach params : targets
 	set_variable('lib_machine' + target,
 		static_library('machine' + target,
 			srcs_machine,
-			pic: false,
+			pic: use_pic,
 			include_directories: inc,
 			c_args: target_c_args + c_args + arg_fnobuiltin))
 endforeach

--- a/libc/machine/loongarch/meson.build
+++ b/libc/machine/loongarch/meson.build
@@ -47,7 +47,7 @@ foreach params : targets
 	set_variable('lib_machine' + target,
 		static_library('machine' + target,
 			srcs_machine,
-			pic: false,
+			pic: use_pic,
 			include_directories: inc,
 			c_args: target_c_args + c_args + arg_fnobuiltin + arg_fnolto))
 endforeach

--- a/libc/machine/m68k/meson.build
+++ b/libc/machine/m68k/meson.build
@@ -53,7 +53,7 @@ foreach params : targets
 	set_variable('lib_machine' + target,
 		static_library('machine' + target,
 			srcs_machine,
-			pic: false,
+			pic: use_pic,
 			include_directories: inc,
 			c_args: target_c_args + c_args + arg_fnobuiltin + arg_fnolto))
 endforeach

--- a/libc/machine/msp430/meson.build
+++ b/libc/machine/msp430/meson.build
@@ -45,7 +45,7 @@ foreach params : targets
   set_variable('lib_machine' + target,
 	       static_library('machine' + target,
 			      srcs_machine,
-			      pic: false,
+			      pic: use_pic,
 			      include_directories: inc,
 			      c_args: target_c_args + c_args + arg_fnobuiltin))
 endforeach

--- a/libc/machine/riscv/meson.build
+++ b/libc/machine/riscv/meson.build
@@ -58,7 +58,7 @@ foreach params : targets
 	set_variable('lib_machine' + target,
 		static_library('machine' + target,
 			srcs_machine,
-			pic: false,
+			pic: use_pic,
 			include_directories: inc,
 			c_args: target_c_args + c_args + arg_fnobuiltin))
 endforeach

--- a/libc/machine/rx/meson.build
+++ b/libc/machine/rx/meson.build
@@ -68,7 +68,7 @@ foreach params : targets
 	set_variable('lib_machine' + target,
 		static_library('machine' + target,
 			srcs_machine,
-			pic: false,
+			pic: use_pic,
 			include_directories: inc,
 			c_args: target_c_args + c_args + arg_fnobuiltin + arg_fnolto))
 endforeach

--- a/libc/machine/x86/meson.build
+++ b/libc/machine/x86/meson.build
@@ -63,7 +63,7 @@ foreach params : targets
   set_variable('lib_machine' + target,
 	       static_library('machine' + target,
 			      srcs_machine,
-			      pic: false,
+			      pic: use_pic,
 			      include_directories: inc,
 			      c_args: target_c_args + c_args + arg_fnobuiltin + arg_fnolto))
 endforeach

--- a/libc/meson.build
+++ b/libc/meson.build
@@ -94,7 +94,7 @@ foreach params : targets
 
   if libobjs != []
     local_lib_cpart_target = static_library('cpart' + target,
-				            pic: false,
+				            pic: use_pic,
 				            objects : libobjs,
 					    include_directories: inc,
 					    c_args: target_c_args + c_args)

--- a/libc/string/meson.build
+++ b/libc/string/meson.build
@@ -200,7 +200,7 @@ if srcs_strcmp_use != []
     set_variable('lib_string' + target,
 		 static_library('strcmp' + target,
 				srcs_strcmp_use,
-				pic: false,
+				pic: use_pic,
 				c_args: target_c_args + c_args + cargs_strcmp,
 				include_directories: inc))
   endforeach

--- a/libdl/dl.c
+++ b/libdl/dl.c
@@ -1,0 +1,447 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/*
+ * dl.c — minimal dlopen/dlsym/dlclose/dlerror for picolibc.
+ *
+ * Reads a shared library using standard POSIX file I/O (open/lseek/read/close),
+ * maps its LOAD segments into malloc'd memory, applies all RELA relocations
+ * via the arch-specific dl_arch_relocate(), then runs DT_INIT_ARRAY.
+ *
+ * Only ET_DYN ELF32 files with RELA relocations are supported.
+ * The arch-specific relocation handler and built-in symbol table live
+ * in machine/<arch>/dl_relocate.c and machine/<arch>/dl_syms.c.
+ */
+
+#include <dlfcn.h>
+#include "elf32.h"
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "dl_impl.h"
+
+/* ------------------------------------------------------------------ */
+/* Error handling                                                       */
+/* ------------------------------------------------------------------ */
+
+static char dl_errbuf[128];
+static int  dl_has_error;
+
+static void
+dl_set_error(const char *msg)
+{
+    strncpy(dl_errbuf, msg, sizeof(dl_errbuf) - 1);
+    dl_errbuf[sizeof(dl_errbuf) - 1] = '\0';
+    dl_has_error = 1;
+}
+
+char *
+dlerror(void)
+{
+    if (!dl_has_error)
+        return NULL;
+    dl_has_error = 0;
+    return dl_errbuf;
+}
+
+/* ------------------------------------------------------------------ */
+/* ELF hash (SysV)                                                      */
+/* ------------------------------------------------------------------ */
+
+static uint32_t
+elf_hash(const char *name)
+{
+    uint32_t h = 0, g;
+    while (*name) {
+        h = (h << 4) + (uint8_t)*name++;
+        if ((g = h & 0xf0000000u))
+            h ^= g >> 24;
+        h &= ~g;
+    }
+    return h;
+}
+
+/* ------------------------------------------------------------------ */
+/* dlopen                                                               */
+/* ------------------------------------------------------------------ */
+
+void *
+dlopen(const char *path, int mode)
+{
+    (void)mode; /* always RTLD_NOW — eager relocation */
+    /* FIXME: honour RTLD_LAZY via a _dl_runtime_resolve PLT trampoline */
+
+    /* 1. Read the .so file via POSIX file I/O */
+    /* FIXME: on Linux use mmap(fd, ...) instead of malloc+read for zero-copy file loading */
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        dl_set_error("dlopen: cannot open file");
+        return NULL;
+    }
+
+    /* Get file size with lseek — works on any POSIX OS or semihosting */
+    off_t file_size_off = lseek(fd, 0, SEEK_END);
+    if (file_size_off <= 0) {
+        close(fd);
+        dl_set_error("dlopen: cannot determine file size");
+        return NULL;
+    }
+    if (lseek(fd, 0, SEEK_SET) != 0) {
+        close(fd);
+        dl_set_error("dlopen: cannot seek to start of file");
+        return NULL;
+    }
+    size_t file_size = (size_t)file_size_off;
+
+    uint8_t *file_buf = malloc(file_size);
+    if (!file_buf) {
+        close(fd);
+        dl_set_error("dlopen: out of memory reading file");
+        return NULL;
+    }
+
+    ssize_t nread = read(fd, file_buf, file_size);
+    close(fd);
+    if (nread < 0 || (size_t)nread != file_size) {
+        free(file_buf);
+        dl_set_error("dlopen: short read");
+        return NULL;
+    }
+
+    /* 2. Validate ELF header */
+    if (file_size < sizeof(Elf32_Ehdr)) {
+        free(file_buf);
+        dl_set_error("dlopen: file too small for ELF header");
+        return NULL;
+    }
+
+    Elf32_Ehdr *ehdr = (Elf32_Ehdr *)file_buf;
+
+    if (ehdr->e_ident[EI_MAG0] != ELFMAG0 ||
+        ehdr->e_ident[EI_MAG1] != ELFMAG1 ||
+        ehdr->e_ident[EI_MAG2] != ELFMAG2 ||
+        ehdr->e_ident[EI_MAG3] != ELFMAG3) {
+        free(file_buf);
+        dl_set_error("dlopen: not an ELF file");
+        return NULL;
+    }
+
+    if (ehdr->e_type != ET_DYN) {
+        free(file_buf);
+        dl_set_error("dlopen: not a shared library (ET_DYN)");
+        return NULL;
+    }
+
+    /* 3. Walk PT_LOAD segments: determine total span */
+    Elf32_Phdr *phdrs = (Elf32_Phdr *)(file_buf + ehdr->e_phoff);
+    uint32_t min_vaddr = UINT32_MAX, max_vaddr = 0;
+
+    for (int i = 0; i < ehdr->e_phnum; i++) {
+        if (phdrs[i].p_type != PT_LOAD)
+            continue;
+        if (phdrs[i].p_vaddr < min_vaddr)
+            min_vaddr = phdrs[i].p_vaddr;
+        uint32_t end = phdrs[i].p_vaddr + phdrs[i].p_memsz;
+        if (end > max_vaddr)
+            max_vaddr = end;
+    }
+
+    if (min_vaddr == UINT32_MAX || max_vaddr == 0) {
+        free(file_buf);
+        dl_set_error("dlopen: no PT_LOAD segments");
+        return NULL;
+    }
+
+    /*
+     * FIXME: on Linux use per-segment mmap(MAP_PRIVATE|MAP_FIXED, fd, p_offset)
+     * with correct PROT_READ|PROT_EXEC / PROT_READ|PROT_WRITE flags instead of
+     * malloc+memcpy.  This gives zero-copy, demand-paged, W^X-correct loading.
+     */
+    size_t load_size = (size_t)(max_vaddr - min_vaddr);
+    uint8_t *raw_buf = malloc(load_size + 0x1000);
+    if (!raw_buf) {
+        free(file_buf);
+        dl_set_error("dlopen: out of memory for segments");
+        return NULL;
+    }
+
+    /* Align load_buf to 0x1000 */
+    uint8_t *load_buf = (uint8_t *)(((uintptr_t)raw_buf + 0xfff) & ~(uintptr_t)0xfff);
+    uintptr_t load_bias = (uintptr_t)load_buf - (uintptr_t)min_vaddr;
+
+    /* Zero the entire region first (handles BSS) */
+    memset(load_buf, 0, load_size);
+
+    /* Copy each PT_LOAD segment */
+    for (int i = 0; i < ehdr->e_phnum; i++) {
+        if (phdrs[i].p_type != PT_LOAD)
+            continue;
+        memcpy(load_buf + (phdrs[i].p_vaddr - min_vaddr),
+               file_buf + phdrs[i].p_offset,
+               phdrs[i].p_filesz);
+    }
+
+    /* 4. Allocate and populate the handle */
+    dl_handle_t *h = calloc(1, sizeof(dl_handle_t));
+    if (!h) {
+        free(raw_buf);
+        free(file_buf);
+        dl_set_error("dlopen: out of memory for handle");
+        return NULL;
+    }
+
+    h->load_buf  = raw_buf;   /* keep raw_buf for free() */
+    h->load_bias = load_bias;
+
+    /* 4b. Parse PT_TLS: allocate and initialise the TLS block.
+     *
+     * The .tdata section (p_filesz bytes) holds initialised TLS data and
+     * is already mapped inside the PT_LOAD region.  We allocate a fresh
+     * block, copy .tdata into it, and zero the .tbss tail.
+     * UGP is set to the base of this block after relocation (step 6b).
+     */
+    for (int i = 0; i < ehdr->e_phnum; i++) {
+        if (phdrs[i].p_type != PT_TLS)
+            continue;
+
+        h->tls_memsz = phdrs[i].p_memsz;
+        h->tls_block = malloc(h->tls_memsz);
+        if (!h->tls_block) {
+            free(raw_buf);
+            free(file_buf);
+            free(h);
+            dl_set_error("dlopen: out of memory for TLS block");
+            return NULL;
+        }
+        /* Zero the entire block first (covers .tbss and any padding).
+         * Use explicit memset rather than calloc so that MALLOC_PERTURB_
+         * (which fills malloc'd memory with a non-zero pattern) does not
+         * corrupt zero-initialised TLS variables.
+         */
+        memset(h->tls_block, 0, h->tls_memsz);
+        /* Copy initialised TLS data (.tdata) */
+        if (phdrs[i].p_filesz > 0)
+            memcpy(h->tls_block,
+                   load_buf + (phdrs[i].p_vaddr - min_vaddr),
+                   phdrs[i].p_filesz);
+        break; /* only one PT_TLS */
+    }
+
+    /* 5. Parse PT_DYNAMIC to locate all needed sections */
+    for (int i = 0; i < ehdr->e_phnum; i++) {
+        if (phdrs[i].p_type != PT_DYNAMIC)
+            continue;
+
+        Elf32_Dyn *dyn = (Elf32_Dyn *)(load_bias + phdrs[i].p_vaddr);
+        uintptr_t rela_dyn_addr = 0, rela_plt_addr = 0;
+        size_t    rela_dyn_sz   = 0, rela_plt_sz   = 0;
+        uintptr_t init_array_addr = 0, fini_array_addr = 0;
+
+        for (; dyn->d_tag != DT_NULL; dyn++) {
+            switch (dyn->d_tag) {
+            case DT_SYMTAB:
+                h->dynsym = (Elf32_Sym *)(load_bias + dyn->d_un.d_ptr);
+                break;
+            case DT_STRTAB:
+                h->dynstr = (const char *)(load_bias + dyn->d_un.d_ptr);
+                break;
+            case DT_HASH:
+                h->hashtab = (uint32_t *)(load_bias + dyn->d_un.d_ptr);
+                break;
+            case DT_RELA:
+                rela_dyn_addr = load_bias + dyn->d_un.d_ptr;
+                break;
+            case DT_RELASZ:
+                rela_dyn_sz = dyn->d_un.d_val;
+                break;
+            case DT_JMPREL:
+                rela_plt_addr = load_bias + dyn->d_un.d_ptr;
+                break;
+            case DT_PLTRELSZ:
+                rela_plt_sz = dyn->d_un.d_val;
+                break;
+            case DT_INIT_ARRAY:
+                init_array_addr = load_bias + dyn->d_un.d_ptr;
+                break;
+            case DT_INIT_ARRAYSZ:
+                h->init_arraysz = dyn->d_un.d_val;
+                break;
+            case DT_FINI_ARRAY:
+                fini_array_addr = load_bias + dyn->d_un.d_ptr;
+                break;
+            case DT_FINI_ARRAYSZ:
+                h->fini_arraysz = dyn->d_un.d_val;
+                break;
+            default:
+                break;
+            }
+        }
+
+        if (rela_dyn_addr) {
+            h->rela_dyn       = (Elf32_Rela *)rela_dyn_addr;
+            h->rela_dyn_count = rela_dyn_sz / sizeof(Elf32_Rela);
+        }
+        if (rela_plt_addr) {
+            h->rela_plt       = (Elf32_Rela *)rela_plt_addr;
+            h->rela_plt_count = rela_plt_sz / sizeof(Elf32_Rela);
+        }
+        if (init_array_addr)
+            h->init_array = (void **)init_array_addr;
+        if (fini_array_addr)
+            h->fini_array = (void **)fini_array_addr;
+
+        /* Derive nsyms from .hash nchain (= number of dynsym entries) */
+        if (h->hashtab)
+            h->nsyms = h->hashtab[1]; /* nchain */
+
+        break; /* only one PT_DYNAMIC */
+    }
+
+    /* 6. Apply all relocations (arch-specific) */
+    if (dl_arch_relocate(h) != 0) {
+        /* Format error message with the unknown relocation type number */
+        char reloc_errbuf[64];
+        snprintf(reloc_errbuf, sizeof(reloc_errbuf),
+                 "dlopen: unsupported relocation type %u", h->last_reloc_type);
+        dl_set_error(reloc_errbuf);
+        free(h->tls_block);
+        free(file_buf);
+        free(raw_buf);
+        free(h);
+        return NULL;
+    }
+
+    /* 6b. Set thread pointer (UGP) to the TLS block, saving the old value
+     *     so dlclose() can restore it.  Must happen after relocation so
+     *     that the DTPREL GOT entries are already filled in.
+     */
+    if (h->tls_block)
+        h->saved_ugp = dl_arch_set_tls(h->tls_block);
+
+    /* 7. Run DT_INIT_ARRAY constructors */
+    if (h->init_array) {
+        size_t n = h->init_arraysz / sizeof(void *);
+        for (size_t i = 0; i < n; i++) {
+            void (*fn)(void) = (void (*)(void))h->init_array[i];
+            if (fn)
+                fn();
+        }
+    }
+
+    free(file_buf);
+    return h;
+}
+
+/* ------------------------------------------------------------------ */
+/* dlsym                                                                */
+/* ------------------------------------------------------------------ */
+
+void *
+dlsym(void *handle, const char *symbol)
+{
+    if (!handle || !symbol)
+        return NULL;
+
+    dl_handle_t *h = (dl_handle_t *)handle;
+
+    if (!h->hashtab || !h->dynsym || !h->dynstr)
+        return NULL;
+
+    uint32_t nbucket = h->hashtab[0];
+    uint32_t *bucket = &h->hashtab[2];
+    uint32_t *chain  = &h->hashtab[2 + nbucket];
+
+    uint32_t idx = bucket[elf_hash(symbol) % nbucket];
+    while (idx != 0 && idx < h->nsyms) {
+        Elf32_Sym *sym = &h->dynsym[idx];
+        if (strcmp(h->dynstr + sym->st_name, symbol) == 0 &&
+            sym->st_value != 0) {
+            return (void *)(h->load_bias + sym->st_value);
+        }
+        idx = chain[idx];
+    }
+
+    dl_set_error("dlsym: symbol not found");
+    return NULL;
+}
+
+/* ------------------------------------------------------------------ */
+/* dlclose                                                              */
+/* ------------------------------------------------------------------ */
+
+int
+dlclose(void *handle)
+{
+    if (!handle)
+        return 0;
+
+    dl_handle_t *h = (dl_handle_t *)handle;
+
+    /* Run DT_FINI_ARRAY destructors in reverse order */
+    if (h->fini_array) {
+        size_t n = h->fini_arraysz / sizeof(void *);
+        for (size_t i = n; i > 0; i--) {
+            void (*fn)(void) = (void (*)(void))h->fini_array[i - 1];
+            if (fn)
+                fn();
+        }
+    }
+
+    free(h->load_buf);
+
+    /* Restore the thread pointer and free the TLS block */
+    if (h->tls_block) {
+        dl_arch_set_tls((void *)h->saved_ugp);
+        free(h->tls_block);
+    }
+
+    free(h);
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* dladdr — stub (not needed for testing)                               */
+/* ------------------------------------------------------------------ */
+
+int
+dladdr(const void *addr, Dl_info *info)
+{
+    (void)addr; (void)info;
+    return 0;
+}

--- a/libdl/dl_impl.h
+++ b/libdl/dl_impl.h
@@ -1,0 +1,94 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef _DL_IMPL_H_
+#define _DL_IMPL_H_
+
+#include <stdint.h>
+#include <stddef.h>
+#include "elf32.h"
+
+/*
+ * Internal handle representing a loaded shared library.
+ * All pointer fields point into load_buf (already relocated by load_bias).
+ */
+typedef struct dl_handle {
+    uint8_t     *load_buf;          /* malloc'd + aligned segment memory        */
+    uintptr_t    load_bias;         /* = (uintptr_t)load_buf - min_vaddr        */
+
+    Elf32_Sym   *dynsym;            /* .dynsym base                             */
+    const char  *dynstr;            /* .dynstr base                             */
+    uint32_t     nsyms;             /* number of .dynsym entries                */
+    uint32_t    *hashtab;           /* .hash base: [nbucket][nchain][b...][c...]*/
+
+    Elf32_Rela  *rela_dyn;          /* .rela.dyn base                           */
+    size_t       rela_dyn_count;    /* number of .rela.dyn entries              */
+    Elf32_Rela  *rela_plt;          /* .rela.plt base                           */
+    size_t       rela_plt_count;    /* number of .rela.plt entries              */
+
+    void       **init_array;        /* DT_INIT_ARRAY base                       */
+    size_t       init_arraysz;      /* DT_INIT_ARRAYSZ in bytes                 */
+    void       **fini_array;        /* DT_FINI_ARRAY base                       */
+    size_t       fini_arraysz;      /* DT_FINI_ARRAYSZ in bytes                 */
+
+    uint8_t     *tls_block;         /* malloc'd TLS block (PT_TLS)              */
+    uint32_t     tls_memsz;         /* PT_TLS p_memsz                           */
+    uintptr_t    saved_ugp;         /* UGP value saved before dlopen            */
+
+    uint32_t     last_reloc_type;   /* set by dl_arch_relocate on unknown type  */
+} dl_handle_t;
+
+/*
+ * Arch-specific: apply all relocations in h->rela_dyn and h->rela_plt.
+ * Returns 0 on success, -1 on error (unknown relocation type encountered).
+ * Implemented in machine/<arch>/dl_relocate.c
+ */
+int dl_arch_relocate(dl_handle_t *h);
+
+/*
+ * Arch-specific: set the thread pointer to tls_block, return the previous
+ * thread pointer value so it can be restored in dlclose().
+ * Implemented in machine/<arch>/dl_relocate.c
+ */
+uintptr_t dl_arch_set_tls(void *tls_block);
+
+/*
+ * Arch-specific: look up a symbol name in the built-in symbol table.
+ * Returns the function/data pointer, or NULL if not found.
+ * Implemented in machine/<arch>/dl_syms.c
+ */
+void *dl_builtin_lookup(const char *name);
+
+#endif /* _DL_IMPL_H_ */

--- a/libdl/elf32.h
+++ b/libdl/elf32.h
@@ -1,0 +1,153 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/*
+ * elf32.h — minimal ELF32 types and constants needed by libdl.
+ * Self-contained; does not depend on any system elf.h.
+ */
+
+#ifndef _LIBDL_ELF32_H_
+#define _LIBDL_ELF32_H_
+
+#include <stdint.h>
+
+/* Basic ELF32 types */
+typedef uint32_t Elf32_Addr;
+typedef uint16_t Elf32_Half;
+typedef uint32_t Elf32_Off;
+typedef int32_t  Elf32_Sword;
+typedef uint32_t Elf32_Word;
+
+/* ELF identification indices */
+#define EI_MAG0     0
+#define EI_MAG1     1
+#define EI_MAG2     2
+#define EI_MAG3     3
+#define EI_CLASS    4
+#define EI_DATA     5
+#define EI_VERSION  6
+#define EI_NIDENT   16
+
+#define ELFMAG0     0x7f
+#define ELFMAG1     'E'
+#define ELFMAG2     'L'
+#define ELFMAG3     'F'
+
+/* ELF file types */
+#define ET_DYN      3
+
+/* ELF header */
+typedef struct {
+    uint8_t     e_ident[EI_NIDENT];
+    Elf32_Half  e_type;
+    Elf32_Half  e_machine;
+    Elf32_Word  e_version;
+    Elf32_Addr  e_entry;
+    Elf32_Off   e_phoff;
+    Elf32_Off   e_shoff;
+    Elf32_Word  e_flags;
+    Elf32_Half  e_ehsize;
+    Elf32_Half  e_phentsize;
+    Elf32_Half  e_phnum;
+    Elf32_Half  e_shentsize;
+    Elf32_Half  e_shnum;
+    Elf32_Half  e_shstrndx;
+} Elf32_Ehdr;
+
+/* Program header types */
+#define PT_LOAD     1
+#define PT_DYNAMIC  2
+#define PT_TLS      7   /* Thread-local storage segment */
+
+/* Program header */
+typedef struct {
+    Elf32_Word  p_type;
+    Elf32_Off   p_offset;
+    Elf32_Addr  p_vaddr;
+    Elf32_Addr  p_paddr;
+    Elf32_Word  p_filesz;
+    Elf32_Word  p_memsz;
+    Elf32_Word  p_flags;
+    Elf32_Word  p_align;
+} Elf32_Phdr;
+
+/* Dynamic section entry */
+typedef struct {
+    Elf32_Sword d_tag;
+    union {
+        Elf32_Word  d_val;
+        Elf32_Addr  d_ptr;
+    } d_un;
+} Elf32_Dyn;
+
+/* Dynamic tags */
+#define DT_NULL         0
+#define DT_PLTRELSZ     2
+#define DT_HASH         4
+#define DT_STRTAB       5
+#define DT_SYMTAB       6
+#define DT_RELA         7
+#define DT_RELASZ       8
+#define DT_SYMENT       11
+#define DT_INIT         12
+#define DT_FINI         13
+#define DT_JMPREL       23
+#define DT_INIT_ARRAY   25
+#define DT_FINI_ARRAY   26
+#define DT_INIT_ARRAYSZ 27
+#define DT_FINI_ARRAYSZ 28
+
+/* Symbol table entry */
+typedef struct {
+    Elf32_Word  st_name;
+    Elf32_Addr  st_value;
+    Elf32_Word  st_size;
+    uint8_t     st_info;
+    uint8_t     st_other;
+    Elf32_Half  st_shndx;
+} Elf32_Sym;
+
+/* RELA relocation entry */
+typedef struct {
+    Elf32_Addr  r_offset;
+    Elf32_Word  r_info;
+    Elf32_Sword r_addend;
+} Elf32_Rela;
+
+/* Standard ELF32 r_info accessors */
+#define ELF32_R_SYM(i)   ((i) >> 8)
+#define ELF32_R_TYPE(i)  ((i) & 0xff)
+
+#endif /* _LIBDL_ELF32_H_ */

--- a/libdl/machine/hexagon/dl_arch.h
+++ b/libdl/machine/hexagon/dl_arch.h
@@ -1,0 +1,52 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef _DL_ARCH_H_
+#define _DL_ARCH_H_
+
+/* Hexagon ELF machine type */
+#define EM_HEXAGON      164
+
+/* Hexagon relocation types present in picolibc libc.so */
+#define R_HEX_32          6   /* word32: S + A                */
+#define R_HEX_GLOB_DAT   33   /* word32: S + A (GOT entry)    */
+#define R_HEX_JMP_SLOT   34   /* word32: S    (PLT slot)      */
+#define R_HEX_RELATIVE   35   /* word32: B + A (base-relative)*/
+
+/* Global-dynamic TLS relocation types (appear when thread-local-storage=true) */
+#define R_HEX_DTPMOD_32  44   /* GOT TLS descriptor: module ID        */
+#define R_HEX_DTPREL_32  47   /* GOT TLS descriptor: offset in block  */
+
+#endif /* _DL_ARCH_H_ */

--- a/libdl/machine/hexagon/dl_relocate.c
+++ b/libdl/machine/hexagon/dl_relocate.c
@@ -1,0 +1,149 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "dl_arch.h"
+#include "../../dl_impl.h"
+#include <stdint.h>
+
+/*
+ * Apply a single RELA section's relocations.
+ * Returns 0 on success, -1 if an unknown relocation type is encountered.
+ */
+static int
+apply_relas(dl_handle_t *h, Elf32_Rela *relas, size_t count)
+{
+    for (size_t i = 0; i < count; i++) {
+        Elf32_Rela *r     = &relas[i];
+        uint32_t   *addr  = (uint32_t *)(h->load_bias + r->r_offset);
+        uint32_t    sym_idx = ELF32_R_SYM(r->r_info);
+        uint32_t    type    = ELF32_R_TYPE(r->r_info);
+        uintptr_t   sym_val = 0;
+
+        if (sym_idx != 0) {
+            Elf32_Sym *sym = &h->dynsym[sym_idx];
+            if (sym->st_value != 0) {
+                /* Symbol defined inside the shared library */
+                sym_val = h->load_bias + sym->st_value;
+            } else {
+                /* Undefined symbol — resolve from built-in table.
+                 * FIXME: on Linux, resolve via the OS dynamic linker's global
+                 * symbol namespace (searching the main exe + all loaded
+                 * libraries) instead of a hardcoded built-in table.
+                 */
+                sym_val = (uintptr_t)dl_builtin_lookup(
+                    h->dynstr + sym->st_name);
+            }
+        }
+
+        switch (type) {
+        case R_HEX_RELATIVE:
+            /* Base-relative: *addr = load_bias + addend */
+            *addr = (uint32_t)(h->load_bias + (uintptr_t)(uint32_t)r->r_addend);
+            break;
+
+        case R_HEX_JMP_SLOT:
+            /* PLT slot: *addr = sym_val (no addend) */
+            /* FIXME: with RTLD_LAZY, set *addr to a _dl_runtime_resolve trampoline instead */
+            *addr = (uint32_t)sym_val;
+            break;
+
+        case R_HEX_GLOB_DAT:
+            /* GOT entry: *addr = sym_val + addend */
+            *addr = (uint32_t)(sym_val + (uintptr_t)(uint32_t)r->r_addend);
+            break;
+
+        case R_HEX_32:
+            /* Absolute 32-bit: *addr = sym_val + addend */
+            *addr = (uint32_t)(sym_val + (uintptr_t)(uint32_t)r->r_addend);
+            break;
+
+        case R_HEX_DTPMOD_32:
+            /* TLS descriptor module ID.
+             * The bare-metal __tls_get_addr ignores this field; set it to 1
+             * (a valid non-zero module ID) for any full RTLD that may be used.
+             */
+            *addr = 1;
+            break;
+
+        case R_HEX_DTPREL_32:
+            /* TLS descriptor offset within the module's TLS block.
+             * The compiler loads this value into r0 before calling
+             * __tls_get_addr, which returns UGP + r0.
+             * The addend is the byte offset of the variable in the TLS block.
+             */
+            *addr = (uint32_t)r->r_addend;
+            break;
+
+        default:
+            /* Unknown relocation type — cannot safely continue */
+            h->last_reloc_type = type;
+            return -1;
+        }
+    }
+    return 0;
+}
+
+/*
+ * dl_arch_relocate - apply all relocations for a loaded Hexagon shared lib.
+ * Called by dl.c after segments are mapped and the handle is populated.
+ * Returns 0 on success, -1 on error.
+ */
+int
+dl_arch_relocate(dl_handle_t *h)
+{
+    if (apply_relas(h, h->rela_dyn, h->rela_dyn_count) != 0)
+        return -1;
+    if (apply_relas(h, h->rela_plt, h->rela_plt_count) != 0)
+        return -1;
+    return 0;
+}
+
+/*
+ * dl_arch_set_tls - set the Hexagon UGP register to tls_block.
+ *
+ * UGP is the Hexagon thread pointer.  The bare-metal __tls_get_addr
+ * computes: result = UGP + ti_tlsoffset, so UGP must point to the base
+ * of the TLS block before any TLS variable in the loaded .so is accessed.
+ *
+ * Returns the previous UGP value so the caller can restore it in dlclose().
+ */
+uintptr_t
+dl_arch_set_tls(void *tls_block)
+{
+    uintptr_t old_ugp;
+    __asm__ volatile("r0 = ugp; %0 = r0" : "=r"(old_ugp) : : "r0");
+    __asm__ volatile("ugp = %0" : : "r"(tls_block));
+    return old_ugp;
+}

--- a/libdl/machine/hexagon/dl_syms.c
+++ b/libdl/machine/hexagon/dl_syms.c
@@ -1,0 +1,253 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/*
+ * Built-in symbol table for Hexagon libdl.
+ *
+ * libc.so has 26 undefined symbols that must be resolved at load time.
+ * 15 are provided by libsemihost.a + libos-fallback.a (already linked
+ * into the test executable).  The remaining 11 are stubbed out here.
+ */
+
+#define _DEFAULT_SOURCE
+#include <stddef.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/times.h>
+#include <time.h>
+#include <termios.h>
+#include <fcntl.h>
+#include <signal.h>
+
+/* ------------------------------------------------------------------ */
+/* 11 stubs for symbols not provided by semihost or os-fallback        */
+/* ------------------------------------------------------------------ */
+
+static clock_t
+stub_times(struct tms *buf)
+{
+    if (buf) {
+        buf->tms_utime  = 0;
+        buf->tms_stime  = 0;
+        buf->tms_cutime = 0;
+        buf->tms_cstime = 0;
+    }
+    return 0;
+}
+
+static int
+stub_clock_gettime(clockid_t id, struct timespec *ts)
+{
+    (void)id; (void)ts;
+    errno = ENOSYS;
+    return -1;
+}
+
+static int
+stub_clock_getres(clockid_t id, struct timespec *ts)
+{
+    (void)id; (void)ts;
+    errno = ENOSYS;
+    return -1;
+}
+
+static int
+stub_dup2(int oldfd, int newfd)
+{
+    (void)oldfd; (void)newfd;
+    errno = ENOSYS;
+    return -1;
+}
+
+static int
+stub_execve(const char *path, char *const argv[], char *const envp[])
+{
+    (void)path; (void)argv; (void)envp;
+    errno = ENOSYS;
+    return -1;
+}
+
+static pid_t
+stub_fork(void)
+{
+    errno = ENOSYS;
+    return -1;
+}
+
+static uid_t
+stub_getuid(void)
+{
+    return 0;
+}
+
+static void
+stub_arc4random_abort(void)
+{
+    /* no-op: arc4random abort hook not needed in bare-metal context */
+}
+
+static void
+stub_arc4random_fork_detect(void)
+{
+    /* no-op: fork detection not applicable on bare-metal */
+}
+
+static int
+stub_getentropy(void *buf, size_t len)
+{
+    /* Return fixed bytes — sufficient for stack canary init on bare-metal.
+     * The semihost getentropy loops on sys_semihost_time() which does not
+     * advance on the simulator, causing an infinite loop.
+     */
+    unsigned char *p = buf;
+    for (size_t i = 0; i < len; i++)
+        p[i] = (unsigned char)(i ^ 0xa5);
+    return 0;
+}
+
+static int
+stub_nanosleep(const struct timespec *req, struct timespec *rem)
+{
+    (void)req; (void)rem;
+    return 0;  /* no-op: success */
+}
+
+static int
+stub_pipe(int pipefd[2])
+{
+    (void)pipefd;
+    errno = ENOSYS;
+    return -1;
+}
+
+static int
+stub_tcgetattr(int fd, struct termios *termios_p)
+{
+    (void)fd; (void)termios_p;
+    errno = ENOSYS;
+    return -1;
+}
+
+static int
+stub_tcsetattr(int fd, int optional_actions, const struct termios *termios_p)
+{
+    (void)fd; (void)optional_actions; (void)termios_p;
+    errno = ENOSYS;
+    return -1;
+}
+
+static pid_t
+stub_waitpid(pid_t pid, int *wstatus, int options)
+{
+    (void)pid; (void)wstatus; (void)options;
+    errno = ENOSYS;
+    return -1;
+}
+
+/* ------------------------------------------------------------------ */
+/* External refs to symbols provided by libsemihost + libos-fallback   */
+/* ------------------------------------------------------------------ */
+
+extern void    _exit(int status);
+extern int     open(const char *path, int flags, ...);
+extern int     close(int fd);
+extern ssize_t read(int fd, void *buf, size_t count);
+extern ssize_t write(int fd, const void *buf, size_t count);
+extern off_t   lseek(int fd, off_t offset, int whence);
+extern int     fstat(int fd, struct stat *statbuf);
+extern int     stat(const char *path, struct stat *statbuf);
+extern int     unlink(const char *path);
+extern int     gettimeofday(struct timeval *tv, void *tz);
+extern int     sigprocmask(int how, const sigset_t *set, sigset_t *oldset);
+extern int     raise(int sig);
+extern void   *sbrk(ptrdiff_t incr);
+
+/* ------------------------------------------------------------------ */
+/* Symbol table                                                         */
+/* ------------------------------------------------------------------ */
+
+void *dl_builtin_lookup(const char *name);
+
+static const struct {
+    const char *name;
+    void       *addr;
+} dl_builtin_syms[] = {
+    /* provided by libsemihost.a */
+    { "_exit",          (void *)_exit         },
+    { "open",           (void *)open          },
+    { "close",          (void *)close         },
+    { "read",           (void *)read          },
+    { "write",          (void *)write         },
+    { "lseek",          (void *)lseek         },
+    { "fstat",          (void *)fstat         },
+    { "stat",           (void *)stat          },
+    { "unlink",         (void *)unlink        },
+    { "times",          (void *)stub_times    },
+    { "gettimeofday",   (void *)gettimeofday  },
+    { "getentropy",     (void *)stub_getentropy  },
+    { "sigprocmask",    (void *)sigprocmask   },
+    /* provided by libos-fallback.a */
+    { "raise",          (void *)raise         },
+    { "sbrk",           (void *)sbrk          },
+    /* stubs defined above */
+    { "clock_gettime",  (void *)stub_clock_gettime },
+    { "clock_getres",   (void *)stub_clock_getres  },
+    { "dup2",           (void *)stub_dup2          },
+    { "execve",         (void *)stub_execve        },
+    { "fork",           (void *)stub_fork          },
+    { "getuid",         (void *)stub_getuid        },
+    { "arc4random_abort",       (void *)stub_arc4random_abort       },
+    { "arc4random_fork_detect", (void *)stub_arc4random_fork_detect },
+    { "nanosleep",      (void *)stub_nanosleep     },
+    { "pipe",           (void *)stub_pipe          },
+    { "tcgetattr",      (void *)stub_tcgetattr     },
+    { "tcsetattr",      (void *)stub_tcsetattr     },
+    { "waitpid",        (void *)stub_waitpid       },
+    { NULL, NULL }
+};
+
+void *
+dl_builtin_lookup(const char *name)
+{
+    for (int i = 0; dl_builtin_syms[i].name != NULL; i++) {
+        if (strcmp(dl_builtin_syms[i].name, name) == 0)
+            return dl_builtin_syms[i].addr;
+    }
+    return NULL;
+}

--- a/libdl/meson.build
+++ b/libdl/meson.build
@@ -1,0 +1,76 @@
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted (subject to the limitations in the
+# disclaimer below) provided that the following conditions are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+#   * Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the following
+#     disclaimer in the documentation and/or other materials provided
+#     with the distribution.
+#
+#   * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+# GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+# HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+# GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+# IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+libdl_machine_dir = 'machine' / host_cpu_family
+
+if build_shared and fs.is_dir(libdl_machine_dir)
+
+  libdl_srcs = files(
+    'dl.c',
+    libdl_machine_dir / 'dl_relocate.c',
+    libdl_machine_dir / 'dl_syms.c',
+  )
+
+  foreach params : targets
+    target      = params['name']
+    target_dir  = params['dir']
+    target_c_args = params['c_args']
+
+    instdir = join_paths(lib_dir, target_dir)
+
+    if meson.version().version_compare('>=1.10')
+      _lib = static_library('dl' + target,
+                            libdl_srcs,
+                            build_subdir : target_dir,
+                            install : really_install,
+                            install_dir : instdir,
+                            include_directories : inc,
+                            c_args : target_c_args + c_args)
+    else
+      target_lib_prefix = params['lib_prefix']
+      _lib = static_library(
+                join_paths(target_dir, target_lib_prefix + 'dl'),
+                libdl_srcs,
+                install : really_install,
+                install_dir : instdir,
+                include_directories : inc,
+                c_args : target_c_args + c_args)
+    endif
+
+    set_variable('lib_dl' + target, _lib)
+
+  endforeach
+
+endif

--- a/libm/meson.build
+++ b/libm/meson.build
@@ -79,7 +79,7 @@ foreach params : targets
 
   if libobjs != []
     local_lib_mpart_target = static_library('mpart' + target,
-					    pic: false,
+					    pic: use_pic,
 					    objects : libobjs,
 					    include_directories: inc,
 					    c_args: target_c_args + c_args)

--- a/meson.build
+++ b/meson.build
@@ -132,6 +132,8 @@ enable_picocrt_lib = get_option('picocrt-lib')
 picocrt_enable_mmu = get_option('picocrt-enable-mmu')
 test_machine = get_option('test-machine')
 enable_tests = get_option('tests')
+build_shared = get_option('shared-library')
+use_pic = build_shared
 if get_option('tests-cdefs') == 'auto'
   enable_cdefs_tests = enable_tests
 else
@@ -331,6 +333,7 @@ tls_model_spec = ''
 thread_local_storage = false
 thread_local_storage_option = get_option('thread-local-storage')
 have_picolibc_tls_api = get_option('thread-local-storage-api') and fs.is_file('libc/machine' / host_cpu_family / 'tls.c')
+
 if thread_local_storage_option == 'auto' or thread_local_storage_option == 'picolibc'
   # We assume that _set_tls() is defined in the arch specific tls.c
   if thread_local_storage_option == 'auto' or have_picolibc_tls_api
@@ -341,9 +344,18 @@ else
 endif
 
 if thread_local_storage
-  tls_model_spec = '%{!ftls-model:-ftls-model=' + get_option('tls-model') + '}'
+  # For shared libraries, we need to use a TLS model that supports dynamic loading
+  # local-exec is only valid for executables and static libraries
+  # global-dynamic is the most flexible model for shared libraries
+  if build_shared
+    tls_model = 'global-dynamic'
+  else
+    tls_model = get_option('tls-model')
+  endif
+  
+  tls_model_spec = '%{!ftls-model:-ftls-model=' + tls_model + '}'
 
-  tls_arg = '-ftls-model=' + get_option('tls-model')
+  tls_arg = '-ftls-model=' + tls_model
   assert(cc.has_argument(tls_arg), 'Compiler does not support \'-ftls-model\'!')
   c_args += [tls_arg]
 endif
@@ -1919,31 +1931,70 @@ foreach params : targets
 
   libc_name = 'c'
 
+  build_shared = get_option('shared-library')
+
   if meson.version().version_compare('>=1.10')
-    local_lib_c_target = static_library(libc_name,
-				        libsrcs_target,
-                                        build_subdir : target_dir,
-				        install : really_install,
-				        install_dir : instdir,
-				        pic: false,
-				        objects : libobjs,
-				        include_directories: inc,
-				        c_args: target_c_args + c_args)
+    if build_shared
+      local_lib_c_target = both_libraries(libc_name,
+				          libsrcs_target,
+                                          build_subdir : target_dir,
+				          install : really_install,
+				          install_dir : instdir,
+				          pic: true,
+				          objects : libobjs,
+				          include_directories: inc,
+				          c_args: target_c_args + c_args,
+				          override_options: ['b_lundef=false'],
+				          link_args: runtime_lib)
+    else
+      local_lib_c_target = static_library(libc_name,
+				          libsrcs_target,
+                                          build_subdir : target_dir,
+				          install : really_install,
+				          install_dir : instdir,
+				          pic: false,
+				          objects : libobjs,
+				          include_directories: inc,
+				          c_args: target_c_args + c_args)
+    endif
 
   else
     target_lib_prefix = params['lib_prefix']
 
-    local_lib_c_target = static_library(join_paths(target_dir, target_lib_prefix + libc_name),
-				        libsrcs_target,
-				        install : really_install,
-				        install_dir : instdir,
-				        pic: false,
-				        objects : libobjs,
-				        include_directories: inc,
-				        c_args: target_c_args + c_args)
+    if build_shared
+      local_lib_c_target = both_libraries(join_paths(target_dir, target_lib_prefix + libc_name),
+				          libsrcs_target,
+				          install : really_install,
+				          install_dir : instdir,
+				          pic: true,
+				          objects : libobjs,
+				          include_directories: inc,
+				          c_args: target_c_args + c_args,
+				          override_options: ['b_lundef=false'],
+				          link_args: runtime_lib)
+    else
+      local_lib_c_target = static_library(join_paths(target_dir, target_lib_prefix + libc_name),
+				          libsrcs_target,
+				          install : really_install,
+				          install_dir : instdir,
+				          pic: false,
+				          objects : libobjs,
+				          include_directories: inc,
+				          c_args: target_c_args + c_args)
+    endif
   endif
 
   set_variable('lib_c' + target, local_lib_c_target)
+
+  # For test linking, always use the static archive.  When build_shared=true,
+  # lib_c is a BothLibraries object whose full_path() returns libc.so, which
+  # cannot be linked with -static.  Store the static variant explicitly so
+  # all test sub-builds can use lib_c_link<target> without special-casing.
+  if build_shared
+    set_variable('lib_c_link' + target, local_lib_c_target.get_static_lib())
+  else
+    set_variable('lib_c_link' + target, local_lib_c_target)
+  endif
 
   if check_duplicate_names
     custom_target('libc_duplicates' + target,

--- a/meson.build
+++ b/meson.build
@@ -1701,6 +1701,10 @@ bios_bin = []
 
 subdir('libos')
 
+if build_shared
+  subdir('libdl')
+endif
+
 if use_stdlib or has_os_linux or has_os_fallback
   has_os_library = true
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -43,6 +43,8 @@ option('multilib-list', type: 'array', value: [],
        description: 'List of multilib configurations to build for')
 option('multilib-exclude', type: 'array', value: [],
        description: 'Multilib configurations containing any of these strings will not be built')
+option('shared-library', type: 'boolean', value: false,
+       description: 'Build shared libraries in addition to static libraries')
 option('sanitize-bounds', type: 'boolean', value: false,
        description: 'Build the library with -fsanitize=bounds')
 option('sanitize-undefined', type: 'boolean', value: false,

--- a/scripts/do-clang-hexagon-configure
+++ b/scripts/do-clang-hexagon-configure
@@ -31,4 +31,4 @@
 # OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 # IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-exec "$(dirname "$0")"/do-configure clang-hexagon -Dtests=true -Dmultilib=false -Dposix-console=true -Dtests-enable-posix-io=true -Dtest-stdin=true -Dc_link_args=-L$(clang -print-resource-dir)/lib/hexagon-unknown-none-elf "$@"
+exec "$(dirname "$0")"/do-configure clang-hexagon -Dtests=true -Dmultilib=false -Dposix-console=true -Dtests-enable-posix-io=true -Dtest-stdin=true -Dc_link_args=-L$(clang -print-resource-dir)/lib/hexagon-unknown-none-elf -Dshared-library=true "$@"

--- a/test/libc-testsuite/meson.build
+++ b/test/libc-testsuite/meson.build
@@ -55,7 +55,7 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
-  _libs = [get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c_link' + target)]
   if is_variable(oslib_test + target)
     _libs += [get_variable(oslib_test + target)]
   endif

--- a/test/meson.build
+++ b/test/meson.build
@@ -392,3 +392,7 @@ subdir('testsuite')
 if has_arm_semihost and oslib_test_variant == 'semihost'
   subdir('semihost')
 endif
+
+if build_shared
+  subdir('test-libdl')
+endif

--- a/test/meson.build
+++ b/test/meson.build
@@ -137,7 +137,7 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
-  _libs = [get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c_link' + target)]
   if is_variable(oslib_test + target)
     _libs += [get_variable(oslib_test + target)]
   endif
@@ -214,9 +214,9 @@ foreach params : targets
 
   if is_variable('lib_semihost_raw' + target) and test_machine == 'qemu'
 
-    _libs_raw = [get_variable('lib_c' + target)]
+    _libs_raw = [get_variable('lib_c_link' + target)]
     _libs_raw += [get_variable('lib_semihost_raw' + target)]
-    
+
     _lib_raw_files=[]
     foreach _lib_raw : _libs_raw
       _lib_raw_files += _lib_raw.full_path()

--- a/test/semihost/meson.build
+++ b/test/semihost/meson.build
@@ -84,7 +84,7 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
-  _libs = [get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c_link' + target)]
   _libs += [get_variable(oslib_test + target)]
   if is_variable(crt0_test + target)
     _objs = [get_variable(crt0_test + target)]

--- a/test/test-ctype/meson.build
+++ b/test/test-ctype/meson.build
@@ -50,7 +50,7 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
-  _libs = [get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c_link' + target)]
   if is_variable(oslib_test + target)
     _libs += [get_variable(oslib_test + target)]
   endif

--- a/test/test-iconv/meson.build
+++ b/test/test-iconv/meson.build
@@ -42,7 +42,7 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
-  _libs = [get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c_link' + target)]
   if is_variable(oslib_test + target)
     _libs += [get_variable(oslib_test + target)]
   endif

--- a/test/test-libdl/meson.build
+++ b/test/test-libdl/meson.build
@@ -1,0 +1,121 @@
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted (subject to the limitations in the
+# disclaimer below) provided that the following conditions are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+#   * Redistributions in binary form must reproduce the above
+#     copyright notice, this list of conditions and the following
+#     disclaimer in the documentation and/or other materials provided
+#     with the distribution.
+#
+#   * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+# GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+# HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+# GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+# IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Individual libdl tests — one executable per test, matching the style
+# of other picolibc test suites.
+#
+# Only built when:
+#   - shared-library=true  (libc.so exists)
+#   - host_cpu_family == 'hexagon'  (arch has dl_relocate + dl_syms)
+#   - has_semihost  (semihosting I/O needed to read libc.so at runtime)
+#   - lib_dl<target> was built by libdl/meson.build
+#
+
+libdl_tests = [
+  'test-libdl-dlerror',
+  'test-libdl-open-error',
+  'test-libdl-null-args',
+  'test-libdl-strlen',
+  'test-libdl-malloc',
+  'test-libdl-sprintf',
+  'test-libdl-memcpy',
+  'test-libdl-memset',
+  'test-libdl-strcmp',
+  'test-libdl-atoi',
+  'test-libdl-dlsym-unknown',
+  'test-libdl-open-twice',
+]
+
+if build_shared and host_cpu_family == 'hexagon' and has_semihost
+
+  foreach params : targets
+    target        = params['name']
+    target_dir    = params['dir']
+    target_c_args = params['c_args']
+
+    if not is_variable('lib_dl' + target)
+      continue
+    endif
+    if not is_variable(oslib_test + target)
+      continue
+    endif
+    if not is_variable(crt0_test + target)
+      continue
+    endif
+
+    _libs = [
+      get_variable('lib_c_link' + target),
+      get_variable(oslib_test + target),
+      get_variable('lib_dl' + target),
+    ]
+    if is_variable(libfallback_var + target)
+      _libs += [get_variable(libfallback_var + target)]
+    endif
+
+    _lib_files = []
+    foreach _lib : _libs
+      _lib_files += _lib.full_path()
+    endforeach
+
+    _objs      = [get_variable(crt0_test + target)]
+    _link_args = target_c_args + _lib_files + get_variable('test_link_args' + target, test_link_args)
+    _link_deps = get_variable('test_link_depends' + target, test_link_depends) + _libs
+
+    # Embed the absolute path to libc.so at compile time so each test
+    # binary is self-contained (no --args needed at run time).
+    _libc_so     = get_variable('lib_c' + target).get_shared_lib()
+    _libc_so_def = '-DLIBC_SO_PATH="' + _libc_so.full_path() + '"'
+
+    _c_args = target_c_args + get_variable('test_c_args' + target, test_c_args) + [_libc_so_def]
+
+    foreach t : libdl_tests
+      _exe = executable(t + target,
+                        t + '.c',
+                        objects             : _objs,
+                        link_with           : [],
+                        c_args              : _c_args,
+                        link_args           : _link_args,
+                        link_depends        : _link_deps,
+                        include_directories : inc)
+
+      test(t + target,
+           _exe,
+           depends : [_libc_so],
+           suite   : 'libdl',
+           env     : test_env)
+    endforeach
+
+  endforeach
+
+endif

--- a/test/test-libdl/test-libdl-atoi.c
+++ b/test/test-libdl/test-libdl-atoi.c
@@ -1,0 +1,57 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* dlsym + atoi/atol from libc.so */
+
+#include "test-libdl.h"
+
+int main(void)
+{
+    void *h = open_libc();
+    if (!h) return 1;
+
+    int  (*my_atoi)(const char *) = dlsym(h, "atoi");
+    long (*my_atol)(const char *) = dlsym(h, "atol");
+    if (!my_atoi)              FAIL("dlsym(atoi)");
+    if (!my_atol)              FAIL("dlsym(atol)");
+    if (my_atoi("42") != 42)   FAIL("atoi(\"42\")");
+    if (my_atoi("-7") != -7)   FAIL("atoi(\"-7\")");
+    if (my_atoi("0") != 0)     FAIL("atoi(\"0\")");
+    if (my_atol("12345") != 12345L) FAIL("atol(\"12345\")");
+
+    dlclose(h);
+    printf("PASS\n");
+    return 0;
+}

--- a/test/test-libdl/test-libdl-dlerror.c
+++ b/test/test-libdl/test-libdl-dlerror.c
@@ -1,0 +1,54 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* dlerror() is NULL before any operation, and clears after first read */
+
+#include "test-libdl.h"
+
+int main(void)
+{
+    if (dlerror() != NULL)
+        FAIL("dlerror should be NULL initially");
+
+    /* Trigger an error */
+    dlopen("/no/such/file.so", RTLD_NOW);
+    char *e1 = dlerror();
+    char *e2 = dlerror();
+    if (!e1) FAIL("dlerror after bad dlopen should be non-NULL");
+    if (e2)  FAIL("dlerror should clear after first call");
+
+    printf("PASS\n");
+    return 0;
+}

--- a/test/test-libdl/test-libdl-dlsym-unknown.c
+++ b/test/test-libdl/test-libdl-dlsym-unknown.c
@@ -1,0 +1,53 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* dlsym of an unknown symbol returns NULL and sets dlerror */
+
+#include "test-libdl.h"
+
+int main(void)
+{
+    void *h = open_libc();
+    if (!h) return 1;
+
+    if (dlsym(h, "__no_such_symbol_xyz__") != NULL)
+        FAIL("dlsym of unknown symbol should return NULL");
+    if (dlerror() == NULL)
+        FAIL("dlsym should set dlerror on failure");
+
+    dlclose(h);
+    printf("PASS\n");
+    return 0;
+}

--- a/test/test-libdl/test-libdl-malloc.c
+++ b/test/test-libdl/test-libdl-malloc.c
@@ -1,0 +1,59 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* dlsym + malloc/free from libc.so */
+
+#include "test-libdl.h"
+
+int main(void)
+{
+    void *h = open_libc();
+    if (!h) return 1;
+
+    void *(*my_malloc)(size_t) = dlsym(h, "malloc");
+    void  (*my_free)(void *)   = dlsym(h, "free");
+    if (!my_malloc)                   FAIL("dlsym(malloc)");
+    if (!my_free)                     FAIL("dlsym(free)");
+
+    char *p = my_malloc(64);
+    if (!p)                           FAIL("malloc(64) returned NULL");
+    strcpy(p, "libdl-test");
+    if (strcmp(p, "libdl-test") != 0) FAIL("strcpy/strcmp via malloc'd buf");
+    my_free(p);
+
+    dlclose(h);
+    printf("PASS\n");
+    return 0;
+}

--- a/test/test-libdl/test-libdl-memcpy.c
+++ b/test/test-libdl/test-libdl-memcpy.c
@@ -1,0 +1,55 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* dlsym + memcpy from libc.so */
+
+#include "test-libdl.h"
+
+int main(void)
+{
+    void *h = open_libc();
+    if (!h) return 1;
+
+    void *(*my_memcpy)(void *, const void *, size_t) = dlsym(h, "memcpy");
+    if (!my_memcpy)                  FAIL("dlsym(memcpy)");
+
+    char src[8] = "abcdefg", dst[8] = {0};
+    my_memcpy(dst, src, 8);
+    if (memcmp(src, dst, 8) != 0)    FAIL("memcpy result mismatch");
+
+    dlclose(h);
+    printf("PASS\n");
+    return 0;
+}

--- a/test/test-libdl/test-libdl-memset.c
+++ b/test/test-libdl/test-libdl-memset.c
@@ -1,0 +1,56 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* dlsym + memset from libc.so */
+
+#include "test-libdl.h"
+
+int main(void)
+{
+    void *h = open_libc();
+    if (!h) return 1;
+
+    void *(*my_memset)(void *, int, size_t) = dlsym(h, "memset");
+    if (!my_memset) FAIL("dlsym(memset)");
+
+    char buf[8];
+    my_memset(buf, 0xab, 8);
+    for (int i = 0; i < 8; i++)
+        if ((unsigned char)buf[i] != 0xab) FAIL("memset result mismatch");
+
+    dlclose(h);
+    printf("PASS\n");
+    return 0;
+}

--- a/test/test-libdl/test-libdl-null-args.c
+++ b/test/test-libdl/test-libdl-null-args.c
@@ -1,0 +1,52 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* NULL argument guards for dlsym() and dlclose() */
+
+#include "test-libdl.h"
+
+int main(void)
+{
+    void *h = open_libc();
+    if (!h) return 1;
+
+    if (dlsym(NULL, "strlen") != NULL) FAIL("dlsym(NULL handle) should return NULL");
+    if (dlsym(h, NULL) != NULL)        FAIL("dlsym(NULL symbol) should return NULL");
+    if (dlclose(NULL) != 0)            FAIL("dlclose(NULL) should return 0");
+
+    dlclose(h);
+    printf("PASS\n");
+    return 0;
+}

--- a/test/test-libdl/test-libdl-open-error.c
+++ b/test/test-libdl/test-libdl-open-error.c
@@ -1,0 +1,50 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* dlopen() of a nonexistent file returns NULL with dlerror set */
+
+#include "test-libdl.h"
+
+int main(void)
+{
+    void *h = dlopen("/no/such/file.so", RTLD_NOW);
+    if (h != NULL)
+        FAIL("dlopen of nonexistent file should return NULL");
+    if (dlerror() == NULL)
+        FAIL("dlerror should be set after failed dlopen");
+
+    printf("PASS\n");
+    return 0;
+}

--- a/test/test-libdl/test-libdl-open-twice.c
+++ b/test/test-libdl/test-libdl-open-twice.c
@@ -1,0 +1,59 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* dlopen the same file twice produces independent handles, both close cleanly */
+
+#include "test-libdl.h"
+
+int main(void)
+{
+    void *h1 = open_libc();
+    if (!h1) return 1;
+
+    void *h2 = dlopen(LIBC_SO_PATH, RTLD_NOW);
+    if (!h2) FAIL("dlopen same file twice");
+
+    size_t (*s1)(const char *) = dlsym(h1, "strlen");
+    size_t (*s2)(const char *) = dlsym(h2, "strlen");
+    if (!s1 || !s2)          FAIL("dlsym on both handles");
+    if (s1("hi") != 2)       FAIL("strlen via first handle");
+    if (s2("hi") != 2)       FAIL("strlen via second handle");
+
+    if (dlclose(h2) != 0)    FAIL("dlclose second handle");
+    if (dlclose(h1) != 0)    FAIL("dlclose first handle");
+
+    printf("PASS\n");
+    return 0;
+}

--- a/test/test-libdl/test-libdl-sprintf.c
+++ b/test/test-libdl/test-libdl-sprintf.c
@@ -1,0 +1,55 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* dlsym + sprintf from libc.so */
+
+#include "test-libdl.h"
+
+int main(void)
+{
+    void *h = open_libc();
+    if (!h) return 1;
+
+    int (*my_sprintf)(char *, const char *, ...) = dlsym(h, "sprintf");
+    if (!my_sprintf)             FAIL("dlsym(sprintf)");
+
+    char buf[32];
+    my_sprintf(buf, "%d", 42);
+    if (strcmp(buf, "42") != 0)  FAIL("sprintf(\"%d\", 42)");
+
+    dlclose(h);
+    printf("PASS\n");
+    return 0;
+}

--- a/test/test-libdl/test-libdl-strcmp.c
+++ b/test/test-libdl/test-libdl-strcmp.c
@@ -1,0 +1,54 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* dlsym + strcmp from libc.so: equal, less-than, greater-than */
+
+#include "test-libdl.h"
+
+int main(void)
+{
+    void *h = open_libc();
+    if (!h) return 1;
+
+    int (*my_strcmp)(const char *, const char *) = dlsym(h, "strcmp");
+    if (!my_strcmp)                    FAIL("dlsym(strcmp)");
+    if (my_strcmp("abc", "abc") != 0)  FAIL("strcmp equal");
+    if (my_strcmp("abc", "abd") >= 0)  FAIL("strcmp less-than");
+    if (my_strcmp("abd", "abc") <= 0)  FAIL("strcmp greater-than");
+
+    dlclose(h);
+    printf("PASS\n");
+    return 0;
+}

--- a/test/test-libdl/test-libdl-strlen.c
+++ b/test/test-libdl/test-libdl-strlen.c
@@ -1,0 +1,53 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* dlsym + strlen from libc.so */
+
+#include "test-libdl.h"
+
+int main(void)
+{
+    void *h = open_libc();
+    if (!h) return 1;
+
+    size_t (*my_strlen)(const char *) = dlsym(h, "strlen");
+    if (!my_strlen)              FAIL("dlsym(strlen)");
+    if (my_strlen("hello") != 5) FAIL("strlen(\"hello\") != 5");
+    if (my_strlen("") != 0)      FAIL("strlen(\"\") != 0");
+
+    dlclose(h);
+    printf("PASS\n");
+    return 0;
+}

--- a/test/test-libdl/test-libdl-tls.c
+++ b/test/test-libdl/test-libdl-tls.c
@@ -1,0 +1,87 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/*
+ * TLS test: verify that TLS variables in libc.so (errno) are accessible
+ * after dlopen() by calling strtol() which writes errno via __tls_get_addr.
+ *
+ * strtol() uses stack protection (__stack_chk_guard).  libc.so's guard is
+ * initialised by its DT_INIT_ARRAY constructor to a fixed value via
+ * stub_getentropy.  We copy the test executable's guard into libc.so's BSS
+ * before calling any stack-protected function from libc.so.
+ *
+ * strtol() writes errno=0 via __tls_get_addr(UGP + tls_offset).  If UGP is
+ * not correctly set to libc.so's TLS block, the write corrupts memory and
+ * the function never returns cleanly.  Correct return values confirm TLS
+ * is working.
+ */
+
+#include "test-libdl.h"
+
+/* The test executable's own stack canary (from libc.a) */
+extern long __stack_chk_guard;
+
+int main(void)
+{
+    void *h = open_libc();
+    if (!h) return 1;
+
+    /* Synchronise libc.so's __stack_chk_guard with the test exe's value
+     * so that stack-protected functions in libc.so pass their canary check.
+     */
+    long *so_guard = dlsym(h, "__stack_chk_guard");
+    if (!so_guard) FAIL("dlsym(__stack_chk_guard)");
+    *so_guard = __stack_chk_guard;
+
+    long (*my_strtol)(const char *, char **, int) = dlsym(h, "strtol");
+    if (!my_strtol) FAIL("dlsym(strtol)");
+
+    /* Each call writes errno=0 via __tls_get_addr(UGP + 0x18).
+     * If UGP is wrong, the write corrupts memory and the function
+     * never returns cleanly.  Correct return values confirm TLS works.
+     */
+    long v = my_strtol("42", NULL, 10);
+    if (v != 42)     FAIL("strtol(\"42\") != 42");
+
+    long neg = my_strtol("-100", NULL, 10);
+    if (neg != -100) FAIL("strtol(\"-100\") != -100");
+
+    long hex = my_strtol("ff", NULL, 16);
+    if (hex != 255)  FAIL("strtol(\"ff\", 16) != 255");
+
+    dlclose(h);
+    printf("PASS\n");
+    return 0;
+}

--- a/test/test-math/meson.build
+++ b/test/test-math/meson.build
@@ -149,7 +149,7 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
-  _libs = [get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c_link' + target)]
   if is_variable(oslib_test + target)
     _libs += [get_variable(oslib_test + target)]
   endif

--- a/test/test-monetary/meson.build
+++ b/test/test-monetary/meson.build
@@ -42,7 +42,7 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
-  _libs = [get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c_link' + target)]
   if is_variable(oslib_test + target)
     _libs += [get_variable(oslib_test + target)]
   endif

--- a/test/test-posix/meson.build
+++ b/test/test-posix/meson.build
@@ -87,7 +87,7 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
-  _libs = [get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c_link' + target)]
   if is_variable(oslib_test + target)
     _libs += [get_variable(oslib_test + target)]
   endif

--- a/test/test-stdio/meson.build
+++ b/test/test-stdio/meson.build
@@ -125,7 +125,7 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
-  _libs = [get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c_link' + target)]
   if is_variable(oslib_test + target)
     _libs += [get_variable(oslib_test + target)]
   endif

--- a/test/test-stdlib/meson.build
+++ b/test/test-stdlib/meson.build
@@ -59,7 +59,7 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
-  _libs = [get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c_link' + target)]
   if is_variable(oslib_test + target)
     _libs += [get_variable(oslib_test + target)]
   endif

--- a/test/test-string/meson.build
+++ b/test/test-string/meson.build
@@ -61,7 +61,7 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
-  _libs = [get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c_link' + target)]
   if is_variable(oslib_test + target)
     _libs += [get_variable(oslib_test + target)]
   endif

--- a/test/testsuite/newlib.iconv/meson.build
+++ b/test/testsuite/newlib.iconv/meson.build
@@ -40,7 +40,7 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
-  _libs = [get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c_link' + target)]
   if is_variable(oslib_test + target)
     _libs += [get_variable(oslib_test + target)]
   endif

--- a/test/testsuite/newlib.locale/meson.build
+++ b/test/testsuite/newlib.locale/meson.build
@@ -46,7 +46,7 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
-  _libs = [get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c_link' + target)]
   if is_variable(oslib_test + target)
     _libs += [get_variable(oslib_test + target)]
   endif

--- a/test/testsuite/newlib.math/meson.build
+++ b/test/testsuite/newlib.math/meson.build
@@ -166,7 +166,7 @@ foreach params : targets
     continue
   endif
   
-  _libs = [get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c_link' + target)]
   if is_variable(oslib_test + target)
     _libs += [get_variable(oslib_test + target)]
   endif

--- a/test/testsuite/newlib.search/meson.build
+++ b/test/testsuite/newlib.search/meson.build
@@ -40,7 +40,7 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
-  _libs = [get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c_link' + target)]
   if is_variable(oslib_test + target)
     _libs += [get_variable(oslib_test + target)]
   endif

--- a/test/testsuite/newlib.stdio/meson.build
+++ b/test/testsuite/newlib.stdio/meson.build
@@ -40,7 +40,7 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
-  _libs = [get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c_link' + target)]
   if is_variable(oslib_test + target)
     _libs += [get_variable(oslib_test + target)]
   endif

--- a/test/testsuite/newlib.stdlib/meson.build
+++ b/test/testsuite/newlib.stdlib/meson.build
@@ -40,7 +40,7 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
-  _libs = [get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c_link' + target)]
   if is_variable(oslib_test + target)
     _libs += [get_variable(oslib_test + target)]
   endif

--- a/test/testsuite/newlib.string/meson.build
+++ b/test/testsuite/newlib.string/meson.build
@@ -40,7 +40,7 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
-  _libs = [get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c_link' + target)]
   if is_variable(oslib_test + target)
     _libs += [get_variable(oslib_test + target)]
   endif

--- a/test/testsuite/newlib.time/meson.build
+++ b/test/testsuite/newlib.time/meson.build
@@ -40,7 +40,7 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
-  _libs = [get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c_link' + target)]
   if is_variable(oslib_test + target)
     _libs += [get_variable(oslib_test + target)]
   endif

--- a/test/testsuite/newlib.wctype/meson.build
+++ b/test/testsuite/newlib.wctype/meson.build
@@ -42,7 +42,7 @@ foreach params : targets
   target_dir = params['dir']
   target_c_args = params['c_args']
 
-  _libs = [get_variable('lib_c' + target)]
+  _libs = [get_variable('lib_c_link' + target)]
   if is_variable(oslib_test + target)
     _libs += [get_variable(oslib_test + target)]
   endif


### PR DESCRIPTION
Add a 'shared-library' boolean option. When enabled: All sub-libraries (cpart, mpart, machine-specific) are compiled with pic: use_pic so their objects can be linked into a shared library The main libc target uses both_libraries() to produce both libc.a and libc.so
TLS model is automatically switched from local-exec to global-dynamic, which is required for shared libraries