### PR TITLE
Compute L_tmpnam from P_tmpdir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,12 +244,11 @@ endif()
 
 # Directory prefix and buffer size for tmpnam()/tmpfile() names. tmpdir must be
 # empty or already end with a path separator (it is concatenated with the
-# template, no slash added); tmpnam-len must hold tmpdir + "TXXXXXX" + NUL.
-if(NOT DEFINED __L_tmpnam)
-  set(__L_tmpnam 8)
-endif()
-if(NOT DEFINED __P_tmpdir)
-  set(__P_tmpdir "\"\"")
+# template, no slash added); __L_tmpnam must hold tmpdir + "TXXXXXX" + NUL.
+if(DEFINED tmpdir)
+  set(__P_tmpdir ${tmpdir})
+  string(LENGTH ${tmpdir} tmpdir_len)
+  math(EXPR __L_tmpnam "${tmpdir_len} + 8")
 endif()
 
 # math library sets errno

--- a/libc/include/stdio.h
+++ b/libc/include/stdio.h
@@ -594,7 +594,7 @@ int vfprintf_s(FILE * __restrict stream, const char * __restrict fmt,
 
 /*
  * P_tmpdir must be empty or end with a path separator; L_tmpnam must fit
- * P_tmpdir + the template + NUL. Both are set via meson tmpdir/tmpnam-len.
+ * P_tmpdir + the template + NUL. Both are set via meson or cmake tmpdir
  */
 #ifdef __L_tmpnam
 #define L_tmpnam __L_tmpnam
@@ -602,10 +602,12 @@ int vfprintf_s(FILE * __restrict stream, const char * __restrict fmt,
 #define L_tmpnam 8
 #endif
 
+#if __MISC_VISIBLE || XSI_VISIBLE
 #ifdef __P_tmpdir
 #define P_tmpdir __P_tmpdir
 #else
 #define P_tmpdir ""
+#endif
 #endif
 
 /*

--- a/meson.build
+++ b/meson.build
@@ -1503,10 +1503,15 @@ tmpdir = get_option('tmpdir')
 if tmpdir != '' and not tmpdir.endswith('/')
   error('tmpdir must be empty or end with a path separator, got "@0@"'.format(tmpdir))
 endif
-conf_data.set('__L_tmpnam', get_option('tmpnam-len'),
-              description: 'Size of the tmpnam() buffer (L_tmpnam)')
-conf_data.set('__P_tmpdir', '"@0@"'.format(tmpdir),
-              description: 'Directory prefix for temporary file names (P_tmpdir)')
+if tmpdir != ''
+  strlen = find_program('scripts/strlen', required : true)
+  tmpdir_len_result = run_command(strlen, tmpdir, capture: true, check: true)
+  tmplen = tmpdir_len_result.stdout().to_int() + 8
+  conf_data.set('__P_tmpdir', '"@0@"'.format(tmpdir),
+                description: 'Directory prefix for temporary file names (P_tmpdir)')
+  conf_data.set('__L_tmpnam', tmplen,
+                description: 'Size of the tmpnam() buffer (L_tmpnam)')
+endif
 conf_data.set('__IO_SMALL_ULTOA',
               printf_small_ultoa,
               description: 'avoid software division in decimal conversion')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -250,8 +250,6 @@ option('stack-protector-guard', type: 'combo', choices: ['global', 'tls', 'auto'
        description: 'Set stack protection canary type')
 option('tmpdir', type: 'string', value: '',
        description: 'Directory prefix for tmpnam()/tmpfile() names (P_tmpdir). Must be empty or end with a path separator. Empty means names are created in the current directory.')
-option('tmpnam-len', type: 'integer', value: 8,
-       description: 'Size of the tmpnam() buffer (L_tmpnam). Must be large enough to hold tmpdir + "TXXXXXX" + NUL.')
 
 #
 # Math options

--- a/picolibc.h.in
+++ b/picolibc.h.in
@@ -132,10 +132,10 @@
 #define __IO_DEFAULT '@__IO_DEFAULT@'
 
 /* Size of the tmpnam() buffer (L_tmpnam) */
-#define __L_tmpnam @__L_tmpnam@
+#cmakedefine __L_tmpnam @__L_tmpnam@
 
 /* Directory prefix for tmpnam()/tmpfile() names (P_tmpdir) */
-#define __P_tmpdir @__P_tmpdir@
+#cmakedefine __P_tmpdir "@__P_tmpdir@"
 
 /* math library sets errno */
 #cmakedefine __MATH_ERRNO

--- a/scripts/do-aarch64-linux-gnu-configure
+++ b/scripts/do-aarch64-linux-gnu-configure
@@ -39,6 +39,7 @@
 exec "$(dirname "$0")"/do-configure aarch64-linux-gnu \
 	-Dsemihost=false \
 	-Dos-linux=true \
+	-Dtmpdir=/tmp/ \
 	-Dnative-tests=true \
 	-Dtests=true \
 	"$@"

--- a/scripts/do-arm-linux-gnueabihf-configure
+++ b/scripts/do-arm-linux-gnueabihf-configure
@@ -38,6 +38,7 @@
 exec "$(dirname "$0")"/do-configure arm-linux-gnueabihf \
 	-Dsemihost=false \
 	-Dos-linux=true \
+	-Dtmpdir=/tmp/ \
 	-Dnative-tests=true \
 	-Dtests=true \
 	"$@"

--- a/scripts/do-i686-linux-gnu-configure
+++ b/scripts/do-i686-linux-gnu-configure
@@ -42,6 +42,7 @@ meson setup \
 	--cross-file "$DIR"/cross-i686-linux-gnu.txt \
 	-Dsemihost=false \
 	-Dos-linux=true \
+	-Dtmpdir=/tmp/ \
 	-Dmultilib=false \
 	-Dtests=true \
 	-Dwerror=true \

--- a/scripts/do-x86_64-linux-gnu-configure
+++ b/scripts/do-x86_64-linux-gnu-configure
@@ -39,6 +39,7 @@
 exec "$(dirname "$0")"/do-configure x86_64-linux-gnu \
 	-Dsemihost=false \
 	-Dos-linux=true \
+	-Dtmpdir=/tmp/ \
 	-Dnative-tests=true \
 	-Dmultilib-exclude=x32 \
 	-Dtests=true \

--- a/scripts/strlen
+++ b/scripts/strlen
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2026 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+import argparse
+import shutil
+
+def error(msg):
+    fprint(msg, file=sys.stderr)
+    exit(1)
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compute string length"
+        )
+    parser.add_argument("string", help="Input string")
+    args = parser.parse_args()
+    print(f"{len(bytes(args.string, 'utf-8'))}")
+    exit(0)
+
+if __name__ == "__main__":
+    main()
+
+        


### PR DESCRIPTION
Instead of requiring that the user specify both and that they match, compute L_tmpnam from the value provided for P_tmpdir.

Also, when P_tmpdir is not specified, don't set it in picolibc.h so that the default value comes from stdio.h.

Finally, hide P_tmpdir unless exposing MISC or XSI symbols so that C and POSIX environments don't see that symbol.