### PR TITLE
[riscv] Add crt variant for zicfilp/zicfiss

### DIFF
--- a/.github/do-linux-riscv
+++ b/.github/do-linux-riscv
@@ -6,4 +6,5 @@ HERE=`dirname "$0"`
 "$HERE"/do-test-noopt clang-rv32imafdc "$@"
 "$HERE"/do-test-noopt rv32imac "$@"
 "$HERE"/do-test-noopt rv32imac -Dcrt0-test=semihost_smrnmi "$@"
+"$HERE"/do-test-noopt clang-rv64-cfi "$@" || true
 "$HERE"/do-test or1k "$@"

--- a/meson.build
+++ b/meson.build
@@ -1779,6 +1779,10 @@ else
   endif
 endif
 
+if crt0_test_variant == 'semihost_cfi'
+  test_env.set('QEMU_ADD_ZICFI', 'true')
+endif
+
 crt0_test = 'crt0_' + crt0_test_variant
 
 oslib_test = ''
@@ -1890,7 +1894,7 @@ if oslib_test != ''
                  ['-nostdlib', '-T', picolibc_noflash_ld_string])
     set_variable(test_link_depends_noflash_variable, [picolibc_noflash_ld_value])
   endforeach
-  test_noflash = linkerscript_test_variant == '' and crt0_test_variant != 'semihost_smrnmi'
+  test_noflash = linkerscript_test_variant == '' and crt0_test_variant != 'semihost_smrnmi' and crt0_test_variant != 'semihost_cfi'
 else
   test_link_args = test_link_args_base
   test_link_depends = []

