### PR TITLE
riscv: `strcmp`: reorder loop for Fused_LDD and parallel ALU dispatch

### DIFF
--- a/libc/machine/riscv/strcmp.S
+++ b/libc/machine/riscv/strcmp.S
@@ -48,36 +48,107 @@ strcmp:
 #endif
 #endif
 
-  .macro check_one_word i n
-    REG_L a2, \i*SZREG(a0)
-    REG_L a3, \i*SZREG(a1)
-#ifdef __riscv_zbb
-    orc.b a4, a2
+/* -------------------------------------------------------------------
+ * Register allocation per target:
+ *
+ *   Non-RV32E (32 regs): use a6, t3, t4, t5 freely.
+ *   RV32E (16 regs) + Zbb: remap a6→a5, t3→t0, t4→t1 (a5 is unused
+ *                          when Zbb provides orc.b, so it's free as
+ *                          the second a1-word slot).
+ *   RV32E + non-Zbb: not enough scratch (mask occupies a5, plus 4
+ *                    data + 4 intermediates + (-1) const = 10 regs).
+ *                    Fall through to single-word loop.
+ * ------------------------------------------------------------------- */
+#if defined(__riscv_e) || defined(__riscv_32e)
+#  ifdef __riscv_zbb
+#    define R_W1A a5    /* second a1 word (was a6) */
+#    define R_O0  t0    /* orc.b result 0 (was t3) */
+#    define R_O1  t1    /* orc.b result 1 (was t4) */
+#    define STRCMP_PAIR 1
+#  else
+     /* RV32E + non-Zbb: not enough registers, use single-word loop */
+#    define STRCMP_PAIR 0
+#  endif
 #else
-    and   a4, a2, a5
-    or    t1, a2, a5
-    add   a4, a4, a5
-    or    a4, a4, t1
+#  define R_W1A a6
+#  define R_O0  t3
+#  define R_O1  t4
+#  define R_TMP t5     /* non-Zbb intermediate (was t5) */
+#  define STRCMP_PAIR 1
 #endif
-    bne   a4, t2, .Lnull\i
-    .if \i+1-\n
-      bne   a2, a3, .Lmismatch
+
+#if STRCMP_PAIR
+  .macro check_word_pair i n
+    /* --- Fused_LDD #1: two loads from base a0 (back-to-back) --- */
+    REG_L a2, \i*SZREG(a0)
+    REG_L a4, \i*SZREG+SZREG(a0)
+
+    /* --- Interleave: orc.b on a2 dual-issues with Fused_LDD #2 below.
+     *     orc.b depends on a2 (ready from Fused_LDD #1), independent of
+     *     the a1 loads → MEM pipe + ALU pipe fire in parallel.        --- */
+#ifdef __riscv_zbb
+    orc.b R_O0, a2
+#endif
+
+    /* --- Fused_LDD #2: two loads from base a1 (back-to-back) --- */
+    REG_L a3, \i*SZREG(a1)
+    REG_L R_W1A, \i*SZREG+SZREG(a1)
+
+    /* --- Second orc.b dual-issues with the first branch below --- */
+#ifdef __riscv_zbb
+    orc.b R_O1, a4
+#else
+    /* Non-Zbb path: keep original grouping (more ALU ops, can't interleave
+     * cleanly without breaking Fused_LDD #2 — most have already paid the
+     * MEM cost by then anyway). */
+    and   R_O0, a2, a5
+    and   R_O1, a4, a5
+    or    t1,   a2, a5
+    or    R_TMP, a4, a5
+    add   R_O0, R_O0, a5
+    add   R_O1, R_O1, a5
+    or    R_O0, R_O0, t1
+    or    R_O1, R_O1, R_TMP
+#endif
+
+    /* --- Branches grouped at end --- */
+    bne   R_O0, t2, .Lnull\i
+    bne   a2, a3, .Lmismatch
+    bne   R_O1, t2, .Lnull_hi_\i
+    .if \i+2-\n
+      bne a4, R_W1A, .Lmismatch_hi_\i   /* a4 vs R_W1A */
     .else
-      add   a0, a0, \n*SZREG
-      add   a1, a1, \n*SZREG
-      beq   a2, a3, .Lloop
-      # fall through to .Lmismatch
+      add a0, a0, \n*SZREG
+      add a1, a1, \n*SZREG
+      beq a4, R_W1A, .Lloop
+      j   .Lmismatch_hi_\i
     .endif
