### PR TITLE
stdlib: Add memalignment from C23

### DIFF
--- a/libc/include/stdlib.h
+++ b/libc/include/stdlib.h
@@ -180,6 +180,9 @@ __malloc_like __warn_unused_result __alloc_size(1) __nothrow __picolibc_export;
 int    mblen(const char *, size_t) __picolibc_export;
 size_t mbstowcs(wchar_t * __restrict, const char * __restrict, size_t) __picolibc_export;
 int    mbtowc(wchar_t    *__restrict, const char    *__restrict, size_t) __picolibc_export;
+#if __ISO_C_VISIBLE >= 2023
+size_t memalignment(const void *) __picolibc_export;
+#endif
 #if __BSD_VISIBLE || __POSIX_VISIBLE >= 200809
 char *mkdtemp(char *) __picolibc_export;
 #endif

--- a/libc/stdlib/CMakeLists.txt
+++ b/libc/stdlib/CMakeLists.txt
@@ -80,6 +80,7 @@ picolibc_sources(
   mbstowcs.c
   mbtowc.c
   mbtowc_r.c
+  memalignment.c
   mrand48.c
   nrand48.c
   putenv.c

--- a/libc/stdlib/memalignment.c
+++ b/libc/stdlib/memalignment.c
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 2000-2026 MIPS Holding, Inc
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _ISOC23_SOURCE
+#include <stdlib.h>
+#include <stdint.h>
+
+size_t
+memalignment(const void *p)
+{
+    uintptr_t u = (uintptr_t)p;
+
+    return (size_t)(u & -u);
+}

--- a/libc/stdlib/meson.build
+++ b/libc/stdlib/meson.build
@@ -103,6 +103,7 @@ srcs_stdlib = [
     'mbstowcs.c',
     'mbtowc.c',
     'mbtowc_r.c',
+    'memalignment.c',
     'mrand48.c',
     'nrand48.c',
     'onexit.c',

--- a/test/test-stdlib/CMakeLists.txt
+++ b/test/test-stdlib/CMakeLists.txt
@@ -42,6 +42,7 @@ set(tests
   test-quick-exit
   test-rand
   test-strtod
+  test-memalignment
   )
 
 set(tests_fail

--- a/test/test-stdlib/meson.build
+++ b/test/test-stdlib/meson.build
@@ -39,6 +39,7 @@ tests = [
   'test-efcvt',
   'test-malloc',
   'test-malloc-stress',
+  'test-memalignment',
   'test-on_exit',
   'test-quick-exit',
   'test-rand',
@@ -136,9 +137,17 @@ foreach params : targets
 
 endforeach
 
+# Host libc may not provide C23 memalignment yet.
+test_skip_native = [
+  'test-memalignment',
+]
+
 if enable_native_tests
 
   foreach t1 : tests
+    if t1 in test_skip_native
+      continue
+    endif
     t1_src = t1 + '.c'
     t1_name = t1 + '-native'
     test_file_name_arg=['-DTEST_FILE_NAME="' + t1_name + '.txt"']

--- a/test/test-stdlib/test-memalignment.c
+++ b/test/test-stdlib/test-memalignment.c
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 2000-2026 MIPS Holding, Inc
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _ISOC23_SOURCE
+#include <stdalign.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static int
+is_power_of_two(size_t x)
+{
+    return x != 0 && (x & (x - 1)) == 0;
+}
+
+int
+main(void)
+{
+    alignas(16) unsigned char buf[32];
+    void                     *p;
+    size_t                    a;
+
+    if (memalignment(NULL) != 0) {
+        printf("NULL failed\n");
+        return 1;
+    }
+
+    a = memalignment(buf);
+    if (!is_power_of_two(a) || a < 16) {
+        printf("aligned buf failed: %zu\n", a);
+        return 1;
+    }
+
+    a = memalignment(buf + 1);
+    if (a != 1) {
+        printf("misaligned failed: %zu\n", a);
+        return 1;
+    }
+
+    p = aligned_alloc(16, 64);
+    if (p == NULL)
+        return 1;
+    a = memalignment(p);
+    if (!is_power_of_two(a) || a < 16) {
+        printf("aligned_alloc failed: %zu\n", a);
+        free(p);
+        return 1;
+    }
+    free(p);
+
+    printf("memalignment tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
Add C23 memalignment (stdlib 7.24.9.1)

Returns the largest power-of-two alignment of a pointer (NULL --> 0). Declared under __ISO_C_VISIBLE >= 2023.
Includes a small regression test.

https://en.cppreference.com/w/c/memory/memalignment