### PR TITLE
Make swprintf and vswprintf return -1 on buffer overflow

### DIFF
--- a/libc/stdio/CMakeLists.txt
+++ b/libc/stdio/CMakeLists.txt
@@ -75,6 +75,7 @@ picolibc_sources(
   filestrputalloc.c
   filestrput.c
   filewstrget.c
+  filewstrput.c
   flockfile.c
   fmemopen.c
   open_memstream.c

--- a/libc/stdio/filewstrput.c
+++ b/libc/stdio/filewstrput.c
@@ -1,0 +1,48 @@
+/*
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+SPDX-License-Identifier: BSD-3-Clause-Clear
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of Qualcomm Technologies, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "local-stdio.h"
+
+int
+__file_wstr_put(char c, FILE *stream)
+{
+    struct __file_str *sstream = (struct __file_str *)stream;
+
+    if (sstream->pos == sstream->end)
+        return _FDEV_ERR;
+
+    *sstream->pos++ = c;
+    return (unsigned char)c;
+}

--- a/libc/stdio/local-stdio.h
+++ b/libc/stdio/local-stdio.h
@@ -63,6 +63,8 @@ int               __file_wstr_get(FILE *stream);
 
 int               __file_str_put(char c, FILE *stream);
 
+int               __file_wstr_put(char c, FILE *stream);
+
 int               __file_str_put_alloc(char c, FILE *stream);
 
 extern const char __match_inf[];
@@ -102,6 +104,14 @@ bool              __matchcaseprefix(const char *input, const char *pattern);
         .file = { .flags = __SWR, .put = __file_str_put, __LOCK_INIT_NONE }, \
         .pos = (_s),                                                         \
         .end = (_end),                                                       \
+    }
+
+/* A zero-sized wide string is an error even when no output is generated. */
+#define FDEV_SETUP_WSTRING_WRITE(_s, _n)                                                 \
+    {                                                                                    \
+        .file = { .flags = (_n) ? __SWR : 0, .put = __file_wstr_put, __LOCK_INIT_NONE }, \
+        .pos = (char *)(_s),                                                             \
+        .end = (char *)FDEV_STRING_WRITE_END((_s), (_n)),                                \
     }
 
 #define FDEV_SETUP_STRING_ALLOC()                                                  \

--- a/libc/stdio/meson.build
+++ b/libc/stdio/meson.build
@@ -76,6 +76,7 @@ srcs_stdio = [
   'filestrputalloc.c',
   'filestrput.c',
   'filewstrget.c',
+  'filewstrput.c',
   'flockfile.c',
   'flockfile_init.c',
   'fmemopen.c',

--- a/libc/stdio/swprintf.c
+++ b/libc/stdio/swprintf.c
@@ -40,7 +40,7 @@ swprintf(wchar_t *s, size_t n, const wchar_t *fmt, ...)
 {
     va_list           ap;
     int               i;
-    struct __file_str f = FDEV_SETUP_STRING_WRITE((char *)s, (char *)FDEV_STRING_WRITE_END(s, n));
+    struct __file_str f = FDEV_SETUP_WSTRING_WRITE(s, n);
     f.file.flags |= __SWIDE;
 
     va_start(ap, fmt);

--- a/libc/stdio/vswprintf.c
+++ b/libc/stdio/vswprintf.c
@@ -38,7 +38,7 @@
 int
 vswprintf(wchar_t *s, size_t n, const wchar_t *fmt, va_list ap)
 {
-    struct __file_str f = FDEV_SETUP_STRING_WRITE((char *)s, (char *)FDEV_STRING_WRITE_END(s, n));
+    struct __file_str f = FDEV_SETUP_WSTRING_WRITE(s, n);
     int               i;
 
     f.file.flags |= __SWIDE;

--- a/test/test-stdio/test-printf-scanf.c
+++ b/test/test-stdio/test-printf-scanf.c
@@ -115,6 +115,18 @@ check_vsnprintf(char *str, size_t size, const char *format, ...)
 #endif
 
 #ifndef NO_WIDE_IO
+static int
+check_vswprintf(wchar_t *str, size_t size, const wchar_t *format, ...)
+{
+    int     i;
+    va_list ap;
+
+    va_start(ap, format);
+    i = vswprintf(str, size, format, ap);
+    va_end(ap);
+    return i;
+}
+
 static const struct {
     const wchar_t * const str;
     const wchar_t * const fmt;
@@ -288,6 +300,53 @@ main(void)
         }
     }
 #endif
+
+    /*
+     * snprintf returns the number of characters that would have been
+     * written, while swprintf returns a negative value on truncation.
+     * "123456" needs 7 characters including the terminating null.
+     */
+    {
+        wchar_t wbuf[8];
+        int     nret;
+        int     wret;
+
+#if ((__GNUC__ == 4 && __GNUC_MINOR__ >= 2) || __GNUC__ > 4)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#endif
+        nret = snprintf(buf, 6, "123456");
+#if ((__GNUC__ == 4 && __GNUC_MINOR__ >= 2) || __GNUC__ > 4)
+#pragma GCC diagnostic pop
+#endif
+        wret = swprintf(wbuf, 6, L"123456");
+        if (nret != 6 || wret >= 0) {
+            printf("truncation: snprintf returned %d, swprintf returned %d\n", nret, wret);
+            ++errors;
+        }
+        if (swprintf(wbuf, 7, L"123456") != 6 || wcscmp(wbuf, L"123456") != 0) {
+            printf("swprintf: exact fit failed\n");
+            ++errors;
+        }
+        if (swprintf(wbuf, 0, L"123456") >= 0) {
+            printf("swprintf: zero size reported as success\n");
+            ++errors;
+        }
+        if (swprintf(NULL, 0, L"") >= 0) {
+            printf("swprintf: empty zero-size output reported as success\n");
+            ++errors;
+        }
+        nret = check_vsnprintf(buf, 6, "123456");
+        wret = check_vswprintf(wbuf, 6, L"123456");
+        if (nret != 6 || wret >= 0) {
+            printf("truncation: vsnprintf returned %d, vswprintf returned %d\n", nret, wret);
+            ++errors;
+        }
+        if (check_vswprintf(NULL, 0, L"") >= 0) {
+            printf("vswprintf: empty zero-size output reported as success\n");
+            ++errors;
+        }
+    }
 #endif
 
 #if !defined(__IO_NO_FLOATING_POINT)


### PR DESCRIPTION
Both functions now return -1 when the formatted output (including the terminating null character) does not fit in the provided buffer, per the C standard.

Fixes #1350