### PR TITLE
Fix strerror() returning NULL for some values

### DIFF
--- a/libc/string/strerror.c
+++ b/libc/string/strerror.c
@@ -338,10 +338,13 @@ char *_user_strerror(int, int, int *) __weak;
 char *
 _strerror_r(int errnum, int internal, int *errptr)
 {
-    if ((unsigned)errnum < NERRNAMES)
-        return (char *)errnames[(unsigned)errnum];
-
     char *error;
+
+    if ((unsigned)errnum < NERRNAMES) {
+        error = (char *)errnames[(unsigned)errnum];
+        if (error)
+            return error;
+    }
 
     if (!errptr)
         errptr = &errno;


### PR DESCRIPTION
the function strerror returns a NULL in different error number is given to it. When errnum is negative (e.g., -1), the cast to unsigned produces a huge positive value that accesses the errnames array out of bounds, causing undefined behavior and return a NULL instead of  "Unknown error"

simple test case:
`
#include <string.h>
#include <stdio.h>
	for (i = -100; i < 100; i ++) {
		res = strerror(i);
		if (res == NULL) {
			printf("NULL is printed fot %d", i);
		}
	}
`