### PR TITLE
native: fix statx call

### DIFF
--- a/libc/native/fstat_host.c
+++ b/libc/native/fstat_host.c
@@ -45,7 +45,7 @@ __fstat_host(int fd, struct if_stat *if_stat)
     struct statx statxb;
     int          ret;
 
-    ret = statx(fd, NULL, AT_STATX_SYNC_AS_STAT | AT_EMPTY_PATH, STATX_BASIC_STATS, &statxb);
+    ret = statx(fd, "", AT_STATX_SYNC_AS_STAT | AT_EMPTY_PATH, STATX_BASIC_STATS, &statxb);
     if (ret >= 0)
         STAT_FROM_HOST(if_stat, &statxb);
     return ret;


### PR DESCRIPTION
Fixes an error on my machine:

```bash
../libc/native/fstat_host.c: In function ‘__fstat_host’:
../libc/native/fstat_host.c:48:11: error: argument 2 null where non-null expected [-Werror=nonnull]
   48 |     ret = statx(fd, NULL, AT_STATX_SYNC_AS_STAT | AT_EMPTY_PATH, STATX_BASIC_STATS, &statxb);
      |           ^~~~~
In file included from /usr/include/x86_64-linux-gnu/bits/statx.h:39,
                 from /usr/include/x86_64-linux-gnu/sys/stat.h:465,
                 from ../libc/native/fstat_host.c:38:
/usr/include/x86_64-linux-gnu/bits/statx-generic.h:61:5: note: in a call to function ‘statx’ declared ‘nonnull’
   61 | int statx (int __dirfd, const char *__restrict __path, int __flags,
      |     ^~~~~
cc1: all warnings being treated as errors

```