### PR TITLE
stdio: add open_memstream implementation

### DIFF
--- a/COPYING.picolibc
+++ b/COPYING.picolibc
@@ -595,6 +595,14 @@ Files: CMakeLists.txt
 Copyright: 2022 Keith Packard
 License: BSD3-1
 
+Files: libc/stdio/open_memstream.c
+Copyright: 2024-2026 Espressif Systems (Shanghai) CO LTD
+License: Other-29
+
+Files: test/test-stdio/test-open_memstream.c
+Copyright: 2026 Alexey Lapshin
+License: BSD3-1
+
 Files: cmake/TC-arm-none-eabi.ld
  cmake/TC-microbit.ld
  hello-world/hello-worldpp.cpp
@@ -6708,6 +6716,19 @@ License: Other-28
  Dave Korn, November 2007.  This file is placed in the
  public domain.  Permission to use, copy, modify, and
  distribute this software is freely granted.
+
+License: Other-29
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ .
+ http://www.apache.org/licenses/LICENSE-2.0
+ .
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
 
 License: UCB-1
  Redistribution and use in source and binary forms are permitted

--- a/libc/include/stdio.h
+++ b/libc/include/stdio.h
@@ -481,6 +481,10 @@ FILE *freopen(const char *path, const char *mode, FILE *stream) __nonnull((3)) _
 FILE *fdopen(int, const char *) __malloc_like_with_free(fclose, 1) __picolibc_export;
 FILE *fmemopen(void *buf, size_t size, const char *mode)
     __malloc_like_with_free(fclose, 1) __picolibc_export;
+#if __POSIX_VISIBLE >= 200809
+FILE *open_memstream(char **bufp, size_t *sizep)
+    __malloc_like_with_free(fclose, 1) __picolibc_export;
+#endif
 int   fseek(FILE *stream, long offset, int whence) __nonnull((1)) __picolibc_export;
 int   fsetpos(FILE *stream, const fpos_t *pos) __nonnull((1)) __picolibc_export;
 long  ftell(FILE *stream) __nonnull((1)) __picolibc_export;