+
+.Lnull_hi_\i:
+    mv    a2, a4
+    mv    a3, R_W1A
+    j     .Lnull\i\()_p1
+.Lmismatch_hi_\i:
+    mv    a2, a4
+    mv    a3, R_W1A
+    j     .Lmismatch
   .endm
 
   .macro foundnull i n
     .ifne \i
-      .Lnull\i:
+.Lnull\i:
       add   a0, a0, \i*SZREG
       add   a1, a1, \i*SZREG
-      .ifeq \i-1
-        .Lnull0:
-      .endif
+    .else
+.Lnull0:
+    .endif
+    bne   a2, a3, .Lmisaligned
+    li    a0, 0
+    ret
+    .ifeq \i & 1
+.Lnull\i\()_p1:
+      add   a0, a0, \i*SZREG+SZREG
+      add   a1, a1, \i*SZREG+SZREG
       bne   a2, a3, .Lmisaligned
       li    a0, 0
       ret
@@ -85,19 +156,45 @@ strcmp:
   .endm
 
 .Lloop:
-  # examine full words at a time, favoring strings of a couple dozen chars
-#if __riscv_xlen == 32
-  check_one_word 0 5
-  check_one_word 1 5
-  check_one_word 2 5
-  check_one_word 3 5
-  check_one_word 4 5
-#else
-  check_one_word 0 3
-  check_one_word 1 3
-  check_one_word 2 3
-#endif
-  # backwards branch to .Lloop contained above
+  check_word_pair 0 2
+
+#else  /* !STRCMP_PAIR : RV32E + non-Zbb fallback (single word) */
+
+  .macro check_one_word i n
+    REG_L a2, \i*SZREG(a0)
+    REG_L a3, \i*SZREG(a1)
+    and   a4, a2, a5
+    or    t1, a2, a5
+    add   a4, a4, a5
+    or    a4, a4, t1
+    bne   a4, t2, .Lnull\i
+    .if \i+1-\n
+      bne a2, a3, .Lmismatch
+    .else
+      add a0, a0, \n*SZREG
+      add a1, a1, \n*SZREG
+      beq a2, a3, .Lloop
+      j   .Lmismatch
+    .endif
+  .endm
+
+  .macro foundnull i n
+    .ifne \i
+.Lnull\i:
+      add   a0, a0, \i*SZREG
+      add   a1, a1, \i*SZREG
+    .else
+.Lnull0:
+    .endif
+    bne   a2, a3, .Lmisaligned
+    li    a0, 0
+    ret
+  .endm
+
+.Lloop:
+  check_one_word 0 1
+
+#endif /* STRCMP_PAIR */
 
 .Lmismatch:
   # words don't match, but a2 has no null byte.
@@ -197,16 +294,11 @@ strcmp:
   ret
 
   # cases in which a null byte was detected
-#if __riscv_xlen == 32
-  foundnull 0 5
-  foundnull 1 5
-  foundnull 2 5
-  foundnull 3 5
-  foundnull 4 5
+#if STRCMP_PAIR
+  foundnull 0 2
+  foundnull 1 2
 #else
-  foundnull 0 3
-  foundnull 1 3
-  foundnull 2 3
+  foundnull 0 1
 #endif
 #if !defined(__riscv_zbb) && SZREG != 4
 .align 3


### PR DESCRIPTION
**Problem**: The current strcmp loop interleaves `lw/orc.b/bne` for each word sequentially. On ARC-V  cores this means:

- No load fusion (consecutive loads use different base registers)
- No parallel ALU dispatch (`orc.b` depends on the immediately preceding `lw`)
- Branches between loads break the fusion window

Fix: Introduce `check_word_pair` macro that processes 2 words per expansion:

- Two `REG_L` from `a0` back-to-back → **Fused_LDD** (1 memory uop)
- Two `REG_L` from `a1` back-to-back → **Fused_LDD** (1 memory uop)
- Two `orc.b` (independent) → **parallel ALU dispatch**
- All branches grouped at end → no fusion break
Loop body = 2 pairs = 4 words/iter (16B on RV32, 32B on RV64).

**Why 2 pairs:** Sweet spot — saturates memory pipe, fits in available registers without callee-saves, keeps code within one I-cache line. More pairs give diminishing returns for `strcmp` (early-exit semantics mean extra loads are often wasted).