### PR TITLE
Add Hexagon floating-point environment support

### DIFF
--- a/libc/include/machine/ieeefp.h
+++ b/libc/include/machine/ieeefp.h
@@ -501,6 +501,7 @@ warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 #ifdef __HEXAGON_ARCH__
 #define __IEEE_LITTLE_ENDIAN
+#define _SUPPORTS_ERREXCEPT
 #endif
 
 #ifdef __x86_64__

--- a/libc/machine/hexagon/machine/fenv-fp.h
+++ b/libc/machine/hexagon/machine/fenv-fp.h
@@ -1,0 +1,160 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* Hexagon hardware fenv inline implementations */
+
+static __inline__ unsigned long
+__hexagon_get_usr(void)
+{
+    unsigned long __r;
+    __asm__ volatile("%0 = usr" : "=r"(__r));
+    return __r;
+}
+
+static __inline__ void
+__hexagon_set_usr(unsigned long __r)
+{
+    __asm__ volatile("usr = %0" ::"r"(__r));
+}
+
+__declare_fenv_inline(int) fegetenv(fenv_t *__envp)
+{
+    *__envp = (fenv_t)(__hexagon_get_usr() & _FE_FP_MASK);
+    return 0;
+}
+
+__declare_fenv_inline(int) fesetenv(const fenv_t *__envp)
+{
+    unsigned long __usr = __hexagon_get_usr();
+    __hexagon_set_usr((__usr & ~(unsigned long)_FE_FP_MASK)
+                      | ((unsigned long)*__envp & _FE_FP_MASK));
+    return 0;
+}
+
+__declare_fenv_inline(int) fegetround(void)
+{
+    return (int)((__hexagon_get_usr() >> _FE_RND_OFF) & _FE_RND_MASK);
+}
+
+__declare_fenv_inline(int) fesetround(int __round)
+{
+    unsigned long __usr;
+    if ((unsigned int)__round > _FE_RND_MASK)
+        return 1;
+    __usr = __hexagon_get_usr();
+    __hexagon_set_usr((__usr & ~((unsigned long)_FE_RND_MASK << _FE_RND_OFF))
+                      | ((unsigned long)__round << _FE_RND_OFF));
+    return 0;
+}
+
+__declare_fenv_inline(int) feclearexcept(int __excepts)
+{
+    __hexagon_set_usr(__hexagon_get_usr() & ~(unsigned long)(__excepts & FE_ALL_EXCEPT));
+    return 0;
+}
+
+__declare_fenv_inline(int) feraiseexcept(int __excepts)
+{
+    __hexagon_set_usr(__hexagon_get_usr() | (unsigned long)(__excepts & FE_ALL_EXCEPT));
+    return 0;
+}
+
+__declare_fenv_inline(int) fesetexcept(int __excepts)
+{
+    return feraiseexcept(__excepts);
+}
+
+__declare_fenv_inline(int) fetestexcept(int __excepts)
+{
+    return (int)(__hexagon_get_usr() & (unsigned long)(__excepts & FE_ALL_EXCEPT));
+}
+
+__declare_fenv_inline(int) fegetexceptflag(fexcept_t *__flagp, int __excepts)
+{
+    *__flagp = (fexcept_t)(__hexagon_get_usr() & (unsigned long)(__excepts & FE_ALL_EXCEPT));
+    return 0;
+}
+
+__declare_fenv_inline(int) fesetexceptflag(const fexcept_t *__flagp, int __excepts)
+{
+    unsigned long __mask = (unsigned long)(__excepts & FE_ALL_EXCEPT);
+    unsigned long __usr = __hexagon_get_usr();
+    __hexagon_set_usr((__usr & ~__mask) | ((unsigned long)*__flagp & __mask));
+    return 0;
+}
+
+__declare_fenv_inline(int) feholdexcept(fenv_t *__envp)
+{
+    unsigned long __usr = __hexagon_get_usr();
+    *__envp = (fenv_t)(__usr & _FE_FP_MASK);
+    /* Clear exception flags and exception enables; preserve rounding mode. */
+    __hexagon_set_usr(
+        __usr
+        & ~(unsigned long)(FE_ALL_EXCEPT | ((unsigned long)FE_ALL_EXCEPT << _FE_ENABLE_SHIFT)));
+    return 0;
+}
+
+__declare_fenv_inline(int) feupdateenv(const fenv_t *__envp)
+{
+    unsigned long __flags = __hexagon_get_usr() & (unsigned long)FE_ALL_EXCEPT;
+    fesetenv(__envp);
+    feraiseexcept((int)__flags);
+    return 0;
+}
+
+__declare_fenv_inline(int) feenableexcept(int __excepts)
+{
+    unsigned long __usr = __hexagon_get_usr();
+    unsigned long __old = (__usr >> _FE_ENABLE_SHIFT) & (unsigned long)FE_ALL_EXCEPT;
+    unsigned long __new = __old | (unsigned long)(__excepts & FE_ALL_EXCEPT);
+    __hexagon_set_usr((__usr & ~((unsigned long)FE_ALL_EXCEPT << _FE_ENABLE_SHIFT))
+                      | (__new << _FE_ENABLE_SHIFT));
+    return (int)__old;
+}
+
+__declare_fenv_inline(int) fedisableexcept(int __excepts)
+{
+    unsigned long __usr = __hexagon_get_usr();
+    unsigned long __old = (__usr >> _FE_ENABLE_SHIFT) & (unsigned long)FE_ALL_EXCEPT;
+    unsigned long __new = __old & ~(unsigned long)(__excepts & FE_ALL_EXCEPT);
+    __hexagon_set_usr((__usr & ~((unsigned long)FE_ALL_EXCEPT << _FE_ENABLE_SHIFT))
+                      | (__new << _FE_ENABLE_SHIFT));
+    return (int)__old;
+}
+
+__declare_fenv_inline(int) fegetexcept(void)
+{
+    return (int)((__hexagon_get_usr() >> _FE_ENABLE_SHIFT) & (unsigned long)FE_ALL_EXCEPT);
+}

