### PR TITLE
tinystdio: vfprintf avoid reading not-set exp

### DIFF
--- a/libc/stdio/vfprintf_float.c
+++ b/libc/stdio/vfprintf_float.c
@@ -33,7 +33,6 @@
     uint8_t       sign;         /* sign character (or 0)	*/
     uint8_t       ndigs;        /* number of digits to convert */
     unsigned char case_convert; /* subtract to correct case */
-    int           exp;          /* exponent of most significant decimal digit */
     int           n;            /* total width */
     uint8_t       ndigs_exp;    /* number of digis in exponent */
 
@@ -58,7 +57,6 @@
                 prec = -1;
             prec = __lfloat_x_engine(fval, &u.dtoa, prec, case_convert);
             ndigs = prec + 1;
-            exp = u.dtoa.exp;
             ndigs_exp = 1;
         } else
 #endif /* _NEED_IO_C99_FORMATS */
@@ -88,7 +86,6 @@
 
             ndigs = __lfloat_d_engine(fval, &u.dtoa, ndigs, fmode, ndecimal);
 
-            exp = u.dtoa.exp;
             ndigs_exp = 2;
         }
     } else
@@ -111,7 +108,6 @@
             ndigs = 1 + __float_x_engine(fval, &u.dtoa, prec, case_convert);
             if (prec <= ndigs)
                 prec = ndigs - 1;
-            exp = u.dtoa.exp;
             ndigs_exp = 1;
         } else
 #endif /* _NEED_IO_C99_FORMATS */
@@ -140,22 +136,9 @@
                 ndigs = FLOAT_MAX_DIG;
 
             ndigs = __float_d_engine(fval, &u.dtoa, ndigs, fmode, ndecimal);
-            exp = u.dtoa.exp;
             ndigs_exp = 2;
         }
     }
-    if (exp < -9 || 9 < exp)
-        ndigs_exp = 2;
-    if (exp < -99 || 99 < exp)
-        ndigs_exp = 3;
-#ifdef _NEED_IO_FLOAT64
-    if (exp < -999 || 999 < exp)
-        ndigs_exp = 4;
-#ifdef _NEED_IO_FLOAT_LARGE
-    if (exp < -9999 || 9999 < exp)
-        ndigs_exp = 5;
-#endif
-#endif
 
     sign = 0;
     if (u.dtoa.flags & DTOA_MINUS)
@@ -185,7 +168,20 @@
         while ((c = *pnt++))
             my_putc(TOCASE(c), stream);
     } else {
+        int exp = u.dtoa.exp; /* exponent of most significant decimal digit */
 
+        if (exp < -9 || 9 < exp)
+            ndigs_exp = 2;
+        if (exp < -99 || 99 < exp)
+            ndigs_exp = 3;
+#ifdef _NEED_IO_FLOAT64
+        if (exp < -999 || 999 < exp)
+            ndigs_exp = 4;
+#ifdef _NEED_IO_FLOAT_LARGE
+        if (exp < -9999 || 9999 < exp)
+            ndigs_exp = 5;
+#endif
+#endif
         if (!(flags & (FL_FLTEXP | FL_FLTFIX))) {
 
             /* 'g(G)' format */


### PR DESCRIPTION
With an input float of NAN or INFINITE, dtoa.exp is not set by __float_d_engine().
The code was using exp, to determine ndigs_exp.
But ndigs_exp is not used for anything in that case. (Meaning there is no bug, just code doing things it does not need to)

Nonetheless, when running this code with valgrind, it warns us about ifs depending on unset variables:
```
Conditional jump or move depends on uninitialised value(s)
	    vfprintf (vfprintf.c:850)
	    (printf.c:41)
Conditional jump or move depends on uninitialised value(s)
	    vfprintf (vfprintf.c:852)
	    printf (printf.c:41)
```

So, let's move the check of exp, into the branch that actually uses it. That should also save a bit of execution time.

------

With Zephyr's version it can be reproduced with:
```
twister -p native_sim  --enable-valgrind   -T tests/lib/sprintf/ -s libraries.libc.picolibc.sprintf`
# or
# in zephyr/build
cmake -GNinja -DBOARD=native_sim ../tests/lib/sprintf/ -DCONF_FILE=prj_picolibc.conf
ninja
valgrind zephyr/zephyr.exe
```