--- a/picocrt/machine/riscv/cfiss-mmu.S
+++ b/picocrt/machine/riscv/cfiss-mmu.S
@@ -1,0 +1,474 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026 picolibc contributors
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES.
+ */
+
+/*
+ * cfiss-mmu.S -- Strong override of _init_cfiss.
+ *
+ * MMU-based Zicfiss shadow-stack initialization, followed by a privilege
+ * drop from M-mode to U-mode.
+ *
+ * The function:
+ *   1. Builds an identity-mapping page table.  Most of the address space is
+ *      covered by large leaf entries; the region containing the shadow
+ *      stack is progressively split down to a table of 4 KiB pages so the
+ *      shadow-stack page can be given its own leaf.  That leaf uses the
+ *      Zicfiss reserved encoding (V=1, R=0, W=1, U=1, A=1, D=1).
+ *        - RV32 / Sv32: 2-level table.  The root (level-1) table maps 4 MiB
+ *          megapages; the megapage holding the shadow stack is split into a
+ *          level-0 table of 4 KiB pages.
+ *        - RV64 / Sv39: 3-level table.  The root (level-2) table maps 1 GiB
+ *          gigapages; the relevant gigapage is split into a level-1 table
+ *          of 2 MiB megapages, and that megapage into a level-0 table of
+ *          4 KiB pages.
+ *   2. Loads satp with the appropriate mode (Sv32/Sv39) + root PPN.
+ *   3. Pre-populates the shadow stack with a zero sentinel (must happen
+ *      before SSE is enabled).
+ *   4. Enables shadow-stack support in M, S, and U environments
+ *      (mseccfg.SSE, menvcfg.SSE, senvcfg.SSE).
+ *   5. Sets ssp to the top of the shadow-stack page.
+ *   6. Programs mstatus.MPP = U and mepc = caller's ra, then mret's to
+ *      U-mode, returning to the caller.
+ *
+ * Memory needed: shadow stack (1 page) + page tables
+ *   - RV32: 2 table pages (root + leaf) + 1 page  = 12 KiB.
+ *   - RV64: 3 table pages (L2 + L1 + L0) + 1 page  = 16 KiB.
+ *
+ * Limitations:
+ *   - Caller's BSS must already be zeroed before entry (this is the case
+ *     when called from POST_MEMORY_SETUP()).
+ */
+
+#if defined(__riscv_shadow_stack)
+
+#   if __riscv_xlen == 32
+
+.option arch, +zicsr
+
+/* PTE flag bits */
+.equ PTE_V, (1 << 0)
+.equ PTE_R, (1 << 1)
+.equ PTE_W, (1 << 2)
+.equ PTE_X, (1 << 3)
+.equ PTE_U, (1 << 4)
+.equ PTE_A, (1 << 6)
+.equ PTE_D, (1 << 7)
+
+/*
+ * Zicfiss shadow-stack PTE encoding:
+ *   V=1, R=0, W=1, X=0, U=1, A=1, D=1
+ * The R=0,W=1 combination is reserved by the base spec and is repurposed
+ * by Zicfiss to mark a page as a shadow-stack page.  Only sspush, sspopchk,
+ * and ssamoswap may write such a page; ordinary stores fault.
+ */
+.equ PTE_SHADOW_STACK, (PTE_V | PTE_W | PTE_U | PTE_A | PTE_D)
+.equ PTE_USER_RWX,     (PTE_V | PTE_R | PTE_W | PTE_X | PTE_U | PTE_A | PTE_D)
+
+.equ PAGE_SIZE,     4096
+
+/* mstatus bits */
+.equ MSTATUS_MPP_MASK, (3 << 11)
+.equ MSTATUS_MPIE,     (1 << 7)
+
+/* xenvcfg / mseccfg bits */
+.equ MENVCFG_SSE, (1 << 3)
+.equ SENVCFG_SSE, (1 << 3)
+.equ MSECCFG_SSE, (1 << 3)
+
+/* ------------------------------------------------------------------------- */
+/* Static storage (BSS, page-aligned)                                        */
+/* ------------------------------------------------------------------------- */
+.section .bss
+.balign PAGE_SIZE
+.local _cfiss_shadow_stack
+_cfiss_shadow_stack:
+    .space PAGE_SIZE                /* 1024 slots × 4 bytes on RV32 */
+
+.balign PAGE_SIZE
+.local _cfiss_pt_root
+_cfiss_pt_root:
+    .space (1024 * 4)               /* Level-1 root table */
+
+.balign PAGE_SIZE
+.local _cfiss_pt_leaf
+_cfiss_pt_leaf:
+    .space (1024 * 4)               /* Level-0 leaf table */
+
+/* ------------------------------------------------------------------------- */
+/* _init_cfiss                                                               */
+/*                                                                           */
+/* Strong override of the weak no-op default in crt0.c.  Called from         */
+/* POST_MEMORY_SETUP() in M-mode after .bss has been zeroed.  Does not       */
+/* "return" through ra; instead uses mret to resume at ra in U-mode.         */
+/* ------------------------------------------------------------------------- */
+.section .text
+.global _init_cfiss
+.type _init_cfiss, @function
+_init_cfiss:
+    /* Save ra (return target for mret) and sp (preserved across mret). */
+    mv      t6, ra
+    mv      t5, sp
+
+    /* ---- 1. Build Sv32 page tables (identity map) -------------------- */
+
+    /* Compute VPN indices for the shadow stack page:
+     *   ssVpn1 = shadow_stack >> 22
+     *   ssVpn0 = (shadow_stack >> 12) & 0x3FF
+     */
+    la      t0, _cfiss_shadow_stack
+    srli    t1, t0, 22              /* t1 = ssVpn1 */
+    srli    t2, t0, 12
+    andi    t2, t2, 0x3FF           /* t2 = ssVpn0 */
+
+    /* Fill the root table.  For each index i in [0,1024):
+     *   - i == ssVpn1: non-leaf pointing at the leaf table
+     *   - else:        4 MiB leaf megapage PTE = (i << 20) | PTE_USER_RWX
+     */
+    la      a0, _cfiss_pt_root      /* a0: cursor */
+    li      a1, 0                   /* a1: loop index i */
+    li      a2, 1024                /* a2: bound */
+    la      a3, _cfiss_pt_leaf
+    srli    a3, a3, 2
+    ori     a3, a3, PTE_V           /* a3: non-leaf PTE -> leaf table */
+    li      a4, PTE_USER_RWX
+.L_root_loop:
+    beq     a1, a2, .L_root_done
+    beq     a1, t1, .L_root_ss
+    slli    a5, a1, 20
+    or      a5, a5, a4
+    sw      a5, 0(a0)
+    j       .L_root_next
+.L_root_ss:
+    sw      a3, 0(a0)
+.L_root_next:
+    addi    a0, a0, 4
+    addi    a1, a1, 1
+    j       .L_root_loop
+.L_root_done:
+
+    /* Fill the leaf table that covers the shadow-stack megapage.
+     * megaBase = ssVpn1 << 22
+     * For each i in [0,1024):
+     *   pa     = megaBase + (i << 12)
+     *   flags  = PTE_SHADOW_STACK if i == ssVpn0 else PTE_USER_RWX
+     *   PTE    = (pa >> 2) | flags
+     */
+    la      a0, _cfiss_pt_leaf
+    li      a1, 0
+    slli    a3, t1, 22              /* a3 = megaBase */
+    li      a4, PTE_USER_RWX
+    li      a5, PTE_SHADOW_STACK
+.L_l0_loop:
+    beq     a1, a2, .L_l0_done
+    slli    a6, a1, 12
+    add     a6, a3, a6              /* pa */
+    srli    a6, a6, 2               /* PPN */
+    beq     a1, t2, .L_l0_ss
+    or      a6, a6, a4
+    j       .L_l0_store
+.L_l0_ss:
+    or      a6, a6, a5
+.L_l0_store:
+    sw      a6, 0(a0)
+    addi    a0, a0, 4
+    addi    a1, a1, 1
+    j       .L_l0_loop
+.L_l0_done:
+
+    /* ---- 2. Activate Sv32 -------------------------------------------- */
+    /* satp = (1 << 31) | (PtRoot >> 12)                                   */
+    la      t0, _cfiss_pt_root
+    srli    t0, t0, 12
+    lui     t3, 0x80000             /* 1u << 31 */
+    or      t0, t0, t3
+    csrw    satp, t0
+    sfence.vma
+
+    /* ---- 3. Pre-populate the shadow stack with a zero sentinel ------- */
+    la      t0, _cfiss_shadow_stack
+    li      t3, PAGE_SIZE
+    add     t0, t0, t3              /* top of page */
+    addi    t0, t0, -4              /* one slot down */
+    sw      zero, 0(t0)             /* sentinel: 0 */
+
+    /* ---- 4. Enable shadow-stack support in M/S/U envcfg --------------- */
+    /* mseccfg.SSE must be set before M-mode accesses ssp.                 */
+    csrr    t3, 0x747               /* mseccfg */
+    ori     t3, t3, MSECCFG_SSE
+    csrw    0x747, t3
+
+    csrr    t3, menvcfg
+    ori     t3, t3, MENVCFG_SSE
+    csrw    menvcfg, t3
+
+    csrr    t3, senvcfg
+    ori     t3, t3, SENVCFG_SSE
+    csrw    senvcfg, t3
+
+    /* ---- 5. Set ssp -------------------------------------------------- */
+    csrw    ssp, t0
+
+    /* ---- 6. mret to U-mode at original ra ---------------------------- */
+    csrr    t0, mstatus
+    li      t3, (~MSTATUS_MPP_MASK) & 0xFFFFFFFF
+    and     t0, t0, t3              /* MPP = 00 (U-mode) */
+    ori     t0, t0, MSTATUS_MPIE
+    csrw    mstatus, t0
+    csrw    mepc, t6
+    mv      sp, t5
+    mret
+
+.size _init_cfiss, .-_init_cfiss
+
+#   elif __riscv_xlen == 64
+
+.option arch, +zicsr
+
+/* PTE flag bits */
+.equ PTE_V, (1 << 0)
+.equ PTE_R, (1 << 1)
+.equ PTE_W, (1 << 2)
+.equ PTE_X, (1 << 3)
+.equ PTE_U, (1 << 4)
+.equ PTE_A, (1 << 6)
+.equ PTE_D, (1 << 7)
+
+/*
+ * Zicfiss shadow-stack PTE encoding:
+ *   V=1, R=0, W=1, X=0, U=1, A=1, D=1
+ * The R=0,W=1 combination is reserved by the base spec and is repurposed
+ * by Zicfiss to mark a page as a shadow-stack page.  Only sspush, sspopchk,
+ * and ssamoswap may write such a page; ordinary stores fault.
+ */
+.equ PTE_SHADOW_STACK, (PTE_V | PTE_W | PTE_U | PTE_A | PTE_D)
+.equ PTE_USER_RWX,     (PTE_V | PTE_R | PTE_W | PTE_X | PTE_U | PTE_A | PTE_D)
+
+.equ PAGE_SIZE,     4096
+.equ PT_ENTRIES,    512             /* Sv39 entries per table (512 x 8B) */
+
+/* satp.MODE = 8 (Sv39), held in bits [63:60] */
+.equ SATP_MODE_SV39, 8
+
+/* mstatus bits */
+.equ MSTATUS_MPP_MASK, (3 << 11)
+.equ MSTATUS_MPIE,     (1 << 7)
+
+/* xenvcfg / mseccfg bits */
+.equ MENVCFG_SSE, (1 << 3)
+.equ SENVCFG_SSE, (1 << 3)
+.equ MSECCFG_SSE, (1 << 3)
+
+/* ------------------------------------------------------------------------- */
+/* Static storage (BSS, page-aligned)                                        */
+/* ------------------------------------------------------------------------- */
+.section .bss
+.balign PAGE_SIZE
+.local _cfiss_shadow_stack
+_cfiss_shadow_stack:
+    .space PAGE_SIZE                /* 512 slots x 8 bytes on RV64 */
+
+.balign PAGE_SIZE
+.local _cfiss_pt_l2
+_cfiss_pt_l2:
+    .space (PT_ENTRIES * 8)         /* Level-2 root table */
+
+.balign PAGE_SIZE
+.local _cfiss_pt_l1
+_cfiss_pt_l1:
+    .space (PT_ENTRIES * 8)         /* Level-1 table (one gigapage) */
+
+.balign PAGE_SIZE
+.local _cfiss_pt_l0
+_cfiss_pt_l0:
+    .space (PT_ENTRIES * 8)         /* Level-0 table (one megapage) */
+
+/* ------------------------------------------------------------------------- */
+/* _init_cfiss                                                               */
+/*                                                                           */
+/* Strong override of the weak no-op default in crt0.c.  Called from         */
+/* POST_MEMORY_SETUP() in M-mode after .bss has been zeroed.  Does not       */
+/* "return" through ra; instead uses mret to resume at ra in U-mode.         */
+/* ------------------------------------------------------------------------- */
+.section .text
+.global _init_cfiss
+.type _init_cfiss, @function
+_init_cfiss:
+    /* Save ra (return target for mret) and sp (preserved across mret). */
+    mv      t6, ra
+    mv      t5, sp
+
+    /* ---- 1. Build Sv39 page tables (identity map) -------------------- */
+
+    /* Compute VPN indices for the shadow stack page:
+     *   ssVpn2 = (shadow_stack >> 30) & 0x1FF
+     *   ssVpn1 = (shadow_stack >> 21) & 0x1FF
+     *   ssVpn0 = (shadow_stack >> 12) & 0x1FF
+     */
+    la      t0, _cfiss_shadow_stack
+    srli    t1, t0, 30
+    andi    t1, t1, 0x1FF           /* t1 = ssVpn2 */
+    srli    t2, t0, 21
+    andi    t2, t2, 0x1FF           /* t2 = ssVpn1 */
+    srli    t3, t0, 12
+    andi    t3, t3, 0x1FF           /* t3 = ssVpn0 */
+
+    /* Fill the level-2 root table.  For each index i in [0,512):
+     *   - i == ssVpn2: non-leaf pointing at the L1 table
+     *   - else:        1 GiB gigapage PTE = (i << 28) | PTE_USER_RWX
+     *                  (PA = i << 30, PPN<<10 = PA >> 2 = i << 28)
+     */
+    la      a0, _cfiss_pt_l2        /* a0: cursor */
+    li      a1, 0                   /* a1: loop index i */
+    li      a2, PT_ENTRIES          /* a2: bound */
+    la      a3, _cfiss_pt_l1
+    srli    a3, a3, 2
+    ori     a3, a3, PTE_V           /* a3: non-leaf PTE -> L1 table */
+    li      a4, PTE_USER_RWX
+.L_l2_loop:
+    beq     a1, a2, .L_l2_done
+    beq     a1, t1, .L_l2_ss
+    slli    a5, a1, 28
+    or      a5, a5, a4
+    sd      a5, 0(a0)
+    j       .L_l2_next
+.L_l2_ss:
+    sd      a3, 0(a0)
+.L_l2_next:
+    addi    a0, a0, 8
+    addi    a1, a1, 1
+    j       .L_l2_loop
+.L_l2_done:
+
+    /* Fill the level-1 table that covers the shadow-stack gigapage.
+     * gigaBase = ssVpn2 << 30
+     * For each j in [0,512):
+     *   - j == ssVpn1: non-leaf pointing at the L0 table
+     *   - else:        2 MiB megapage PTE for pa = gigaBase + (j << 21)
+     */
+    la      a0, _cfiss_pt_l1
+    li      a1, 0
+    slli    a3, t1, 30              /* a3 = gigaBase */
+    la      a6, _cfiss_pt_l0
+    srli    a6, a6, 2
+    ori     a6, a6, PTE_V           /* a6: non-leaf PTE -> L0 table */
+    li      a4, PTE_USER_RWX
+.L_l1_loop:
+    beq     a1, a2, .L_l1_done
+    beq     a1, t2, .L_l1_ss
+    slli    a5, a1, 21
+    add     a5, a3, a5              /* pa = gigaBase + (j << 21) */
+    srli    a5, a5, 2               /* PPN << 10 */
+    or      a5, a5, a4
+    sd      a5, 0(a0)
+    j       .L_l1_next
+.L_l1_ss:
+    sd      a6, 0(a0)
+.L_l1_next:
+    addi    a0, a0, 8
+    addi    a1, a1, 1
+    j       .L_l1_loop
+.L_l1_done:
+
+    /* Fill the level-0 table that covers the shadow-stack megapage.
+     * megaBase = (ssVpn2 << 30) + (ssVpn1 << 21)
+     * For each k in [0,512):
+     *   pa     = megaBase + (k << 12)
+     *   flags  = PTE_SHADOW_STACK if k == ssVpn0 else PTE_USER_RWX
+     *   PTE    = (pa >> 2) | flags
+     */
+    la      a0, _cfiss_pt_l0
+    li      a1, 0
+    slli    a3, t1, 30              /* gigaBase */
+    slli    a5, t2, 21
+    add     a3, a3, a5              /* a3 = megaBase */
+    li      a4, PTE_USER_RWX
+    li      a7, PTE_SHADOW_STACK
+.L_l0_loop:
+    beq     a1, a2, .L_l0_done
+    slli    a5, a1, 12
+    add     a5, a3, a5              /* pa */
+    srli    a5, a5, 2               /* PPN << 10 */
+    beq     a1, t3, .L_l0_ss
+    or      a5, a5, a4
+    j       .L_l0_store
+.L_l0_ss:
+    or      a5, a5, a7
+.L_l0_store:
+    sd      a5, 0(a0)
+    addi    a0, a0, 8
+    addi    a1, a1, 1
+    j       .L_l0_loop
+.L_l0_done:
+
+    /* ---- 2. Activate Sv39 -------------------------------------------- */
+    /* satp = (SATP_MODE_SV39 << 60) | (PtL2 >> 12)                        */
+    la      t0, _cfiss_pt_l2
+    srli    t0, t0, 12
+    li      t4, SATP_MODE_SV39
+    slli    t4, t4, 60
+    or      t0, t0, t4
+    csrw    satp, t0
+    sfence.vma
+
+    /* ---- 3. Pre-populate the shadow stack with a zero sentinel ------- */
+    la      t0, _cfiss_shadow_stack
+    li      t4, PAGE_SIZE
+    add     t0, t0, t4              /* top of page */
+    addi    t0, t0, -8              /* one slot down (8 bytes on RV64) */
+    sd      zero, 0(t0)             /* sentinel: 0 */
+
+    /* ---- 4. Enable shadow-stack support in M/S/U envcfg --------------- */
+    /* mseccfg.SSE must be set before M-mode accesses ssp.                 */
+    csrr    t4, 0x747               /* mseccfg */
+    ori     t4, t4, MSECCFG_SSE
+    csrw    0x747, t4
+
+    csrr    t4, menvcfg
+    ori     t4, t4, MENVCFG_SSE
+    csrw    menvcfg, t4
+
+    csrr    t4, senvcfg
+    ori     t4, t4, SENVCFG_SSE
+    csrw    senvcfg, t4
+
+    /* ---- 5. Set ssp -------------------------------------------------- */
+    csrw    ssp, t0
+
+    /* ---- 7. mret to U-mode at original ra ---------------------------- */
+    csrr    t0, mstatus
+    li      t4, ~MSTATUS_MPP_MASK
+    and     t0, t0, t4              /* MPP = 00 (U-mode) */
+    ori     t0, t0, MSTATUS_MPIE
+    csrw    mstatus, t0
+    csrw    mepc, t6
+    mv      sp, t5
+    mret
+
+.size _init_cfiss, .-_init_cfiss
+#   else 
+
+#       error "Unsupported RISC-V XLEN"
+
+#   endif   /*__riscv_xlen */
+#endif  /* __riscv_shadow_stack*/

