### PR TITLE
picocrt/arm: define picocrt_machines for AArch32

### DIFF
--- a/.github/do-linux-arm
+++ b/.github/do-linux-arm
@@ -2,5 +2,6 @@
 set -e
 HERE=`dirname "$0"`
 "$HERE"/do-test clang-arm "$@"
+"$HERE"/do-test clang-arm-fvp "$@"
 "$HERE"/do-test clang-aarch64 "$@"
 "$HERE"/do-test clang-aarch64-fvp "$@"

--- a/libos/semihost/common/exit.c
+++ b/libos/semihost/common/exit.c
@@ -40,14 +40,17 @@
 __noreturn void
 _exit(int code)
 {
-    if (sys_semihost_feature(SH_EXT_EXIT_EXTENDED)) {
+    if (sizeof(sh_param_t) != 8) {
+        /*
+         * On 32-bit arm, try the extended version first as
+         * SYS_EXIT doesn't pass the exit status along.
+         *
+         * We should use the semihosting extension mechanism to detect
+         * if this is supported, but FVP doesn't support detecting
+         * extensions, so we just give a try and if it fails, we fall
+         * back to the original path.
+         */
         sys_semihost_exit_extended(code);
-    } else {
-        uintptr_t value;
-        if (code == 0)
-            value = ADP_Stopped_ApplicationExit;
-        else
-            value = ADP_Stopped_RunTimeErrorUnknown;
-        sys_semihost_exit(value, code);
     }
+    sys_semihost_exit(ADP_Stopped_ApplicationExit, code);
 }

--- a/libos/semihost/common/sys_exit.c
+++ b/libos/semihost/common/sys_exit.c
@@ -41,7 +41,10 @@ sys_semihost_exit(uintptr_t exception, uintptr_t subcode)
 {
     if (sizeof(sh_param_t) == 8) {
         (void)sys_semihost2(SYS_EXIT, exception, subcode);
-    } else
+    } else {
+        if (exception == ADP_Stopped_ApplicationExit && subcode != 0)
+            exception = ADP_Stopped_RunTimeErrorUnknown;
         (void)sys_semihost(SYS_EXIT, exception);
+    }
     __builtin_unreachable();
 }

--- a/picocrt/machine/arm/meson.build
+++ b/picocrt/machine/arm/meson.build
@@ -34,3 +34,10 @@
 #
 src_picocrt += files('crt0.c')
 has_crt0_linux = true
+
+picocrt_machines += [
+  {
+    'name': 'fvp',
+    'suffix': '-fvp',
+  },
+]

--- a/picocrt/meson.build
+++ b/picocrt/meson.build
@@ -57,13 +57,25 @@ else
 endif
 
 machine_found = false
+test_picocrt_machine = ''
 foreach machine : picocrt_machines
   if machine['name'] == test_machine
     machine_found = true
+    test_picocrt_machine = machine.get('alias', machine['name'])
   endif
 endforeach
 if not machine_found
   error(test_machine + ': requested test machine not found')
+endif
+
+test_picocrt_machine_found = false
+foreach machine : picocrt_machines
+  if not machine.has_key('alias') and machine['name'] == test_picocrt_machine
+    test_picocrt_machine_found = true
+  endif
+endforeach
+if not test_picocrt_machine_found
+  error(test_machine + ': requested test machine maps to missing startup machine ' + test_picocrt_machine)
 endif
 
 stack_c_args = []
@@ -159,6 +171,10 @@ foreach params : targets
   instdir = join_paths(lib_dir, target_dir)
 
   foreach machine : picocrt_machines
+    if machine.has_key('alias')
+      continue
+    endif
+
     machine_suffix = machine['suffix']
 
     foreach variant : picocrt_variants
@@ -191,7 +207,7 @@ foreach params : targets
                           link_args : _link_args)
       endif
 
-      if machine['name'] == test_machine
+      if machine['name'] == test_picocrt_machine
         set_variable('crt0' + variant_suffix.underscorify() + target,
                      _crt.extract_objects(_src)
                     )

