### PR TITLE
Added opendir, closedir, readdir semihosting syscalls for hexagon

### DIFF
--- a/libos/semihost/common/meson.build
+++ b/libos/semihost/common/meson.build
@@ -77,10 +77,13 @@ src_semihost += files([
                        'sys_write0.c',
                      ]) + [
   src_semihost_fake_access,
+  src_semihost_fake_closedir,
   src_semihost_fake_ftruncate,
   src_semihost_fake_getcwd,
   src_semihost_fake_getpid,
   src_semihost_fake_kill,
+  src_semihost_fake_opendir,
+  src_semihost_fake_readdir,
   src_semihost_fake_stat,
   ]
 

--- a/libos/semihost/common/meson.build
+++ b/libos/semihost/common/meson.build
@@ -76,8 +76,11 @@ src_semihost += files([
                        'sys_write.c',
                        'sys_write0.c',
                      ]) + [
+  src_semihost_fake_closedir,
   src_semihost_fake_getpid,
   src_semihost_fake_kill,
+  src_semihost_fake_opendir,
+  src_semihost_fake_readdir,
   src_semihost_fake_stat,
   ]
 

--- a/libos/semihost/fake/fake_closedir.c
+++ b/libos/semihost/fake/fake_closedir.c
@@ -1,0 +1,50 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#define _DEFAULT_SOURCE
+#include <dirent.h>
+#include <errno.h>
+
+int
+closedir(DIR *dir)
+{
+    (void)dir;
+    errno = ENOSYS;
+    return -1;
+}
+
+#ifdef __strong_reference
+__strong_reference(closedir, __fake_closedir);
+#endif

--- a/libos/semihost/fake/fake_opendir.c
+++ b/libos/semihost/fake/fake_opendir.c
@@ -1,0 +1,50 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#define _DEFAULT_SOURCE
+#include <dirent.h>
+#include <errno.h>
+
+DIR *
+opendir(const char *name)
+{
+    (void)name;
+    errno = ENOSYS;
+    return 0;
+}
+
+#ifdef __strong_reference
+__strong_reference(opendir, __fake_opendir);
+#endif

--- a/libos/semihost/fake/fake_readdir.c
+++ b/libos/semihost/fake/fake_readdir.c
@@ -1,0 +1,50 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#define _DEFAULT_SOURCE
+#include <dirent.h>
+#include <errno.h>
+
+struct dirent *
+readdir(DIR *dir)
+{
+    (void)dir;
+    errno = ENOSYS;
+    return 0;
+}
+
+#ifdef __strong_reference
+__strong_reference(readdir, __fake_readdir);
+#endif