--- a/picocrt/machine/riscv/crt0.c
+++ b/picocrt/machine/riscv/crt0.c
@@ -34,7 +34,35 @@
  */
 
 #include <stddef.h>
+
+#if defined(__riscv_shadow_stack)
+#define _PICOLIBC_CFISS_ENABLED 1
+#endif
+
+#ifdef _PICOLIBC_CFISS_ENABLED
+/*
+ * Optional shadow-stack initialization hook. The default implementation
+ * (defined below) is a no-op; targets that need to set up page-table
+ * or PMP protection for the shadow stack and program the SSP CSR can
+ * provide a strong override of this symbol.
+ *
+ * Called from __start() via POST_MEMORY_SETUP, i.e. after .bss has been
+ * cleared, so that any storage used as the shadow stack (which typically
+ * lives in .bss) has been zeroed before it is marked as a shadow-stack
+ * region.
+ */
+extern void _init_cfiss(void);
+#define POST_MEMORY_SETUP() _init_cfiss()
+#endif
+
 #include "../../crt0.h"
+
+#ifdef _PICOLIBC_CFISS_ENABLED
+__attribute__((weak)) void
+_init_cfiss(void)
+{
+}
+#endif
 
 static void __used __section(".init")
 _cstart(void)
@@ -269,6 +297,54 @@ _start(void)
             ".Lafter_jvt_init:\n");
 #endif
 
