### PR TITLE
aarch64: add minimal SME runtime support

### DIFF
--- a/picocrt/machine/aarch64/crt0.S
+++ b/picocrt/machine/aarch64/crt0.S
@@ -153,6 +153,12 @@ __identity_page_table:
          */
 #define SMCR_EL1 S3_0_c1_c2_6
 
+#if defined(MACHINE_qemu)
+#define SMCR_BOOT_EL SMCR_EL1
+#elif defined(MACHINE_fvp) && __ARM_ARCH_PROFILE != 'R'
+#define SMCR_BOOT_EL SMCR_EL3
+#endif
+
 /************ Entry point ************/
 
   // Defined in crt0.c
@@ -198,6 +204,7 @@ _start:
 #error "Unknown machine type"
 #endif
 
+#ifdef SMCR_BOOT_EL
 	/* Determine if SME or SME2 is available */
 	bl      __arm_has_sme
 	cbz     x0, .Lnosme
@@ -217,13 +224,14 @@ _start:
 	mov     x2, #0xF
 
 	/* Try to set the maximum value supported by the architecture (2048). */
-	mrs     x1, BOOT_EL(SMCR) /* mrs  x1, smcr */
+	mrs     x1, SMCR_BOOT_EL /* mrs  x1, smcr */
 	bfi     x1, x2, 0, 4
-	msr     BOOT_EL(SMCR), x1 /* msr  smcr, x1 */
+	msr     SMCR_BOOT_EL, x1 /* msr  smcr, x1 */
 	isb
 
 .Lnosme:
 
+#endif
 
 #endif // __ARM_FP
 #endif


### PR DESCRIPTION
  Add minimal AArch64 SME runtime support for bare-metal picocrt/libc builds.

  This series:
  - detects SME/SME2 availability during AArch64 crt0 startup
  - clears `TPIDR2_EL0` before entering C runtime code
  - initializes the streaming SVE vector length through `SMCR_EL3`
  - records SME availability after memory initialization
  - adds `__arm_sme_state` so callers can query SME state, `SVCR`, and `TPIDR2_EL0`
  - builds the new SME ABI routine in both Meson and CMake AArch64 libc builds

  The startup-side state and libc ABI routine are kept in one PR because `__arm_sme_state` depends on the SME availability detected by
  crt0.

  Notes for review:
  - This assumes bare-metal startup has access to the relevant AArch64 system registers.
  - The new `sme-abi.S` file uses `MIT OR Apache-2.0 WITH LLVM-exception`; please confirm this is acceptable for this AArch64 machine
  code.

  Testing:
  - Ran `git diff --check upstream/main..atfe/aarch64-sme-runtime`