### PR TITLE
Add bounds checking to wctob for invalid wide characters

### DIFF
--- a/libc/stdlib/wctob.c
+++ b/libc/stdlib/wctob.c
@@ -5,6 +5,7 @@ Copyright (c) 2002 Thomas Fitzsimmons <fitzsim@redhat.com>
 #include <stdio.h>
 #include <string.h>
 #include <limits.h>
+#include <stdint.h>
 #include "local.h"
 
 int
@@ -12,8 +13,10 @@ wctob(wint_t wc)
 {
     mbstate_t     mbs;
     unsigned char pmb[MB_LEN_MAX];
+    uintmax_t     uwc = (uintmax_t)wc;
 
-    if (wc == WEOF)
+    /* The unsigned conversion maps negative values above WCHAR_MAX. */
+    if (wc == WEOF || uwc > (uintmax_t)WCHAR_MAX)
         return EOF;
 
     /* Put mbs in initial state. */

--- a/test/test-wctomb.c
+++ b/test/test-wctomb.c
@@ -112,6 +112,11 @@ main(void)
     int       status = 0;
     mbstate_t mbstate;
 
+    if (wctob(WEOF) != EOF || wctob((wint_t)-2) != EOF || wctob((wint_t)-3) != EOF) {
+        printf("wctob accepted an invalid negative value\n");
+        status = 1;
+    }
+
 #if !defined(__PICOLIBC__) || defined(__MB_CAPABLE)
     if (!setlocale(LC_CTYPE, "C.UTF-8")) {
         printf("setlocale(LC_CTYPE, \"C.UTF-8\") failed\n");


### PR DESCRIPTION
Add stdint.h include and validate that wc doesn't exceed WCHAR_MAX before processing. Add test cases for negative wint_t values.

Tries to fix #1355 