### PR TITLE
Fix scanf scanset range detection for trailing hyphens

### DIFF
--- a/libc/stdio/vfscanf.c
+++ b/libc/stdio/vfscanf.c
@@ -388,7 +388,8 @@ conv_brk(FILE *stream, scanf_context_t *context, width_t width, void *addr, cons
             if (fmt != _fmt + 1) {
                 if (f == ']')
                     break;
-                if (f == '-' && !frange) {
+                /* A trailing '-' is a literal scanset member. */
+                if (f == '-' && !frange && *fmt != ']') {
                     frange = true;
                     continue;
                 }

--- a/test/test-stdio/test-printf-scanf.c
+++ b/test/test-stdio/test-printf-scanf.c
@@ -319,6 +319,30 @@ main(void)
 #endif
 #endif
 
+    {
+        struct {
+            const char *input;
+            const char *format;
+            const char *expected;
+        } scansets[] = {
+            { "aconve-rsion", "%[acveron-]", "aconve-r" },
+            { "-abc",         "%[-a]",       "-a"       },
+            { "abcXYZ",       "%[a-c]",      "abc"      },
+        };
+        unsigned i;
+
+        for (i = 0; i < sizeof(scansets) / sizeof(scansets[0]); i++) {
+            char result[16] = "";
+            int  ret = sscanf(scansets[i].input, scansets[i].format, result);
+
+            if (ret != 1 || strcmp(result, scansets[i].expected) != 0) {
+                printf("scanset %s on %s: wanted %s, got %s (ret %d)\n", scansets[i].format,
+                       scansets[i].input, scansets[i].expected, result, ret);
+                errors++;
+            }
+        }
+    }
+
     /*
      * test snprintf and vsnprintf to make sure they don't
      * overwrite the specified buffer length (even if that is


### PR DESCRIPTION
Add validation to distinguish literal hyphens from range operators in character class expressions. A hyphen is treated as literal when it appears at the end, at the start of a descending range, or before the closing bracket.