### PR TITLE
sys/_types.h: make SSIZE_MAX usable in the preprocessor

### DIFF
--- a/libc/include/sys/_types.h
+++ b/libc/include/sys/_types.h
@@ -144,7 +144,16 @@ typedef unsigned long __size_t;
 #define unsigned signed
 typedef __SIZE_TYPE__ __ssize_t;
 #undef unsigned
-#define __SSIZE_MAX__ ((__ssize_t)(__SIZE_MAX__ >> 1))
+/* Use __PTRDIFF_MAX__ rather than a cast of (__SIZE_MAX__ >> 1): it is the
+   signed, pointer-width maximum and, unlike a cast expression, is usable in
+   preprocessor #if directives as <limits.h> macros are required to be. */
+#define __SSIZE_MAX__ __PTRDIFF_MAX__
+/* Guarded because this header is also parsed as C++ and as pre-C11 C, where
+   _Static_assert is not accepted. */
+#if defined(__SIZE_MAX__) && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+_Static_assert((__size_t)__SSIZE_MAX__ == (__SIZE_MAX__ >> 1),
+               "__SSIZE_MAX__ must be the top half of the __size_t range");
+#endif
 #else
 #if defined(__INT_MAX__) && __INT_MAX__ == 2147483647
 typedef int __ssize_t;

--- a/test/meson.build
+++ b/test/meson.build
@@ -43,6 +43,7 @@ tests = [
   'test-hello',
   'test-hosted-exit',
   'test-lseek-overflow',
+  'test-ssize-max',
   'test-hosted-exit-fail',
   'test-ilp32',
   'test-raise',

--- a/test/test-ssize-max.c
+++ b/test/test-ssize-max.c
@@ -1,0 +1,70 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026 Polykarpos Vergos
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * SSIZE_MAX, like every macro exposed through <limits.h>, must be an
+ * integer constant expression usable in #if preprocessing directives.
+ * A cast-based definition ((__ssize_t)(__SIZE_MAX__ >> 1)) is not, and
+ * broke code such as curl that tests it in #if (see issue #1358). The
+ * #if below is the regression check: it fails to build if SSIZE_MAX is
+ * not a valid constant expression.
+ */
+
+/* SSIZE_MAX is exposed under POSIX visibility. */
+#define _POSIX_C_SOURCE 200809L
+
+#include <limits.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#if SSIZE_MAX < 32767
+#error "SSIZE_MAX must be usable in #if and no smaller than _POSIX_SSIZE_MAX"
+#endif
+
+int
+main(void)
+{
+    /* SSIZE_MAX is the maximum value of the signed type ssize_t, so it
+       must be positive. */
+    if (SSIZE_MAX <= 0)
+        return 1;
+
+    /* ssize_t differs from size_t only in signedness, so its maximum is
+       exactly the top half of the size_t range. */
+    if ((size_t)SSIZE_MAX != (SIZE_MAX >> 1))
+        return 2;
+
+    return 0;
+}


### PR DESCRIPTION
Fixes #1358.

The GCC branch in `libc/include/sys/_types.h` defines `SSIZE_MAX` with a cast:

```c
#define __SSIZE_MAX__ ((__ssize_t)(__SIZE_MAX__ >> 1))
```

A cast isn't a constant expression the preprocessor can evaluate, so `SSIZE_MAX` can't be used in `#if`, even though `<limits.h>` macros are supposed to be usable there. That's what the curl report in the issue runs into. Its `warnless.c` has `#if INT_MAX < SSIZE_MAX` and fails to build against 1.8.12 with `error: missing binary operator before token '('`.

The issue notes that the trouble is needing a cast to a signed type because `SIZE_MAX` is unsigned. `__PTRDIFF_MAX__` sidesteps that. It's already the signed pointer-width maximum, so there's no cast and it works fine in the preprocessor. Since `ssize_t` here is just `size_t` with the sign flipped, and `ptrdiff_t` is the same width as `size_t` on every GCC/clang target, the value is identical to `(__SIZE_MAX__ >> 1)` but stays signed. `stdint.h` already relies on `__PTRDIFF_MAX__` the same way for `PTRDIFF_MAX`, and the other two branches here already use plain `__INT_MAX__`/`__LONG_MAX__`, so this keeps things consistent.

Using `(__SIZE_MAX__ >> 1)` on its own would compile in `#if` too, but it's unsigned, which changes the type of `SSIZE_MAX` and can bite in signed comparisons, so I avoided that.

The test adds `test-ssize-max`, which uses `SSIZE_MAX` in an `#if` and checks its value. It won't build against the old definition and passes with this one.
