### PR TITLE
libos/linux: Add linux statfs struct type

### DIFF
--- a/libos/linux/machine/aarch64/linux/linux-dirent64-struct.h
+++ b/libos/linux/machine/aarch64/linux/linux-dirent64-struct.h
@@ -45,13 +45,17 @@ struct __kernel_dirent64 {
     __uint8_t  __adjust_275[5];
 };
 
-#define SIMPLE_MAP_DIRENT64(_t, _f)      \
-    do {                                 \
-        (_t)->d_ino = (_f)->d_ino;       \
-        (_t)->d_off = (_f)->d_off;       \
-        (_t)->d_reclen = (_f)->d_reclen; \
-        (_t)->d_type = (_f)->d_type;     \
-        (_t)->d_name = (_f)->d_name;     \
+#define SIMPLE_MAP_DIRENT64(_t, _f)                    \
+    do {                                               \
+        (_t)->d_ino = (_f)->d_ino;                     \
+        (_t)->d_off = (_f)->d_off;                     \
+        (_t)->d_reclen = (_f)->d_reclen;               \
+        (_t)->d_type = (_f)->d_type;                   \
+        {                                              \
+            unsigned __i;                              \
+            for (__i = 0; i < 256; i++)                \
+                (_t)->d_name[__i] = (_f)->d_name[__i]; \
+        }                                              \
     } while (0)
 
 #endif /* _LINUX_DIRENT64_STRUCT_H_ */

--- a/libos/linux/machine/aarch64/linux/linux-fsid-struct.h
+++ b/libos/linux/machine/aarch64/linux/linux-fsid-struct.h
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _LINUX_FSID_STRUCT_H_
+#define _LINUX_FSID_STRUCT_H_
+
+struct __kernel___fsid {
+    __int32_t __val[2];
+};
+typedef struct __kernel___fsid __kernel___fsid_t;
+
+#define SIMPLE_MAP___FSID(_t, _f)                    \
+    do {                                             \
+        {                                            \
+            unsigned __i;                            \
+            for (__i = 0; i < 2; i++)                \
+                (_t)->__val[__i] = (_f)->__val[__i]; \
+        }                                            \
+    } while (0)
+
+#endif /* _LINUX_FSID_STRUCT_H_ */

--- a/libos/linux/machine/aarch64/linux/linux-statfs-struct.h
+++ b/libos/linux/machine/aarch64/linux/linux-statfs-struct.h
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _LINUX_STATFS_STRUCT_H_
+#define _LINUX_STATFS_STRUCT_H_
+
+struct __kernel_statfs {
+    __int64_t         f_type;
+    __int64_t         f_bsize;
+    __uint64_t        f_blocks;
+    __uint64_t        f_bfree;
+    __uint64_t        f_bavail;
+    __uint64_t        f_files;
+    __uint64_t        f_ffree;
+    __kernel___fsid_t f_fsid;
+    __int64_t         f_namelen;
+    __int64_t         f_frsize;
+    __int64_t         f_flags;
+    __uint8_t         __adjust_88[32];
+};
+
+#define SIMPLE_MAP_STATFS(_t, _f)          \
+    do {                                   \
+        (_t)->f_type = (_f)->f_type;       \
+        (_t)->f_bsize = (_f)->f_bsize;     \
+        (_t)->f_blocks = (_f)->f_blocks;   \
+        (_t)->f_bfree = (_f)->f_bfree;     \
+        (_t)->f_bavail = (_f)->f_bavail;   \
+        (_t)->f_files = (_f)->f_files;     \
+        (_t)->f_ffree = (_f)->f_ffree;     \
+        (_t)->f_namelen = (_f)->f_namelen; \
+        (_t)->f_frsize = (_f)->f_frsize;   \
+        (_t)->f_flags = (_f)->f_flags;     \
+    } while (0)
+
+#endif /* _LINUX_STATFS_STRUCT_H_ */

--- a/libos/linux/machine/arm/linux/linux-dirent64-struct.h
+++ b/libos/linux/machine/arm/linux/linux-dirent64-struct.h
@@ -45,13 +45,17 @@ struct __kernel_dirent64 {
     __uint8_t  __adjust_275[5];
 };
 
-#define SIMPLE_MAP_DIRENT64(_t, _f)      \
-    do {                                 \
-        (_t)->d_ino = (_f)->d_ino;       \
-        (_t)->d_off = (_f)->d_off;       \
-        (_t)->d_reclen = (_f)->d_reclen; \
-        (_t)->d_type = (_f)->d_type;     \
-        (_t)->d_name = (_f)->d_name;     \
+#define SIMPLE_MAP_DIRENT64(_t, _f)                    \
+    do {                                               \
+        (_t)->d_ino = (_f)->d_ino;                     \
+        (_t)->d_off = (_f)->d_off;                     \
+        (_t)->d_reclen = (_f)->d_reclen;               \
+        (_t)->d_type = (_f)->d_type;                   \
+        {                                              \
+            unsigned __i;                              \
+            for (__i = 0; i < 256; i++)                \
+                (_t)->d_name[__i] = (_f)->d_name[__i]; \
+        }                                              \
     } while (0)
 
 #endif /* _LINUX_DIRENT64_STRUCT_H_ */

--- a/libos/linux/machine/arm/linux/linux-fsid-struct.h
+++ b/libos/linux/machine/arm/linux/linux-fsid-struct.h
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _LINUX_FSID_STRUCT_H_
+#define _LINUX_FSID_STRUCT_H_
+
+struct __kernel___fsid {
+    __int32_t __val[2];
+};
+typedef struct __kernel___fsid __kernel___fsid_t;
+
+#define SIMPLE_MAP___FSID(_t, _f)                    \
+    do {                                             \
+        {                                            \
+            unsigned __i;                            \
+            for (__i = 0; i < 2; i++)                \
+                (_t)->__val[__i] = (_f)->__val[__i]; \
+        }                                            \
+    } while (0)
+
+#endif /* _LINUX_FSID_STRUCT_H_ */

--- a/libos/linux/machine/arm/linux/linux-statfs-struct.h
+++ b/libos/linux/machine/arm/linux/linux-statfs-struct.h
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _LINUX_STATFS_STRUCT_H_
+#define _LINUX_STATFS_STRUCT_H_
+
+struct __kernel_statfs {
+    __int32_t         f_type;
+    __int32_t         f_bsize;
+    __uint64_t        f_blocks;
+    __uint64_t        f_bfree;
+    __uint64_t        f_bavail;
+    __uint64_t        f_files;
+    __uint64_t        f_ffree;
+    __kernel___fsid_t f_fsid;
+    __int32_t         f_namelen;
+    __int32_t         f_frsize;
+    __int32_t         f_flags;
+    __uint8_t         __adjust_68[20];
+};
+
+#define SIMPLE_MAP_STATFS(_t, _f)          \
+    do {                                   \
+        (_t)->f_type = (_f)->f_type;       \
+        (_t)->f_bsize = (_f)->f_bsize;     \
+        (_t)->f_blocks = (_f)->f_blocks;   \
+        (_t)->f_bfree = (_f)->f_bfree;     \
+        (_t)->f_bavail = (_f)->f_bavail;   \
+        (_t)->f_files = (_f)->f_files;     \
+        (_t)->f_ffree = (_f)->f_ffree;     \
+        (_t)->f_namelen = (_f)->f_namelen; \
+        (_t)->f_frsize = (_f)->f_frsize;   \
+        (_t)->f_flags = (_f)->f_flags;     \
+    } while (0)
+
+#endif /* _LINUX_STATFS_STRUCT_H_ */

--- a/libos/linux/machine/i686/linux/linux-dirent64-struct.h
+++ b/libos/linux/machine/i686/linux/linux-dirent64-struct.h
@@ -45,13 +45,17 @@ struct __kernel_dirent64 {
     __uint8_t  __adjust_275[1];
 };
 
-#define SIMPLE_MAP_DIRENT64(_t, _f)      \
-    do {                                 \
-        (_t)->d_ino = (_f)->d_ino;       \
-        (_t)->d_off = (_f)->d_off;       \
-        (_t)->d_reclen = (_f)->d_reclen; \
-        (_t)->d_type = (_f)->d_type;     \
-        (_t)->d_name = (_f)->d_name;     \
+#define SIMPLE_MAP_DIRENT64(_t, _f)                    \
+    do {                                               \
+        (_t)->d_ino = (_f)->d_ino;                     \
+        (_t)->d_off = (_f)->d_off;                     \
+        (_t)->d_reclen = (_f)->d_reclen;               \
+        (_t)->d_type = (_f)->d_type;                   \
+        {                                              \
+            unsigned __i;                              \
+            for (__i = 0; i < 256; i++)                \
+                (_t)->d_name[__i] = (_f)->d_name[__i]; \
+        }                                              \
     } while (0)
 
 #endif /* _LINUX_DIRENT64_STRUCT_H_ */

--- a/libos/linux/machine/i686/linux/linux-fsid-struct.h
+++ b/libos/linux/machine/i686/linux/linux-fsid-struct.h
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _LINUX_FSID_STRUCT_H_
+#define _LINUX_FSID_STRUCT_H_
+
+struct __kernel___fsid {
+    __int32_t __val[2];
+};
+typedef struct __kernel___fsid __kernel___fsid_t;
+
+#define SIMPLE_MAP___FSID(_t, _f)                    \
+    do {                                             \
+        {                                            \
+            unsigned __i;                            \
+            for (__i = 0; i < 2; i++)                \
+                (_t)->__val[__i] = (_f)->__val[__i]; \
+        }                                            \
+    } while (0)
+
+#endif /* _LINUX_FSID_STRUCT_H_ */

--- a/libos/linux/machine/i686/linux/linux-statfs-struct.h
+++ b/libos/linux/machine/i686/linux/linux-statfs-struct.h
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _LINUX_STATFS_STRUCT_H_
+#define _LINUX_STATFS_STRUCT_H_
+
+struct __kernel_statfs {
+    __int32_t         f_type;
+    __int32_t         f_bsize;
+    __uint32_t        f_blocks;
+    __uint32_t        f_bfree;
+    __uint32_t        f_bavail;
+    __uint32_t        f_files;
+    __uint32_t        f_ffree;
+    __kernel___fsid_t f_fsid;
+    __int32_t         f_namelen;
+    __int32_t         f_frsize;
+    __int32_t         f_flags;
+    __uint8_t         __adjust_48[16];
+};
+
+#define SIMPLE_MAP_STATFS(_t, _f)          \
+    do {                                   \
+        (_t)->f_type = (_f)->f_type;       \
+        (_t)->f_bsize = (_f)->f_bsize;     \
+        (_t)->f_blocks = (_f)->f_blocks;   \
+        (_t)->f_bfree = (_f)->f_bfree;     \
+        (_t)->f_bavail = (_f)->f_bavail;   \
+        (_t)->f_files = (_f)->f_files;     \
+        (_t)->f_ffree = (_f)->f_ffree;     \
+        (_t)->f_namelen = (_f)->f_namelen; \
+        (_t)->f_frsize = (_f)->f_frsize;   \
+        (_t)->f_flags = (_f)->f_flags;     \
+    } while (0)
+
+#endif /* _LINUX_STATFS_STRUCT_H_ */

--- a/libos/linux/machine/x86/linux/linux-fsid-struct.h
+++ b/libos/linux/machine/x86/linux/linux-fsid-struct.h
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifdef __x86_64
+#include "../../x86_64/linux/linux-fsid-struct.h"
+#else
+#include "../../i686/linux/linux-fsid-struct.h"
+#endif

--- a/libos/linux/machine/x86/linux/linux-statfs-struct.h
+++ b/libos/linux/machine/x86/linux/linux-statfs-struct.h
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifdef __x86_64
+#include "../../x86_64/linux/linux-statfs-struct.h"
+#else
+#include "../../i686/linux/linux-statfs-struct.h"
+#endif

--- a/libos/linux/machine/x86_64/linux/linux-dirent64-struct.h
+++ b/libos/linux/machine/x86_64/linux/linux-dirent64-struct.h
@@ -45,13 +45,17 @@ struct __kernel_dirent64 {
     __uint8_t  __adjust_275[5];
 };
 
-#define SIMPLE_MAP_DIRENT64(_t, _f)      \
-    do {                                 \
-        (_t)->d_ino = (_f)->d_ino;       \
-        (_t)->d_off = (_f)->d_off;       \
-        (_t)->d_reclen = (_f)->d_reclen; \
-        (_t)->d_type = (_f)->d_type;     \
-        (_t)->d_name = (_f)->d_name;     \
+#define SIMPLE_MAP_DIRENT64(_t, _f)                    \
+    do {                                               \
+        (_t)->d_ino = (_f)->d_ino;                     \
+        (_t)->d_off = (_f)->d_off;                     \
+        (_t)->d_reclen = (_f)->d_reclen;               \
+        (_t)->d_type = (_f)->d_type;                   \
+        {                                              \
+            unsigned __i;                              \
+            for (__i = 0; i < 256; i++)                \
+                (_t)->d_name[__i] = (_f)->d_name[__i]; \
+        }                                              \
     } while (0)
 
 #endif /* _LINUX_DIRENT64_STRUCT_H_ */

--- a/libos/linux/machine/x86_64/linux/linux-fsid-struct.h
+++ b/libos/linux/machine/x86_64/linux/linux-fsid-struct.h
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _LINUX_FSID_STRUCT_H_
+#define _LINUX_FSID_STRUCT_H_
+
+struct __kernel___fsid {
+    __int32_t __val[2];
+};
+typedef struct __kernel___fsid __kernel___fsid_t;
+
+#define SIMPLE_MAP___FSID(_t, _f)                    \
+    do {                                             \
+        {                                            \
+            unsigned __i;                            \
+            for (__i = 0; i < 2; i++)                \
+                (_t)->__val[__i] = (_f)->__val[__i]; \
+        }                                            \
+    } while (0)
+
+#endif /* _LINUX_FSID_STRUCT_H_ */

--- a/libos/linux/machine/x86_64/linux/linux-statfs-struct.h
+++ b/libos/linux/machine/x86_64/linux/linux-statfs-struct.h
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _LINUX_STATFS_STRUCT_H_
+#define _LINUX_STATFS_STRUCT_H_
+
+struct __kernel_statfs {
+    __int64_t         f_type;
+    __int64_t         f_bsize;
+    __uint64_t        f_blocks;
+    __uint64_t        f_bfree;
+    __uint64_t        f_bavail;
+    __uint64_t        f_files;
+    __uint64_t        f_ffree;
+    __kernel___fsid_t f_fsid;
+    __int64_t         f_namelen;
+    __int64_t         f_frsize;
+    __int64_t         f_flags;
+    __uint8_t         __adjust_88[32];
+};
+
+#define SIMPLE_MAP_STATFS(_t, _f)          \
+    do {                                   \
+        (_t)->f_type = (_f)->f_type;       \
+        (_t)->f_bsize = (_f)->f_bsize;     \
+        (_t)->f_blocks = (_f)->f_blocks;   \
+        (_t)->f_bfree = (_f)->f_bfree;     \
+        (_t)->f_bavail = (_f)->f_bavail;   \
+        (_t)->f_files = (_f)->f_files;     \
+        (_t)->f_ffree = (_f)->f_ffree;     \
+        (_t)->f_namelen = (_f)->f_namelen; \
+        (_t)->f_frsize = (_f)->f_frsize;   \
+        (_t)->f_flags = (_f)->f_flags;     \
+    } while (0)
+
+#endif /* _LINUX_STATFS_STRUCT_H_ */

--- a/libos/linux/utils/fsid.json
+++ b/libos/linux/utils/fsid.json
@@ -1,0 +1,8 @@
+{
+    "name": "__fsid",
+    "typedef": "__fsid_t",
+    "headers": [ "sys/statfs.h" ],
+    "members": [
+	{ "name": "__val", "array": "true" }
+    ]
+}

--- a/libos/linux/utils/make-bits
+++ b/libos/linux/utils/make-bits
@@ -22,7 +22,7 @@ declare -a structs
 
 arch=(arm aarch64 x86_64 i686)
 headers=(dirent errno fcntl ioctl poll resource signal syscall sysconf termios time wait)
-structs=(rlimit sigval siginfo winsize dirent64 itimerspec itimerval statx statx_timestamp termios timespec timeval timezone tms) 
+structs=(fsid rlimit sigval siginfo winsize dirent64 itimerspec itimerval statfs statx statx_timestamp termios timespec timeval timezone tms)
 
 #arch=(x86_64)
 #headers=()

--- a/libos/linux/utils/make-struct
+++ b/libos/linux/utils/make-struct
@@ -88,6 +88,7 @@ def analyze_struct(s, file=sys.stdout):
     print(f'static const char *name = "{name}";', file=file)
     if 'typedef' in s:
         type = s['typedef']
+        print(f'#define MAKE_TYPEDEF "{type}"', file=file)
         print(f'static {type} val;', file=file)
     elif 'type' in s:
         type = type_name(s['type'])

--- a/libos/linux/utils/statfs.json
+++ b/libos/linux/utils/statfs.json
@@ -1,0 +1,18 @@
+{
+    "name": "statfs",
+    "headers": [ "sys/statfs.h" ],
+    "types": [ "__fsid_t" ],
+    "members": [
+	{ "name": "f_type" },
+	{ "name": "f_bsize" },
+	{ "name": "f_blocks" },
+	{ "name": "f_bfree" },
+	{ "name": "f_bavail" },
+	{ "name": "f_files" },
+	{ "name": "f_ffree" },
+	{ "name": "f_fsid", "type": "__fsid_t" },
+	{ "name": "f_namelen" },
+	{ "name": "f_frsize" },
+	{ "name": "f_flags" }
+    ]
+}

--- a/libos/linux/utils/struct-analyze.c
+++ b/libos/linux/utils/struct-analyze.c
@@ -204,6 +204,9 @@ main(int argc, char **argv)
     if (offset < sizeof(val))
         printf("    __uint8_t  __adjust_%zd[%zd];\n", offset, sizeof(val) - offset);
     printf("};\n");
+#ifdef MAKE_TYPEDEF
+    printf("typedef %s __kernel_%s __kernel_%s;\n", STRUCT_OR_UNION, name, MAKE_TYPEDEF);
+#endif
 
     printf("\n");
 

--- a/libos/linux/utils/struct-analyze.c
+++ b/libos/linux/utils/struct-analyze.c
@@ -213,8 +213,15 @@ main(int argc, char **argv)
     printf("(_t, _f) do {\\\n");
     for (i = 0; i < NELT; i++) {
         e = &elts[i];
-        if (!e->typename)
-            printf("        (_t)->%s = (_f)->%s;\\\n", e->name, e->name);
+        if (!e->typename) {
+            if (e->nelt > 0) {
+                printf("        { unsigned __i; for(__i = 0; i < %d; i++) (_t)->%s[__i] = "
+                       "(_f)->%s[__i]; } \\\n",
+                       e->nelt, e->name, e->name);
+            } else {
+                printf("        (_t)->%s = (_f)->%s;\\\n", e->name, e->name);
+            }
+        }
     }
     printf("    } while(0)\n");
 


### PR DESCRIPTION
This is needed for the statfs syscall.