### PR TITLE
stdio: Call _bufio_exit_flush from fflush when -Dstdio-exit-flush=true

### DIFF
--- a/.github/workflows/linux-arm.yml
+++ b/.github/workflows/linux-arm.yml
@@ -65,7 +65,7 @@ jobs:
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
           "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
-          "-Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
+          "-Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [
           "./.github/do-linux-arm-linux",
@@ -100,7 +100,7 @@ jobs:
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
           "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
-          "-Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
+          "-Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [
           "./.github/do-linux-arm-linux",

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -96,7 +96,7 @@ jobs:
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
           "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
-          "-Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
+          "-Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [
           "./.github/do-linux-arm",
@@ -131,7 +131,7 @@ jobs:
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
           "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
-          "-Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
+          "-Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [
           "./.github/do-linux-riscv",
@@ -166,7 +166,7 @@ jobs:
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
           "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
-          "-Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
+          "-Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [
           "./.github/do-linux-misc",
@@ -201,7 +201,7 @@ jobs:
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
           "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
-          "-Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
+          "-Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [
           "./.github/do-linux-arm",
@@ -236,7 +236,7 @@ jobs:
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
           "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
-          "-Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
+          "-Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [
           "./.github/do-linux-riscv",
@@ -271,7 +271,7 @@ jobs:
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
           "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
-          "-Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
+          "-Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [
           "./.github/do-linux-misc",

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -62,7 +62,7 @@ jobs:
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
           "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
-          "-Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
+          "-Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [
           "./.github/do-native-math",
@@ -97,7 +97,7 @@ jobs:
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
           "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
-          "-Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
+          "-Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [
           "./.github/do-native-math",

--- a/.github/workflows/variants
+++ b/.github/workflows/variants
@@ -7,5 +7,5 @@
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
           "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
-          "-Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
+          "-Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -62,7 +62,7 @@ jobs:
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
           "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
-          "-Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
+          "-Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [
           "./.github/do-zephyr",
@@ -97,7 +97,7 @@ jobs:
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
           "-Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
-          "-Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
+          "-Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [
           "./.github/do-zephyr",

--- a/libc/stdio/fflush.c
+++ b/libc/stdio/fflush.c
@@ -35,25 +35,30 @@
 
 #include "local-stdio.h"
 
+static int
+fflush_unlocked(FILE *stream)
+{
+    int ret;
+    __flockfile(stream);
+    ret = __fflush_locked(stream);
+    __funlock_return(stream, ret);
+}
+
 int
 fflush(FILE *stream)
 {
-    int ret = 0;
 #ifdef __STDIO_EXIT_FLUSH
     if (stream == NULL) {
-        void                _bufio_exit_flush(void) __weak;
         extern FILE * const stdout __weak;
         extern FILE * const stderr __weak;
         if (_bufio_exit_flush)
             _bufio_exit_flush();
         if (&stdout)
-            fflush(stdout);
+            fflush_unlocked(stdout);
         if (&stderr)
-            fflush(stderr);
+            fflush_unlocked(stderr);
         return 0;
     }
 #endif
-    __flockfile(stream);
-    ret = __fflush_locked(stream);
-    __funlock_return(stream, ret);
+    return fflush_unlocked(stream);
 }

--- a/libc/stdio/local-stdio.h
+++ b/libc/stdio/local-stdio.h
@@ -262,7 +262,9 @@ bufio_remove_file(FILE *f)
 #define bufio_remove_file(f)
 #endif
 
-int __stdio_flags(const char *mode, int *optr);
+int  __stdio_flags(const char *mode, int *optr);
+
+void _bufio_exit_flush(void) __weak;
 
 #ifdef __STDIO_LOCKING
 void __flockfile_init(FILE *f);

--- a/test/test-stdio/meson.build
+++ b/test/test-stdio/meson.build
@@ -81,6 +81,7 @@ if tests_enable_posix_io
     'test-dprintf',
     'test-fgetc',
     'test-fgets-eof',
+    'test-fflush',
     'test-fopen',
     'test-fread-fwrite',
     'test-mktemp',

--- a/test/test-stdio/test-fflush.c
+++ b/test/test-stdio/test-fflush.c
@@ -33,32 +33,76 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "local-stdio.h"
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
-#ifdef __STDIO_EXIT_FLUSH
-
-FILE *__stdio_file_list;
-
-void
-_bufio_exit_flush(void)
-{
-    for (;;) {
-        __LIBC_LOCK();
-        FILE                *f = __stdio_file_list;
-        struct __file_bufio *bf = (struct __file_bufio *)f;
-        if (bf)
-            __stdio_file_list = bf->next;
-        __LIBC_UNLOCK();
-        if (!f)
-            break;
-        fflush(f);
-    }
-}
-
-__attribute__((constructor)) static void
-_bufio_exit_register(void)
-{
-    atexit(_bufio_exit_flush);
-}
-
+#if !defined(__PICOLIBC__) || defined(__STDIO_EXIT_FLUSH)
+#define USE_FFLUSH_NULL
 #endif
+
+#ifndef TEST_FILE_NAME
+#define TEST_FILE_NAME "fflush-test-file"
+#endif
+
+static const char file_name[] = TEST_FILE_NAME;
+static const char test_string[] = "hello, world\n";
+
+static void
+test_cleanup(void)
+{
+    remove(file_name);
+}
+
+static int
+test_cmp(FILE *f, const char *t)
+{
+    int c;
+    while ((c = getc(f)) != EOF) {
+        if ((char)c != *t) {
+            printf("read incorrect byte %c != %c\n", c, *t);
+            return 1;
+        }
+        t++;
+    }
+    if (*t != '\0') {
+        printf("read EOF instead of %c\n", *t);
+        return 1;
+    }
+    return 0;
+}
+
+int
+main(void)
+{
+    FILE *out, *in;
+
+    atexit(test_cleanup);
+    out = fopen(file_name, "w");
+    if (!out) {
+        printf("failed to open \"%s\" for writing\n", file_name);
+        return 1;
+    }
+    in = fopen(file_name, "r");
+    if (!in) {
+        printf("failed to open \"%s\" for reading\n", file_name);
+        return 1;
+    }
+
+    if ((size_t)fprintf(out, "%s", test_string) != strlen(test_string)) {
+        printf("failed to fprintf test string %s\n", test_string);
+        return 1;
+    }
+#ifdef USE_FFLUSH_NULL
+    fflush(NULL);
+#else
+    fflush(out);
+#endif
+
+    if (test_cmp(in, test_string))
+        return 1;
+
+    printf("success\n");
+    exit(0);
+}


### PR DESCRIPTION
The stdio-exit-flush code records all allocated FILE structs so that they can be flushed at exit time (as required by POSIX). (This is optional, as most embedded systems don't use exit at all, and the overhead of including all of the necessary code isn't useful there).

This same list can be used for fflush(NULL), and the code was all in place. However, it uses a __weak reference to _bufio_exit_flush to avoid pulling in all of the bufio code unless some bufio FILE is used by the application. The definition of _bufio_exit_flush was made static, so the __weak symbol would not be resolved when that function was linked in, breaking this operation.

Change that symbol to extern, move the __weak definition to local-stdio.h so that we'll verify that the definition and declaration match.

Add a test for fflush(NULL) to make sure this all works as designed.

This is intended to replace #1302 