### PR TITLE
riscv: speed up vector memcpy with `vle32/vse32` fast path

### DIFF
--- a/libc/machine/riscv/memcpy-asm.S
+++ b/libc/machine/riscv/memcpy-asm.S
@@ -12,6 +12,25 @@
 #include "rv_string.h"
 
 #ifdef _MACHINE_RISCV_MEMCPY_VECTOR_
+/*
+ * RISC-V Vector memcpy
+ *
+ * Strategy:
+ *   - n < small  : single e8 vector copy (handles any alignment, any size)
+ *   - common case: align dst to 4 bytes, then bulk copy with vle32/vse32
+ *   - if src and dst can't be co-aligned (different mod-4 offsets):
+ *       fall back to e8 bulk copy (no alignment requirement on vle8)
+ *   - tail < 4 bytes: single e8 copy
+ *
+ * Registers:
+ *   a0 = dst (return value, preserved in t0)
+ *   a1 = src
+ *   a2 = n   (consumed during copy)
+ *   t0 = running dst
+ *   t1 = running src
+ *   t2,t3,t4,t5 = scratch
+ */
+
 .section .text.memcpy
 .global memcpy
 .type memcpy, @function
@@ -22,41 +41,60 @@ memcpy:
   mv     t1, a1                   /* t1 = running src */
   beqz   a2, .Ldone               /* if n == 0, return */
 
-  /* Align dst to SZREG: skip when __riscv_misaligned_fast, else align */
-#ifndef __riscv_misaligned_fast
-  /* process small data directly with vectors, no alignment optimization */
-  li     t3, 32
-  bltu   a2, t3, .Lbulk_copy
-#if __riscv_xlen == 64
-  andi   t2, t0, 7                /* t2 = dst & 7 */
-  beqz   t2, .Lbulk_copy       /* already aligned to 8 bytes */
-  li     t4, 8
-  sub    t2, t4, t2               /* pad = 8 - (dst & 7) */
-#else
-  andi   t2, t0, 3                /* t2 = dst & 3 */
-  beqz   t2, .Lbulk_copy       /* already aligned to 4 bytes */
-  li     t4, 4
-  sub    t2, t4, t2               /* pad = 4 - (dst & 3) */
-#endif
-  /* copy prologue using vectors */
-  vsetvli t3, t2, e8, m8, ta, ma
-  vle8.v v0, (t1)
-  vse8.v v0, (t0)
-  add    t0, t0, t3
-  add    t1, t1, t3
-  sub    a2, a2, t3
-  beqz   a2, .Ldone
-#endif
+  /* Small copies: just one e8 vector op handles it (any alignment) */
+  li      t3, 16
+  bltu    a2, t3, .Lbyte_tail
 
-.Lbulk_copy:
+  /* --- Align dst to 4 bytes (vle32 requires 4-byte aligned address) --- */
+  andi    t2, t0, 3
+  beqz    t2, .Lcheck_src
+  li      t4, 4
+  sub     t2, t4, t2     /* pad = 4 - (dst & 3) */
+  vsetvli t3, t2, e8, m1, ta, ma
+  vle8.v  v0, (t1)
+  vse8.v  v0, (t0)
+  add     t0, t0, t3
+  add     t1, t1, t3
+  sub     a2, a2, t3
+  beqz    a2, .Ldone
+
+.Lcheck_src:
+  /*
+   * dst is now 4-aligned. If src has the same mod-4 offset (i.e. is also
+   * 4-aligned now), use the fast e32 path. Otherwise fall back to e8.
+   */
+  andi    t2, t1, 3
+  bnez    t2, .Lbyte_tail  /* src unalignable → e8 fallback */
+
+  /* Fast e32 path */
+  srli    t3, a2, 2         /* t3 = remaining word count */
+  beqz    t3, .Lbyte_tail
+  andi    a2, a2, 3        /* precompute tail */
+.Lbulk_e32_loop:
+  vsetvli t2, t3, e32, m8, ta, ma
+  vle32.v v0, (t1)
+  vse32.v v0, (t0)
+  sub     t3, t3, t2
+  slli    t5, t2, 2         /* bytes processed this iter */
+  add     t0, t0, t5
+  add     t1, t1, t5
+  bnez    t3, .Lbulk_e32_loop
+  /* fall through to byte tail (a2 < 4) */
+
+/* ============================================================
+ * Byte tail: handles 1..VLMAX bytes, loops if more remain
+ * Also entry point for very small copies.
+ * ============================================================ */
+.Lbyte_tail:
+  beqz    a2, .Ldone
+.Lbyte_tail_loop:
   vsetvli t2, a2, e8, m8, ta, ma
   vle8.v v0, (t1)
   vse8.v v0, (t0)
   add    t0, t0, t2
   add    t1, t1, t2
   sub    a2, a2, t2
-  bnez   a2, .Lbulk_copy
-  /* fallthrough */
+  bnez    a2, .Lbyte_tail_loop
 
 .Ldone:
   ret


### PR DESCRIPTION
Optimizing the existing RISC-V Vector memcpy by introducing a `vle32.v/vse32.v` fast path. The previous implementation used `vle8.v/vse8.v` (byte elements) for the entire copy, regardless of pointer alignment. This change keeps the byte-element loop as a safe fallback but routes the common aligned case through 32-bit element vector ops, which match the memory bus width and dramatically reduce cycle count.

Motivation
Profiling the previous e8-only vector loop showed the memory subsystem servicing one byte per bus cycle on a 32-bit data path — 75% of bus bandwidth was wasted. A NOP test confirmed the bottleneck was memory bandwidth, not pipeline hazards. Switching to `e32` lets the hardware issue word-sized transactions that fully utilize the bus.

Changes:

- New aligned fast path (`.Lbulk_e32_loop`):
  - Aligns `dst` to 4 bytes via a short `e8` prologue (1–3 bytes, `LMUL=1`).
  - Verifies `src` shares the same mod-4 offset; if so, both are now 4-aligned.
  - Bulk-copies with `vle32.v/vse32.v` at `LMUL=8` for maximum bytes/instruction.
- Fallback path (`.Lbyte_tail_loop`):
  - Used when `src` and `dst` cannot be co-aligned (different mod-4 offsets).
  - Same `vle8.v/vse8.v` loop as before, now also reused as the < 4-byte tail handler and the small-copy (< 16 bytes) entry point.
- Tail handling:
  - Tail count (a2 & 3) pre-computed before the `e32` loop, so it falls through cleanly into `.Lbyte_tail` without re-computation.
  - The byte-tail loop correctly handles remainders larger than `VLMAX` (matters on the misaligned-src fallback path).

Notes:
- Neither alignment of src nor dst is assumed at entry — both are checked.
  `__riscv_misaligned_fast` does not affect this code: vector alignment requirements are independent of scalar misaligned-access support.
- `n == 0` and `n < 16` short-circuits avoid setup cost on trivial copies.