### PR TITLE
stdio: Reject invalid whence in fmemopen seek

### DIFF
--- a/libc/stdio/fmemopen.c
+++ b/libc/stdio/fmemopen.c
@@ -113,6 +113,9 @@ __fmem_seek(FILE *f, off_t pos, int whence)
     case SEEK_END:
         pos += mf->size;
         break;
+    default:
+        errno = EINVAL;
+        return EOF;
     }
     _Static_assert(sizeof(off_t) >= sizeof(size_t), "must avoid truncation");
     if (pos < 0 || (off_t)mf->bufsize < pos)

--- a/test/test-stdio/test-fmemopen.c
+++ b/test/test-stdio/test-fmemopen.c
@@ -1177,6 +1177,27 @@ ATF_TC_BODY(test22, tc)
     }
 }
 
+ATF_TC(test23);
+ATF_TC_HEAD(test23, tc)
+{
+    atf_tc_set_md_var(tc, "descr", "test23");
+}
+ATF_TC_BODY(test23, tc)
+{
+    char  buf[BUFSIZ] = "contents";
+    FILE *fp = fmemopen(buf, sizeof(buf), "r+");
+
+    ATF_CHECK(fp != NULL);
+    ATF_CHECK(fseeko(fp, (off_t)2, SEEK_SET) == 0);
+
+    errno = 0;
+    ATF_CHECK(fseeko(fp, (off_t)0, INT_MAX) == -1);
+    ATF_CHECK(errno == EINVAL);
+    ATF_CHECK(ftello(fp) == (off_t)2);
+
+    ATF_CHECK(fclose(fp) == 0);
+}
+
 ATF_TP_ADD_TCS(tp)
 {
     ATF_TP_ADD_TC(tp, test00);
@@ -1202,6 +1223,7 @@ ATF_TP_ADD_TCS(tp)
     ATF_TP_ADD_TC(tp, test20);
     ATF_TP_ADD_TC(tp, test21);
     ATF_TP_ADD_TC(tp, test22);
+    ATF_TP_ADD_TC(tp, test23);
 
     return atf_no_error();
 }


### PR DESCRIPTION
## Problem

`__fmem_seek()` handles `SEEK_SET`, `SEEK_CUR`, and `SEEK_END`, but had no default branch. Any other `whence` value therefore kept the supplied offset unchanged and could be accepted as a successful absolute seek.

For example, after positioning an `fmemopen()` stream at offset 2, `fseeko(fp, 0, INT_MAX)` returned success and moved the stream to offset 0. POSIX requires an invalid `whence` to fail with `EINVAL` ([fseek/fseeko specification](https://pubs.opengroup.org/onlinepubs/9799919799/functions/fseek.html)).

## Fix

Reject unsupported seek origins before updating the memory-stream position, set `errno` to `EINVAL`, and return the seek callback's failure value.

The regression test checks all three observable properties: `fseeko()` returns `-1`, `errno` is `EINVAL`, and the previous stream position remains unchanged.

## Verification

- The new test fails against the unmodified Picolibc implementation because the invalid seek is accepted.
- Rebuilt the Picolibc static implementation and ran `test-fmemopen`: `test00` through `test23` all pass.
- Built and ran the same suite against the native glibc implementation: `test00` through `test23` all pass.
- The affected target was compiled with GCC 13, C18, `-Wall -Wextra -Werror`, `-fanalyzer`, and `-fsanitize=bounds`.
- `git diff --check` passes.

A full repository `ninja` invocation is currently blocked later by an unrelated pre-existing GCC C++ preprocessing error in `sys/cdefs.h`; the library and both affected test targets build and run successfully.
