### PR TITLE
libc: fix __noreturn macro usage

### DIFF
--- a/libc/include/ssp/ssp.h
+++ b/libc/include/ssp/ssp.h
@@ -75,9 +75,9 @@
 #define __ssp_overlap(a, b, l) (((a) <= (b) && (b) < (a) + (l)) || ((b) <= (a) && (a) < (b) + (l)))
 
 _BEGIN_STD_C
-void __stack_chk_fail(void) __noreturn __picolibc_export;
-void __chk_fail(void) __noreturn __picolibc_export;
-void set_fortify_handler(void (*handler)(int sig)) __picolibc_export;
+__noreturn void __stack_chk_fail(void) __picolibc_export;
+__noreturn void __chk_fail(void) __picolibc_export;
+void            set_fortify_handler(void (*handler)(int sig)) __picolibc_export;
 _END_STD_C
 
 #endif /* _SSP_SSP_H_ */


### PR DESCRIPTION
`__noreturn` macro should not be used at the end of function declaration.

Because in case it defined as `[[noreturn]]` with c++ compiler it can give warning like this:

```
test.h:2:27: warning: ‘noreturn’ attribute does not apply to types [-Wattributes]
    3 | void foo(void) [[noreturn]];
      |                           ^
```

```C
//test.h
extern "C" {
void foo(void) [[noreturn]];
}
```