### PR TITLE
headers: skip _Static_assert/_Alignof macros on Clang

### DIFF
--- a/libc/include/sys/cdefs.h
+++ b/libc/include/sys/cdefs.h
@@ -504,10 +504,12 @@
 #endif
 #endif
 
+#if !__has_feature(c_alignof) && !__has_extension(c_alignof)
 #if defined(__cplusplus) && __cplusplus >= 201103L
 #define _Alignof(x) alignof(x)
 #else
 #define _Alignof(x) __alignof(x)
+#endif
 #endif
 
 #if !defined(__cplusplus) && !__has_feature(c_atomic) && !__has_feature(cxx_atomic) \
@@ -522,7 +524,7 @@
     }
 #endif
 
-#if !__has_feature(c_static_assert)
+#if !__has_feature(c_static_assert) && !__has_extension(c_static_assert)
 #if (defined(__cplusplus) && __cplusplus >= 201103L) || __has_feature(cxx_static_assert)
 #define _Static_assert(x, y) static_assert(x, y)
 #elif __GNUC_PREREQ__(4, 6) && !defined(__cplusplus)

--- a/test/meson.build
+++ b/test/meson.build
@@ -295,6 +295,20 @@ foreach params : targets
            suite: 'test-no-flash',
            env: test_env)
     endif
+
+    t1 = 'test-cdefs-cxx03'
+    t1_src = t1 + '.cpp'
+    _cxx03_args = _cpp_args + ['-std=c++03']
+    test(t1 + target,
+         executable(t1 + target, t1_src,
+                    cpp_args: _cxx03_args,
+                    link_args: _cxx03_args + _link_args,
+                    objects: _objs,
+                    link_depends: _link_depends,
+                    include_directories: inc),
+         depends: bios_bin,
+         suite: 'test',
+         env: test_env)
   endif
 
   foreach t1 : tests
@@ -355,6 +369,13 @@ if enable_native_tests
          suite: 'test',
          env: test_env
         )
+
+    test('test-cdefs-cxx03-native',
+         executable('test-cdefs-cxx03-native', 'test-cdefs-cxx03.cpp',
+                    cpp_args: native_cpp_args + ['-std=c++03'],
+                    link_args: native_cpp_args + ['-std=c++03']),
+         suite: 'test',
+         env: test_env)
   endif
 
   foreach t1 : tests

--- a/test/test-cdefs-cxx03.cpp
+++ b/test/test-cdefs-cxx03.cpp
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted (subject to the limitations in the
+ * disclaimer below) provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Qualcomm Innovation Center, Inc. nor the names
+ *     of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written
+ *     permission.
+ *
+ * NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+ * GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+ * HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Test that _Static_assert and _Alignof work with template types whose
+ * argument lists contain commas, when compiled in C++03 mode.
+ *
+ * When Clang compiles in pre-C++11 mode, _Static_assert and _Alignof are
+ * available as built-in keywords.  If they were instead defined as
+ * function-like macros (the fallback for other compilers), the comma inside
+ * a template argument such as pair<int,int> would be treated as a macro
+ * argument separator, causing a compilation error.
+ *
+ * This test is skipped on non-Clang compilers because the fallback macro
+ * definitions do not support comma-containing arguments.
+ */
+
+#ifdef __clang__
+
+#include <sys/cdefs.h>
+#include <stddef.h>
+
+template <typename A, typename B>
+struct pair {
+    A first;
+    B second;
+};
+
+/* These would fail if _Static_assert/_Alignof were function-like macros:
+ * the comma in pair<int,int> would be seen as a macro argument separator. */
+_Static_assert(sizeof(pair<int,int>) == 2 * sizeof(int), "pair size");
+_Static_assert(_Alignof(pair<int,int>) == _Alignof(int), "pair align");
+
+#endif /* __clang__ */
+
+#ifdef __clang__
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#pragma GCC diagnostic ignored "-Wmain"
+#endif
+
+extern "C" {
+
+int main(void);
+
+int main(void) { return 0; }
+
+}


### PR DESCRIPTION
Clang supports _Static_assert and _Alignof as built-in keywords in all language modes, not just C11 and later.

https://github.com/llvm/llvm-project/blob/main/clang/docs/LanguageExtensions.rst#c-keywords-supported-in-all-language-modes

When these are defined as function-like macros, they break when used with template arguments containing commas
(e.g. in libcxx headers), because the preprocessor splits the comma-separated template parameters into separate macro arguments. When the compiler sees them as keywords instead of macros, it handles the arguments correctly.

Use __has_extension(c_static_assert) and __has_extension(c_alignof) to detect Clang's built-in support in any language mode (including C++03), and skip the macro definitions in that case.  The existing __has_feature() checks already handle the C11-and-later case; the new __has_extension() checks cover pre-C11 and pre-C++11 modes where __has_feature() returns 0 but the keywords are still available.

Other compilers are unaffected: those that do not define __has_extension fall through to the existing fallback macro definitions.