+#ifdef __riscv_landing_pad
+    /*
+     * Zicfilp: enable M-mode landing-pad enforcement by setting
+     * mseccfg.MLPE (bit 10). This macro is defined by the compiler
+     * only when both the Zicfilp extension is enabled and code is
+     * generated with -fcf-protection=branch (so that `lpad`
+     * instructions are emitted at indirect-call targets). After this
+     * is set, every indirect call or jump executed in M-mode must
+     * target an `lpad` instruction or a software-check exception
+     * (mcause=18, mtval=2) is raised.
+     */
+    __asm__("csrr	t0, mseccfg\n"
+            "li	t1, 1024\n"
+            "or	t0, t0, t1\n"
+            "csrw	0x747, t0");
+    /*
+     * Also enable landing-pad enforcement in S- and U-mode via
+     * menvcfg.LPE (bit 2) and senvcfg.LPE (bit 2). This is harmless on
+     * pure M-mode runs and is required when a crt0 variant drops to
+     * S/U-mode (e.g. for the Zicfiss shadow-stack MMU configuration).
+     */
+    __asm__("csrr	t0, menvcfg\n"
+            "li	t1, 4\n"
+            "or	t0, t0, t1\n"
+            "csrw	menvcfg, t0\n"
+            "csrr	t0, senvcfg\n"
+            "or	t0, t0, t1\n"
+            "csrw	senvcfg, t0");
+#endif
+#ifdef __riscv_shadow_stack
+    /*
+     * Zicfiss: enable shadow-stack support in mseccfg (SSE = bit 3) so
+     * that ssp may be written from M-mode, and in menvcfg/senvcfg so
+     * that the shadow-stack instructions are enabled for S/U.  The
+     * actual shadow-stack page mapping and ssp initialization is
+     * deferred to _init_cfiss() (invoked from POST_MEMORY_SETUP).
+     */
+    __asm__("csrr	t0, mseccfg\n"
+            "li	t1, 8\n"
+            "or	t0, t0, t1\n"
+            "csrw	0x747, t0\n"
+            "csrr	t0, menvcfg\n"
+            "or	t0, t0, t1\n"
+            "csrw	menvcfg, t0\n"
+            "csrr	t0, senvcfg\n"
+            "or	t0, t0, t1\n"
+            "csrw	senvcfg, t0");
+#endif
 #ifdef CRT0_SEMIHOST
 #ifdef __riscv_cmodel_large
     __asm__("ld     t0,.start_trap");

