### PR TITLE
Set EOF flag in fgetwc on end of stream

### DIFF
--- a/libc/stdio/fgetwc.c
+++ b/libc/stdio/fgetwc.c
@@ -53,8 +53,10 @@ __STDIO_UNLOCKED(getwc)(FILE *stream)
 
     for (i = 0; i < sizeof(wchar_t); i++) {
         sc = stream->get(stream);
-        if (sc < 0)
+        if (sc < 0) {
+            stream->flags |= (sc == _FDEV_ERR) ? __SERR : __SEOF;
             return WEOF;
+        }
         u.c[i] = (char)sc;
     }
 

--- a/test/test-stdio/test-printf-scanf.c
+++ b/test/test-stdio/test-printf-scanf.c
@@ -270,6 +270,14 @@ main(void)
             ++errors;
         }
     }
+    {
+        char result[4];
+
+        if (swscanf(L"", L"%[Gdo]", result) != EOF) {
+            printf("swscanf did not report an input failure for an empty string\n");
+            ++errors;
+        }
+    }
 #ifndef NO_MULTI_BYTE
     {
         wchar_t c;

--- a/test/test-stdio/test-wchar.c
+++ b/test/test-stdio/test-wchar.c
@@ -80,6 +80,11 @@ main(void)
         unlink(TEST_FILE_NAME);
         return 1;
     }
+    if (!feof(file)) {
+        printf("Test Failed: fgetwc did not set the end-of-file indicator\n");
+        unlink(TEST_FILE_NAME);
+        return 1;
+    }
 
     fclose(file);
 


### PR DESCRIPTION
Add logic to set the appropriate stream flags (`__SERR` or `__SEOF`) when fgetwc encounters an error or end-of-file condition. Include tests to verify EOF indicator is properly set and swscanf correctly reports input failure on empty input.

Fixes #1352 