### PR TITLE
Replace inline with __inline for C89 compatibility

### DIFF
--- a/libc/include/signal.h
+++ b/libc/include/signal.h
@@ -258,7 +258,7 @@ int sigaction(int, const struct sigaction * __restrict, struct sigaction * __res
 
 int sigaddset(sigset_t *, const int);
 
-static inline int
+static __inline int
 __sigaddset(sigset_t *what, int sig)
 {
     *what |= (sigset_t)1 << sig;


### PR DESCRIPTION
Hi Keith,

I'm investigating C89 compatibility issue in picolibc. I found that signal.h uses the `inline` keyword in `__sigaddset` fucntion, and it gives the below error 

```
error: unknown type name 'inline'
  261 | static inline int
      |        ^
1 error generated.
```

So I was wondering is changing to __inline is better or guard it with some macro based on the C version ?