--- a/picocrt/machine/riscv/meson.build
+++ b/picocrt/machine/riscv/meson.build
@@ -33,3 +33,7 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 src_picocrt += files('crt0.c')
+
+# Sources for the optional `semihost-cfi' crt0 variant: standard riscv crt0
+# plus the MMU-based Zicfiss shadow-stack initialiser.
+src_picocrt_riscv_cfi = src_picocrt + files('cfiss-mmu.S')

--- a/picocrt/meson.build
+++ b/picocrt/meson.build
@@ -161,6 +161,16 @@ if host_cpu_family == 'riscv'
     'c_args': ['-DCRT0_EXIT', '-DCRT0_SEMIHOST', '-DCRT0_SMRNMI'],
     'src': src_picocrt,
   }
+  # A CRT0 Semihosting variant that performs Zicfiss shadow-stack
+  # initialization via an Sv32 MMU page-table setup and drops to U-mode
+  # before running the application.  Only useful for builds that target
+  # Zicfilp+Zicfiss and are linked with -fcf-protection.
+  picocrt_variants += {
+    'name': 'semihost-cfi',
+    'suffix': '-semihost-cfi',
+    'c_args': ['-DCRT0_EXIT', '-DCRT0_SEMIHOST'],
+    'src': src_picocrt_riscv_cfi,
+  }
 endif
 
 foreach params : targets

