### PR TITLE
build: support libc++ linking

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1443,6 +1443,18 @@ NEWLIB_MAJOR_VERSION=4
 NEWLIB_MINOR_VERSION=3
 NEWLIB_PATCHLEVEL_VERSION=0
 
+conf_data.set('_GNU_SOURCE', '',
+        description: '''Enable GNU functions like strtof_l.
+It's necessary to set this globally because inline functions in
+libc++ headers call the GNU functions.'''
+)
+
+conf_data.set('_PICOLIBC_CTYPE_SMALL', '0',
+        description: '''Disable picolibc's small ctype implementation.
+libc++ expects newlib-style ctype tables, and also expects support for locales
+and extended character sets, so picolibc's small ctype is not compatible with it'''
+)
+
 conf_data.set('__HAVE_CC_INHIBIT_LOOP_TO_LIBCALL',
 	      cc.has_argument('-fno-tree-loop-distribute-patterns'),
 	      description: 'Compiler flag to prevent detecting memcpy/memset patterns')

--- a/picolibc.ld.in
+++ b/picolibc.ld.in
@@ -70,6 +70,9 @@ SECTIONS
 		*(.literal.startup .text.startup .literal.startup.* .text.startup.*)
 		*(SORT(.text.sorted.*))
 		*(.literal .text .literal.* .text.* .opd .opd.* .branch_lt .branch_lt.* @EXTRA_TEXT_SECTIONS@)
+		PROVIDE (__start___lcxx_override = .);
+		*(__lcxx_override)
+		PROVIDE (__stop___lcxx_override = .);
 		*(.gnu.linkonce.t.*)
 		KEEP (*(.fini .fini.*))
 		@PREFIX@__text_end = .;


### PR DESCRIPTION
  Add the build configuration and linker-script support needed for applications linked against libc++.

  This change:
  - enables GNU interfaces globally so libc++ headers can use functions such as `strtof_l`
  - disables Picolibc's small ctype implementation, since libc++ expects newlib-style ctype tables and locale-capable behavior
  - adds the `__lcxx_override` linker section bounds used by libc++ override machinery

  The ctype/default-size tradeoff is intentional for libc++ compatibility, but called out here because it changes configuration
  generated by the build.

  Testing:
  - Ran `git diff --check upstream/main..atfe/libcxx-build-support`
