### PR TITLE
Add missing ungetc call in float conversion error path

### DIFF
--- a/libc/stdio/conv_flt.c
+++ b/libc/stdio/conv_flt.c
@@ -391,8 +391,10 @@ conv_flt(FLT_STREAM *stream, FLT_CONTEXT *context, width_t width, void *addr, ui
         } while (CHECK_WIDTH() && !IS_EOF(i = scanf_getc(stream, context)));
 
         if (!(flags & FL_ANY)) {
-            if (!(flags & FL_FHEX))
+            if (!(flags & FL_FHEX)) {
+                scanf_ungetc(i, stream, context);
                 return 0;
+            }
 #if defined(STRTOD) || defined(STRTOF) || defined(STRTOLD)
             scanf_ungetc(i, stream, context);
             scanf_ungetc(i, stream, context);

--- a/test/test-stdio/test-printf-scanf.c
+++ b/test/test-stdio/test-printf-scanf.c
@@ -517,6 +517,33 @@ main(void)
     }
 #endif
 
+#if !defined(__IO_NO_FLOATING_POINT)
+    /*
+     * On a matching failure the differing input character must remain
+     * unread. "left777" is used because 'l' cannot start a float and,
+     * unlike 'i' or 'n', does not enter the inf/nan matching path.
+     */
+    {
+        FILE      *f = fmemopen((void *)"left777", 7, "r");
+        float_type fv;
+
+        if (f == NULL) {
+            printf("fmemopen failed\n");
+            errors++;
+        } else {
+            if (fscanf(f, scanf_format, &fv) != 0) {
+                printf("scanf rollback: wanted a matching failure\n");
+                errors++;
+            }
+            if (fgetc(f) != 'l') {
+                printf("scanf rollback: nonmatching input was consumed\n");
+                errors++;
+            }
+            fclose(f);
+        }
+    }
+#endif
+
     for (x = -37; x <= 37; x++) {
         float_type r;
         unsigned   t;


### PR DESCRIPTION
When no valid characters are found and FL_FHEX flag is not set, the last character needs to be returned to the stream before returning an error.

This closes #1348