### PR TITLE
scripts: add MicroBlaze little-endian cross-clang build config

### DIFF
--- a/scripts/cross-clang-microblazeel-unknown-elf.txt
+++ b/scripts/cross-clang-microblazeel-unknown-elf.txt
@@ -1,0 +1,22 @@
+[binaries]
+c = ['/Users/sprice5/src/claude-mb/llvm-build/bin/clang', '--target=microblazeel-unknown-elf', '-nostdlib']
+cpp = ['/Users/sprice5/src/claude-mb/llvm-build/bin/clang', '--target=microblazeel-unknown-elf', '-nostdlib']
+c_ld = '/Users/sprice5/src/claude-mb/llvm-build/bin/ld.lld'
+cpp_ld = '/Users/sprice5/src/claude-mb/llvm-build/bin/ld.lld'
+ar = '/Users/sprice5/src/claude-mb/llvm-build/bin/llvm-ar'
+nm = '/Users/sprice5/src/claude-mb/llvm-build/bin/llvm-nm'
+strip = '/Users/sprice5/src/claude-mb/llvm-build/bin/llvm-strip'
+
+[host_machine]
+system = 'none'
+cpu_family = 'microblaze'
+cpu = 'microblazeel'
+endian = 'little'
+
+[properties]
+skip_sanity_check = true
+has_link_defsym = true
+default_flash_addr = '0x00000000'
+default_flash_size = '0x08000000'
+default_ram_addr   = '0x08000000'
+default_ram_size   = '0x10000000'


### PR DESCRIPTION
## Summary

- Adds `scripts/cross-clang-microblazeel-unknown-elf.txt`, a Meson cross-file for building picolibc targeting `microblazeel-unknown-elf` with a Clang/LLVM toolchain.

Targets the MicroBlaze soft-core processor (little-endian variant) running bare-metal. Intended for use alongside the upstream LLVM MicroBlaze backend restoration effort.

Usage:
```sh
mkdir build && cd build
meson setup --cross-file ../scripts/cross-clang-microblazeel-unknown-elf.txt ..
ninja
```

## Test plan
- [ ] `meson setup` succeeds with the cross file
- [ ] `ninja` produces `libm.a` and `libc.a` for `microblazeel-unknown-elf`
- [ ] Basic math functions link and run correctly under QEMU `petalogix-s3adsp1800`

🤖 Generated with [Claude Code](https://claude.com/claude-code)