### PR TITLE
stdio: fix getdelim capacity and EOF handling

### DIFF
--- a/libc/stdio/getdelim.c
+++ b/libc/stdio/getdelim.c
@@ -34,6 +34,7 @@
  */
 
 #include "local-stdio.h"
+#include <stdint.h>
 
 #define INCR 16
 
@@ -50,7 +51,18 @@ getdelim(char ** restrict lineptr, size_t * restrict nptr, int delim, FILE * res
         if (c == EOF)
             break;
 
-        if (count >= (ssize_t)n) {
+        if ((size_t)count == (SIZE_MAX >> 1)) {
+            errno = EOVERFLOW;
+            count = -1;
+            break;
+        }
+
+        if ((size_t)count + 1 >= n) {
+            if (n > SIZE_MAX - INCR) {
+                errno = ENOMEM;
+                count = -1;
+                break;
+            }
             size_t newsize = n + INCR;
             char  *newline = realloc(line, newsize);
             if (newline == NULL) {
@@ -62,11 +74,14 @@ getdelim(char ** restrict lineptr, size_t * restrict nptr, int delim, FILE * res
         }
 
         line[count++] = c;
-        if (c == delim) {
-            line[count] = '\0';
+        if (c == delim)
             break;
-        }
     }
+
+    if (count > 0)
+        line[count] = '\0';
+    else if (count == 0)
+        count = -1;
 
     *lineptr = line;
     *nptr = n;

--- a/test/test-posix/test-getdelim.c
+++ b/test/test-posix/test-getdelim.c
@@ -66,6 +66,68 @@ main(void)
             result |= 4;
         free(line);
     }
+    {
+        char  *line = NULL;
+        size_t siz = 0;
+        if (getdelim(&line, &siz, '\n', in) != -1 ||
+            getdelim(&line, &siz, '\n', in) != -1)
+            result |= 8;
+        free(line);
+    }
     fclose(in);
+
+    {
+        static const char input[] = "\n";
+        FILE             *one = fmemopen((void *)input, sizeof(input) - 1, "r");
+        char             *line = malloc(2);
+        size_t            siz = 1;
+        int               len;
+
+        if (!one || !line)
+            return 1;
+        line[0] = 'x';
+        line[1] = 'x';
+        len = getdelim(&line, &siz, '\n', one);
+        if (!(len == 1 && siz >= 2 && line[0] == '\n' && line[1] == '\0'))
+            result |= 16;
+        free(line);
+        fclose(one);
+    }
+
+    {
+        static const char input[] = "123456789012345\n";
+        FILE             *exact = fmemopen((void *)input, sizeof(input) - 1, "r");
+        char             *line = malloc(sizeof(input));
+        size_t            siz = sizeof(input) - 1;
+        int               len;
+
+        if (!exact || !line)
+            return 1;
+        memset(line, 'x', sizeof(input));
+        len = getdelim(&line, &siz, '\n', exact);
+        if (!(len == (int)sizeof(input) - 1 && siz >= sizeof(input) &&
+              memcmp(line, input, sizeof(input)) == 0))
+            result |= 32;
+        free(line);
+        fclose(exact);
+    }
+
+    {
+        static const char input[] = "tail";
+        FILE             *partial = fmemopen((void *)input, sizeof(input) - 1, "r");
+        char             *line = malloc(8);
+        size_t            siz = 8;
+        int               len;
+
+        if (!partial || !line)
+            return 1;
+        memset(line, 'x', siz);
+        len = getdelim(&line, &siz, '\n', partial);
+        if (!(len == (int)sizeof(input) - 1 && strcmp(line, input) == 0))
+            result |= 64;
+        free(line);
+        fclose(partial);
+    }
+
     return result;
 }


### PR DESCRIPTION
## Summary

- reserve space for the terminating NUL when growing the caller buffer
- terminate a final partial record and return `-1` when EOF arrives before any bytes
- reject results that cannot be represented by `ssize_t`
- cover one-byte, exact-capacity, partial-record, and repeated-EOF cases

## Testing

- Picolibc CMake x86_64 `test-getdelim` build and QEMU run
- GCC 13 `-Wall -Wextra -Werror -fanalyzer` with ASan and UBSan
- reduced-limit `EOVERFLOW` harness and glibc behavior comparison