### PR TITLE
Add fopencookie implementation

### DIFF
--- a/libc/include/stdio.h
+++ b/libc/include/stdio.h
@@ -516,6 +516,23 @@ FILE *funopen(const void *cookie, ssize_t (*readfn)(void *cookie, void *buf, siz
 #define fwopen(__cookie, __fn) funopen(__cookie, NULL, __fn, NULL, NULL)
 #endif /*__BSD_VISIBLE */
 
+#if __GNU_VISIBLE
+typedef ssize_t cookie_read_function_t(void *cookie, char *buf, size_t n);
+typedef ssize_t cookie_write_function_t(void *cookie, const char *buf, size_t n);
+typedef int     cookie_seek_function_t(void *cookie, off_t *pos, int whence);
+typedef int     cookie_close_function_t(void *cookie);
+
+typedef struct cookie_io_functions_t {
+    cookie_read_function_t  *read;
+    cookie_write_function_t *write;
+    cookie_seek_function_t  *seek;
+    cookie_close_function_t *close;
+} cookie_io_functions_t;
+
+FILE *fopencookie(void *cookie, const char *modes,
+                  cookie_io_functions_t io_funcs) __picolibc_export;
+#endif /* __GNU_VISIBLE */
+
 #if __POSIX_VISIBLE >= 199309L
 int getc_unlocked(FILE *) __nonnull((1)) __picolibc_export;
 int getchar_unlocked(void) __picolibc_export;

--- a/libc/stdio/CMakeLists.txt
+++ b/libc/stdio/CMakeLists.txt
@@ -93,6 +93,7 @@ picolibc_sources(
   ftox_engine.c
   ftrylockfile.c
   funlockfile.c
+  fopencookie.c
   funopen.c
   fwide.c
   fwprintf.c

--- a/libc/stdio/bufio.c
+++ b/libc/stdio/bufio.c
@@ -214,39 +214,44 @@ off_t
 __bufio_seek(FILE *f, off_t offset, int whence)
 {
     struct __file_bufio *bf = (struct __file_bufio *)f;
-    off_t                ret;
+    off_t                ret = _FDEV_ERR;
 
     __bufio_lock(f);
+    if (!bufio_seekable(bf)) {
+        goto exit;
+    }
     if (__bufio_setdir_locked(f, __SRD) < 0) {
-        ret = _FDEV_ERR;
-    } else {
-        /* compute offset of the first char in the buffer */
-        __off_t buf_pos = bf->pos - bf->len;
+        goto exit;
+    }
 
-        switch (whence) {
-        case SEEK_CUR:
-            /* Map CUR -> SET, accounting for position within buffer */
-            whence = SEEK_SET;
-            offset += buf_pos + bf->off;
-            __fallthrough;
-        case SEEK_SET:
-            /* Optimize for seeks within buffer or just past buffer */
-            if (buf_pos <= offset && offset <= buf_pos + bf->len) {
-                bf->off = offset - buf_pos;
-                ret = offset;
-                break;
-            }
-            __fallthrough;
-        default:
-            ret = bufio_lseek(bf, offset, whence);
-            if (ret >= 0)
-                bf->pos = ret;
-            /* Flush any buffered data after a real seek */
-            bf->len = 0;
-            bf->off = 0;
+    /* compute offset of the first char in the buffer */
+    __off_t buf_pos = bf->pos - bf->len;
+
+    switch (whence) {
+    case SEEK_CUR:
+        /* Map CUR -> SET, accounting for position within buffer */
+        whence = SEEK_SET;
+        offset += buf_pos + bf->off;
+        __fallthrough;
+    case SEEK_SET:
+        /* Optimize for seeks within buffer or just past buffer */
+        if (buf_pos <= offset && offset <= buf_pos + bf->len) {
+            bf->off = offset - buf_pos;
+            ret = offset;
             break;
         }
+        __fallthrough;
+    default:
+        ret = bufio_lseek(bf, offset, whence);
+        if (ret >= 0)
+            bf->pos = ret;
+        /* Flush any buffered data after a real seek */
+        bf->len = 0;
+        bf->off = 0;
+        break;
     }
+
+exit:
     __bufio_unlock(f);
     return ret;
 }

--- a/libc/stdio/fopencookie.c
+++ b/libc/stdio/fopencookie.c
@@ -1,0 +1,120 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026 Alexey Lapshin
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "local-stdio.h"
+
+struct __file_cookie {
+    struct __file_bufio   bfile;
+    void                 *cookie;
+    cookie_io_functions_t io;
+    char                  buf[BUFSIZ];
+};
+
+static ssize_t
+fopencookie_read(void *ptr, void *buf, size_t count)
+{
+    struct __file_cookie *pf = ptr;
+
+    if (!pf->io.read)
+        return 0;
+
+    return pf->io.read(pf->cookie, buf, count);
+}
+
+static ssize_t
+fopencookie_write(void *ptr, const void *buf, size_t count)
+{
+    struct __file_cookie *pf = ptr;
+    ssize_t               ret;
+
+    if (!pf->io.write)
+        return -1;
+
+    ret = pf->io.write(pf->cookie, buf, count);
+    if (ret == 0)
+        return -1;
+
+    return ret;
+}
+
+static __off_t
+fopencookie_seek(void *ptr, __off_t offset, int whence)
+{
+    struct __file_cookie *pf = ptr;
+
+    if (!pf->io.seek)
+        return (__off_t)-1;
+
+    if (pf->io.seek(pf->cookie, &offset, whence) == -1)
+        return (__off_t)-1;
+
+    return offset;
+}
+
+static int
+fopencookie_close(void *ptr)
+{
+    struct __file_cookie *pf = ptr;
+
+    if (!pf->io.close)
+        return 0;
+
+    return pf->io.close(pf->cookie);
+}
+
+FILE *
+fopencookie(void *cookie, const char *mode, cookie_io_functions_t io_funcs)
+{
+    struct __file_cookie *pf;
+    int                   open_flags;
+    int                   o;
+
+    open_flags = __stdio_flags(mode, &o);
+    if (!open_flags)
+        return NULL;
+
+    pf = calloc(1, sizeof(struct __file_cookie));
+    if (pf == NULL)
+        return NULL;
+
+    pf->cookie = cookie;
+    pf->io = io_funcs;
+
+    pf->bfile = (struct __file_bufio)FDEV_SETUP_BUFIO_PTR(
+        pf, pf->buf, BUFSIZ, fopencookie_read, fopencookie_write,
+        io_funcs.seek ? fopencookie_seek : NULL, fopencookie_close, open_flags, __BFALL);
+
+    return &pf->bfile.xfile.cfile.file;
+}

--- a/libc/stdio/local-stdio.h
+++ b/libc/stdio/local-stdio.h
@@ -187,6 +187,16 @@ bufio_lseek(struct __file_bufio *bf, __off_t offset, int whence)
     return _FDEV_ERR;
 }
 
+static inline bool
+bufio_seekable(struct __file_bufio *bf)
+{
+#ifndef BUFIO_ABI_MATCHES
+    if (!(bf->bflags & __BFPTR))
+        return bf->lseek_int != NULL;
+#endif
+    return bf->lseek_ptr != NULL;
+}
+
 static inline int
 bufio_close(struct __file_bufio *bf)
 {

--- a/libc/stdio/meson.build
+++ b/libc/stdio/meson.build
@@ -97,6 +97,7 @@ srcs_stdio = [
   'ftox_engine.c',
   'ftrylockfile.c',
   'funlockfile.c',
+  'fopencookie.c',
   'funopen.c',
   'fwide.c',
   'fwprintf.c',

--- a/test/test-stdio/CMakeLists.txt
+++ b/test/test-stdio/CMakeLists.txt
@@ -35,6 +35,7 @@
 
 set(tests
   test-fmemopen
+  test-fopencookie
   test-funopen
   test-put
   test-printf

--- a/test/test-stdio/meson.build
+++ b/test/test-stdio/meson.build
@@ -37,6 +37,7 @@ tests = [
   'test-fdevopen',
   'test-fmemopen',
   'test-freopen',
+  'test-fopencookie',
   'test-funopen',
   'test-put',
   'test-sprintf-percent-n',

--- a/test/test-stdio/test-fopencookie.c
+++ b/test/test-stdio/test-fopencookie.c
@@ -1,0 +1,164 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026 Alexey Lapshin
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _GNU_SOURCE
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#define IO_T   ssize_t
+#define BUF_T  char
+#define SEEK_T off_t
+
+static char   test_buf[1024];
+static SEEK_T test_pos;
+static SEEK_T test_end;
+
+#define min(a, b) ((SEEK_T)(a) < (SEEK_T)(b) ? (SEEK_T)(a) : (SEEK_T)(b))
+#define max(a, b) ((SEEK_T)(a) > (SEEK_T)(b) ? (SEEK_T)(a) : (SEEK_T)(b))
+
+static IO_T
+test_read(void *cookie, BUF_T *buf, size_t n)
+{
+    (void)cookie;
+    assert(test_pos <= test_end);
+    n = min(n, test_end - test_pos);
+    memcpy(buf, test_buf + test_pos, n);
+    test_pos += n;
+    return n;
+}
+
+static IO_T
+test_write(void *cookie, const BUF_T *buf, size_t n)
+{
+    (void)cookie;
+    assert((size_t)test_pos <= sizeof(test_buf));
+    n = min(n, sizeof(test_buf) - test_pos);
+    memcpy(test_buf + test_pos, buf, n);
+    test_pos += n;
+    test_end = max(test_end, test_pos);
+    return n;
+}
+
+static int
+test_seek(void *cookie, SEEK_T *pos, int whence)
+{
+    SEEK_T new_pos = test_pos;
+
+    (void)cookie;
+    switch (whence) {
+    case SEEK_CUR:
+        new_pos = test_pos + *pos;
+        break;
+    case SEEK_SET:
+        new_pos = *pos;
+        break;
+    case SEEK_END:
+        new_pos = test_end + *pos;
+        break;
+    default:
+        return -1;
+    }
+    if (new_pos < 0 || new_pos > test_end)
+        return -1;
+    test_pos = new_pos;
+    *pos = new_pos;
+    return 0;
+}
+
+static int
+test_close(void *cookie)
+{
+    (void)cookie;
+    return 0;
+}
+
+#define check(condition, message)                    \
+    do {                                             \
+        if (!(condition)) {                          \
+            printf("%s: %s\n", message, #condition); \
+            exit(1);                                 \
+        }                                            \
+    } while (0)
+
+#define MESSAGE "hello, world"
+
+int
+main(void)
+{
+    cookie_io_functions_t io = {
+        .read = test_read,
+        .write = test_write,
+        .seek = test_seek,
+        .close = test_close,
+    };
+    FILE  *fp = fopencookie(NULL, "w+", io);
+    char   buf[sizeof(MESSAGE)];
+    size_t ret;
+
+    check(fp != NULL, "fopencookie");
+    fprintf(fp, "%s", MESSAGE);
+    fflush(fp);
+    check(memcmp(test_buf, MESSAGE, strlen(MESSAGE)) == 0, "printf");
+    check(fseek(fp, 0L, SEEK_END) == 0, "fseek end");
+    check(ftell(fp) == (long)strlen(MESSAGE), "ftell end");
+    check(fseek(fp, -5L, SEEK_CUR) == 0, "fseek cur");
+    check(ftell(fp) == (long)(strlen(MESSAGE) - 5), "ftell cur");
+    check(fseek(fp, 0L, SEEK_SET) == 0, "fseek set");
+    ret = fread(buf, 1, sizeof(buf), fp);
+    check(ret == strlen(MESSAGE), "fread size");
+    check(memcmp(buf, MESSAGE, strlen(MESSAGE)) == 0, "fread contents");
+    fclose(fp);
+
+    // dummy write and read test
+    io.read = NULL;
+    io.write = NULL;
+    io.seek = NULL;
+    io.close = NULL;
+    fp = fopencookie(NULL, "w+", io);
+    check(fp != NULL, "fopencookie");
+    check(setvbuf(fp, NULL, _IONBF, 0) == 0, "setvbuf");
+    check(fwrite(MESSAGE, 1, strlen(MESSAGE), fp) == 0, "fwrite size");
+    check(fseek(fp, 0L, SEEK_END) == -1, "fseek end");
+    check(ftell(fp) == -1, "ftell end");
+    check(fseek(fp, -5L, SEEK_CUR) == -1, "fseek cur");
+    check(ftell(fp) == -1, "ftell cur");
+    check(fseek(fp, 0L, SEEK_SET) == -1, "fseek set");
+    check(fread(buf, 1, sizeof(buf), fp) == 0, "fread size");
+    check(memcmp(buf, MESSAGE, strlen(MESSAGE)) == 0, "fread contents");
+    fclose(fp);
+    return 0;
+}


### PR DESCRIPTION
Add fopencookie implementation. It is more convenient to have both funopen and fopencookie in libc. No need to adapt code when porting to picolibc