### PR TITLE
test, avr, xdr: add CI for clang AVR, fix setjmp and xdr_sizeof

### DIFF
--- a/.github/do-build
+++ b/.github/do-build
@@ -22,6 +22,11 @@ case "$TARGET" in
             [ -d "$p" ] && PATH="$p":$PATH
         done
         ;;
+    *clang-avr*)
+        for p in "$TOP"/*avr*/bin; do
+            [ -d "$p" ] && PATH="$p":$PATH
+        done
+        ;;
     *)
         for p in "$TOP"/*/bin "$TOP"/*/models/*; do
             PATH="$p":$PATH

--- a/.github/do-clang-avr-build
+++ b/.github/do-clang-avr-build
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+HERE=$(dirname "$0")
+AVR_SDK_INSTALL_DIR=${AVR_SDK_INSTALL_DIR:-/opt/avr}
+C_INCLUDE_PATH="$AVR_SDK_INSTALL_DIR/avr/include${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}"
+export C_INCLUDE_PATH
+
+exec "$HERE"/do-build clang-avr "$@" -Danalyzer=false

--- a/.github/do-linux-misc
+++ b/.github/do-linux-misc
@@ -20,5 +20,6 @@ HERE=`dirname "$0"`
 "$HERE"/do-test m68k-unknown-elf "$@"
 "$HERE"/do-test sh-unknown-elf "$@"
 "$HERE"/do-avr-build avr "$@"
+"$HERE"/do-clang-avr-build "$@"
 "$HERE"/do-test msp430-unknown-elf "$@"
 "$HERE"/do-test lm32-unknown-elf "$@"

--- a/libc/machine/avr/sectionname.h
+++ b/libc/machine/avr/sectionname.h
@@ -34,14 +34,11 @@
 
 /* Put all avr-libc functions in a common, unique sub-section name under .text. */
 
-#define CLIB_SECTION           .text.avr - libc
-#define MLIB_SECTION           .text.avr - libc.fplib
+#define CLIB_SECTION           ".text.avr-libc"
+#define MLIB_SECTION           ".text.avr-libc.fplib"
 
-#define STR(x)                 _STR(x)
-#define _STR(x)                #x
-
-#define ATTRIBUTE_CLIB_SECTION __section(STR(CLIB_SECTION))
-#define ATTRIBUTE_MLIB_SECTION __section(STR(MLIB_SECTION))
+#define ATTRIBUTE_CLIB_SECTION __section(CLIB_SECTION)
+#define ATTRIBUTE_MLIB_SECTION __section(MLIB_SECTION)
 
 #define ASSEMBLY_CLIB_SECTION  .section CLIB_SECTION, "ax", @progbits
 #define ASSEMBLY_MLIB_SECTION  .section MLIB_SECTION, "ax", @progbits

--- a/libc/machine/avr/setjmp.S
+++ b/libc/machine/avr/setjmp.S
@@ -60,10 +60,18 @@
 #include <avr/io.h>
 #include "macros.inc"
 
-/* ???: What was a reason to use aliases for common registers?
-   Check the address: is it a port number (value for IN/OUT)?	*/
-#if	AVR_STACK_POINTER_LO_ADDR != 0x3D	\
-     || AVR_STATUS_ADDR != 0x3F
+#ifndef SPL_IO_ADDR
+#define SPL_IO_ADDR AVR_STACK_POINTER_LO_ADDR
+#endif
+#ifndef SPH_IO_ADDR
+#define SPH_IO_ADDR AVR_STACK_POINTER_HI_ADDR
+#endif
+#ifndef SREG_IO_ADDR
+#define SREG_IO_ADDR AVR_STATUS_ADDR
+#endif
+
+/* These registers are accessed with IN/OUT below. */
+#if	SPL_IO_ADDR != 0x3D || SREG_IO_ADDR != 0x3F
 # error  "Strange address of common registers SPL, SREG"
 #endif
 
@@ -97,16 +105,16 @@ _U(setjmp):
 	pop	ZH
 	pop	ZL
   ; save stack pointer (after poping)
-	in	ret_lo, AVR_STACK_POINTER_LO_ADDR
+	in	ret_lo, SPL_IO_ADDR
 	st	X+, ret_lo
-#ifdef __HAVE_AVR_STACK_POINTER_HI    
-	in	ret_lo, AVR_STACK_POINTER_HI_ADDR
+#ifdef SPH
+	in	ret_lo, SPH_IO_ADDR
 	st	X+, ret_lo
 #else
 	st	X+, __zero_reg__
 #endif
   ; save status register (I flag)