--- a/scripts/cross-clang-rv32-cfi-unknown-elf.txt
+++ b/scripts/cross-clang-rv32-cfi-unknown-elf.txt
@@ -1,0 +1,46 @@
+[binaries]
+c = ['clang', '-m32', '-target', 'riscv32-unknown-elf',
+     '-march=rv32gc_zicfilp1p0_zicfiss1p0_zimop1p0_zcmop1p0',
+     '-mabi=ilp32d',
+     '-menable-experimental-extensions',
+     '-fcf-protection=full',
+     '-nostdlib']
+cpp = ['clang', '-m32', '-target', 'riscv32-unknown-elf',
+       '-march=rv32gc_zicfilp1p0_zicfiss1p0_zimop1p0_zcmop1p0',
+       '-mabi=ilp32d',
+       '-menable-experimental-extensions',
+       '-fcf-protection=full',
+       '-nostdlib', '-stdlib=libstdc++']
+c_ld = '/usr/bin/riscv64-unknown-elf-ld'
+cpp_ld = '/usr/bin/riscv64-unknown-elf-ld'
+ar = 'riscv64-unknown-elf-ar'
+as = 'riscv64-unknown-elf-as'
+nm = 'riscv64-unknown-elf-nm'
+strip = 'riscv64-unknown-elf-strip'
+# only needed to run tests
+exe_wrapper = ['env', 'run-riscv']
+
+[host_machine]
+system = 'none'
+cpu_family = 'riscv32'
+cpu = 'riscv'
+endian = 'little'
+
+[properties]
+# CFI requires Zicfilp / Zicfiss / Zimop, all of which are still tagged
+# "experimental" in current LLVM releases (<=21).  We therefore enable
+# experimental extensions and disable -Werror=double-promotion which can
+# fire from libgcc helpers compiled without the same flags.
+c_args = ['-Werror=double-promotion']
+c_link_args = ['-Wl,-melf32lriscv',
+               '-L/usr/lib/gcc/riscv64-unknown-elf/15/rv32imafdc/ilp32d',
+               '-L/usr/lib/gcc/riscv64-unknown-elf/15.2.0/rv32imafdc/ilp32d']
+cpp_link_args = ['-Wl,-melf32lriscv',
+                 '-L/usr/lib/gcc/riscv64-unknown-elf/15/rv32imafdc/ilp32d',
+                 '-L/usr/lib/gcc/riscv64-unknown-elf/15.2.0/rv32imafdc/ilp32d']
+skip_sanity_check = true
+has_link_defsym = true
+default_flash_addr = '0x80000000'
+default_flash_size = '0x00400000'
+default_ram_addr   = '0x80400000'
+default_ram_size   = '0x00200000'