--- a/libc/stdio/CMakeLists.txt
+++ b/libc/stdio/CMakeLists.txt
@@ -77,6 +77,7 @@ picolibc_sources(
   filewstrget.c
   flockfile.c
   fmemopen.c
+  open_memstream.c
   fopen.c
   fprintf.c
   fputc.c

--- a/libc/stdio/meson.build
+++ b/libc/stdio/meson.build
@@ -79,6 +79,7 @@ srcs_stdio = [
   'flockfile.c',
   'flockfile_init.c',
   'fmemopen.c',
+  'open_memstream.c',
   'fopen.c',
   'fprintf.c',
   'fputc.c',

--- a/libc/stdio/open_memstream.c
+++ b/libc/stdio/open_memstream.c
@@ -1,0 +1,184 @@
+/*
+ * SPDX-FileCopyrightText: 2024-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "local-stdio.h"
+
+#define GET_BUF(mf)  (*(mf->pbuf))
+#define GET_SIZE(mf) (*(mf->psize))
+
+struct __file_open_mem {
+    struct __file_ext xfile;
+    char            **pbuf;
+    size_t           *psize;
+    size_t            bsize; /* allocated buffer size */
+    size_t            fsize; /* file content size */
+    size_t            pos;   /* current position in the buffer */
+};
+
+static int
+__open_mem_grow(struct __file_open_mem *mf, size_t additional_size)
+{
+    size_t bsize = mf->bsize;
+    char  *tmp;
+
+    if (additional_size > SIZE_MAX - mf->pos) {
+        errno = ENOMEM;
+        return _FDEV_ERR;
+    }
+
+    size_t required_size = mf->pos + additional_size;
+    if (required_size < bsize)
+        return 0;
+
+    /* Avoid geometric growth, increase the buffer size by 1.5x */
+    bsize += bsize / 2;
+
+    /* seek can move position beyond calculated size */
+    if (bsize < required_size)
+        bsize = required_size;
+
+    /* +1 for the null terminator */
+    bsize += 1;
+
+    /* check for overflow */
+    if (bsize < mf->bsize) {
+        errno = ENOMEM;
+        return _FDEV_ERR;
+    }
+
+    tmp = realloc(GET_BUF(mf), bsize);
+    if (!tmp)
+        return _FDEV_ERR;
+
+    /* fill the new buffer with zeros */
+    memset(tmp + mf->bsize, 0, bsize - mf->bsize);
+
+    /* update structure */
+    GET_BUF(mf) = tmp;
+    mf->bsize = bsize;
+
+    return 0;
+}
+
+static int
+__open_mem_put(char c, FILE *f)
+{
+    struct __file_open_mem *mf = (struct __file_open_mem *)f;
+
+    /* 2 = 1 for the new character + 1 for the null terminator
+     *
+     * Allocation will zero fill the extended part of the buffer.
+     * No need to set null terminator character explicitly.
+     */
+    int                     ret = __open_mem_grow(mf, 2);
+    if (ret != 0)
+        return ret;
+
+    GET_BUF(mf)[mf->pos++] = c;
+
+    mf->fsize = mf->pos;
+
+    return (unsigned char)c;
+}
+
+static int
+__open_mem_flush(FILE *f)
+{
+    struct __file_open_mem *mf = (struct __file_open_mem *)f;
+
+    GET_SIZE(mf) = mf->fsize;
+
+    return 0;
+}
+
+static off_t
+__open_mem_seek(FILE *f, off_t pos, int whence)
+{
+    struct __file_open_mem *mf = (struct __file_open_mem *)f;
+
+    switch (whence) {
+    case SEEK_SET:
+        break;
+    case SEEK_CUR:
+        pos += mf->pos;
+        break;
+    case SEEK_END:
+        pos += mf->fsize;
+        break;
+    default:
+        errno = EINVAL;
+        return (off_t)-1;
+    }
+
+    if (pos < 0) {
+        errno = EINVAL;
+        return (off_t)-1;
+    }
+
+    _Static_assert(sizeof(off_t) >= sizeof(size_t), "must avoid truncation");
+    size_t offset = pos;
+    if (mf->bsize < offset) {
+        if (__open_mem_grow(mf, offset - mf->pos) != 0)
+            return (off_t)-1;
+    }
+    mf->pos = offset;
+    mf->fsize = offset;
+    return pos;
+}
+
+static int
+__open_mem_close(FILE *f)
+{
+    __open_mem_flush(f);
+    free(f);
+    return 0;
+}
+
+FILE *
+open_memstream(char **buf, size_t *size)
+{
+    struct __file_open_mem *mf;
+
+    if (!buf || !size) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    mf = calloc(1, sizeof(struct __file_open_mem));
+    if (mf == NULL) {
+        return NULL;
+    }
+
+    *buf = calloc(1, BUFSIZ);
+    if (*buf == NULL) {
+        free(mf);
+        return NULL;
+    }
+
+    *mf = (struct __file_open_mem) {
+        .xfile = FDEV_SETUP_EXT(__open_mem_put, NULL, __open_mem_flush, __open_mem_close,
+                                __open_mem_seek, NULL, __SWR),
+        .pbuf = buf,
+        .psize = size,
+        .bsize = BUFSIZ,
+        .fsize = 0,
+        .pos = 0,
+    };
+
+    return (FILE *)mf;
+}

--- a/test/test-stdio/CMakeLists.txt
+++ b/test/test-stdio/CMakeLists.txt
@@ -36,6 +36,7 @@
 set(tests
   test-fmemopen
   test-fopencookie
+  test-open_memstream
   test-funopen
   test-put
   test-printf

--- a/test/test-stdio/meson.build
+++ b/test/test-stdio/meson.build
@@ -36,6 +36,7 @@
 tests = [
   'test-fdevopen',
   'test-fmemopen',
+  'test-open_memstream',
   'test-freopen',
   'test-fopencookie',
   'test-funopen',

--- a/test/test-stdio/test-open_memstream.c
+++ b/test/test-stdio/test-open_memstream.c
@@ -1,0 +1,172 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026 Alexey Lapshin
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _DEFAULT_SOURCE
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <malloc.h>
+
+#define check(condition, message)                    \
+    do {                                             \
+        if (!(condition)) {                          \
+            printf("%s: %s\n", message, #condition); \
+            exit(1);                                 \
+        }                                            \
+    } while (0)
+
+#define MESSAGE "Hello picolibc!"
+
+int
+main(void)
+{
+    FILE  *stream = NULL;
+    char  *buf = NULL;
+    size_t len = 0;
+    int    i;
+    char   zero_buf[32] = { 0 };
+
+    stream = open_memstream(&buf, &len);
+    check(stream != NULL, "open_memstream");
+    fprintf(stream, MESSAGE);
+    fflush(stream);
+    check(strcmp(buf, MESSAGE) == 0, "fprintf contents");
+    check(len == strlen(MESSAGE), "fprintf length");
+    fseek(stream, 0, SEEK_SET);
+    fprintf(stream, "HELLO");
+    fflush(stream);
+    check(strcmp(buf, "HELLO picolibc!") == 0, "SEEK_SET 0");
+    fseek(stream, sizeof(zero_buf), SEEK_CUR);
+    fprintf(stream, MESSAGE);
+    int zeroed_len = sizeof(zero_buf) - (strlen(MESSAGE) - strlen("HELLO"));
+    check(memcmp(&buf[strlen(MESSAGE)], zero_buf, zeroed_len) == 0, "seek zero fill");
+    check(strcmp(&buf[strlen(MESSAGE) + zeroed_len], MESSAGE) == 0, "write after SEEK_CUR");
+    check(fseek(stream, -1000, SEEK_SET) != 0, "fseek beyond start of stream");
+    fclose(stream);
+    check(strcmp(buf, "HELLO picolibc!") == 0, "fseek patch");
+    check(len == strlen(MESSAGE) * 2 + zeroed_len, "fseek patch length");
+    free(buf);
+
+    stream = open_memstream(&buf, &len);
+    check(stream != NULL, "open_memstream SEEK_END");
+    fprintf(stream, MESSAGE);
+    fflush(stream);
+    check(len == strlen(MESSAGE), "len changed after fflush");
+    fseek(stream, sizeof(zero_buf), SEEK_END);
+    fprintf(stream, MESSAGE);
+    fclose(stream);
+    check(strcmp(buf, MESSAGE) == 0, "keep data before SEEK_END");
+    check(memcmp(&buf[strlen(MESSAGE)], zero_buf, zeroed_len) == 0, "seek zero fill");
+    check(strcmp(&buf[strlen(MESSAGE) + sizeof(zero_buf)], MESSAGE) == 0, "write after SEEK_END");
+    check(len == strlen(MESSAGE) * 2 + sizeof(zero_buf), "fseek SEEK_END length");
+    free(buf);
+
+    stream = open_memstream(&buf, &len);
+    check(stream != NULL, "open_memstream unflushed SEEK_END");
+    fprintf(stream, MESSAGE);
+    fseek(stream, 0, SEEK_END);
+    fprintf(stream, MESSAGE);
+    check(fseek(stream, 0, 12345) != 0, "invalid whence");
+    fclose(stream);
+    check(strcmp(buf, MESSAGE MESSAGE) == 0, "SEEK_END uses unflushed stream size");
+    check(len == strlen(MESSAGE) * 2, "unflushed SEEK_END length");
+    free(buf);
+
+    stream = open_memstream(&buf, &len);
+    check(stream != NULL, "open_memstream unflushed SEEK_END");
+    fprintf(stream, MESSAGE);
+    fseek(stream, sizeof(zero_buf), SEEK_END);
+    fprintf(stream, MESSAGE);
+    fflush(stream);
+    /*
+     * Buffer is now:
+     *
+     *     MESSAGE\0...\0MESSAGE\0
+     *                           ^
+     */
+    fseek(stream, strlen(MESSAGE) + 1, SEEK_SET);
+    fprintf(stream, MESSAGE);
+    fflush(stream);
+    /*
+     * Buffer is now:
+     *
+     *     MESSAGE\0MESSAGE\0...\0MESSAGE\0
+     *             ^
+     */
+    check(len == strlen(MESSAGE) * 2 + 1, "SEEK_END length");
+    check(fseek(stream, -strlen(MESSAGE) * 2, SEEK_END) == 0, "fseek SEEK_END");
+    fflush(stream);
+    check(len == 1, "SEEK_END length");
+    check(fseek(stream, strlen(MESSAGE), SEEK_END) == 0, "fseek SEEK_END twice in row");
+    fflush(stream);
+    check(len == strlen(MESSAGE) + 1, "SEEK_END length");
+    fprintf(stream, "TEST");
+    fflush(stream);
+    /*
+     * Buffer is now:
+     *
+     *     MESSAGE\0TEST${MESSAGE[4:]}\0...\0MESSAGE\0
+     *                 ^
+     */
+    check(len == strlen(MESSAGE) + 1 + strlen("TEST"), "SEEK_END length");
+    check(buf[strlen(MESSAGE) + 1 + strlen("TEST") + 1] != 0,
+          "fwrite does override data with null terminator");
+    fclose(stream);
+    free(buf);
+
+#ifdef __PICOLIBC__ // we know what memory allocated on the start and how it grows
+    stream = open_memstream(&buf, &len);
+    check(stream != NULL, "open_memstream sparse flush terminator");
+    check(fseek(stream, BUFSIZ + 32, SEEK_SET) == 0, "sparse SEEK_SET");
+    fclose(stream);
+    for (i = 0; i < BUFSIZ + BUFSIZ / 2; i++)
+        if (buf[i] != 0)
+            check(0, "sparse flush zero fill");
+    free(buf);
+#endif
+
+    stream = open_memstream(&buf, &len);
+    check(stream != NULL, "open_memstream realloc");
+    fprintf(stream, MESSAGE);
+    fflush(stream);
+    check(malloc_usable_size(buf) <= BUFSIZ * 4, "malloc_usable_size <= BUFSIZ * 4");
+    for (i = 0; i < BUFSIZ * 8; i++)
+        fputc('A' + (i % ('Z' - 'A')), stream);
+    fclose(stream);
+    check(malloc_usable_size(buf) >= BUFSIZ * 8, "malloc_usable_size >= BUFSIZ * 8");
+    free(buf);
+
+    return 0;
+}


### PR DESCRIPTION
Copied from https://github.com/espressif/esp-idf/blob/9281e783816872e22f55fb5c3bcef458462b534e/components/esp_libc/src/picolibc/open_memstream.c

I don't know if we need to do something about licensing