### PR TITLE
stdlib: Fix typemismatch for _rand_next

### DIFF
--- a/libc/stdlib/local.h
+++ b/libc/stdlib/local.h
@@ -24,6 +24,8 @@ extern uint32_t __environ_sequence;
 #include <wchar.h>
 #endif
 
+extern __THREAD_LOCAL uint64_t _rand_next;
+
 #ifdef __AVR__
 typedef unsigned int uwchar_t;
 #else

--- a/libc/stdlib/random.c
+++ b/libc/stdlib/random.c
@@ -55,6 +55,7 @@ algorithm as <<rand>>.
 #define _DEFAULT_SOURCE
 #include <stdlib.h>
 #include <stdint.h>
+#include "local.h"
 
 __THREAD_LOCAL uint64_t _rand_next = 1;
 

--- a/libc/stdlib/srandom.c
+++ b/libc/stdlib/srandom.c
@@ -54,8 +54,7 @@ algorithm as <<rand>>.
 
 #define _DEFAULT_SOURCE
 #include <stdlib.h>
-
-extern __THREAD_LOCAL long long _rand_next;
+#include "local.h"
 
 void
 srandom(unsigned int seed)


### PR DESCRIPTION
_rand_next was defined as uint64_t in random.c and referenced in srandom.c as long long. Fix that by declaring it in local.h (as uint64_t) and then removing the declaration from srandom.c.