--- a/scripts/cross-clang-rv64-cfi-unknown-elf.txt
+++ b/scripts/cross-clang-rv64-cfi-unknown-elf.txt
@@ -1,0 +1,50 @@
+[binaries]
+c = ['clang', '-target', 'riscv64-unknown-elf',
+     '-mcmodel=medany',
+     '-march=rv64gc_zicfilp1p0_zicfiss1p0_zimop1p0_zcmop1p0',
+     '-mabi=lp64d',
+     '-menable-experimental-extensions',
+     '-fcf-protection=full',
+     '-nostdlib']
+cpp = ['clang', '-target', 'riscv64-unknown-elf',
+       '-mcmodel=medany',
+       '-march=rv64gc_zicfilp1p0_zicfiss1p0_zimop1p0_zcmop1p0',
+       '-mabi=lp64d',
+       '-menable-experimental-extensions',
+       '-fcf-protection=full',
+       '-nostdlib', '-stdlib=libstdc++']
+c_ld = '/usr/bin/riscv64-unknown-elf-ld'
+cpp_ld = '/usr/bin/riscv64-unknown-elf-ld'
+ar = 'riscv64-unknown-elf-ar'
+as = 'riscv64-unknown-elf-as'
+nm = 'riscv64-unknown-elf-nm'
+strip = 'riscv64-unknown-elf-strip'
+# only needed to run tests
+exe_wrapper = ['env', 'run-riscv']
+
+[host_machine]
+system = 'none'
+cpu_family = 'riscv64'
+cpu = 'riscv'
+endian = 'little'
+
+[properties]
+# CFI requires Zicfilp / Zicfiss / Zimop, all of which are still tagged
+# "experimental" in current LLVM releases (<=21).  We therefore enable
+# experimental extensions and disable -Werror=double-promotion which can
+# fire from libgcc helpers compiled without the same flags.
+c_args = ['-Werror=double-promotion', '-fshort-enums']
+c_link_args = ['-Wl,-melf64lriscv',
+               '-L/usr/lib/gcc/riscv64-unknown-elf/15/rv64ifd/lp64d',
+               '-L/usr/lib/gcc/riscv64-unknown-elf/15.2.0/rv64ifd/lp64d',
+               '-Wno-unused-command-line-argument']
+cpp_link_args = ['-Wl,-melf64lriscv',
+                 '-L/usr/lib/gcc/riscv64-unknown-elf/15/rv64ifd/lp64d',
+                 '-L/usr/lib/gcc/riscv64-unknown-elf/15.2.0/rv64ifd/lp64d',
+                 '-Wno-unused-command-line-argument']
+skip_sanity_check = true
+has_link_defsym = true
+default_flash_addr = '0x80000000'
+default_flash_size = '0x00400000'
+default_ram_addr   = '0x80400000'
+default_ram_size   = '0x00200000'

--- a/scripts/do-clang-rv32-cfi-configure
+++ b/scripts/do-clang-rv32-cfi-configure
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Configure picolibc for a RISC-V 32-bit Clang build with CFI support
+# (Zicfilp + Zicfiss + Zimop) and select the matching `semihost-cfi'
+# crt0 variant.
+#
+exec "$(dirname "$0")"/do-configure clang-rv32-cfi-unknown-elf \
+     -Dtests=true \
+     -Dtests-enable-stack-protector=false \
+     -Dmultilib=false \
+     -Dcrt0-test=semihost_cfi \
+     "$@"

