### PR TITLE
stdio: support C23 0b/0B prefixes in strtol family

### DIFF
--- a/libc/stdio/strtoi.h
+++ b/libc/stdio/strtoi.h
@@ -102,6 +102,12 @@ strtoi(const strtoi_char * __restrict nptr, strtoi_char ** __restrict endptr, in
             nptr = (const strtoi_char *)s;
             i = s[1];
             s += 2;
+        } else if (TOLOWER(*s) == 'b' && ((base | 2) == 2)) {
+            base = 2;
+            /* Parsed the '0' */
+            nptr = (const strtoi_char *)s;
+            i = s[1];
+            s += 2;
         } else if (base == 0) {
             base = 8;
         }

--- a/test/libc-testsuite/strtol.c
+++ b/test/libc-testsuite/strtol.c
@@ -141,6 +141,21 @@ test_strtol(void)
     TEST(l, strtol(s = "0x1234", &c, 16), 0x1234, "%ld != %ld");
     TEST2(i, c - s, 6, "wrong final position %ld != %ld");
 
+#ifndef NO_NEWLIB
+    /* C23 0b/0B prefixes: picolibc only. Host libc may still be pre-C23. */
+    TEST(l, strtol(s = "0b101", &c, 0), 5, "%ld != %ld");
+    TEST2(i, c - s, 5, "wrong final position %d != %d");
+
+    TEST(l, strtol(s = "0B101", &c, 0), 5, "%ld != %ld");
+    TEST2(i, c - s, 5, "wrong final position %d != %d");
+
+    TEST(l, strtol(s = "0b101", &c, 2), 5, "%ld != %ld");
+    TEST2(i, c - s, 5, "wrong final position %d != %d");
+
+    TEST(l, strtol(s = "0bz", &c, 0), 0, "%ld != %ld");
+    TEST2(i, c - s, 1, "wrong final position %d != %d");
+#endif
+
     char delim_buf[6] = "09af:";
 
     for (int j = 0; j < 256; j++) {


### PR DESCRIPTION
- Add C23 `0b`/`0B` binary prefixes to the shared `strtoi` parser used by `strtol` and related functions. Previously `"0b101"` with `base == 0` was misparsed as octal and returned 0.

- Includes libc-testsuite coverage for the new prefixes.

- References: C23 standard (ISO/IEC 9899:2024) --> 7.24.1.7 The strtol, strtoll, strtoul, and strtoull functions (p: 362-363)