--- a/libos/semihost/fake/meson.build
+++ b/libos/semihost/fake/meson.build
@@ -36,6 +36,7 @@
 srcs_semihost_fake = [
   'fake_access.c',
   'fake_close.c',
+  'fake_closedir.c',
   'fake_exit.c',
   'fake_fstat.c',
   'fake_ftruncate.c',
@@ -48,7 +49,9 @@ srcs_semihost_fake = [
   'fake_kill.c',
   'fake_lseek.c',
   'fake_open.c',
+  'fake_opendir.c',
   'fake_read.c',
+  'fake_readdir.c',
   'fake_rename.c',
   'fake_stat.c',
   'fake_unlink.c',

--- a/libos/semihost/fake/meson.build
+++ b/libos/semihost/fake/meson.build
@@ -35,6 +35,7 @@
 
 srcs_semihost_fake = [
   'fake_close.c',
+  'fake_closedir.c',
   'fake_exit.c',
   'fake_fstat.c',
   'fake_getentropy.c',
@@ -45,7 +46,9 @@ srcs_semihost_fake = [
   'fake_kill.c',
   'fake_lseek.c',
   'fake_open.c',
+  'fake_opendir.c',
   'fake_read.c',
+  'fake_readdir.c',
   'fake_rename.c',
   'fake_stat.c',
   'fake_unlink.c',

--- a/libos/semihost/machine/arc/meson.build
+++ b/libos/semihost/machine/arc/meson.build
@@ -45,6 +45,7 @@ src_semihost += files([
                        'arc_write.c',
                      ]) + [
   src_semihost_fake_access,
+  src_semihost_fake_closedir,
   src_semihost_fake_ftruncate,
   src_semihost_fake_getcwd,
   src_semihost_fake_getentropy,
@@ -52,5 +53,7 @@ src_semihost += files([
   src_semihost_fake_gettimeofday,
   src_semihost_fake_isatty,
   src_semihost_fake_kill,
+  src_semihost_fake_opendir,
+  src_semihost_fake_readdir,
   src_semihost_fake_rename,
   ]

--- a/libos/semihost/machine/arc/meson.build
+++ b/libos/semihost/machine/arc/meson.build
@@ -44,10 +44,13 @@ src_semihost += files([
                        'arc_unlink.c',
                        'arc_write.c',
                      ]) + [
+  src_semihost_fake_closedir,
   src_semihost_fake_getentropy,
   src_semihost_fake_getpid,
   src_semihost_fake_gettimeofday,
   src_semihost_fake_isatty,
   src_semihost_fake_kill,
+  src_semihost_fake_opendir,
+  src_semihost_fake_readdir,
   src_semihost_fake_rename,
   ]

--- a/libos/semihost/machine/arc64/meson.build
+++ b/libos/semihost/machine/arc64/meson.build
@@ -46,6 +46,7 @@ src_semihost += files([
                        '../arc/arc_write.c',
                      ]) + [
   src_semihost_fake_access,
+  src_semihost_fake_closedir,
   src_semihost_fake_ftruncate,
   src_semihost_fake_getcwd,
   src_semihost_fake_getentropy,
@@ -53,6 +54,7 @@ src_semihost += files([
   src_semihost_fake_gettimeofday,
   src_semihost_fake_isatty,
   src_semihost_fake_kill,
+  src_semihost_fake_opendir,
+  src_semihost_fake_readdir,
   src_semihost_fake_rename,
   ]
-

--- a/libos/semihost/machine/arc64/meson.build
+++ b/libos/semihost/machine/arc64/meson.build
@@ -45,11 +45,14 @@ src_semihost += files([
                        '../arc/arc_unlink.c',
                        '../arc/arc_write.c',
                      ]) + [
+  src_semihost_fake_closedir,
   src_semihost_fake_getentropy,
   src_semihost_fake_getpid,
   src_semihost_fake_gettimeofday,
   src_semihost_fake_isatty,
   src_semihost_fake_kill,
+  src_semihost_fake_opendir,
+  src_semihost_fake_readdir,
   src_semihost_fake_rename,
   ]
 

--- a/libos/semihost/machine/hexagon/hexagon_closedir.c
+++ b/libos/semihost/machine/hexagon/hexagon_closedir.c
@@ -1,0 +1,53 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#define _DEFAULT_SOURCE
+#include "hexagon_semihost.h"
+#include <dirent.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+int
+closedir(DIR *dir)
+{
+    register uintptr_t r0 __asm__("r0") = SYS_CLOSEDIR;
+    register uintptr_t r1 __asm__("r1") = (uintptr_t)dir->fd;
+    __asm__ __volatile__(SWI : "=r"(r0), "=r"(r1) : "r"(r0), "r"(r1));
+    int retval = (int)r0;
+    free(dir);
+    if (retval == -1)
+        hexagon_semihost_errno((int)r1);
+    return retval;
+}

--- a/libos/semihost/machine/hexagon/hexagon_opendir.c
+++ b/libos/semihost/machine/hexagon/hexagon_opendir.c
@@ -1,0 +1,58 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#define _DEFAULT_SOURCE
+#include "hexagon_semihost.h"
+#include <dirent.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+DIR *
+opendir(const char *name)
+{
+    register uintptr_t r0 __asm__("r0") = SYS_OPENDIR;
+    register uintptr_t r1 __asm__("r1") = (uintptr_t)name;
+    __asm__ __volatile__(SWI : "=r"(r0), "=r"(r1) : "r"(r0), "r"(r1));
+    if (r0 == 0) {
+        if (r1 != 0)
+            hexagon_semihost_errno((int)r1);
+        return 0;
+    }
+    DIR *dir = calloc(1, sizeof(DIR));
+    if (!dir)
+        return 0;
+    dir->fd = (int)r0;
+    return dir;
+}

--- a/libos/semihost/machine/hexagon/hexagon_readdir.c
+++ b/libos/semihost/machine/hexagon/hexagon_readdir.c
@@ -1,0 +1,71 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#define _DEFAULT_SOURCE
+#include "hexagon_semihost.h"
+#include <dirent.h>
+#include <string.h>
+#include <stdint.h>
+
+/*
+ * Semihosting dirent as defined by the Hexagon semihosting specification.
+ * d_name size matches __NAME_MAX + 1 from sys/dirent.h so names are not
+ * silently truncated by the host.
+ */
+struct __semihost_dirent {
+    long d_ino;
+    char d_name[256];
+};
+
+struct dirent *
+readdir(DIR *dir)
+{
+    struct __semihost_dirent shd;
+    register uintptr_t       r0 __asm__("r0") = SYS_READDIR;
+    register uintptr_t       r1 __asm__("r1") = (uintptr_t)dir->fd;
+    register uintptr_t       r2 __asm__("r2") = (uintptr_t)&shd;
+    __asm__ __volatile__(SWI : "=r"(r0), "=r"(r1) : "r"(r0), "r"(r1), "r"(r2));
+    if (r0 == 0) {
+        /* r1==0 means end-of-directory; r1!=0 means error */
+        if (r1 != 0)
+            hexagon_semihost_errno((int)r1);
+        return 0;
+    }
+    dir->dirent.d_ino = (ino_t)shd.d_ino;
+    dir->dirent.d_type = DT_UNKNOWN;
+    strncpy(dir->dirent.d_name, shd.d_name, sizeof(dir->dirent.d_name) - 1);
+    dir->dirent.d_name[sizeof(dir->dirent.d_name) - 1] = '\0';
+    return &dir->dirent;
+}

--- a/libos/semihost/machine/hexagon/meson.build
+++ b/libos/semihost/machine/hexagon/meson.build
@@ -34,6 +34,7 @@
 src_semihost += files([
                        'hexagon_access.c',
                        'hexagon_close.c',
+                       'hexagon_closedir.c',
                        'hexagon_exit.c',
                        'hexagon_errno.c',
                        'hexagon_flen.c',
@@ -45,7 +46,9 @@ src_semihost += files([
                        'hexagon_isatty.c',
                        'hexagon_lseek.c',
                        'hexagon_open.c',
+                       'hexagon_opendir.c',
                        'hexagon_read.c',
+                       'hexagon_readdir.c',
                        'hexagon_rename.c',
                        'hexagon_semihost.c',
                        'hexagon_stat.c',

--- a/libos/semihost/machine/hexagon/meson.build
+++ b/libos/semihost/machine/hexagon/meson.build
@@ -33,6 +33,7 @@
 
 src_semihost += files([
                        'hexagon_close.c',
+                       'hexagon_closedir.c',
                        'hexagon_exit.c',
                        'hexagon_errno.c',
                        'hexagon_flen.c', 
@@ -42,7 +43,9 @@ src_semihost += files([
                        'hexagon_isatty.c',
                        'hexagon_lseek.c',
                        'hexagon_open.c',
+                       'hexagon_opendir.c',
                        'hexagon_read.c',
+                       'hexagon_readdir.c',
                        'hexagon_rename.c',
                        'hexagon_semihost.c',
                        'hexagon_stat.c',

--- a/libos/semihost/machine/lm32/meson.build
+++ b/libos/semihost/machine/lm32/meson.build
@@ -45,6 +45,7 @@ src_semihost += files([
                        'lm32_write.c',
                      ]) + [
   src_semihost_fake_access,
+  src_semihost_fake_closedir,
   src_semihost_fake_fstat,
   src_semihost_fake_ftruncate,
   src_semihost_fake_getcwd,
@@ -53,6 +54,8 @@ src_semihost += files([
   src_semihost_fake_gettimeofday,
   src_semihost_fake_isatty,
   src_semihost_fake_kill,
+  src_semihost_fake_opendir,
+  src_semihost_fake_readdir,
   src_semihost_fake_rename,
   src_semihost_fake_stat,
   ]

--- a/libos/semihost/machine/lm32/meson.build
+++ b/libos/semihost/machine/lm32/meson.build
@@ -44,12 +44,15 @@ src_semihost += files([
                        'lm32_unlink.c',
                        'lm32_write.c',
                      ]) + [
+  src_semihost_fake_closedir,
   src_semihost_fake_fstat,
   src_semihost_fake_getentropy,
   src_semihost_fake_getpid,
   src_semihost_fake_gettimeofday,
   src_semihost_fake_isatty,
   src_semihost_fake_kill,
+  src_semihost_fake_opendir,
+  src_semihost_fake_readdir,
   src_semihost_fake_rename,
   src_semihost_fake_stat,
   ]

--- a/libos/semihost/machine/m68k/meson.build
+++ b/libos/semihost/machine/m68k/meson.build
@@ -48,10 +48,13 @@ src_semihost += files([
                        'm68k_write.c',
                      ]) + [
   src_semihost_fake_access,
+  src_semihost_fake_closedir,
   src_semihost_fake_ftruncate,
   src_semihost_fake_getcwd,
   src_semihost_fake_getentropy,
   src_semihost_fake_getpid,
   src_semihost_fake_isatty,
   src_semihost_fake_kill,
+  src_semihost_fake_opendir,
+  src_semihost_fake_readdir,
   ]

--- a/libos/semihost/machine/m68k/meson.build
+++ b/libos/semihost/machine/m68k/meson.build
@@ -47,8 +47,11 @@ src_semihost += files([
                        'm68k_unlink.c',
                        'm68k_write.c',
                      ]) + [
+  src_semihost_fake_closedir,
   src_semihost_fake_getentropy,
   src_semihost_fake_getpid,
   src_semihost_fake_isatty,
   src_semihost_fake_kill,
+  src_semihost_fake_opendir,
+  src_semihost_fake_readdir,
   ]

--- a/libos/semihost/machine/mips/meson.build
+++ b/libos/semihost/machine/mips/meson.build
@@ -46,6 +46,7 @@ src_semihost += files([
                        'mips_write.c',
                      ]) + [
   src_semihost_fake_access,
+  src_semihost_fake_closedir,
   src_semihost_fake_ftruncate,
   src_semihost_fake_getcwd,
   src_semihost_fake_getentropy,
@@ -53,6 +54,8 @@ src_semihost += files([
   src_semihost_fake_gettimeofday,
   src_semihost_fake_isatty,
   src_semihost_fake_kill,
+  src_semihost_fake_opendir,
+  src_semihost_fake_readdir,
   src_semihost_fake_rename,
   src_semihost_fake_stat,
   ]

--- a/libos/semihost/machine/mips/meson.build
+++ b/libos/semihost/machine/mips/meson.build
@@ -45,11 +45,14 @@ src_semihost += files([
                        'mips_unlink.c',
                        'mips_write.c',
                      ]) + [
+  src_semihost_fake_closedir,
   src_semihost_fake_getentropy,
   src_semihost_fake_getpid,
   src_semihost_fake_gettimeofday,
   src_semihost_fake_isatty,
   src_semihost_fake_kill,
+  src_semihost_fake_opendir,
+  src_semihost_fake_readdir,
   src_semihost_fake_rename,
   src_semihost_fake_stat,
   ]

--- a/libos/semihost/machine/msp430/meson.build
+++ b/libos/semihost/machine/msp430/meson.build
@@ -39,6 +39,7 @@ src_semihost += files([
                      ]) + [
   src_semihost_fake_access,
   src_semihost_fake_close,
+  src_semihost_fake_closedir,
   src_semihost_fake_fstat,
   src_semihost_fake_ftruncate,
   src_semihost_fake_getcwd,
@@ -50,7 +51,9 @@ src_semihost += files([
   src_semihost_fake_rename,
   src_semihost_fake_lseek,
   src_semihost_fake_open,
+  src_semihost_fake_opendir,
   src_semihost_fake_read,
+  src_semihost_fake_readdir,
   src_semihost_fake_stat,
   src_semihost_fake_unlink,
   src_semihost_fake_write,

--- a/libos/semihost/machine/msp430/meson.build
+++ b/libos/semihost/machine/msp430/meson.build
@@ -38,6 +38,7 @@ src_semihost += files([
                        'msp430-iob.c',
                      ]) + [
   src_semihost_fake_close,
+  src_semihost_fake_closedir,
   src_semihost_fake_fstat,
   src_semihost_fake_getentropy,
   src_semihost_fake_getpid,
@@ -47,7 +48,9 @@ src_semihost += files([
   src_semihost_fake_rename,
   src_semihost_fake_lseek,
   src_semihost_fake_open,
+  src_semihost_fake_opendir,
   src_semihost_fake_read,
+  src_semihost_fake_readdir,
   src_semihost_fake_stat,
   src_semihost_fake_unlink,
   src_semihost_fake_write,

--- a/libos/semihost/machine/nios2/meson.build
+++ b/libos/semihost/machine/nios2/meson.build
@@ -46,6 +46,7 @@ src_semihost += files([
                        'nios2_write.c',
                      ]) + [
   src_semihost_fake_access,
+  src_semihost_fake_closedir,
   src_semihost_fake_ftruncate,
   src_semihost_fake_getcwd,
   src_semihost_fake_getentropy,
@@ -53,5 +54,7 @@ src_semihost += files([
   src_semihost_fake_gettimeofday,
   src_semihost_fake_isatty,
   src_semihost_fake_kill,
+  src_semihost_fake_opendir,
+  src_semihost_fake_readdir,
   src_semihost_fake_rename,
   ]

--- a/libos/semihost/machine/nios2/meson.build
+++ b/libos/semihost/machine/nios2/meson.build
@@ -45,10 +45,13 @@ src_semihost += files([
                        'nios2_unlink.c',
                        'nios2_write.c',
                      ]) + [
+  src_semihost_fake_closedir,
   src_semihost_fake_getentropy,
   src_semihost_fake_getpid,
   src_semihost_fake_gettimeofday,
   src_semihost_fake_isatty,
   src_semihost_fake_kill,
+  src_semihost_fake_opendir,
+  src_semihost_fake_readdir,
   src_semihost_fake_rename,
   ]

--- a/libos/semihost/machine/or1k/meson.build
+++ b/libos/semihost/machine/or1k/meson.build
@@ -39,6 +39,7 @@ src_semihost += files([
                      ]) + [
   src_semihost_fake_access,
   src_semihost_fake_close,
+  src_semihost_fake_closedir,
   src_semihost_fake_fstat,
   src_semihost_fake_ftruncate,
   src_semihost_fake_getcwd,
@@ -50,7 +51,9 @@ src_semihost += files([
   src_semihost_fake_rename,
   src_semihost_fake_lseek,
   src_semihost_fake_open,
+  src_semihost_fake_opendir,
   src_semihost_fake_read,
+  src_semihost_fake_readdir,
   src_semihost_fake_unlink,
   src_semihost_fake_write,
 ]

--- a/libos/semihost/machine/or1k/meson.build
+++ b/libos/semihost/machine/or1k/meson.build
@@ -38,6 +38,7 @@ src_semihost += files([
                        'or1k_iob.c',
                      ]) + [
   src_semihost_fake_close,
+  src_semihost_fake_closedir,
   src_semihost_fake_fstat,
   src_semihost_fake_getentropy,
   src_semihost_fake_getpid,
@@ -47,7 +48,9 @@ src_semihost += files([
   src_semihost_fake_rename,
   src_semihost_fake_lseek,
   src_semihost_fake_open,
+  src_semihost_fake_opendir,
   src_semihost_fake_read,
+  src_semihost_fake_readdir,
   src_semihost_fake_unlink,
   src_semihost_fake_write,
 ]

--- a/libos/semihost/machine/powerpc/meson.build
+++ b/libos/semihost/machine/powerpc/meson.build
@@ -44,6 +44,7 @@ if cc.get_define('_CALL_ELF') == '1'
                           ]) + [
     src_semihost_fake_access,
     src_semihost_fake_close,
+    src_semihost_fake_closedir,
     src_semihost_fake_fstat,
     src_semihost_fake_ftruncate,
     src_semihost_fake_getcwd,
@@ -55,7 +56,9 @@ if cc.get_define('_CALL_ELF') == '1'
     src_semihost_fake_rename,
     src_semihost_fake_lseek,
     src_semihost_fake_open,
+    src_semihost_fake_opendir,
     src_semihost_fake_read,
+    src_semihost_fake_readdir,
     src_semihost_fake_unlink,
     src_semihost_fake_write,
   ]

--- a/libos/semihost/machine/powerpc/meson.build
+++ b/libos/semihost/machine/powerpc/meson.build
@@ -43,6 +43,7 @@ if cc.get_define('_CALL_ELF') == '1'
                             'powerpc_io.c',
                           ]) + [
     src_semihost_fake_close,
+    src_semihost_fake_closedir,
     src_semihost_fake_fstat,
     src_semihost_fake_getentropy,
     src_semihost_fake_getpid,
@@ -52,7 +53,9 @@ if cc.get_define('_CALL_ELF') == '1'
     src_semihost_fake_rename,
     src_semihost_fake_lseek,
     src_semihost_fake_open,
+    src_semihost_fake_opendir,
     src_semihost_fake_read,
+    src_semihost_fake_readdir,
     src_semihost_fake_unlink,
     src_semihost_fake_write,
   ]

--- a/libos/semihost/machine/rx/meson.build
+++ b/libos/semihost/machine/rx/meson.build
@@ -39,6 +39,7 @@ src_semihost += files([
                      ]) + [
   src_semihost_fake_access,
   src_semihost_fake_close,
+  src_semihost_fake_closedir,
   src_semihost_fake_fstat,
   src_semihost_fake_ftruncate,
   src_semihost_fake_getcwd,
@@ -50,7 +51,9 @@ src_semihost += files([
   src_semihost_fake_rename,
   src_semihost_fake_lseek,
   src_semihost_fake_open,
+  src_semihost_fake_opendir,
   src_semihost_fake_read,
+  src_semihost_fake_readdir,
   src_semihost_fake_unlink,
   src_semihost_fake_write,
 ]

--- a/libos/semihost/machine/rx/meson.build
+++ b/libos/semihost/machine/rx/meson.build
@@ -38,6 +38,7 @@ src_semihost += files([
                        'rx_iob.c',
                      ]) + [
   src_semihost_fake_close,
+  src_semihost_fake_closedir,
   src_semihost_fake_fstat,
   src_semihost_fake_getentropy,
   src_semihost_fake_getpid,
@@ -47,7 +48,9 @@ src_semihost += files([
   src_semihost_fake_rename,
   src_semihost_fake_lseek,
   src_semihost_fake_open,
+  src_semihost_fake_opendir,
   src_semihost_fake_read,
+  src_semihost_fake_readdir,
   src_semihost_fake_unlink,
   src_semihost_fake_write,
 ]

--- a/libos/semihost/machine/sh/meson.build
+++ b/libos/semihost/machine/sh/meson.build
@@ -41,6 +41,7 @@ src_semihost += files([
                      ]) + [
   src_semihost_fake_access,
   src_semihost_fake_close,
+  src_semihost_fake_closedir,
   src_semihost_fake_fstat,
   src_semihost_fake_ftruncate,
   src_semihost_fake_getcwd,
@@ -52,6 +53,8 @@ src_semihost += files([
   src_semihost_fake_rename,
   src_semihost_fake_lseek,
   src_semihost_fake_open,
+  src_semihost_fake_opendir,
   src_semihost_fake_read,
+  src_semihost_fake_readdir,
   src_semihost_fake_unlink,
   ]

--- a/libos/semihost/machine/sh/meson.build
+++ b/libos/semihost/machine/sh/meson.build
@@ -40,6 +40,7 @@ src_semihost += files([
                        'sh_write.c',
                      ]) + [
   src_semihost_fake_close,
+  src_semihost_fake_closedir,
   src_semihost_fake_fstat,
   src_semihost_fake_getentropy,
   src_semihost_fake_getpid,
@@ -49,6 +50,8 @@ src_semihost += files([
   src_semihost_fake_rename,
   src_semihost_fake_lseek,
   src_semihost_fake_open,
+  src_semihost_fake_opendir,
   src_semihost_fake_read,
+  src_semihost_fake_readdir,
   src_semihost_fake_unlink,
   ]

--- a/libos/semihost/machine/sparc/meson.build
+++ b/libos/semihost/machine/sparc/meson.build
@@ -39,6 +39,7 @@ src_semihost += files([
                      ]) + [
   src_semihost_fake_access,
   src_semihost_fake_close,
+  src_semihost_fake_closedir,
   src_semihost_fake_fstat,
   src_semihost_fake_ftruncate,
   src_semihost_fake_getcwd,
@@ -50,7 +51,9 @@ src_semihost += files([
   src_semihost_fake_rename,
   src_semihost_fake_lseek,
   src_semihost_fake_open,
+  src_semihost_fake_opendir,
   src_semihost_fake_read,
+  src_semihost_fake_readdir,
   src_semihost_fake_unlink,
   src_semihost_fake_write,
 ]

--- a/libos/semihost/machine/sparc/meson.build
+++ b/libos/semihost/machine/sparc/meson.build
@@ -38,6 +38,7 @@ src_semihost += files([
                        'sparc_iob.c',
                      ]) + [
   src_semihost_fake_close,
+  src_semihost_fake_closedir,
   src_semihost_fake_fstat,
   src_semihost_fake_getentropy,
   src_semihost_fake_getpid,
@@ -47,7 +48,9 @@ src_semihost += files([
   src_semihost_fake_rename,
   src_semihost_fake_lseek,
   src_semihost_fake_open,
+  src_semihost_fake_opendir,
   src_semihost_fake_read,
+  src_semihost_fake_readdir,
   src_semihost_fake_unlink,
   src_semihost_fake_write,
 ]

--- a/libos/semihost/machine/x86/meson.build
+++ b/libos/semihost/machine/x86/meson.build
@@ -39,6 +39,7 @@ src_semihost += files([
                      ]) + [
   src_semihost_fake_access,
   src_semihost_fake_close,
+  src_semihost_fake_closedir,
   src_semihost_fake_fstat,
   src_semihost_fake_ftruncate,
   src_semihost_fake_getcwd,
@@ -50,7 +51,9 @@ src_semihost += files([
   src_semihost_fake_rename,
   src_semihost_fake_lseek,
   src_semihost_fake_open,
+  src_semihost_fake_opendir,
   src_semihost_fake_read,
+  src_semihost_fake_readdir,
   src_semihost_fake_stat,
   src_semihost_fake_unlink,
   src_semihost_fake_write,

--- a/libos/semihost/machine/x86/meson.build
+++ b/libos/semihost/machine/x86/meson.build
@@ -38,6 +38,7 @@ src_semihost += files([
                        'e9_io.c',
                      ]) + [
   src_semihost_fake_close,
+  src_semihost_fake_closedir,
   src_semihost_fake_fstat,
   src_semihost_fake_getentropy,
   src_semihost_fake_getpid,
@@ -47,7 +48,9 @@ src_semihost += files([
   src_semihost_fake_rename,
   src_semihost_fake_lseek,
   src_semihost_fake_open,
+  src_semihost_fake_opendir,
   src_semihost_fake_read,
+  src_semihost_fake_readdir,
   src_semihost_fake_stat,
   src_semihost_fake_unlink,
   src_semihost_fake_write,

--- a/libos/semihost/machine/xtensa/meson.build
+++ b/libos/semihost/machine/xtensa/meson.build
@@ -45,6 +45,7 @@ src_semihost += files([
                        'simcall.S',
                      ]) + [
   src_semihost_fake_access,
+  src_semihost_fake_closedir,
   src_semihost_fake_fstat,
   src_semihost_fake_ftruncate,
   src_semihost_fake_getcwd,
@@ -53,6 +54,8 @@ src_semihost += files([
   src_semihost_fake_gettimeofday,
   src_semihost_fake_isatty,
   src_semihost_fake_kill,
+  src_semihost_fake_opendir,
+  src_semihost_fake_readdir,
   src_semihost_fake_rename,
   src_semihost_fake_stat,
   ]

--- a/libos/semihost/machine/xtensa/meson.build
+++ b/libos/semihost/machine/xtensa/meson.build
@@ -44,12 +44,15 @@ src_semihost += files([
                        'xtensa-write.c',
                        'simcall.S',
                      ]) + [
+  src_semihost_fake_closedir,
   src_semihost_fake_fstat,
   src_semihost_fake_getentropy,
   src_semihost_fake_getpid,
   src_semihost_fake_gettimeofday,
   src_semihost_fake_isatty,
   src_semihost_fake_kill,
+  src_semihost_fake_opendir,
+  src_semihost_fake_readdir,
   src_semihost_fake_rename,
   src_semihost_fake_stat,
   ]

--- a/test/test-posix/CMakeLists.txt
+++ b/test/test-posix/CMakeLists.txt
@@ -39,6 +39,7 @@ set(tests
   test-getcwd
   test-getdelim
   test-grp
+  test-dirent
   test-pwd
   test-signal
   test-stat

--- a/test/test-posix/CMakeLists.txt
+++ b/test/test-posix/CMakeLists.txt
@@ -37,6 +37,7 @@ set(tests
   test-fnmatch
   test-getdelim
   test-grp
+  test-dirent
   test-pwd
   test-signal
   test-stat

--- a/test/test-posix/meson.build
+++ b/test/test-posix/meson.build
@@ -50,6 +50,12 @@ tests = [
 tests_failure = []
 test_skip = []
 
+if enable_native_tests
+  test_skip += [
+    'test-dirent',
+  ]
+endif
+
 if has_os_posix
   tests += [
     'test-alarm',

--- a/test/test-posix/meson.build
+++ b/test/test-posix/meson.build
@@ -40,6 +40,7 @@ tests = [
   'test-getcwd',
   'test-getdelim',
   'test-grp',
+  'test-dirent',
   'test-pwd',
   'test-rename',
   'test-signal',

--- a/test/test-posix/meson.build
+++ b/test/test-posix/meson.build
@@ -37,6 +37,7 @@ tests = [
   'test-fnmatch',
   'test-getdelim',
   'test-grp',
+  'test-dirent',
   'test-pwd',
   'test-rename',
   'test-signal',

--- a/test/test-posix/test-dirent.c
+++ b/test/test-posix/test-dirent.c
@@ -39,27 +39,8 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string.h>
 #include <limits.h>
 #include <dirent.h>
-#include <errno.h>
 
-/*
- * On Linux, readdir(3) may be provided by glibc whose struct dirent includes
- * d_off (off_t) and d_reclen (unsigned short) between d_ino and d_type,
- * shifting d_name 10 bytes later than picolibc's struct dirent.  Use a
- * compatible view to read d_name at the correct offset regardless of which
- * readdir implementation is linked.
- */
-#if defined(__linux__) && defined(__PICOLIBC__)
-struct __linux_dirent {
-    ino_t          d_ino;
-    off_t          d_off;
-    unsigned short d_reclen;
-    unsigned char  d_type;
-    char           d_name[NAME_MAX + 1];
-};
-#define dirent_name(ent) (((struct __linux_dirent *)(void *)(ent))->d_name)
-#else
 #define dirent_name(ent) ((ent)->d_name)
-#endif
 
 #ifndef TEST_FILE_NAME
 #define TEST_FILE_NAME "DIRENT.TXT"

--- a/test/test-posix/test-dirent.c
+++ b/test/test-posix/test-dirent.c
@@ -37,8 +37,29 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h>
 #include <dirent.h>
 #include <errno.h>
+
+/*
+ * On Linux, readdir(3) may be provided by glibc whose struct dirent includes
+ * d_off (off_t) and d_reclen (unsigned short) between d_ino and d_type,
+ * shifting d_name 10 bytes later than picolibc's struct dirent.  Use a
+ * compatible view to read d_name at the correct offset regardless of which
+ * readdir implementation is linked.
+ */
+#if defined(__linux__) && defined(__PICOLIBC__)
+struct __linux_dirent {
+    ino_t          d_ino;
+    off_t          d_off;
+    unsigned short d_reclen;
+    unsigned char  d_type;
+    char           d_name[NAME_MAX + 1];
+};
+#define dirent_name(ent) (((struct __linux_dirent *)(void *)(ent))->d_name)
+#else
+#define dirent_name(ent) ((ent)->d_name)
+#endif
 
 #ifndef TEST_FILE_NAME
 #define TEST_FILE_NAME "DIRENT.TXT"
@@ -96,7 +117,7 @@ main(void)
     /* readdir: scan entries until the test file is found */
     found = 0;
     while ((ent = readdir(dir)) != NULL) {
-        if (strcmp(ent->d_name, TEST_FILE_NAME) == 0) {
+        if (strcmp(dirent_name(ent), TEST_FILE_NAME) == 0) {
             found = 1;
             break;
         }

--- a/test/test-posix/test-dirent.c
+++ b/test/test-posix/test-dirent.c
@@ -1,0 +1,115 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#define _DEFAULT_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <dirent.h>
+#include <errno.h>
+
+#ifndef TEST_FILE_NAME
+#define TEST_FILE_NAME "DIRENT.TXT"
+#endif
+
+#define check(condition, message)                    \
+    do {                                             \
+        if (!(condition)) {                          \
+            printf("%s: %s\n", message, #condition); \
+            (void)remove(TEST_FILE_NAME);            \
+            exit(1);                                 \
+        }                                            \
+    } while (0)
+
+#ifdef __PICOLIBC__
+__typeof(opendir)  __fake_opendir __weak;
+__typeof(readdir)  __fake_readdir __weak;
+__typeof(closedir) __fake_closedir __weak;
+#define not_fake(sym) ((sym) != __fake_##sym)
+#else
+#define not_fake(sym) 1
+#endif
+
+int
+main(void)
+{
+    FILE          *f;
+    DIR           *dir;
+    struct dirent *ent;
+    int            found;
+
+#ifndef TESTS_ENABLE_POSIX_IO
+    printf("POSIX I/O not enabled, skipping\n");
+    return 77;
+#endif
+
+    if (!not_fake(opendir) || !not_fake(readdir) || !not_fake(closedir)) {
+        printf("fake dirent ops, skipping\n");
+        return 77;
+    }
+
+    /* Clean up any leftover file from a previous run */
+    (void)remove(TEST_FILE_NAME);
+
+    /* Create a test file so we have a known entry to look for */
+    f = fopen(TEST_FILE_NAME, "w");
+    check(f != NULL, "fopen w " TEST_FILE_NAME);
+    fputs("dirent test\n", f);
+    fclose(f);
+
+    /* opendir: open the current directory */
+    dir = opendir(".");
+    check(dir != NULL, "opendir .");
+
+    /* readdir: scan entries until the test file is found */
+    found = 0;
+    while ((ent = readdir(dir)) != NULL) {
+        if (strcmp(ent->d_name, TEST_FILE_NAME) == 0) {
+            found = 1;
+            break;
+        }
+    }
+
+    /* closedir: close the directory handle */
+    check(closedir(dir) == 0, "closedir");
+
+    check(found, "test file not found in directory listing");
+
+    /* Clean up */
+    (void)remove(TEST_FILE_NAME);
+
+    printf("dirent test passed\n");
+    exit(0);
+}


### PR DESCRIPTION
This PR adds `opendir`, `closedir` and `readdir` semihosting syscalls for hexagon as per the hexagon semihosting spec, also adding a test for these syscalls.