### PR TITLE
libc: Avoid NULL conversions for function pointers

### DIFF
--- a/libc/machine/spu/spu_timer_svcs.c
+++ b/libc/machine/spu/spu_timer_svcs.c
@@ -61,7 +61,7 @@ spu_timer_alloc(int interval, void (*func)(int))
 {
     unsigned was_enabled;
     int      id;
-    if (interval < MIN_INTVL || interval > MAX_INTVL || func == NULL)
+    if (interval < MIN_INTVL || interval > MAX_INTVL || func == 0)
         return SPU_TIMER_ERR_INVALID_PARM;
 
     was_enabled = spu_readch(SPU_RdMachStat) & 0x1;

--- a/libc/search/twalk.c
+++ b/libc/search/twalk.c
@@ -75,6 +75,6 @@ void
 twalk(const void *vroot, /* Root of the tree to be walked */
       void        (*action)(const void *, VISIT, int))
 {
-    if (vroot != NULL && action != NULL)
+    if (vroot != NULL && action != 0)
         trecurse(vroot, action, 0);
 }

--- a/libc/stdio/local-stdio.h
+++ b/libc/stdio/local-stdio.h
@@ -192,9 +192,9 @@ bufio_seekable(struct __file_bufio *bf)
 {
 #ifndef BUFIO_ABI_MATCHES
     if (!(bf->bflags & __BFPTR))
-        return bf->lseek_int != NULL;
+        return bf->lseek_int != 0;
 #endif
-    return bf->lseek_ptr != NULL;
+    return bf->lseek_ptr != 0;
 }
 
 static inline int

--- a/libc/stdio/sprintf_s.c
+++ b/libc/stdio/sprintf_s.c
@@ -66,7 +66,7 @@ sprintf_s(char * __restrict s, rsize_t bufsize, const char * __restrict fmt, ...
     return rc;
 
 handle_error:
-    if (__cur_handler != NULL) {
+    if (__cur_handler != 0) {
         __cur_handler(msg, NULL, -1);
     }
 

--- a/libc/stdio/vfprintf.c
+++ b/libc/stdio/vfprintf.c
@@ -585,7 +585,7 @@ vfprintf(FILE *stream, const CHAR *fmt, va_list ap_orig)
 
     if (stream == NULL || fmt == NULL) {
         msg = stream == NULL ? "output stream is null" : "null format string";
-        if (__cur_handler != NULL)
+        if (__cur_handler != 0)
             __cur_handler(msg, NULL, -1);
         if (stream)
             stream->flags |= __SERR;
@@ -842,7 +842,7 @@ fail:
     goto ret;
 #ifdef VFPRINTF_S
 handle_error:
-    if (__cur_handler != NULL)
+    if (__cur_handler != 0)
         __cur_handler(msg, NULL, -1);
     stream->flags |= __SERR;
     __funlock_return(stream, -1);

--- a/libc/stdio/vsnprintf_s.c
+++ b/libc/stdio/vsnprintf_s.c
@@ -79,7 +79,7 @@ vsnprintf_s(char * __restrict s, rsize_t n, const char * __restrict fmt, va_list
     return rc;
 
 handle_error:
-    if (__cur_handler != NULL) {
+    if (__cur_handler != 0) {
         __cur_handler(msg, NULL, -1);
     }
 

--- a/libc/stdlib/set_constraint_handler_s.c
+++ b/libc/stdlib/set_constraint_handler_s.c
@@ -51,7 +51,7 @@ set_constraint_handler_s(constraint_handler_t handler)
 {
     constraint_handler_t h = __cur_handler;
 
-    if (handler == (constraint_handler_t)NULL) {
+    if (handler == 0) {
         __cur_handler = abort_handler_s; // null restores to default handler
     } else {
         __cur_handler = handler;

--- a/libc/string/memcpy_s.c
+++ b/libc/string/memcpy_s.c
@@ -86,7 +86,7 @@ handle_error:
         (void)memset(s1, (int32_t)'\0', s1max);
     }
 
-    if (__cur_handler != NULL) {
+    if (__cur_handler != 0) {
         __cur_handler(msg, NULL, -1);
     }
 

--- a/libc/string/memmove_s.c
+++ b/libc/string/memmove_s.c
@@ -78,7 +78,7 @@ handle_error:
         (void)memset(s1, (int32_t)'\0', s1max);
     }
 
-    if (__cur_handler != NULL) {
+    if (__cur_handler != 0) {
         __cur_handler(msg, NULL, -1);
     }
 

--- a/libc/string/memset_s.c
+++ b/libc/string/memset_s.c
@@ -75,7 +75,7 @@ handle_error:
         __asm__ __volatile__("" ::"r"(s) : "memory");
     }
 
-    if (__cur_handler != NULL) {
+    if (__cur_handler != 0) {
         __cur_handler(msg, NULL, -1);
     }
 

--- a/libc/string/strcat_s.c
+++ b/libc/string/strcat_s.c
@@ -134,7 +134,7 @@ handle_error:
         *s1 = '\0';
     }
 
-    if (__cur_handler != NULL) {
+    if (__cur_handler != 0) {
         __cur_handler(msg, NULL, -1);
     }
 

--- a/libc/string/strcpy_s.c
+++ b/libc/string/strcpy_s.c
@@ -117,7 +117,7 @@ handle_error:
         *s1 = '\0';
     }
 
-    if (__cur_handler != NULL) {
+    if (__cur_handler != 0) {
         __cur_handler(msg, NULL, -1);
     }
 

--- a/libc/string/strerror.c
+++ b/libc/string/strerror.c
@@ -348,7 +348,7 @@ _strerror_r(int errnum, int internal, int *errptr)
 
     if (!errptr)
         errptr = &errno;
-    if (&_user_strerror == NULL || (error = _user_strerror(errnum, internal, errptr)) == 0)
+    if (&_user_strerror == 0 || (error = _user_strerror(errnum, internal, errptr)) == 0)
         error = "Unknown error";
     return error;
 }

--- a/libc/string/strerror_s.c
+++ b/libc/string/strerror_s.c
@@ -77,7 +77,7 @@ strerror_s(char *buf, rsize_t buflen, __errno_t errnum)
     return result;
 
 handle_error:
-    if (__cur_handler != NULL) {
+    if (__cur_handler != 0) {
         __cur_handler(msg, NULL, -1);
     }
 

--- a/libc/string/strncat_s.c
+++ b/libc/string/strncat_s.c
@@ -161,7 +161,7 @@ handle_error:
         *s1 = '\0';
     }
 
-    if (__cur_handler != NULL) {
+    if (__cur_handler != 0) {
         __cur_handler(msg, NULL, -1);
     }
 

--- a/libc/string/strncpy_s.c
+++ b/libc/string/strncpy_s.c
@@ -139,7 +139,7 @@ handle_error:
         *s1 = '\0';
     }
 
-    if (__cur_handler != NULL) {
+    if (__cur_handler != 0) {
         __cur_handler(msg, NULL, -1);
     }
 


### PR DESCRIPTION
Noticed this in https://github.com/tinygo-org/tinygo/pull/5570

601003acc85 in #1208 contains `&_user_strerror == NULL` which clang AVR does not like because function expressions are in a different address space than `(void*) 0` and then aborts.

```
tinygo.test: /home/runner/work/tinygo/tinygo/llvm-project/clang/lib/CodeGen/CGExprScalar.cpp:2565: llvm::Value* {anonymous}::ScalarExprEmitter::VisitCastExpr(clang::CastExpr*): Assertion `(!SrcTy->isPtrOrPtrVectorTy() || !DstTy->isPtrOrPtrVectorTy() || SrcTy->getPointerAddressSpace() == DstTy->getPointerAddressSpace()) && "Address-space cast must be used to convert address spaces"' failed.
SIGABRT: abort
```

I think flipping this to `!_user_stderror` works to test for zero as a replacement.

I did a scan though and there are actually \~14 other cases like this, it's just that `strerror.c` is compiled by tinygo and hits this. I could fix all of them if that's preferrable. I am not sure what CI could catch these, though, given this requires assertions?