--- a/scripts/do-clang-rv64-cfi-configure
+++ b/scripts/do-clang-rv64-cfi-configure
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Configure picolibc for a RISC-V 64-bit Clang build with CFI support
+# (Zicfilp + Zicfiss + Zimop) and select the matching `semihost-cfi'
+# crt0 variant.
+#
+exec "$(dirname "$0")"/do-configure clang-rv64-cfi-unknown-elf \
+     -Dtests=true \
+     -Dtests-enable-stack-protector=false \
+     -Dmultilib=false \
+     -Dcrt0-test=semihost_cfi \
+     "$@"

--- a/scripts/run-riscv
+++ b/scripts/run-riscv
@@ -102,6 +102,18 @@ if [ -z "$options" ]; then
     options="$(echo "$elf" | sed 's/.*rv[36][24]\([a-z]*\)_.*$/\1/' | sed 's/\(.\)/\1 /g')"
 fi
 
+# The CFI shadow-stack crt0 variant builds an Sv32 page table and drops
+# to U-mode; it needs the QEMU MMU model to be enabled.  Re-enable mmu
+# when the test environment asks for Zicfi support.
+if [ -n "$QEMU_ADD_ZICFI" ]; then
+    cpu="$(echo "$cpu" | sed 's/,mmu=false//')"
+    # Zicfiss is only legal on a CPU model that includes the Supervisor
+    # extension;
+    for need in s u i m a f d c zicsr zifencei; do
+        echo "$options" | grep -q -w "$need" || options="$options $need"
+    done
+fi
+
 for o in $options; do
     # Old versions of qemu don't have new extension subsets
     case "$qemu_version" in
@@ -119,6 +131,11 @@ for o in $options; do
     case "$o" in
         zvl*)
             # qemu doesn't list zvl extensions
+            ;;
+        zicfilp|zicfiss|zimop|zcmop)
+            # Added below via $QEMU_ADD_ZICFI, but only on qemu >= 9.1.
+            # Skip here to avoid passing them on older qemu that would
+            # reject the option.
             ;;
         *)
             cpu="$cpu,$o=true"
@@ -138,6 +155,16 @@ case "$qemu_version" in
         enabled_options="$enabled_options zawrs zfa zihintntl"
         ;;
 esac
+
+# QEMU only models Zicfilp/Zicfiss starting from v9.1.  When asked for
+# them via the test environment, add the corresponding cpu options.
+if [ -n "$QEMU_ADD_ZICFI" ]; then
+    case "$qemu_version" in
+        9.[1-9]*|9.[1-9][0-9]*|[1-9][0-9]*)
+            cpu="$cpu,zicfilp=true,zicfiss=true,zimop=true,zcmop=true"
+            ;;
+    esac
+fi
 
 for enabled in $enabled_options; do
     if echo "$options" | grep -q -w $enabled; then
@@ -177,6 +204,15 @@ chardev=stdio,mux=on,id=stdio0
 # Point the semihosting driver at our new chardev
 
 semi=enable=on,chardev=stdio0,arg="program-name $args"
+
+# The CFI shadow-stack crt0 variant drops to U-mode before running the
+# application so that the MMU-enforced Zicfiss shadow-stack page is actually
+# exercised.  QEMU only honors the semihosting ebreak sequence from U-mode
+# when userspace semihosting is explicitly enabled; otherwise the ebreak is
+# taken as a plain breakpoint (mcause=3) and semihosting never runs
+if [ -n "$QEMU_ADD_ZICFI" ]; then
+    semi="$semi,userspace=on"
+fi
 
 # Disable monitor
 


### PR DESCRIPTION
Adding CRT variant for CFI (Zicfilp/Zicfiss) extension for RISC-V

- Add Meson cross file and configure script for clang-rv32-cfi
  (rv32gc with    Zicfi/iss/lp/mo extensions, -fcf-protection=full).
- Implement strong _init_cfiss override (cfiss-mmu.S): sets up
  Sv32 page tables with Zicfiss shadow stack, enables SSE, sets ssp, drops to U-mode.
- Update crt0.c: enable Zicfiss (SSE) and landing pad enforcement (LPE)
  in startup for CFI/landing pad variants.
- Extend meson.build: add semihost-cfi crt0 variant, include cfiss-mmu.S,
  adjust test_env and test_noflash for CFI.
- Update run-riscv: handle QEMU_ADD_ZICFI, pass correct cpu options for QEMU 9.1+
- Update do-linux-riscv: add non-fatal clang-rv32-cfi test job for CI.