--- a/libc/machine/hexagon/machine/fenv.h
+++ b/libc/machine/hexagon/machine/fenv.h
@@ -1,0 +1,78 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef _MACHINE_FENV_H
+#define _MACHINE_FENV_H
+
+/* Exception flags */
+#define FE_INVALID    0x00000002u /* bit 1 */
+#define FE_DIVBYZERO  0x00000004u /* bit 2 */
+#define FE_OVERFLOW   0x00000008u /* bit 3 */
+#define FE_UNDERFLOW  0x00000010u /* bit 4 */
+#define FE_INEXACT    0x00000020u /* bit 5 */
+
+#define FE_ALL_EXCEPT (FE_INVALID | FE_DIVBYZERO | FE_OVERFLOW | FE_UNDERFLOW | FE_INEXACT)
+
+/* Rounding modes */
+#define FE_TONEAREST     0
+#define FE_TOWARDZERO    1
+#define FE_DOWNWARD      2
+#define FE_UPWARD        3
+
+#define _FE_RND_OFF      22u
+#define _FE_RND_MASK     0x3u
+
+#define _FE_ENABLE_SHIFT 24u
+
+/*
+ * Mask of all FP-relevant USR bits.  fegetenv/fesetenv only touch
+ * these bits so that non-FP USR fields (loop counters, etc.) are
+ * never disturbed.
+ */
+#define _FE_FP_MASK                                                                       \
+    (FE_ALL_EXCEPT | (_FE_RND_MASK << _FE_RND_OFF) | (FE_ALL_EXCEPT << _FE_ENABLE_SHIFT))
+
+typedef unsigned long fenv_t;
+typedef unsigned long fexcept_t;
+
+#if !defined(__declare_fenv_inline) && defined(__declare_extern_inline)
+#define __declare_fenv_inline(type) __declare_extern_inline(type)
+#endif
+
+#ifdef __declare_fenv_inline
+#include <machine/fenv-fp.h>
+#endif
+
+#endif /* _MACHINE_FENV_H */

--- a/libc/machine/hexagon/machine/meson.build
+++ b/libc/machine/hexagon/machine/meson.build
@@ -12,7 +12,7 @@
 #     copyright notice, this list of conditions and the following
 #     disclaimer in the documentation and/or other materials provided
 #     with the distribution.
-# 
+#
 #   * Neither the name of Qualcomm Technologies, Inc. nor the names of its
 #     contributors may be used to endorse or promote products derived
 #     from this software without specific prior written permission.
@@ -31,22 +31,14 @@
 # OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 # IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-srcs_machine = [
-  'setjmp.S',
-  'longjmp.S',
-  'tls.c',
+inc_machine_headers_machine = [
+        'fenv.h',
+        'fenv-fp.h',
 ]
 
-subdir('machine')
-
-foreach params : targets
-  target = params['name']
-  target_dir = params['dir']
-  target_c_args = params['c_args']
-	set_variable('lib_machine' + target,
-		static_library('machine' + target,
-			srcs_machine,
-			pic: false,
-			include_directories: inc,
-			c_args: target_c_args + c_args + arg_fnobuiltin))
-endforeach
+if really_install
+        install_headers(
+                inc_machine_headers_machine,
+                install_dir: include_dir / 'machine',
+        )
+endif

