### PR TITLE
[riscv][crt] Add Support for Xqccmt

### DIFF
--- a/picocrt/machine/riscv/crt0.c
+++ b/picocrt/machine/riscv/crt0.c
@@ -174,7 +174,7 @@ _trap(void)
 #endif
             ".option	pop");
 
-#ifdef __riscv_zcmt
+#if defined(__riscv_zcmt) || defined(__riscv_xqccmt)
     __asm__(".weak __jvt_base$\n"
 #ifdef __riscv_cmodel_large
             "ld t0, .trap_jvt_base\n"
@@ -206,7 +206,7 @@ _trap(void)
     __asm__(".align 3\n"
             ".trap_sp: .dword __stack\n" /* FIXME: this is __heap_end in non-large code models. */
             ".trap_gp: .dword __global_pointer$\n"
-#ifdef __riscv_zcmt
+#if defined(__riscv_zcmt) || defined(__riscv_xqccmt)
             ".trap_jvt_base: .dword __jvt_base$\n"
 #endif
     );
@@ -256,7 +256,7 @@ _start(void)
             "csrwi	vxrm, 1");
 #endif
 
-#ifdef __riscv_zcmt
+#if defined(__riscv_zcmt) || defined(__riscv_xqccmt)
     __asm__(".weak __jvt_base$\n"
 #ifdef __riscv_cmodel_large
             "ld t0, .start_jvt_base\n"
@@ -294,7 +294,7 @@ _start(void)
 #ifdef CRT0_SEMIHOST
             ".start_trap: .dword _trap\n"
 #endif
-#ifdef __riscv_zcmt
+#if defined(__riscv_zcmt) || defined(__riscv_xqccmt)
             ".start_jvt_base: .dword __jvt_base$\n"
 #endif
     );

--- a/test/test-riscv-jvt.c
+++ b/test/test-riscv-jvt.c
@@ -36,7 +36,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#if !defined(__riscv) || !defined(__riscv_jvt)
+#if !defined(__riscv) || (!defined(__riscv_zcmt) && !defined(__riscv_xqccmt))
 
 const char    *get_message(void);
 
@@ -77,7 +77,7 @@ main(void)
     /*
      * This is a RISC-V specific feature.
      */
-#if !defined(__riscv) || !defined(__riscv_zcmt)
+#if !defined(__riscv) || (!defined(__riscv_zcmt) && !defined(__riscv_xqccmt))
     printf("jvt not supported for this target\n");
     return 77;
 #else


### PR DESCRIPTION
Xqccmt is a vendor-specific variant of Zcmt with additional capabilities. Enabling it in the CRT is exactly the same as for Zcmt - the `jvt` csr nees to be initialised with `__jvt_base$`.