### PR TITLE
stdio: Handle integer promotions for wint_t varargs

### DIFF
--- a/libc/stdio/vfprintf.c
+++ b/libc/stdio/vfprintf.c
@@ -440,7 +440,7 @@ skip_to_arg(const CHAR *fmt_orig, my_va_list *ap, int target_argno)
                 SKIP_FLOAT_ARG(flags, ap->ap);
             } else if (c == 'c') {
                 if (flags & FL_LONG)
-                    (void)va_arg(ap->ap, wint_t);
+                    (void)va_arg(ap->ap, __typeof__(+(wint_t)0));
                 else
                     (void)va_arg(ap->ap, int);
             } else if (c == 's') {

--- a/libc/stdio/vfprintf_char.c
+++ b/libc/stdio/vfprintf_char.c
@@ -36,7 +36,7 @@
 
 #ifdef _NEED_IO_WCHAR
     if (flags & FL_LONG) {
-        wint_t wc = (wchar_t)va_arg(ap, wint_t);
+        wint_t wc = (wchar_t)va_arg(ap, __typeof__(+(wint_t)0));
         u.wbuf[0] = wc;
         wstr = u.wbuf;
 

--- a/test/test-stdio/test-printf-scanf.c
+++ b/test/test-stdio/test-printf-scanf.c
@@ -309,6 +309,14 @@ main(void)
         errors++;
         fflush(stdout);
     }
+#ifndef NO_MULTI_BYTE
+    r = snprintf(buf, sizeof(buf), "%2$lc %1$d", 3, (wint_t)L'㌰');
+    if (r != 5 || strcmp(buf, "㌰ 3") != 0) {
+        printf("pos: wanted \"㌰ 3\" (ret %d) got \"%s\" (ret %d)\n", 5, buf, r);
+        errors++;
+        fflush(stdout);
+    }
+#endif
 #endif
 
     /*


### PR DESCRIPTION
I noticed this in https://github.com/tinygo-org/tinygo/pull/5570

eedcb6910dd65249ef8dc358e710121e9958097e from #1208 did fix a bug, but tinygo has a UEFI platform where `wint_t` is a short, which for variadic funcs like `printf` actually get promoted to `int`. See the compiler error from CI there:

```
/home/runner/go/bin/tinygo build             -o test.efi -target=uefi-amd64          examples/test
/home/runner/lib/tinygo/lib/picolibc/libc/stdio/vfprintf.c:443:42: error: second argument to 'va_arg' is of promotable type 'wint_t' (aka 'unsigned short'); this va_arg has undefined behavior because arguments will be promoted to 'int' [-Werror,-Wvarargs]
  443 |                     (void)va_arg(ap->ap, wint_t);
      |                  
```

I think asking for the `__typeof__` that conversion should work (it does locally), so hopefully this is right.