### PR TITLE
[RFC] limits.h: workaround compiler __STDC_WANT_LIB_EXT1__ definition

### DIFF
--- a/libc/include/limits.h
+++ b/libc/include/limits.h
@@ -147,5 +147,12 @@
 #define __GLIBC_USE(x) 1
 #endif
 #endif
+/* Workaround buggy toolchains that define __STDC_WANT_LIB_EXT1__ in limits.h */
+#ifndef __STDC_WANT_LIB_EXT1__
+#define __UNDEF__STDC_WANT_LIB_EXT1__
+#endif
 #include_next <limits.h>
+#ifdef __UNDEF__STDC_WANT_LIB_EXT1__
+#undef __STDC_WANT_LIB_EXT1__
+#endif
 #endif /* __GNUC__ && !_GCC_LIMITS_H_ */


### PR DESCRIPTION
xt-clang provided limits.h in both RI-2021.8 and RJ-2023.2 releases defines __STDC_WANT_LIB_EXT1__ if not previously defined. This breaks build when limits.h is included between other headers that indirectly include sys/_types.h. On first sys/_types.h include, __STDC_WANT_LIB_EXT1__ is not defined, so __errno_t typedef is skipped. Later, once limits.h defines __STDC_WANT_LIB_EXT1__, stdlib.h expects __errno_t, but sys/_types.h include is ineffective.

Make sure __STDC_WANT_LIB_EXT1__ is not defined after limits.h, unless it was previously defined.

This solution is obviously extremely ugly. Is there a better way?