--- a/libm/common/pow.c
+++ b/libm/common/pow.c
@@ -313,11 +313,14 @@ pow(double x, double y)
            (|y| < 0x1p-65 or |y| >= 0x1p63 or nan).  */
         if (unlikely(zeroinfnan(iy))) {
             if (2 * iy == 0)
-                return issignaling64_inline(x) ? x + y : 1.0;
+                /* y==0 here; literal 0.0 instead of y avoids speculative +inf+(-inf) raising FE_INVALID. */
+                return issignaling64_inline(x) ? x + 0.0 : 1.0;
             if (ix == asuint64(1.0))
-                return issignaling64_inline(y) ? x + y : 1.0;
+                /* x==1.0 here; literal 1.0 instead of x, same reason as above. */
+                return issignaling64_inline(y) ? y + 1.0 : 1.0;
             if (2 * ix > 2 * asuint64((double)INFINITY) || 2 * iy > 2 * asuint64((double)INFINITY))
-                return x + y;
+                /* x or y is NaN; +0.0 propagates it safely; sNaN still raises FE_INVALID. */
+                return (2 * ix > 2 * asuint64((double)INFINITY)) ? x + 0.0 : y + 0.0;
             if (2 * ix == 2 * asuint64(1.0))
                 return 1.0;
             if ((2 * ix < 2 * asuint64(1.0)) == !(iy >> 63))

--- a/libm/common/pow.c
+++ b/libm/common/pow.c
@@ -313,7 +313,8 @@ pow(double x, double y)
            (|y| < 0x1p-65 or |y| >= 0x1p63 or nan).  */
         if (unlikely(zeroinfnan(iy))) {
             if (2 * iy == 0)
-                /* y==0 here; literal 0.0 instead of y avoids speculative +inf+(-inf) raising FE_INVALID. */
+                /* y==0 here; literal 0.0 instead of y avoids speculative +inf+(-inf) raising
+                 * FE_INVALID. */
                 return issignaling64_inline(x) ? x + 0.0 : 1.0;
             if (ix == asuint64(1.0))
                 /* x==1.0 here; literal 1.0 instead of x, same reason as above. */

--- a/libm/common/sf_exp.c
+++ b/libm/common/sf_exp.c
@@ -69,7 +69,7 @@ expf(float x)
         if (asuint(x) == asuint(-INFINITY))
             return 0.0f;
         if (abstop >= top12(INFINITY))
-            return x + x;
+            return opt_barrier_float(x) + opt_barrier_float(x);
         if (x > 0x1.62e42ep6f) /* x > log(0x1p128) ~= 88.72 */
             return __math_oflowf(0);
         if (x < -0x1.9fe368p6f) /* x < log(0x1p-150) ~= -103.97 */

--- a/libm/common/sf_exp2.c
+++ b/libm/common/sf_exp2.c
@@ -69,7 +69,7 @@ exp2f(float x)
         if (asuint(x) == asuint(-INFINITY))
             return 0.0f;
         if (abstop >= top12(INFINITY))
-            return x + x;
+            return opt_barrier_float(x) + opt_barrier_float(x);
         if (x > 0.0f)
             return __math_oflowf(0);
         if (x <= -150.0f)

--- a/libm/common/sf_expm1.c
+++ b/libm/common/sf_expm1.c
@@ -49,13 +49,13 @@ expm1f(float x)
     /* filter out huge and non-finite argument */
     if (hx >= 0x4195b844) { /* if |x|>=27*ln2 */
         if (FLT_UWORD_IS_NAN(hx))
-            return x + x;
+            return opt_barrier_float(x) + opt_barrier_float(x);
         if (FLT_UWORD_IS_INFINITE(hx))
             return (xsb == 0) ? x : -1.0f;      /* exp(+-inf)={inf,-1} */
         if (xsb == 0 && hx > FLT_UWORD_LOG_MAX) /* if x>=o_threshold */
             return __math_oflowf(0);            /* overflow */
         if (xsb != 0)                           /* x < -27*ln2, return -1.0 with inexact */
-            return __math_inexactf(tiny - one); /* return -1 */
+            return __math_inexactf(opt_barrier_float(tiny) - one); /* return -1 */
     }
 
     /* argument reduction */

--- a/libm/common/sf_finite.c
+++ b/libm/common/sf_finite.c
@@ -23,7 +23,13 @@
 int
 finitef(float x)
 {
+    /* volatile prevents Clang from replacing the integer comparison with
+       sfcmp on Hexagon, which would raise FE_INVALID for signaling NaN.  */
+#ifdef __hexagon__
+    volatile __int32_t ix;
+#else
     __int32_t ix;
+#endif
     GET_FLOAT_WORD(ix, x);
     ix &= 0x7fffffff;
     return (FLT_UWORD_IS_FINITE(ix));

--- a/libm/common/sf_fpclassify.c
+++ b/libm/common/sf_fpclassify.c
@@ -11,8 +11,13 @@
 int
 __fpclassifyf(float x)
 {
+    /* volatile prevents Clang from replacing the integer comparisons with
+       sfcmp on Hexagon, which would raise FE_INVALID for signaling NaN.  */
+#ifdef __hexagon__
+    volatile __uint32_t w;
+#else
     __uint32_t w;
-
+#endif
     GET_FLOAT_WORD(w, x);
 
     if (w == 0x00000000 || w == 0x80000000)

--- a/libm/common/sf_isinf.c
+++ b/libm/common/sf_isinf.c
@@ -25,7 +25,13 @@ is preserved.
 int
 isinff(float x)
 {
+    /* volatile prevents Clang from replacing the integer comparison with
+       sfcmp on Hexagon, which would raise FE_INVALID for signaling NaN.  */
+#ifdef __hexagon__
+    volatile __int32_t ix;
+#else
     __int32_t ix;
+#endif
     GET_FLOAT_WORD(ix, x);
     ix &= 0x7fffffff;
     return FLT_UWORD_IS_INFINITE(ix);

--- a/libm/common/sf_pow.c
+++ b/libm/common/sf_pow.c
@@ -164,11 +164,14 @@ powf(float x, float y)
         /* Either (x < 0x1p-126 or inf or nan) or (y is 0 or inf or nan).  */
         if (__builtin_expect(zeroinfnan(iy), 0)) {
             if (2 * iy == 0)
-                return issignalingf_inline(x) ? x + y : 1.0f;
+                /* y==0 here; literal 0.0f instead of y avoids speculative +inf+(-inf) raising FE_INVALID. */
+                return issignalingf_inline(x) ? x + 0.0f : 1.0f;
             if (ix == 0x3f800000)
-                return issignalingf_inline(y) ? x + y : 1.0f;
+                /* x==1.0f here; literal 1.0f instead of x, same reason as above. */
+                return issignalingf_inline(y) ? y + 1.0f : 1.0f;
             if (2 * ix > 2u * (uint32_t)0x7f800000 || 2 * iy > 2u * (uint32_t)0x7f800000)
-                return x + y;
+                /* x or y is NaN; +0.0f propagates it safely; sNaN still raises FE_INVALID. */
+                return (2 * ix > 2u * (uint32_t)0x7f800000) ? x + 0.0f : y + 0.0f;
             if (2 * ix == 2 * (uint32_t)0x3f800000)
                 return 1.0f;
             if ((2 * ix < 2 * (uint32_t)0x3f800000) == !(iy & (uint32_t)0x80000000))

--- a/libm/common/sf_pow.c
+++ b/libm/common/sf_pow.c
@@ -164,7 +164,8 @@ powf(float x, float y)
         /* Either (x < 0x1p-126 or inf or nan) or (y is 0 or inf or nan).  */
         if (__builtin_expect(zeroinfnan(iy), 0)) {
             if (2 * iy == 0)
-                /* y==0 here; literal 0.0f instead of y avoids speculative +inf+(-inf) raising FE_INVALID. */
+                /* y==0 here; literal 0.0f instead of y avoids speculative +inf+(-inf) raising
+                 * FE_INVALID. */
                 return issignalingf_inline(x) ? x + 0.0f : 1.0f;
             if (ix == 0x3f800000)
                 /* x==1.0f here; literal 1.0f instead of x, same reason as above. */

--- a/libm/math/s_pow.c
+++ b/libm/math/s_pow.c
@@ -111,7 +111,7 @@ pow64(__float64 x, __float64 y)
     /* y==zero: x**0 = 1 unless x is snan */
     if ((iy | ly) == 0) {
         if (issignaling64_inline(x))
-            return x + y;
+            return opt_barrier_double(x) + opt_barrier_double(y);
         return one;
     }
 
@@ -121,7 +121,7 @@ pow64(__float64 x, __float64 y)
         if ((((__uint32_t)hx - 0x3ff00000) | lx) == 0 && !issignaling64_inline(y))
             return one;
         else
-            return x + y;
+            return opt_barrier_double(x) + opt_barrier_double(y);
     }
 
     /* determine if y is an odd int when x < 0

--- a/libm/math/sf_exp.c
+++ b/libm/math/sf_exp.c
@@ -50,7 +50,7 @@ expf(float x) /* default IEEE double exp */
 
     /* filter out non-finite argument */
     if (FLT_UWORD_IS_NAN(hx))
-        return x + x; /* NaN */
+        return opt_barrier_float(x) + opt_barrier_float(x); /* NaN */
     if (FLT_UWORD_IS_INFINITE(hx))
         return (xsb == 0) ? x : 0.0f; /* exp(+-inf)={inf,0} */
     if (sx > FLT_UWORD_LOG_MAX)


### PR DESCRIPTION
Add fenv implementation for Hexagon architecture with exception handling and rounding mode control. Also fix signaling NaN handling in libm functions to prevent unwanted FE_INVALID exceptions on Hexagon by using volatile variables and opt_barrier macros.