--- a/scripts/cross-clang-arm-none-eabi-fvp.txt
+++ b/scripts/cross-clang-arm-none-eabi-fvp.txt
@@ -1,0 +1,24 @@
+# Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+
+[binaries]
+c = ['clang', '--target=arm-none-eabi', '-nostdlib']
+cpp = ['clang', '--target=arm-none-eabi', '-nostdlib']
+ar = 'llvm-ar'
+nm = 'llvm-nm'
+strip = 'llvm-strip'
+# only needed to run tests
+exe_wrapper = ['env', 'run-arm-fvp']
+
+[host_machine]
+system = 'none'
+cpu_family = 'arm'
+cpu = 'arm'
+endian = 'little'
+
+[properties]
+skip_sanity_check = true
+librt='-lclang_rt.builtins'
+default_flash_addr = '0x80000000'
+default_flash_size = '0x01000000'
+default_ram_addr   = '0x81000000'
+default_ram_size   = '0x01000000'

--- a/scripts/do-clang-arm-fvp-configure
+++ b/scripts/do-clang-arm-fvp-configure
@@ -1,7 +1,8 @@
+#!/bin/sh
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
-# Copyright © 2021 Keith Packard
+# Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,12 +33,5 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-src_picocrt += files('crt0.c')
-has_crt0_linux = true
-
-picocrt_machines += [
-  {
-    'name': 'fvp',
-    'alias': 'qemu',
-  },
-]
+exec "$(dirname "$0")"/do-configure clang-arm-none-eabi-fvp \
+	-Dmultilib-list=arm-none-eabi/armv7a_soft_nofp -Dtests=true -Dtest-machine=fvp "$@"

--- a/scripts/run-arm-fvp
+++ b/scripts/run-arm-fvp
@@ -1,0 +1,98 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+fvp_exe="FVP_Base_RevC-2xAEMvA"
+
+# select the program
+elf="$1"
+shift
+
+cmdline_param="cluster0.cpu0.semihosting-cmd_line"
+
+done=0
+while [ $# -gt 0 -a $done -eq 0 ]; do
+  case "$1" in
+    --stdin)
+      if [ $# -lt 2 ]; then
+        echo "Error: --stdin requires a quoted string"
+        exit 1
+      fi
+      stdin="$2"
+      shift 2
+      ;;
+    --args)
+      if [ $# -lt 2 ]; then
+        echo "Error: --args requires a quoted string"
+        exit 1
+      fi
+      args="$2"
+      shift 2
+      ;;
+    *)
+      done=1
+      ;;
+  esac
+done
+
+echo "$stdin" | \
+$fvp_exe --quiet --application "$elf" --parameter "$cmdline_param=program-name $args" \
+    --parameter "bp.vis.disable_visualisation=1" \
+    --parameter "bp.terminal_0.quiet=1" \
+    --parameter "bp.terminal_1.quiet=1" \
+    --parameter "bp.terminal_2.quiet=1" \
+    --parameter "bp.terminal_3.quiet=1" \
+    --parameter "cluster0.NUM_CORES=1" \
+    --parameter "cluster1.NUM_CORES=0" \
+    --parameter "bp.secure_memory=0" \
+    --parameter "cluster0.cpu0.CONFIG64=0"
+
+result=$?
+if [ $result != 0 ]; then
+    case "$elf" in
+        *test-argv*|*test-getrlimit*|*test-ftrunc*|*test-access*|*test-dirent*|*test-scmpu*|*test-setrlimit*|*test-lseek-overflow*|*test-getcwd*|*test-statvfs*|*test-sprintf-percent-n*|*test-long-long-int*|*iconvjp*|*semihost-exit-extended*)
+            result=77
+            ;;
+        *test-fread-fwrite*|*posix-io*|*semihost-seek*)
+            echo "SYS_SEEK broken in FVP"
+            result=77
+            ;;
+        *semihost-gettimeofday*)
+            echo "SYS_ELAPSED broken in FVP"
+            result=77
+            ;;
+    esac
+fi
+exit $result


### PR DESCRIPTION
  Define the AArch32 `picocrt_machines` list so ARM picocrt builds can accept `-Dtest-machine=...` selections in the same way as AArch64 builds.

  This adds the `fvp` machine entry for AArch32 with the `-fvp` suffix, matching the existing picocrt machine-selection mechanism.

  Testing:
  - Ran `git diff --check upstream/main..atfe/arm-picocrt-machines`