### PR TITLE
stdio: return partial fgetws lines at EOF

### DIFF
--- a/libc/stdio/fgetws.c
+++ b/libc/stdio/fgetws.c
@@ -40,8 +40,11 @@ __STDIO_UNLOCKED(fgetws)(wchar_t *str, int size, FILE *stream)
 
     size--;
     for (c = 0, cp = str; c != L'\n' && size > 0; size--, cp++) {
-        if ((c = __STDIO_UNLOCKED(getwc)(stream)) == WEOF)
-            return NULL;
+        if ((c = __STDIO_UNLOCKED(getwc)(stream)) == WEOF) {
+            if (cp == str)
+                return NULL;
+            break;
+        }
         *cp = (wchar_t)c;
     }
     *cp = L'\0';

--- a/test/test-stdio/test-wchar.c
+++ b/test/test-stdio/test-wchar.c
@@ -50,6 +50,7 @@ main(void)
     FILE          *file;
     const wchar_t *ref;
     wint_t         res;
+    wchar_t        buf[8];
 
     /* Create testfile.dat in write mode */
     file = fopen(TEST_FILE_NAME, "w");
@@ -79,6 +80,40 @@ main(void)
         unlink(TEST_FILE_NAME);
         return 1;
     }
+
+    fclose(file);
+
+    file = fopen(TEST_FILE_NAME, "w");
+    if (file == NULL)
+        return 1;
+    if (fputws(L"Hello", file) < 0) {
+        fclose(file);
+        unlink(TEST_FILE_NAME);
+        return 1;
+    }
+    fclose(file);
+
+    file = fopen(TEST_FILE_NAME, "r");
+    if (file == NULL) {
+        unlink(TEST_FILE_NAME);
+        return 1;
+    }
+
+    if (fgetws(buf, sizeof(buf) / sizeof(buf[0]), file) == NULL ||
+        wcscmp(buf, L"Hello") != 0) {
+        printf("Test Failed: fgetws discarded a partial line at EOF\n");
+        fclose(file);
+        unlink(TEST_FILE_NAME);
+        return 1;
+    }
+    if (fgetws(buf, sizeof(buf) / sizeof(buf[0]), file) != NULL) {
+        printf("Test Failed: fgetws did not report an empty EOF\n");
+        fclose(file);
+        unlink(TEST_FILE_NAME);
+        return 1;
+    }
+
+    fclose(file);
 
     printf("Test Passed: Wide characters were written & read successfuly\n");
     unlink(TEST_FILE_NAME);

--- a/test/test-stdio/test-wchar.c
+++ b/test/test-stdio/test-wchar.c
@@ -99,8 +99,7 @@ main(void)
         return 1;
     }
 
-    if (fgetws(buf, sizeof(buf) / sizeof(buf[0]), file) == NULL ||
-        wcscmp(buf, L"Hello") != 0) {
+    if (fgetws(buf, sizeof(buf) / sizeof(buf[0]), file) == NULL || wcscmp(buf, L"Hello") != 0) {
         printf("Test Failed: fgetws discarded a partial line at EOF\n");
         fclose(file);
         unlink(TEST_FILE_NAME);


### PR DESCRIPTION
## What changed

`fgetws()` returned `NULL` whenever `getwc()` reached EOF, even after characters had already been stored in the caller's buffer. A final wide-character record without a newline was therefore discarded.

The EOF path now mirrors `fgets()`: an empty record returns `NULL`, while a partially read record is NUL-terminated and returned. The regression test covers a newline-free `Hello` record and confirms the following empty EOF still returns `NULL`.

## Tests

- Real-source `libc/stdio/fgetws.c` harness: detached baseline fails on the partial record; this branch passes.
- MinGW GCC 8: `-std=c11 -Wall -Wextra -Werror`.
- Linux GCC with AddressSanitizer and UBSan: pass.
- Host `test-wchar` regression with MinGW and glibc: pass.

A complete local Picolibc Meson build was not available because the installed Meson 1.3.2 rejects the repository's existing `build_subdir` keyword; the CI configuration remains unchanged and will exercise the integrated test.