### PR TITLE
riscv: generic memcpy: fix unrolled loop copying 9 words instead of 8

### DIFF
--- a/libc/machine/riscv/memcpy.c
+++ b/libc/machine/riscv/memcpy.c
@@ -111,8 +111,8 @@ memcpy(void * __restrict aa, const void * __restrict bb, size_t n)
     const uintxlen_t *lb = (const uintxlen_t *)b;
     uintxlen_t       *lend = (uintxlen_t *)((uintptr_t)end & ~msk);
 
-    if (unlikely(lend - la > 8)) {
-        while (lend - la > 8) {
+    if (unlikely(lend - la >= 8)) {
+        while (lend - la >= 8) {
             uintxlen_t b0 = *lb++;
             uintxlen_t b1 = *lb++;
             uintxlen_t b2 = *lb++;
@@ -121,7 +121,6 @@ memcpy(void * __restrict aa, const void * __restrict bb, size_t n)
             uintxlen_t b5 = *lb++;
             uintxlen_t b6 = *lb++;
             uintxlen_t b7 = *lb++;
-            uintxlen_t b8 = *lb++;
             *la++ = b0;
             *la++ = b1;
             *la++ = b2;
@@ -130,7 +129,6 @@ memcpy(void * __restrict aa, const void * __restrict bb, size_t n)
             *la++ = b5;
             *la++ = b6;
             *la++ = b7;
-            *la++ = b8;
         }
     }
 


### PR DESCRIPTION
Performance bug: The unrolled word-copy loop copied 9 words per iteration but only entered when 9+ words remained, so an 8-word remainder (one full cache line on RV64) was always copied bytewise.

Fix: Reduce unroll to 8 words, change guard from > 8 to >= 8. The two changes must go together — fixing only the condition with a 9-element body would cause a 1-word overrun.

Effect: Sizes that are multiples of 8×SZREG (e.g. 64, 128, 256 bytes on RV64) now take the fast word-copy path instead of falling back to bytewise.