### PR TITLE
test-math: Guard opt_barrier_long_double with _TEST_LONG_DOUBLE

### DIFF
--- a/test/test-math/test-math-errhandling.c
+++ b/test/test-math/test-math-errhandling.c
@@ -75,7 +75,7 @@ opt_barrier_double(double x)
     return y;
 }
 
-#if __SIZEOF_LONG_DOUBLE__ > 0
+#if __SIZEOF_LONG_DOUBLE__ > 0 && defined(_TEST_LONG_DOUBLE)
 static ALWAYS_INLINE long double
 opt_barrier_long_double(long double x)
 {


### PR DESCRIPTION
opt_barrier_long_double() is only referenced via force_eval(), which is defined as clang_barrier_long_double() inside the "#ifdef _TEST_LONG_DOUBLE" block. Its definition, however, was guarded by "#if __SIZEOF_LONG_DOUBLE__ > 0", which is always true since the long double type always exists.
As a result, building with -Dtest-long-double=false compiles the function but never uses it, triggering -Werror,-Wunused-function with