### PR TITLE
specs: stop forcing --gc-sections; keep toolchain options overridable

### DIFF
--- a/picolibc-native.specs.in
+++ b/picolibc-native.specs.in
@@ -7,13 +7,13 @@
 @SPECS_ISYSTEM@ %(picolibc_cpp)
 
 *cc1:
-@TLSMODEL@ @STACKGUARD@ %(picolibc_cc1) @CC1_SPEC@
+@TLSMODEL@ @STACKGUARD@ @CC1_SPEC@ %(picolibc_cc1)
 
 *cc1plus:
-@SPECS_ISYSTEM@ @TLSMODEL@ @STACKGUARD@ %(picolibc_cc1plus) @CC1_SPEC@ @CC1PLUS_SPEC@
+@SPECS_ISYSTEM@ @TLSMODEL@ @STACKGUARD@ @CC1_SPEC@ @CC1PLUS_SPEC@ %(picolibc_cc1plus)
 
 *link:
-@SPECS_PRINTF@ @SPECS_LIBPATH@ %(picolibc_link) --gc-sections @LINK_SPEC@
+@SPECS_PRINTF@ @SPECS_LIBPATH@ @LINK_SPEC@ %(picolibc_link)
 
 *lib:
 --start-group %(libgcc) @ADDITIONAL_LIBS@ -lc %{-oslib=*:-l%*} --end-group

--- a/picolibc.specs.in
+++ b/picolibc.specs.in
@@ -7,13 +7,13 @@
 @SPECS_ISYSTEM@ %{-printf=*: -D_PICOLIBC_PRINTF='%*'} %{-scanf=*: -D_PICOLIBC_SCANF='%*'} %(picolibc_cpp)
 
 *cc1:
-@TLSMODEL@ @STACKGUARD@ %(picolibc_cc1) @CC1_SPEC@
+@TLSMODEL@ @STACKGUARD@ @CC1_SPEC@ %(picolibc_cc1)
 
 *cc1plus:
-@SPECS_ISYSTEM@ @TLSMODEL@ @STACKGUARD@ %(picolibc_cc1plus) @CC1_SPEC@ @CC1PLUS_SPEC@
+@SPECS_ISYSTEM@ @TLSMODEL@ @STACKGUARD@ @CC1_SPEC@ @CC1PLUS_SPEC@ %(picolibc_cc1plus)
 
 *link:
-@SPECS_PRINTF@ @SPECS_LIBPATH@ %{-printf=*:--defsym=@PREFIX@vfprintf=@PREFIX@__%*_vfprintf} %{-scanf=*:--defsym=@PREFIX@vfscanf=@PREFIX@__%*_vfscanf} %{!T:-T@PICOLIBC_LD@} %(picolibc_link) --gc-sections @LINK_SPEC@
+@SPECS_PRINTF@ @SPECS_LIBPATH@ %{-printf=*:--defsym=@PREFIX@vfprintf=@PREFIX@__%*_vfprintf} %{-scanf=*:--defsym=@PREFIX@vfscanf=@PREFIX@__%*_vfscanf} %{!T:-T@PICOLIBC_LD@} @LINK_SPEC@ %(picolibc_link)
 
 *lib:
 --start-group %(libgcc) @ADDITIONAL_LIBS@ -lc @OSLIB_SPEC@ --end-group


### PR DESCRIPTION
Some build systems compile and inspect probe binaries to detect ABI details. For example, CMake's compiler ABI check relies on data emitted into the test binary:
  https://github.com/Kitware/CMake/blob/88be26a6/Modules/CMakeCompilerABI.h

When `--gc-sections` is forced from specs, sections carrying probe data can be discarded, which can produce incorrect ABI detection results.

Also, placing picolibc-provided options after "original" options looks wrong. It ruins overrideability (e.g., making `--no-gc-sections` ineffective). Reorder cc1/cc1plus/link composition so default picolibc fragments are applied last in a way that preserves explicit user control.

Keeping `--gc-sections` in specs is not a good idea because it creates inconsistent behavior across picolibc roles:
  - primary C library: `--no-gc-sections` by default
  - companion library: `--gc-sections` by default (in the specs file)

These environments need different linker policies, so the `--gc-sections` choice should stay with the invoking build system.