### PR TITLE
riscv/CFI: add Zicfilp/Zicfiss CFI support

### DIFF
--- a/libc/machine/riscv/asm.h
+++ b/libc/machine/riscv/asm.h
@@ -47,4 +47,13 @@
 # endif
 #endif
 
+/*
+ * LPAD - emit landing pad when Forward-Edge CFI is enabled.
+ */
+#ifdef __riscv_landing_pad
+# define LPAD  lpad 0
+#else
+# define LPAD  /* empty */
+#endif
+
 #endif /* sys/asm.h */

--- a/libc/machine/riscv/memcpy-asm.S
+++ b/libc/machine/riscv/memcpy-asm.S
@@ -10,6 +10,7 @@
 */
 
 #include "rv_string.h"
+#include "asm.h"
 
 #ifdef _MACHINE_RISCV_MEMCPY_VECTOR_
 /*
@@ -37,6 +38,7 @@
 .option push
 .option arch, +zve32x
 memcpy:
+  LPAD
   mv     t0, a0                   /* t0 = running dst */
   mv     t1, a1                   /* t1 = running src */
   beqz   a2, .Ldone               /* if n == 0, return */
@@ -108,6 +110,7 @@ memcpy:
 .global memcpy
 .type	memcpy, @function
 memcpy:
+  LPAD
   mv a3, a0
   beqz a2, 2f
 

--- a/libc/machine/riscv/memmove.S
+++ b/libc/machine/riscv/memmove.S
@@ -10,6 +10,7 @@
 */
 
 #include "rv_string.h"
+#include "asm.h"
 
 #ifdef _MACHINE_RISCV_MEMMOVE_VECTOR_
 .section .text.memmove
@@ -46,6 +47,7 @@
  *   t2,t3,t4,t5 = scratch
  */
 memmove:
+  LPAD
   beqz   a2, .Ldone_move          /* n == 0 */
   beq    a0, a1, .Ldone_move      /* dst == src */
 
@@ -174,6 +176,7 @@ memmove:
 .global memmove
 .type	memmove, @function
 memmove:
+  LPAD
   beqz a2, .Ldone		/* in case there are 0 bytes to be copied, return immediately */
 
   mv a4, a0			/* copy the destination address over to a4, since memmove should return that address in a0 at the end */

--- a/libc/machine/riscv/memset.S
+++ b/libc/machine/riscv/memset.S
@@ -47,6 +47,7 @@
 .global memset
 .type	memset, @function
 memset:
+  LPAD
 #if defined(__PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
   mv     a3, a0
   beqz   a2, .Ldone

--- a/libc/machine/riscv/setjmp.S
+++ b/libc/machine/riscv/setjmp.S
@@ -18,6 +18,7 @@
   .globl  setjmp
   .type   setjmp, @function
 setjmp:
+	LPAD
 	REG_S ra,  0*SZREG(a0)
   #if __riscv_xlen == 32 && (__riscv_zilsd) && (__riscv_misaligned_fast)
 	  sd    s0,  1*SZREG(a0)
@@ -65,6 +66,19 @@ setjmp:
 	FREG_S fs11,14*SZREG+11*SZFREG(a0)
 #endif
 
+#ifdef __riscv_shadow_stack
+	/* Save the current shadow stack pointer into jmp_buf.
+	 * ssrdp returns 0 if shadow stack is not active (SSE=0),
+	 * so this is safe even when the shadow stack is not enabled. */
+  #ifndef __riscv_float_abi_soft
+	ssrdp t0
+	REG_S t0, 14*SZREG+12*SZFREG(a0)
+  #else
+	ssrdp t0
+	REG_S t0, 14*SZREG(a0)
+  #endif
+#endif
+
 	li    a0, 0
 	ret
 	.size	setjmp, .-setjmp
@@ -74,6 +88,7 @@ setjmp:
   .globl  longjmp
   .type   longjmp, @function
 longjmp:
+	LPAD
 	REG_L ra,  0*SZREG(a0)
   #if __riscv_xlen == 32 && (__riscv_zilsd) && (__riscv_misaligned_fast)
     ld s0, 1*SZREG(a0)
@@ -118,6 +133,37 @@ longjmp:
 	FREG_L fs9, 14*SZREG+ 9*SZFREG(a0)
 	FREG_L fs10,14*SZREG+10*SZFREG(a0)
 	FREG_L fs11,14*SZREG+11*SZFREG(a0)
+#endif
+
+#ifdef __riscv_shadow_stack
+	/* Restore the shadow stack pointer saved by setjmp.
+	 * Skip unwinding if shadow stack is not enabled (ssrdp returns 0).
+	 * Advance SSP in page-sized chunks toward the saved value, validating
+	 * each step with sspush/sspopchk to detect guard pages. */
+  #ifndef __riscv_float_abi_soft
+	REG_L t1, 14*SZREG+12*SZFREG(a0)
+  #else
+	REG_L t1, 14*SZREG(a0)
+  #endif
+	ssrdp t0
+	beqz  t0, .Lss_done
+.Lss_unwind:
+	/* If current SSP (t0) has reached saved SSP (t1), we are done */
+	bleu  t1, t0, .Lss_done
+	/* Advance by at most one page (4096 bytes) to ensure we hit a
+	 * guard page before accidentally landing on another shadow stack.
+	 * t0 = (t1 - t0 >= 4096) ? t0 + 4096 : t1 */
+	lui   a0, 1                 /* a0 = 4096 */
+	add   t0, t0, a0
+	bleu  t0, t1, 1f
+	mv    t0, t1
+1:
+	csrw  ssp, t0
+	/* Validate that the new SSP points to a legal shadow stack page */
+	sspush x5
+	sspopchk x5
+	j     .Lss_unwind
+.Lss_done:
 #endif
 
 	seqz a0, a1

--- a/libc/machine/riscv/strcmp.S
+++ b/libc/machine/riscv/strcmp.S
@@ -17,6 +17,7 @@
 .globl strcmp
 .type  strcmp, @function
 strcmp:
+  LPAD
 #if defined(__PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
 .Lcompare:
   lbu   a2, 0(a0)


### PR DESCRIPTION
This PR Adds Forward and Backward Edge CFI (unlabeled landing pad/shadow stack) support by adding unlabeled lpad instruction (Zicfilp) to RISC-V assembly entry points and updating setjmp/longjmp to correctly manage the shadow stack pointer (Zicfiss) on save and restore.

When a user builds with -fcf-protection on CFI capable toolchain, these changes ensure that:

1- Indirect calls into picolibc assembly functions land on a valid LPAD instruction on entry and do not raise a software-check exception.

2- setjmp/longjmp correctly checkpoint and restore the shadow stack pointer, this ensures that stale shadow stack entries accumulated between setjmp and longjmp are properly discarded, preventing a SoftwareCheck exception when the caller of setjmp eventually returns.