### PR TITLE
stdio: reject zero-length ecvt output buffers

### DIFF
--- a/libc/stdio/ecvt_r.c
+++ b/libc/stdio/ecvt_r.c
@@ -49,7 +49,7 @@ ecvt_r(double invalue, int ndigit, int *decpt, int *sign, char *buf, size_t len)
     if (ndigit < 0)
         ndigit = 0;
 
-    if ((size_t)ndigit > len - 1)
+    if (len == 0 || (size_t)ndigit >= len)
         return -1;
 
     if (!isfinite(invalue)) {

--- a/libc/stdio/ecvtf_r.c
+++ b/libc/stdio/ecvtf_r.c
@@ -47,7 +47,7 @@ ecvtf_r(float invalue, int ndigit, int *decpt, int *sign, char *buf, size_t len)
     if (ndigit < 0)
         ndigit = 0;
 
-    if ((size_t)ndigit > len - 1)
+    if (len == 0 || (size_t)ndigit >= len)
         return -1;
 
     ngot = __ftoa_engine(asuint(invalue), &dtoa, ndigit, false, 0);

--- a/libc/stdio/ecvtl_r.c
+++ b/libc/stdio/ecvtl_r.c
@@ -49,7 +49,7 @@ ecvtl_r(long double invalue, int ndigit, int *decpt, int *sign, char *buf, size_
     if (ndigit < 0)
         ndigit = 0;
 
-    if ((size_t)ndigit > len - 1)
+    if (len == 0 || (size_t)ndigit >= len)
         return -1;
 
     if (!isfinite(invalue)) {

--- a/test/test-stdlib/test-efcvt.c
+++ b/test/test-stdlib/test-efcvt.c
@@ -206,6 +206,19 @@ const struct test fcvtf_tests[] = {
         }                                                                                        \
     } while (0)
 
+#define zero_len_test(func, value)                                                               \
+    do {                                                                                         \
+        char buf[1] = { 'x' };                                                                   \
+        int  decpt = -1;                                                                         \
+        int  sign = -1;                                                                          \
+        int  ret = func(value, 0, &decpt, &sign, buf, 0);                                        \
+                                                                                                 \
+        if (ret != -1 || buf[0] != 'x') {                                                       \
+            printf(#func " zero-len failed: ret %d buf %c\n", ret, buf[0]);                    \
+            error = 1;                                                                           \
+        }                                                                                        \
+    } while (0)
+
 int
 main(void)
 {
@@ -216,10 +229,13 @@ main(void)
     many_tests(fcvt_tests, fcvt_r, N_FCVT_TESTS, SKIP_LONGISH_FLOAT);
     many_tests(fcvt_extra_tests, fcvt_r, N_FCVT_EXTRA_TESTS, SKIP_LONG_FLOAT);
     many_tests(ecvt_tests, ecvt_r, N_ECVT_TESTS, SKIP_LONGISH_FLOAT);
+    zero_len_test(ecvt_r, 1.0);
 #ifdef __PICOLIBC__
     many_tests(fcvt_tests, fcvtf_r, N_FCVT_TESTS, SKIP_LONG_FLOAT);
     many_tests(fcvtf_tests, fcvtf_r, N_FCVTF_TESTS, SKIP_LONG_FLOAT);
     many_tests(ecvt_tests, ecvtf_r, N_ECVT_TESTS, SKIP_LONGISH_FLOAT);
+    zero_len_test(ecvtf_r, 1.0f);
+    zero_len_test(ecvtl_r, 1.0L);
 #endif
     return error;
 }


### PR DESCRIPTION
## Summary

- Reject zero-length output buffers before the capacity arithmetic in `ecvt_r`, `ecvtf_r`, and `ecvtl_r`.
- Add sentinel regression coverage for all three entry points.

## Details

The previous check used `(size_t)ndigit > len - 1`. When `len` was zero, the subtraction wrapped and the call could continue to the shared `buf[ndigit] = '\0'` write. The new check explicitly rejects `len == 0` and keeps the existing exact-capacity behavior for nonzero buffers.

## Validation

- Linux GCC 13 with AddressSanitizer and UndefinedBehaviorSanitizer, compiling the real source files: the unmodified sources returned `0` and changed the zero-length sentinel for all three functions; the patched sources returned `-1` and preserved `'x'`. The ordinary `ndigit=4`, `len=8` cases remained unchanged.
- MinGW real-source regression run of `test/test-stdlib/test-efcvt.c`; the pre-existing `fcvtf_r` failures are identical before and after this change.
- `git diff --check` passes.

The full Meson native suite could not complete on this host because of existing toolchain/environment errors (the `duplicate-names` helper is not executable from the mounted worktree and the native C++ header checks fail); those failures occur outside the changed code.
