### PR TITLE
meson: declare feature-probe functions to satisfy -Wmissing-prototypes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -670,12 +670,14 @@ endif
 # CompCert does not support bitfields in packed structs, so avoid using this optimization
 bitfields_in_packed_structs_code = '''
 struct test { int part: 24; } __attribute__((packed));
+unsigned int foobar (const struct test *p);
 unsigned int foobar (const struct test *p) { return p->part; }
 '''
 have_bitfields_in_packed_structs = cc.compiles(bitfields_in_packed_structs_code, name : 'packed structs may contain bitfields', args: c_args)
 
 # CompCert does not support _Complex
 complex_code = '''
+float _Complex test(float _Complex z);
 float _Complex test(float _Complex z) { return z; }
 '''
 have_complex = cc.compiles(complex_code, name : 'supports _Complex', args: c_args)


### PR DESCRIPTION
The `_Complex` and packed-bitfield probes in `meson.build` define a function at file scope with no prior declaration.

Since fa3db286 ("meson.build: Clean up c_args computations") both probes run with the full `c_args` rather than `core_c_args`, and `c_args` includes `-Wmissing-prototypes`.

A toolchain that puts `-Werror` in the host `c_args` therefore turns the diagnostic into an error, and the probes conclude the feature is unsupported:

```
error: no previous prototype for function 'test' [-Werror,-Wmissing-prototypes]
    1 | float _Complex test(float _Complex z) { return z; }
      |                ^
```

This is the same class of bug as b7783864 (#1315), which fixed the constructor/destructor probe.


Fixed by adding a forward declaration to each snippet

My first PR to the project, so I may not be following preferred conventions!