### PR TITLE
Add gettimeofday semihosting syscall for hexagon

### DIFF
--- a/libos/semihost/machine/hexagon/hexagon_gettimeofday.c
+++ b/libos/semihost/machine/hexagon/hexagon_gettimeofday.c
@@ -1,0 +1,58 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "hexagon_semihost.h"
+#include <sys/time.h>
+
+/*
+ * SYS_TIME — returns seconds since Unix epoch in r0.
+ * On error r0 == -1 and r1 holds the errno code.
+ * This does not give us microsecond resolution.
+ */
+int
+gettimeofday(struct timeval * restrict tv, void * restrict tz)
+{
+    (void)tz;
+    register uintptr_t r0 __asm__("r0") = SYS_TIME;
+    register uintptr_t r1 __asm__("r1");
+    __asm__ __volatile__(SWI : "=r"(r0), "=r"(r1) : "r"(r0));
+    if ((int)r0 == -1) {
+        hexagon_semihost_errno((int)r1);
+        return -1;
+    }
+    tv->tv_sec  = (time_t)r0;
+    tv->tv_usec = 0;
+    return 0;
+}

--- a/libos/semihost/machine/hexagon/hexagon_gettimeofday.c
+++ b/libos/semihost/machine/hexagon/hexagon_gettimeofday.c
@@ -52,7 +52,7 @@ gettimeofday(struct timeval * restrict tv, void * restrict tz)
         hexagon_semihost_errno((int)r1);
         return -1;
     }
-    tv->tv_sec  = (time_t)r0;
+    tv->tv_sec = (time_t)r0;
     tv->tv_usec = 0;
     return 0;
 }

--- a/libos/semihost/machine/hexagon/hexagon_semihost.h
+++ b/libos/semihost/machine/hexagon/hexagon_semihost.h
@@ -54,6 +54,7 @@ enum hexagon_system_call_code {
     SYS_FLEN = 12,
     SYS_REMOVE = 14,
     SYS_RENAME = 15,
+    SYS_TIME = 0x11,
     SYS_GET_CMDLINE = 21,
     SYS_EXIT = 24,
     SYS_FTELL = 0x100,

--- a/libos/semihost/machine/hexagon/meson.build
+++ b/libos/semihost/machine/hexagon/meson.build
@@ -43,6 +43,7 @@ src_semihost += files([
                        'hexagon_ftruncate.c',
                        'hexagon_get_cmdline.c',
                        'hexagon_getcwd.c',
+                       'hexagon_gettimeofday.c',
                        'hexagon_isatty.c',
                        'hexagon_lseek.c',
                        'hexagon_open.c',
@@ -57,6 +58,5 @@ src_semihost += files([
                      ]) + [
   src_semihost_fake_getentropy,
   src_semihost_fake_getpid,
-  src_semihost_fake_gettimeofday,
   src_semihost_fake_kill,
   ]

--- a/libos/semihost/machine/rx/CMakeLists.txt
+++ b/libos/semihost/machine/rx/CMakeLists.txt
@@ -36,6 +36,7 @@
 target_sources(semihost PRIVATE
   rx_exit.c
   rx_iob.c
+  ../../fake/fake_gettimeofday.c
   ../../fake/fake_close.c
   ../../fake/fake_fstat.c
   ../../fake/fake_getentropy.c

--- a/test/test-posix/CMakeLists.txt
+++ b/test/test-posix/CMakeLists.txt
@@ -40,6 +40,7 @@ set(tests
   test-getdelim
   test-grp
   test-dirent
+  test-posix-time
   test-pwd
   test-signal
   test-stat

--- a/test/test-posix/meson.build
+++ b/test/test-posix/meson.build
@@ -41,6 +41,7 @@ tests = [
   'test-getdelim',
   'test-grp',
   'test-dirent',
+  'test-posix-time',
   'test-pwd',
   'test-rename',
   'test-signal',

--- a/test/test-posix/test-posix-time.c
+++ b/test/test-posix/test-posix-time.c
@@ -1,0 +1,92 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#define _DEFAULT_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define check(condition, message)                    \
+    do {                                             \
+        if (!(condition)) {                          \
+            printf("%s: %s\n", message, #condition); \
+            exit(1);                                 \
+        }                                            \
+    } while (0)
+
+/*
+ * time() is implemented in terms of gettimeofday().
+ */
+#ifdef __PICOLIBC__
+__typeof(gettimeofday) __fake_gettimeofday __weak;
+#define not_fake_gettimeofday ((gettimeofday) != __fake_gettimeofday)
+#else
+#define not_fake_gettimeofday 1
+#endif
+
+/* 2020-09-13 00:00:00 UTC — a known past date */
+#define NOT_BEFORE ((time_t)1600000000)
+
+int
+main(void)
+{
+    time_t stored = 0;
+    time_t t1, t2;
+
+    /* time(NULL) must not return -1 */
+    t1 = time(NULL);
+    check(t1 != (time_t)-1, "time(NULL) failed");
+
+    /* time(&stored) must store the same value it returns */
+    t2 = time(&stored);
+    check(t2 != (time_t)-1, "time(&stored) failed");
+    check(stored == t2, "time(&stored) did not store return value");
+
+    if (not_fake_gettimeofday) {
+        /* Wall-clock time must be after our known past date */
+        check(t1 >= NOT_BEFORE, "time() returned value before 2020-09-13");
+
+        /* A second call must not go backwards */
+        t2 = time(NULL);
+        check(t2 >= t1, "time() went backwards");
+
+        printf("time() returned %lld, test passed\n", (long long)t1);
+    } else {
+        printf("fake gettimeofday present, skipping wall-clock checks\n");
+    }
+
+    exit(0);
+}


### PR DESCRIPTION
This PR adds `gettimeofday` semihosting syscall support for Hexagon.

One note: It's not possible to get microseconds precision for hexagon via semihosting calls, so currently we give only seconds precision.