### PR TITLE
Update obsolete math flags to use integer values

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,10 +254,10 @@ if(NOT DEFINED __ELIX_LEVEL)
 endif()
 
 # Use old math code for double funcs (0 no, 1 yes)
-set(__OBSOLETE_MATH_FLOAT ON)
+set(__OBSOLETE_MATH_FLOAT 1)
 
 # Use old math code for double funcs (0 no, 1 yes)
-set(__OBSOLETE_MATH_DOUBLE ON)
+set(__OBSOLETE_MATH_DOUBLE 1)
 
 # Compute static memory area sizes at runtime instead of link time
 set(__PICOCRT_RUNTIME_SIZE OFF)


### PR DESCRIPTION
The value of __OBSOLETE_MATH_FLOAT should be 0 or 1, not ON or OFF; otherwise, the #if conditional expression will not work correctly.