-	in	ret_lo, AVR_STATUS_ADDR
+	in	ret_lo, SREG_IO_ADDR
 	st	X+, ret_lo
   ; save return address
 	st	X+, ZL
@@ -148,19 +156,19 @@ _U(longjmp):
 #if  defined (__AVR_XMEGA__) && __AVR_XMEGA__
 	/* A write to SPL will automatically disable interrupts for up to 4
 	   instructions or until the next I/O memory write.	*/
-	out	AVR_STATUS_ADDR, __tmp_reg__
-	out	AVR_STACK_POINTER_LO_ADDR, ZL
-	out	AVR_STACK_POINTER_HI_ADDR, ZH
+	out	SREG_IO_ADDR, __tmp_reg__
+	out	SPL_IO_ADDR, ZL
+	out	SPH_IO_ADDR, ZH
 #else
-# ifdef __HAVE_AVR_STACK_POINTER_HI
+# ifdef SPH
 	/* interrupts disabled for shortest possible time (3 cycles) */
 	cli
-	out	AVR_STACK_POINTER_HI_ADDR, ZH
+	out	SPH_IO_ADDR, ZH
 # endif
 	/* Restore status register (including the interrupt enable flag).
 	   Interrupts are re-enabled only after the next instruction.  */
-	out	AVR_STATUS_ADDR, __tmp_reg__
-	out	AVR_STACK_POINTER_LO_ADDR, ZL
+	out	SREG_IO_ADDR, __tmp_reg__
+	out	SPL_IO_ADDR, ZL
 #endif
   ; get return address and jump
 	ld	ZL, X+

--- a/libc/xdr/xdr_sizeof.c
+++ b/libc/xdr/xdr_sizeof.c
@@ -135,6 +135,12 @@ x_putint32(XDR *xdrs, const int32_t *int32p)
     return TRUE;
 }
 
+#ifdef __GNUCLIKE_PRAGMA_DIAGNOSTIC
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
+
 unsigned long
 xdr_sizeof(xdrproc_t func, void *data)
 {
@@ -155,9 +161,9 @@ xdr_sizeof(xdrproc_t func, void *data)
     ops.x_putint32 = x_putint32;
 
     /* the other harmless ones */
-    ops.x_getlong = (dummyfunc1)(void *)harmless;
-    ops.x_getbytes = (dummyfunc2)(void *)harmless;
-    ops.x_getint32 = (dummyfunc3)(void *)harmless;
+    ops.x_getlong = (dummyfunc1)harmless;
+    ops.x_getbytes = (dummyfunc2)harmless;
+    ops.x_getint32 = (dummyfunc3)harmless;
 
     x.x_op = XDR_ENCODE;
     x.x_ops = &ops;

--- a/scripts/cross-clang-avr.txt
+++ b/scripts/cross-clang-avr.txt
@@ -1,0 +1,20 @@
+[binaries]
+c = ['clang', '--target=avr', '-mmcu=atmega1284p', '-nostdlib', '-D__AVR_HAVE_SPH__']
+cpp = ['clang', '--target=avr', '-mmcu=atmega1284p', '-nostdlib', '-D__AVR_HAVE_SPH__']
+c_ld = 'lld'
+cpp_ld = 'lld'
+ar = 'avr-ar'
+nm = 'avr-nm'
+strip = 'avr-strip'
+
+[host_machine]
+system = 'none'
+cpu_family = 'avr'
+cpu = 'avr'
+endian = 'little'
+
+[properties]
+skip_sanity_check = true
+
+[built-in options]
+c_args = ['-Wno-tautological-compare']

--- a/scripts/do-clang-avr-configure
+++ b/scripts/do-clang-avr-configure
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec "$(dirname "$0")"/do-configure clang-avr -Dtests=false -Dmultilib=false "$@"


### PR DESCRIPTION
This is a followup to #1340 and #1341; I've added a clang AVR build to CI.

That reveals the `setjmp` problem; the first commit fixes to the best of my knowledge. There are register addresses my headers define differently, and the section name thing makes clang mad.

This does however not add an asserting build of clang; the third commit fixes a problem that I found in my local build. I could probably add the code to `picolibc-ci-tools` as noted in https://github.com/picolibc/picolibc/pull/1341#issuecomment-5160630820 if you wanted to verify that now and into the future, I just didn't have that change sitting around. That and while I am testing this on AVR, I would think that other platforms might be worth testing?