### PR TITLE
Reserve atexit slot for stdio exit flush

### DIFF
--- a/libc/stdlib/exitprocs.c
+++ b/libc/stdlib/exitprocs.c
@@ -48,7 +48,18 @@ struct on_exit {
     enum pico_onexit_kind kind;
 };
 
-static struct on_exit on_exits[ATEXIT_MAX];
+/*
+ * stdio-exit-flush registers one internal atexit handler before main. Keep
+ * that implementation detail from reducing the ISO C guarantee of at least
+ * ATEXIT_MAX registrations available to the application.
+ */
+#ifdef __STDIO_EXIT_FLUSH
+#define __ATEXIT_COUNT (ATEXIT_MAX + 1)
+#else
+#define __ATEXIT_COUNT ATEXIT_MAX
+#endif
+
+static struct on_exit on_exits[__ATEXIT_COUNT];
 
 int
 _on_exit(enum pico_onexit_kind kind, union on_exit_func func, void *arg)
@@ -56,7 +67,7 @@ _on_exit(enum pico_onexit_kind kind, union on_exit_func func, void *arg)
     int ret = -1;
     int o;
     __LIBC_LOCK();
-    for (o = 0; o < ATEXIT_MAX; o++) {
+    for (o = 0; o < __ATEXIT_COUNT; o++) {
         if (on_exits[o].kind == PICO_ONEXIT_EMPTY) {
             on_exits[o].func = func;
             on_exits[o].arg = arg;
@@ -91,7 +102,7 @@ __call_exitprocs(int code, void *param)
         void                 *arg = 0;
 
         __LIBC_LOCK();
-        for (i = ATEXIT_MAX - 1; i >= 0; i--) {
+        for (i = __ATEXIT_COUNT - 1; i >= 0; i--) {
             kind = on_exits[i].kind;
             if (kind != PICO_ONEXIT_EMPTY) {
                 func = on_exits[i].func;

--- a/test/test-stdio/meson.build
+++ b/test/test-stdio/meson.build
@@ -78,6 +78,7 @@ endif
 if tests_enable_posix_io
   tests += [
     'test-posix-io',
+    'test-atexit-max',
     'test-dprintf',
     'test-fgetc',
     'test-fgets-eof',

--- a/test/test-stdio/test-atexit-max.c
+++ b/test/test-stdio/test-atexit-max.c
@@ -1,0 +1,96 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/*
+ * ATEXIT_MAX registrations must be available to the application. Internal
+ * library handlers must not come out of that budget.
+ *
+ * A buffered stream is opened first because the exit flush handler is
+ * registered from a constructor in the buffered stdio code, which is only
+ * linked in once something uses it.
+ */
+
+#define _DEFAULT_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <limits.h>
+
+/*
+ * ATEXIT_MAX is optional. Implementations with no fixed limit, such as
+ * glibc, do not define it, so fall back to the value POSIX requires an
+ * implementation to support at minimum.
+ */
+#ifndef ATEXIT_MAX
+#define ATEXIT_MAX 32
+#endif
+
+#ifndef TEST_FILE_NAME
+#define TEST_FILE_NAME "atexit-max-test-file"
+#endif
+
+static const char file_name[] = TEST_FILE_NAME;
+
+static void
+noop(void)
+{
+}
+
+int
+main(void)
+{
+    FILE *f;
+    int   i;
+
+    f = fopen(file_name, "w");
+    if (!f) {
+        printf("failed to open \"%s\" for writing\n", file_name);
+        return 1;
+    }
+    fputs("hello, world\n", f);
+
+    for (i = 0; i < ATEXIT_MAX; i++) {
+        if (atexit(noop) != 0) {
+            printf("atexit failed at registration %d of %d\n", i, ATEXIT_MAX);
+            fclose(f);
+            remove(file_name);
+            return 1;
+        }
+    }
+
+    fclose(f);
+    remove(file_name);
+    printf("success\n");
+    return 0;
+}


### PR DESCRIPTION
When stdio-exit-flush registers an internal atexit handler before main, ensure the ISO C guarantee of at least ATEXIT_MAX registrations remains available to the application by increasing the internal limit.