### PR TITLE
libos/linux: remove __GNU_VISIBLE guard from mlockall_munlockall.c

### DIFF
--- a/libos/linux/mlockall_munlockall.c
+++ b/libos/linux/mlockall_munlockall.c
@@ -45,10 +45,8 @@ mlockall(int flags)
         linux_flags |= LINUX_MCL_CURRENT;
     if (flags & MCL_FUTURE)
         linux_flags |= LINUX_MCL_FUTURE;
-#if __GNU_VISIBLE
     if (flags & MCL_ONFAULT)
         linux_flags |= LINUX_MCL_ONFAULT;
-#endif
 
     return (int)syscall(LINUX_SYS_mlockall, linux_flags);
 }


### PR DESCRIPTION
Library source code should not test __GNU_VISIBLE; visibility guards belong only in application-facing headers. Remove the #if __GNU_VISIBLE guard around the MCL_ONFAULT branch in mlockall() so the flag is always handled unconditionally.
Note: local-linux.h defines _GNU_SOURCE which sets __GNU_VISIBLE, so this guard was already a no-op in practice.