### PR TITLE
inttypes: use wchar_t in C++ declarations

### DIFF
--- a/libc/include/inttypes.h
+++ b/libc/include/inttypes.h
@@ -29,11 +29,13 @@ typedef struct {
 } imaxdiv_t;
 
 /*
- * Try to avoid defining wchar_t by using __WCHAR_TYPE__ when
- * available.
+ * In C++, wchar_t is a distinct built-in type, even when __WCHAR_TYPE__
+ * names an integer type. In C, avoid defining wchar_t when possible.
  */
 
-#ifdef __WCHAR_TYPE__
+#ifdef __cplusplus
+typedef wchar_t _wchar_t;
+#elif defined(__WCHAR_TYPE__)
 typedef __WCHAR_TYPE__ _wchar_t;
 #else
 #define __need_wchar_t

--- a/test/meson.build
+++ b/test/meson.build
@@ -295,6 +295,19 @@ foreach params : targets
   endif
 
   if have_cplusplus
+    t1 = 'test-inttypes-cplusplus'
+    t1_src = t1 + '.cpp'
+    test(t1 + target,
+         executable(t1 + target, t1_src,
+                    cpp_args: _cpp_args,
+		    link_args: _cpp_args + _link_args,
+		    objects: _objs,
+		    link_depends: _link_depends,
+                    include_directories: inc),
+         depends: bios_bin,
+         suite: 'test',
+         env: test_env)
+
     t1 = 'test-cplusplus'
     t1_src = t1 + '.cpp'
     test(t1 + target,
@@ -441,4 +454,3 @@ endif
 if has_arm_semihost and oslib_test_variant == 'semihost'
   subdir('semihost')
 endif
-

--- a/test/test-inttypes-cplusplus.cpp
+++ b/test/test-inttypes-cplusplus.cpp
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 2026 Qualcomm Innovation Center, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <inttypes.h>
+
+#ifdef __clang__
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#pragma GCC diagnostic ignored "-Wmain"
+#endif
+
+extern "C" {
+
+int main(void);
+
+int
+main(void)
+{
+    wchar_t *end;
+
+    if (wcstoimax(L"123", &end, 10) != 123 || *end != L'\0')
+        return 1;
+    if (wcstoumax(L"456", &end, 10) != 456 || *end != L'\0')
+        return 1;
+    return 0;
+}
+
+}


### PR DESCRIPTION
Use the built-in wchar_t type for wcstoimax and wcstoumax declarations when compiling as C++. __WCHAR_TYPE__ may expand to an integer type, which is distinct from wchar_t in C++ and rejects valid wide-string arguments.