### PR TITLE
include: expose C23 symbols under __ISO_C_VISIBLE >= 2023

### DIFF
--- a/libc/include/math.h
+++ b/libc/include/math.h
@@ -693,15 +693,21 @@ extern void sincosf(float, float *, float *) __picolibc_export;
 #ifdef __HAVE_LONG_DOUBLE_MATH
 extern void sincosl(long double, long double *, long double *) __picolibc_export;
 #endif
-extern double exp10(double) __picolibc_export;
 extern double pow10(double) __picolibc_export;
-extern float  exp10f(float) __picolibc_export;
 extern float  pow10f(float) __picolibc_export;
 #ifdef __HAVE_LONG_DOUBLE_MATH
-extern long double exp10l(long double) __picolibc_export;
 extern long double pow10l(long double) __picolibc_export;
 #endif
 #endif /* __GNU_VISIBLE */
+
+/* C23 / GNU */
+#if __GNU_VISIBLE || __ISO_C_VISIBLE >= 2023
+extern double exp10(double) __picolibc_export;
+extern float  exp10f(float) __picolibc_export;
+#ifdef __HAVE_LONG_DOUBLE_MATH
+extern long double exp10l(long double) __picolibc_export;
+#endif
+#endif /* __GNU_VISIBLE || __ISO_C_VISIBLE >= 2023 */
 
 #if __MISC_VISIBLE || __XSI_VISIBLE
 extern __picolibc_export int signgam;

--- a/libc/include/string.h
+++ b/libc/include/string.h
@@ -75,7 +75,7 @@ char * __nonnull((1)) basename(const char *) _ASMNAME("__gnu_basename");
 #endif
 #endif
 
-#if __MISC_VISIBLE || __POSIX_VISIBLE
+#if __MISC_VISIBLE || __POSIX_VISIBLE || __ISO_C_VISIBLE >= 2023
 void *memccpy(void * __restrict, const void * __restrict, int, size_t) __picolibc_export;
 #endif
 void *memchr(const void *, int, size_t) __picolibc_export;
@@ -115,7 +115,7 @@ int strcoll_l(const char *, const char *, locale_t) __picolibc_export;
 #endif
 char  *strcpy(char  *__restrict, const char  *__restrict) __picolibc_export;
 size_t strcspn(const char *, const char *) __picolibc_export;
-#if __MISC_VISIBLE || __POSIX_VISIBLE >= 200809 || __XSI_VISIBLE >= 4
+#if __MISC_VISIBLE || __POSIX_VISIBLE >= 200809 || __XSI_VISIBLE >= 4 || __ISO_C_VISIBLE >= 2023
 void  free(void *) __nothrow __picolibc_export; /* for __malloc_like */
 char *strdup(const char *) __malloc_like __warn_unused_result __picolibc_export;
 #endif
@@ -171,7 +171,7 @@ char *strlwr(char *) __picolibc_export;
 char *strncat(char * __restrict, const char * __restrict, size_t) __picolibc_export;
 int   strncmp(const char *, const char *, size_t) __picolibc_export;
 char *strncpy(char * __restrict, const char * __restrict, size_t) __picolibc_export;
-#if __POSIX_VISIBLE >= 200809
+#if __POSIX_VISIBLE >= 200809 || __ISO_C_VISIBLE >= 2023
 char                                    *
 strndup(const char *, size_t)
 __malloc_like __warn_unused_result __picolibc_export;

--- a/libc/include/sys/features.h
+++ b/libc/include/sys/features.h
@@ -257,7 +257,7 @@ extern "C" {
  *	g++ -std=c++11 or newer (on by default since GCC 6), or with
  *	_ISOC11_SOURCE.
  *
- * __ISO_C_VISIBLE >= 2020
+ * __ISO_C_VISIBLE >= 2023
  *	ISO C23; enabled with gcc -std=c23 or newer,
  *	g++ -std=c++20 or newer, or with
  *	_ISOC23_SOURCE or _ISOC2x_SOURCE.

--- a/libc/include/time.h
+++ b/libc/include/time.h
@@ -228,13 +228,13 @@ int getdate_r(const char *, struct tm *) __picolibc_export;
 
 struct tm *gmtime(const time_t *_timer) __picolibc_export;
 
-#if __POSIX_VISIBLE || __ZEPHYR_VISIBLE
+#if __POSIX_VISIBLE || __ZEPHYR_VISIBLE || __ISO_C_VISIBLE >= 2023
 struct tm *gmtime_r(const time_t * __restrict, struct tm * __restrict) __picolibc_export;
 #endif
 
 struct tm *localtime(const time_t *_timer) __picolibc_export;
 
-#if __POSIX_VISIBLE
+#if __POSIX_VISIBLE || __ISO_C_VISIBLE >= 2023
 struct tm *localtime_r(const time_t * __restrict, struct tm * __restrict) __picolibc_export;
 #endif
 
@@ -267,7 +267,7 @@ char *strptime_l(const char * __restrict, const char * __restrict, struct tm * _
 
 time_t time(time_t *_timer) __picolibc_export;
 
-#if __BSD_VISIBLE || __SVID_VISIBLE || __GNU_VISIBLE
+#if __BSD_VISIBLE || __SVID_VISIBLE || __GNU_VISIBLE || __ISO_C_VISIBLE >= 2023
 time_t timegm(struct tm *_timeptr) __picolibc_export;
 #endif
 


### PR DESCRIPTION
For symbols adopted into C23 from other standards, the complete "existing practice standardized" set is:

<string.h>: memccpy, strdup, strndup
<time.h>: gmtime_r, localtime_r, timegm

References:

WG14 N2349 (memccpy from POSIX/XSI) --> https://www.open-std.org/JTC1/SC22/WG14/www/docs/n2349.htm
WG14 N2353 (strdup/strndup from POSIX) --> https://www.open-std.org/JTC1/SC22/WG14/www/docs/n2353.htm
cppreference (gmtime_r/localtime_r) --> https://en.cppreference.com/c/chrono/gmtime
https://en.cppreference.com/c/chrono/localtime
WG14 N2833 (timegm from BSD/GNU practice) --> https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2833.htm
exp10/exp10f/exp10l are also in C23 <math.h> (7.12.6.2), but they come from IEC 60559 / former GNU extensions, not POSIX.
--> https://cigix.me/c23#7.12.6.2

Fixes https://github.com/picolibc/picolibc/issues/1284