### PR TITLE
stdlib: Skip-list based malloc

### DIFF
--- a/.github/workflows/linux-arm.yml
+++ b/.github/workflows/linux-arm.yml
@@ -64,7 +64,7 @@ jobs:
           "-Dsanitize=undefined",
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
-          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
+          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true -Dmalloc-skip-list=true",
           "-Danalyzer=true -Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [
@@ -99,7 +99,7 @@ jobs:
           "-Dsanitize=undefined",
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
-          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
+          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true -Dmalloc-skip-list=true",
           "-Danalyzer=true -Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -95,7 +95,7 @@ jobs:
           "-Dsanitize=undefined",
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
-          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
+          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true -Dmalloc-skip-list=true",
           "-Danalyzer=true -Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [
@@ -130,7 +130,7 @@ jobs:
           "-Dsanitize=undefined",
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
-          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
+          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true -Dmalloc-skip-list=true",
           "-Danalyzer=true -Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [
@@ -165,7 +165,7 @@ jobs:
           "-Dsanitize=undefined",
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
-          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
+          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true -Dmalloc-skip-list=true",
           "-Danalyzer=true -Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [
@@ -200,7 +200,7 @@ jobs:
           "-Dsanitize=undefined",
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
-          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
+          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true -Dmalloc-skip-list=true",
           "-Danalyzer=true -Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [
@@ -235,7 +235,7 @@ jobs:
           "-Dsanitize=undefined",
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
-          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
+          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true -Dmalloc-skip-list=true",
           "-Danalyzer=true -Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [
@@ -270,7 +270,7 @@ jobs:
           "-Dsanitize=undefined",
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
-          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
+          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true -Dmalloc-skip-list=true",
           "-Danalyzer=true -Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -61,7 +61,7 @@ jobs:
           "-Dsanitize=undefined",
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
-          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
+          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true -Dmalloc-skip-list=true",
           "-Danalyzer=true -Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [
@@ -96,7 +96,7 @@ jobs:
           "-Dsanitize=undefined",
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
-          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
+          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true -Dmalloc-skip-list=true",
           "-Danalyzer=true -Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [

--- a/.github/workflows/variants
+++ b/.github/workflows/variants
@@ -6,6 +6,6 @@
           "-Dsanitize=undefined",
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
-          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
+          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true -Dmalloc-skip-list=true",
           "-Danalyzer=true -Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -61,7 +61,7 @@ jobs:
           "-Dsanitize=undefined",
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
-          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
+          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true -Dmalloc-skip-list=true",
           "-Danalyzer=true -Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [
@@ -96,7 +96,7 @@ jobs:
           "-Dsanitize=undefined",
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
-          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
+          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true -Dmalloc-skip-list=true",
           "-Danalyzer=true -Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [

--- a/libc/stdio/getdelim.c
+++ b/libc/stdio/getdelim.c
@@ -71,6 +71,8 @@ getdelim(char ** restrict lineptr, size_t * restrict nptr, int delim, FILE * res
                 count = -1;
                 goto bail;
             }
+            *lineptr = line;
+            *nptr = n;
         }
 
         if (is_eof)
@@ -82,8 +84,6 @@ getdelim(char ** restrict lineptr, size_t * restrict nptr, int delim, FILE * res
     }
     line[count] = '\0';
 
-    *lineptr = line;
-    *nptr = n;
 bail:
     __funlock_return(stream, count);
 }

--- a/libc/stdlib/free.c
+++ b/libc/stdlib/free.c
@@ -40,8 +40,8 @@
 void __disable_sanitizer
 __malloc_free(void *free_p)
 {
-    chunk_t  *p_to_free;
-    chunk_t **p, *c;
+    chunk_t *p_to_free;
+    chunk_t *c;
 
     if (free_p == NULL)
         return;
@@ -54,7 +54,9 @@ __malloc_free(void *free_p)
 #ifdef __MALLOC_CLEAR_FREED
     memset(p_to_free, 0, chunk_usable(p_to_free));
 #else
+#ifndef __MALLOC_SKIP_LIST
     p_to_free->next = NULL;
+#endif
 #endif
 
 #if MALLOC_DEBUG
@@ -71,15 +73,51 @@ __malloc_free(void *free_p)
         int    bucket = BUCKET_NUM(s);
         size_t expect = BUCKET_SIZE(bucket);
         if (s == expect) {
+            chunk_t **p;
             p = &__malloc_bucket_list[bucket];
-            p_to_free->next = *p;
+            __next_bucket(p_to_free) = *p;
             *p = p_to_free;
             goto unlock;
         }
     }
 #endif
 
-    for (p = &__malloc_free_list; (c = *p) != NULL; p = &c->next) {
+    malloc_prev_t prev;
+#ifdef __MALLOC_SKIP_LIST
+    _ms_find(p_to_free, &prev);
+
+    c = _ms_this(&prev);
+
+    /* Check for double free */
+    if (c == p_to_free) {
+        errno = ENOMEM;
+        goto unlock;
+    }
+
+    /* Add the next block to this block if they're adjacent */
+    if (chunk_after(p_to_free) == c) {
+        *_size_ref(p_to_free) += _size(c);
+        _ms_clip_out(c, &prev);
+    }
+
+    /* prev[0] points at the *reference* to the next chunk,
+     * which is the same as the address of the previous chunk
+     */
+    chunk_t *prior = (chunk_t *)prev.prev[0];
+
+    /* Add this block to the prior block if they're adjacent */
+    if (prior != (chunk_t *)&__malloc_skip_list && chunk_after(prior) == p_to_free) {
+        *_size_ref(prior) += _size(p_to_free);
+#if __MALLOC_SMALL_BUCKET
+        p_to_free = prior;
+        _ms_find(p_to_free, &prev);
+#endif
+    } else {
+        _ms_clip_in(p_to_free, &prev);
+    }
+
+#else
+    for (_ms_step_init(&prev); (c = _ms_this(&prev)) != NULL; _ms_step(c, &prev)) {
         /* Insert in address order */
         if (p_to_free <= c) {
 
@@ -101,8 +139,7 @@ __malloc_free(void *free_p)
         }
     }
 
-    p_to_free->next = c;
-    *p = p_to_free;
+    _ms_clip_in(p_to_free, &prev);
 
 no_insert:
 
@@ -120,6 +157,7 @@ no_insert:
 #endif
         p_to_free->next = c->next;
     }
+#endif
 
 #if __MALLOC_SMALL_BUCKET
     s = _size(p_to_free);
@@ -130,14 +168,13 @@ no_insert:
         /* Move from general free list to bucket */
         if (s == bucket_size) {
 #ifdef MALLOC_DEBUG
-            assert(*p == p_to_free);
+            assert(_ms_this(&prev) == p_to_free);
 #endif
-
             /* unlink from general list */
-            *p = p_to_free->next;
+            _ms_clip_out(p_to_free, &prev);
 
             /* link to bucket list */
-            p_to_free->next = __malloc_bucket_list[bucket];
+            __next_bucket(p_to_free) = __malloc_bucket_list[bucket];
             __malloc_bucket_list[bucket] = p_to_free;
         }
     }

--- a/libc/stdlib/local-malloc.h
+++ b/libc/stdlib/local-malloc.h
@@ -106,8 +106,64 @@ typedef struct malloc_head {
 } head_t;
 
 typedef struct malloc_chunk {
+#ifdef __MALLOC_SKIP_LIST
+    struct {
+    } empty; /* C doesn't allow a struct with only a flex-array member */
+    struct malloc_chunk *next[];
+#else
     struct malloc_chunk *next;
+#endif
 } chunk_t;
+
+#ifdef __MALLOC_SKIP_LIST
+#include "malloc-skip.h"
+
+extern malloc_head_t __malloc_skip_list;
+
+#define __malloc_free_list (__malloc_skip_list.next[0])
+#define __next_chunk(c)    _ms_next(c)
+#define __next_bucket(c)   ((c)->next[0])
+
+#else
+
+extern chunk_t   *__malloc_free_list;
+
+#define __next_chunk(c)  ((c)->next)
+#define __next_bucket(c) ((c)->next)
+
+typedef chunk_t **malloc_prev_t;
+
+static inline void
+_ms_step_init(malloc_prev_t *prev)
+{
+    *prev = &__malloc_free_list;
+}
+
+static inline chunk_t *
+_ms_this(malloc_prev_t *prev)
+{
+    return **prev;
+}
+
+static inline void
+_ms_step(chunk_t *c, malloc_prev_t *prev)
+{
+    *prev = &c->next;
+}
+
+static inline void
+_ms_clip_out(chunk_t *c, malloc_prev_t *prev)
+{
+    **prev = c->next;
+}
+
+static inline void
+_ms_clip_in(chunk_t *c, malloc_prev_t *prev)
+{
+    c->next = **prev;
+    **prev = c;
+}
+#endif
 
 /* Alignment of allocated chunk. Compute the alignment required from a
  * range of types */
@@ -123,13 +179,23 @@ typedef struct malloc_chunk {
 
 #define MALLOC_HEAD_SIZE   sizeof(head_t)
 
-#define MALLOC_CHUNK_SIZE  sizeof(chunk_t)
+#define MALLOC_CHUNK_SIZE  sizeof(chunk_t *)
 
 /* nominal "page size" */
 #define MALLOC_PAGE_ALIGN (0x1000)
 
 /* Minimum chunk size */
 #define MALLOC_CHUNK_MIN __align_up(MALLOC_CHUNK_SIZE + MALLOC_HEAD_SIZE, MALLOC_CHUNK_ALIGN)
+
+/* Minimum chunk split size */
+#ifdef __MALLOC_SKIP_LIST
+#define MALLOC_SPLIT_PTRS (MS_MAX_LEVEL + 1)
+#else
+#define MALLOC_SPLIT_PTRS 1
+#endif
+
+#define MALLOC_SPLIT_MIN                                                                    \
+    __align_up(MALLOC_CHUNK_SIZE *MALLOC_SPLIT_PTRS + MALLOC_HEAD_SIZE, MALLOC_CHUNK_ALIGN)
 
 /* Maximum chunk size */
 #define MALLOC_CHUNK_MAX (SIZE_MAX - 2 * MAX(MALLOC_CHUNK_SIZE, MALLOC_CHUNK_ALIGN))
@@ -202,10 +268,8 @@ void __malloc_validate_chunk(chunk_t *c);
 #define MALLOC_UNLOCK __LIBC_UNLOCK()
 #endif
 
-/* Forward data declarations */
-extern chunk_t *__malloc_free_list;
-extern char    *__malloc_sbrk_start;
-extern char    *__malloc_sbrk_top;
+extern char *__malloc_sbrk_start;
+extern char *__malloc_sbrk_top;
 
 #ifdef MALLOC_MAX_BUCKET_POT
 
@@ -271,7 +335,7 @@ static inline void * __disable_sanitizer
 chunk_end(chunk_t *c)
 {
     size_t *s = _size_ref(c);
-    return (char *)s + *s;
+    return (char *)s + (*s & ~(size_t)1);
 }
 
 /* next chunk in memory -- address of chunk header past this chunk */

--- a/libc/stdlib/mallinfo.c
+++ b/libc/stdlib/mallinfo.c
@@ -52,7 +52,7 @@ mallinfo(void)
             total_size = (size_t)(sbrk_now - __malloc_sbrk_start);
     }
 
-    for (pf = __malloc_free_list; pf; pf = pf->next) {
+    for (pf = __malloc_free_list; pf; pf = __next_chunk(pf)) {
         ordblks++;
         free_size += _size(pf);
     }
@@ -61,7 +61,7 @@ mallinfo(void)
     size_t smblks = 0;
     size_t fsmblks = 0;
     for (b = 0; b < NUM_BUCKET_POT; b++)
-        for (pf = __malloc_bucket_list[b]; pf; pf = pf->next) {
+        for (pf = __malloc_bucket_list[b]; pf; pf = __next_bucket(pf)) {
             smblks++;
             fsmblks += _size(pf);
         }

--- a/libc/stdlib/malloc-skip.c
+++ b/libc/stdlib/malloc-skip.c
@@ -1,0 +1,278 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "local-malloc.h"
+
+#ifdef __MALLOC_SKIP_LIST
+
+static inline size_t
+_ms_new_level(size_t size)
+{
+    long   bits = random();
+    size_t level = 0;
+
+    while (!(bits & MS_LEVEL_MASK) && level < MS_MAX_LEVEL
+           && malloc_size(size) >= _ms_size(level + 1)) {
+        level++;
+        bits >>= MS_LEVEL_BITS;
+    }
+    return level;
+}
+
+static void
+_ms_init(chunk_t *ms)
+{
+    size_t level = _ms_new_level(_size(ms));
+    size_t o;
+    for (o = 0; o < level; o++)
+        ms->next[o] = (chunk_t *)((uintptr_t)1);
+    ms->next[o] = NULL;
+}
+
+/*
+ * Find the position for 'template'. Return pointers to the pointer
+ * at each level; this allows simple list modification for both
+ * insert and delete
+ */
+void
+_ms_find(const chunk_t *template, malloc_prev_t *prev)
+{
+    size_t    o;
+    chunk_t  *next;
+    chunk_t **p;
+
+    p = &__malloc_skip_list.next[MS_MAX_LEVEL];
+
+    /* For all levels */
+    for (o = MS_MAX_LEVEL;; o--) {
+
+        /* Search at this level for the insertion point */
+        while ((next = _ms_ref(*p)) != NULL) {
+
+            /* Stop when template doesn't follow next */
+            if (!_ms_greater(template, next))
+                break;
+
+            p = &next->next[o];
+        }
+
+        /* Save this position */
+        prev->prev[o] = p;
+
+        /* all done ? */
+        if (o == 0)
+            break;
+
+        /* Step to the previous reference */
+        p--;
+    }
+}
+
+/* Insert 'ms' into lists at position prev */
+void
+_ms_clip_in(chunk_t *ms, malloc_prev_t *prev)
+{
+    size_t o;
+
+    _ms_init(ms);
+    /* Insert into all levels for the new object */
+    for (o = 0;; o++) {
+        _ms_set_ref(&ms->next[o], _ms_ref(*prev->prev[o]));
+        _ms_set_ref(prev->prev[o], ms);
+        if (_ms_is_last(ms->next[o]))
+            break;
+    }
+}
+
+/* Remove 'ms' from lists at position prev */
+void
+_ms_clip_out(chunk_t *ms, malloc_prev_t *prev)
+{
+    size_t o;
+
+    /* Delete from all levels for the old object */
+    for (o = 0;; o++) {
+        chunk_t *ref = ms->next[o];
+        _ms_set_ref(prev->prev[o], _ms_ref(ref));
+        if (_ms_is_last(ref))
+            break;
+    }
+}
+
+/* Step forward one object, updating all of the prev pointers */
+void
+_ms_step(chunk_t *ms, malloc_prev_t *prev)
+{
+    chunk_t ***p;
+    chunk_t  **n;
+
+    /*
+     * Update the 'prev' pointer array to reference the current
+     * object for all levels it contains.
+     */
+    n = ms->next;
+    p = prev->prev;
+    for (;;) {
+        *p = n;
+        if (_ms_is_last(*n))
+            break;
+        p++;
+        n++;
+    }
+}
+
+#ifdef MALLOC_SKIP_API
+
+/* This higher level API is unused by malloc */
+
+void
+_ms_insert(chunk_t *new)
+{
+    malloc_prev_t prev;
+
+    _ms_find(new, &prev);
+    _ms_clip_in(new, &prev);
+}
+
+bool
+_ms_delete(chunk_t *old)
+{
+    malloc_prev_t prev;
+
+    _ms_find(old, &prev);
+
+    if (_ms_this(&prev) != old)
+        return false;
+
+    _ms_clip_out(old, &prev);
+    return true;
+}
+
+chunk_t *
+_ms_search(chunk_t *pattern)
+{
+    malloc_prev_t prev;
+    chunk_t      *found;
+
+    _ms_find(pattern, &prev);
+
+    found = _ms_this(&prev);
+    if (found && _ms_greater(pattern, found))
+        found = NULL;
+    return found;
+}
+#endif
+
+#ifdef MALLOC_DEBUG
+void
+_ms_dump(void)
+{
+    chunk_t      *ms;
+    malloc_prev_t prev;
+    size_t        o;
+
+    _ms_step_init(&prev);
+
+    printf("##########\n");
+    for (_ms_step_init(&prev); (ms = _ms_this(&prev)) != NULL; _ms_step(ms, &prev)) {
+        printf("%p(%6zd):", ms, _size((chunk_t *)ms));
+
+        bool pass_through = false;
+
+        for (o = 0; o <= MS_MAX_LEVEL; o++) {
+            if (pass_through)
+                printf("  |  ");
+            else {
+                if (_ms_ref(*prev.prev[o]) != ms)
+                    printf("--?--");
+                else
+                    printf("--+--");
+                if (_ms_is_last(ms->next[o]))
+                    pass_through = true;
+            }
+        }
+        printf("\n");
+    }
+    printf("##########\n");
+}
+
+void
+_ms_validate(void)
+{
+    size_t   o;
+    chunk_t *ms, *next, *down;
+    size_t   prev_count = 0;
+    size_t   count;
+
+    for (o = MS_MAX_LEVEL;; o--) {
+
+        count = 0;
+        /* Make sure that this chain is in order */
+        for (ms = __malloc_skip_list.next[o]; ms; ms = next) {
+
+            count++;
+
+            next = _ms_ref(ms->next[o]);
+
+            assert(!next || !_ms_greater(ms, next));
+
+            if (o != 0) {
+                /* Make sure we find 'next' on the next chain down */
+                for (down = ms;; down = _ms_ref(down->next[o - 1])) {
+                    if (down == next)
+                        break;
+                    assert(down != NULL);
+                }
+            }
+        }
+        /*
+         * Make sure the counts are "reasonable", increasing at about
+         * 4x per level
+         */
+        if (count >= 32) {
+            if ((count && count < prev_count * 2) || (prev_count && count > prev_count * 32)) {
+                printf("level %zd: %zd level %zd %zd\n", o, count, o + 1, prev_count);
+            }
+        }
+
+        prev_count = count;
+
+        if (o == 0)
+            break;
+    }
+}
+#endif /* MALLOC_DEBUG */
+
+#endif /* __MALLOC_SKIP_LIST */

--- a/libc/stdlib/malloc-skip.h
+++ b/libc/stdlib/malloc-skip.h
@@ -1,0 +1,137 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _MALLOC_SKIP_H_
+#define _MALLOC_SKIP_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+
+#define MS_LEVEL_BITS 2
+#define MS_LEVEL_MASK ((1 << MS_LEVEL_BITS) - 1)
+#define MS_MAX_LEVEL  (30 / MS_LEVEL_BITS)
+
+typedef struct {
+    chunk_t *next[MS_MAX_LEVEL + 1];
+} malloc_head_t;
+
+typedef struct {
+    chunk_t **prev[MS_MAX_LEVEL + 1];
+} malloc_prev_t;
+
+extern malloc_head_t __malloc_skip_list;
+
+static inline size_t
+_ms_size(size_t level)
+{
+    return (level + 1) * sizeof(chunk_t *);
+}
+
+/* Mask off the low bit from a pointer */
+static inline chunk_t *
+_ms_ref(chunk_t *ptr)
+{
+    return (chunk_t *)((uintptr_t)ptr & ~1);
+}
+
+static inline bool
+_ms_greater(const chunk_t *a, const chunk_t *b)
+{
+    return (uintptr_t)a > (uintptr_t)b;
+}
+
+/* Store a pointer while preserving the low bit in the destination */
+static inline void
+_ms_set_ref(chunk_t **ref, chunk_t *ptr)
+{
+    *ref = (chunk_t *)(((uintptr_t)*ref & 1) | (uintptr_t)ptr);
+}
+
+static inline chunk_t *
+_ms_next(chunk_t *ms)
+{
+    return _ms_ref(ms->next[0]);
+}
+
+static inline bool
+_ms_is_last(chunk_t *ms)
+{
+    return ((uintptr_t)ms & 1) == 0;
+}
+
+static inline void
+_ms_step_init(malloc_prev_t *prev)
+{
+    size_t o;
+
+    for (o = 0; o <= MS_MAX_LEVEL; o++)
+        prev->prev[o] = &__malloc_skip_list.next[o];
+}
+
+static inline chunk_t *
+_ms_this(malloc_prev_t *prev)
+{
+    return _ms_ref(*prev->prev[0]);
+}
+
+void _ms_clip_in(chunk_t *ms, malloc_prev_t *prev);
+void _ms_clip_out(chunk_t *ms, malloc_prev_t *prev);
+
+void _ms_find(const chunk_t *template, malloc_prev_t *prev);
+void _ms_step(chunk_t *ms, malloc_prev_t *prev);
+
+#ifdef MALLOC_SKIP_API
+/* This higher level API is unused by malloc */
+void     _ms_insert(chunk_t *new);
+bool     _ms_delete(chunk_t *old);
+chunk_t *_ms_search(chunk_t *pattern);
+#endif
+
+#ifdef MALLOC_DEBUG
+void _ms_validate(void);
+void _ms_dump(void);
+#else
+static inline void
+_ms_validate(void)
+{
+}
+static inline void
+_ms_dump(void)
+{
+}
+#endif
+
+#endif /* _MALLOC_SKIP_H_ */

--- a/libc/stdlib/malloc.c
+++ b/libc/stdlib/malloc.c
@@ -28,8 +28,12 @@
 
 #include "local-malloc.h"
 
-/* List list header of free blocks */
+/* List header of free chunks */
+#ifdef __MALLOC_SKIP_LIST
+malloc_head_t __malloc_skip_list;
+#else
 chunk_t *__malloc_free_list;
+#endif
 
 #if __MALLOC_SMALL_BUCKET
 chunk_t *__malloc_bucket_list[NUM_BUCKET_POT];
@@ -107,7 +111,7 @@ __malloc_grow_chunk(chunk_t *c, size_t new_size)
 
     if (chunk_e != __malloc_sbrk_top)
         return false;
-    size_t add_size = MAX(MALLOC_CHUNK_MIN, new_size - _size(c));
+    size_t add_size = MAX(MALLOC_SPLIT_MIN, new_size - _size(c));
 
     /* Ask for the extra memory needed */
     char  *heap = __malloc_sbrk_aligned(add_size);
@@ -134,9 +138,9 @@ __malloc_grow_chunk(chunk_t *c, size_t new_size)
 void * __disable_sanitizer
 malloc(size_t s)
 {
-    chunk_t **p, *c;
-    char     *ptr;
-    size_t    alloc_size;
+    chunk_t *c;
+    char    *ptr;
+    size_t   alloc_size;
 
     if (s > MALLOC_ALLOC_MAX) {
         errno = ENOMEM;
@@ -150,23 +154,27 @@ malloc(size_t s)
 #if __MALLOC_SMALL_BUCKET
     /* Small allocations use the bucket allocator */
     if (alloc_size <= MALLOC_MAX_BUCKET) {
-        int bucket = BUCKET_NUM(alloc_size);
+        int       bucket = BUCKET_NUM(alloc_size);
+        chunk_t **p;
 
         alloc_size = BUCKET_SIZE(bucket);
         p = &__malloc_bucket_list[bucket];
         if ((c = *p) != NULL)
-            *p = c->next;
+            *p = __next_bucket(c);
     } else
 #endif
     {
-        for (p = &__malloc_free_list; (c = *p) != NULL; p = &c->next) {
+        malloc_prev_t prev;
+        for (_ms_step_init(&prev); (c = _ms_this(&prev)) != NULL; _ms_step(c, &prev)) {
             if (_size(c) >= alloc_size) {
                 size_t rem = _size(c) - alloc_size;
 
-                if (rem >= MALLOC_CHUNK_MIN) {
+                if (rem >= MALLOC_SPLIT_MIN) {
                     /* Find a chunk_t that much larger than required size, break
                      * it into two chunks and return the first one
                      */
+
+                    _ms_clip_out(c, &prev);
 
                     chunk_t *s = (chunk_t *)((char *)c + alloc_size);
                     _set_size(c, alloc_size);
@@ -182,30 +190,29 @@ malloc(size_t s)
                         int    bucket = BUCKET_NUM(rem);
                         size_t bucket_size = BUCKET_SIZE(bucket);
                         if (rem == bucket_size) {
-                            s->next = __malloc_bucket_list[bucket];
+                            /* insert into bucket list */
+                            __next_bucket(s) = __malloc_bucket_list[bucket];
                             __malloc_bucket_list[bucket] = s;
-
-                            /* unlink from the general list */
-                            *p = c->next;
                             break;
                         }
                     }
 #endif
-                    s->next = c->next;
-                    *p = s;
+
+                    _ms_clip_in(s, &prev);
                 } else {
                     /* Find a chunk_t that is exactly the size or slightly bigger
                      * than requested size, just return this chunk_t
                      */
-                    *p = c->next;
+                    _ms_clip_out(c, &prev);
                 }
                 break;
             }
-            if (!c->next && __malloc_grow_chunk(c, alloc_size)) {
-                /* Grow the last chunk in memory to the requested size,
+            if (!__next_chunk(c) && __malloc_grow_chunk(c, alloc_size)) {
+                /*
+                 * Grew the last chunk in memory to the requested size,
                  * just return it
                  */
-                *p = c->next;
+                _ms_clip_out(c, &prev);
                 break;
             }
         }
@@ -213,6 +220,26 @@ malloc(size_t s)
 
     /* Failed to find a appropriate chunk_t. Ask for more memory */
     if (c == NULL) {
+
+#ifdef __MALLOC_SKIP_LIST__
+        /*
+         * Avoid a large number of tiny allocations making our skip list
+         * too flat by randomly increasing chunk sizes using our skip
+         * list allocation scheme
+         */
+        size_t need_size = chunk_size(_ms_size(MS_MAX_LEVEL));
+        if (alloc_size < need_size) {
+            long   bits = random();
+            size_t level = 0;
+            while (!(bits & MS_LEVEL_MASK) && level < MS_MAX_LEVEL) {
+                level++;
+                bits >>= MS_LEVEL_BITS;
+            }
+            size_t need_size = chunk_size(_ms_size(level));
+            if (alloc_size < need_size)
+                alloc_size = need_size;
+        }
+#endif
         void *blob = __malloc_sbrk_aligned(alloc_size);
 
         /* sbrk returns -1 if fail to allocate */
@@ -253,7 +280,7 @@ __malloc_validate_chunk(chunk_t *c)
     assert(__align_up(chunk_to_ptr(c), MALLOC_CHUNK_ALIGN) == chunk_to_ptr(c));
     assert(__align_up(c, MALLOC_HEAD_ALIGN) == c);
     assert(_size(c) >= MALLOC_CHUNK_MIN);
-    assert(_size(c) < 0x80000000UL);
+    assert(_size(c) < MALLOC_CHUNK_MAX);
     assert(__align_up(_size(c), MALLOC_HEAD_ALIGN) == _size(c));
 }
 
@@ -262,7 +289,7 @@ __malloc_validate(void)
 {
     chunk_t *c;
 
-    for (c = __malloc_free_list; c; c = c->next) {
+    for (c = __malloc_free_list; c; c = __next_chunk(c)) {
         assert(_is_free(c));
         __malloc_validate_chunk(c);
 #if __MALLOC_SMALL_BUCKET
@@ -272,18 +299,21 @@ __malloc_validate(void)
         size_t bucket_size = BUCKET_SIZE(bucket);
         assert(s > max_bucket || s != bucket_size);
 #endif
-        assert(c->next == NULL || chunk_after(c) <= c->next);
+        assert(__next_chunk(c) == NULL || chunk_after(c) <= __next_chunk(c));
     }
 #if __MALLOC_SMALL_BUCKET
     size_t b;
 
     for (b = 0; b < NUM_BUCKET_POT; b++) {
-        for (c = __malloc_bucket_list[b]; c; c = c->next) {
+        for (c = __malloc_bucket_list[b]; c; c = __next_bucket(c)) {
             assert(_is_free(c));
             __malloc_validate_chunk(c);
             assert(_size(c) == BUCKET_SIZE(b));
         }
     }
+#endif
+#ifdef __MALLOC_SKIP_LIST
+    _ms_validate();
 #endif
 }
 

--- a/libc/stdlib/memalign.c
+++ b/libc/stdlib/memalign.c
@@ -67,7 +67,7 @@ memalign(size_t align, size_t s)
     /* Make sure there's space to align the allocation and split
      * off chunk_t from the front
      */
-    size_with_padding = s + align + MALLOC_CHUNK_MIN;
+    size_with_padding = s + align + MALLOC_SPLIT_MIN;
 
     allocated = __malloc_malloc(size_with_padding);
     if (allocated == NULL)
@@ -81,7 +81,7 @@ memalign(size_t align, size_t s)
 
     /* Split off the front piece if necessary */
     if (offset) {
-        if (offset < MALLOC_CHUNK_MIN) {
+        if (offset < MALLOC_SPLIT_MIN) {
             aligned_p += align;
             offset += align;
         }
@@ -97,7 +97,7 @@ memalign(size_t align, size_t s)
     offset = _size(chunk_p) - s;
 
     /* Split off the back piece if large enough */
-    if (offset >= MALLOC_CHUNK_MIN) {
+    if (offset >= MALLOC_SPLIT_MIN) {
         *_size_ref(chunk_p) -= offset;
 
         make_free_chunk(chunk_after(chunk_p), offset);

--- a/libc/stdlib/meson.build
+++ b/libc/stdlib/meson.build
@@ -39,6 +39,7 @@ malloc_srcs_stdlib = [
   'mallinfo.c',
   'malloc.c',
   'malloc-error.c',
+  'malloc-skip.c',
   'malloc-stats.c',
   'malloc-usable-size.c',
   'mallopt.c',

--- a/libc/stdlib/realloc.c
+++ b/libc/stdlib/realloc.c
@@ -82,31 +82,41 @@ realloc(void *ptr, size_t size)
         if (__malloc_grow_chunk(p_to_realloc, new_size)) {
             /* clear new memory */
             memset(chunk_e, '\0', new_size - old_size);
-            /* adjust chunk_t size */
-            old_size = new_size;
+            /* update size */
+            old_size = _size(p_to_realloc);
         } else {
-            chunk_t **p, *r;
-
-            /* Check to see if there's a chunk_t of free space just past
-             * the current chunk, merge it in in case that's useful
+            /*
+             * Check to see if there's a chunk_t of free space just
+             * past the current chunk, merge it in in case that's
+             * useful
              */
-            for (p = &__malloc_free_list; (r = *p) != NULL; p = &r->next) {
-                if (r == chunk_e) {
-                    size_t r_size = _size(r);
+            chunk_t      *c;
+            malloc_prev_t prev;
+#ifdef __MALLOC_SKIP_LIST
+            _ms_find(p_to_realloc, &prev);
+            c = _ms_this(&prev);
+#else
+            for (_ms_step_init(&prev); (c = _ms_this(&prev)) != NULL; _ms_step(c, &prev)) {
+                if (p_to_realloc < c)
+                    break;
+            }
+#endif
+            if (c && chunk_to_blob(c) == chunk_e) {
+                size_t c_size = _size(c);
+                if (old_size + c_size >= new_size) {
 
-                    /* remove R from the free list */
-                    *p = r->next;
+                    /* Remove c from the free list */
+                    _ms_clip_out(c, &prev);
 
-                    /* clear the memory from r */
-                    memset(r, '\0', r_size);
+                    /* clear the memory from c */
+                    memset(chunk_to_blob(c), 0, new_size - old_size);
 
                     /* add it's size to our chunk */
-                    old_size += r_size;
+                    old_size += c_size;
                     _set_size(p_to_realloc, old_size);
-                    break;
+                    MALLOC_UNLOCK;
+                    goto add_leftover;
                 }
-                if (p_to_realloc < r)
-                    break;
             }
         }
 
@@ -114,15 +124,18 @@ realloc(void *ptr, size_t size)
     }
 
     if (new_size <= old_size) {
-        size_t extra = old_size - new_size;
 
 #ifdef __MALLOC_CLEAR_FREED
         memset((char *)ptr + size, 0, old_size - size);
 #endif
+
+    add_leftover:;
         /* If there's enough space left over, split it out
          * and free it
          */
-        if (!is_bucket && extra >= MALLOC_CHUNK_MIN) {
+        size_t extra = old_size - new_size;
+
+        if (!is_bucket && extra >= MALLOC_SPLIT_MIN) {
             _set_size(p_to_realloc, new_size);
             make_free_chunk(chunk_after(p_to_realloc), extra);
         }

--- a/libos/linux/cfsetispeed.c
+++ b/libos/linux/cfsetispeed.c
@@ -41,4 +41,5 @@ cfsetispeed(struct termios *termios, speed_t speed)
     if (speed == 0)
         speed = termios->c_ospeed;
     termios->c_ispeed = speed;
+    return 0;
 }

--- a/libos/linux/cfsetospeed.c
+++ b/libos/linux/cfsetospeed.c
@@ -39,4 +39,5 @@ int
 cfsetospeed(struct termios *termios, speed_t speed)
 {
     termios->c_ospeed = speed;
+    return 0;
 }

--- a/libos/linux/cfsetspeed.c
+++ b/libos/linux/cfsetspeed.c
@@ -40,4 +40,5 @@ cfsetospeed(struct termios *termios, speed_t speed)
 {
     termios->c_ospeed = speed;
     termios->c_ispeed = speed;
+    return 0;
 }

--- a/meson.build
+++ b/meson.build
@@ -460,7 +460,7 @@ endif
 
 test_link_args_base = runtime_lib
 
-test_link_args_extra = ['-Wl,--gc-sections', '-Wl,--no-warn-rwx-segments']
+test_link_args_extra = ['-Wl,--gc-sections', '-Wl,--no-warn-rwx-segments', '-Wl,--no-fatal-warnings']
 
 if profile
   test_link_args_extra += ['-pg']
@@ -1753,6 +1753,8 @@ if get_option('test-long-double')
   test_c_args += ['-D_TEST_LONG_DOUBLE']
   native_c_args += ['-D_TEST_LONG_DOUBLE']
 endif
+
+native_c_args += ['-Wl,--no-fatal-warnings']
 
 test_env = environment()
 test_env.prepend('PATH', meson.current_source_dir() / 'scripts')

--- a/meson.build
+++ b/meson.build
@@ -1482,6 +1482,7 @@ conf_data.set('__SINGLE_THREAD', get_option('single-thread'), description: 'Disa
 conf_data.set('__HAVE_FCNTL', get_option('have-fcntl'), description: 'System provides fcntl function')
 conf_data.set('__MALLOC_CLEAR_FREED', get_option('malloc-clear-freed'))
 conf_data.set('__MALLOC_SMALL_BUCKET', get_option('malloc-small-bucket'))
+conf_data.set('__MALLOC_SKIP_LIST', get_option('malloc-skip-list'))
 conf_data.set('__MALLOC_ERROR_ABORT', get_option('malloc-error-abort'))
 if internal_heap != 0
   conf_data.set('__INTERNAL_HEAP', internal_heap)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -224,6 +224,8 @@ option('malloc-error-abort', type: 'boolean', value: false,
        description: 'Abort when malloc usage errors are detected')
 option('malloc-small-bucket', type: 'integer', value: 0,
        description: 'use fixed bucket sizes for allocations no larger than this')
+option('malloc-skip-list', type: 'boolean', value: false,
+       description: 'Use skip-list for free list')
 
 #
 # Locking options

--- a/test/libc-testsuite/qsort.c
+++ b/test/libc-testsuite/qsort.c
@@ -45,8 +45,13 @@ struct three {
     unsigned char b[3];
 };
 
-#define i3(x) \
-    { (unsigned char)(((int32_t)(x)) >> 16), (unsigned char)((x) >> 8), (unsigned char)((x) >> 0) }
+#define i3(x)                                         \
+    {                                                 \
+        .b                                            \
+            = {(unsigned char)(((int32_t)(x)) >> 16), \
+               (unsigned char)((x) >> 8),             \
+               (unsigned char)((x) >> 0) }            \
+    }
 
 static int
 tcmp(const void *av, const void *bv)

--- a/test/test-regex.c
+++ b/test/test-regex.c
@@ -37,6 +37,7 @@
 #include <sys/types.h>
 #include <regex.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 #define MAX_MATCH 10
 
@@ -102,8 +103,9 @@ main(void)
                     if (matches[m].rm_so != tests[t].matches[m].rm_so
                         || matches[m].rm_eo != tests[t].matches[m].rm_eo) {
                         printf("match %d wrong range got (%td,%td) expect (%td,%td)\n", m,
-                               matches[m].rm_so, matches[m].rm_eo, tests[t].matches[m].rm_so,
-                               tests[t].matches[m].rm_eo);
+                               (ptrdiff_t)matches[m].rm_so, (ptrdiff_t)matches[m].rm_eo,
+                               (ptrdiff_t)tests[t].matches[m].rm_so,
+                               (ptrdiff_t)tests[t].matches[m].rm_eo);
                         errors++;
                     }
                 } else {

--- a/test/test-stdlib/meson.build
+++ b/test/test-stdlib/meson.build
@@ -39,6 +39,7 @@ tests = [
   'test-efcvt',
   'test-malloc',
   'test-malloc-stress',
+  'test-many-malloc',
   'test-memalignment',
   'test-on_exit',
   'test-quick-exit',

--- a/test/test-stdlib/test-malloc.c
+++ b/test/test-stdlib/test-malloc.c
@@ -257,7 +257,7 @@ main(void)
             char *med = realloc(small, 1024);
             if (med) {
 //                                printf("med %p\n", med);
-#ifdef __NANO_MALLOC
+#ifdef __PICOLIBC__
                 int i;
                 for (i = 128; i < 1024; i++)
                     if (med[i] != 0) {
@@ -271,6 +271,30 @@ main(void)
             free(small);
         }
     }
+
+#ifdef __PICOLIBC__
+    /* try to get realloc to merge an adjacent free block */
+
+    void *first = malloc(2048);
+    if (first)
+        memset(first, '1', 2048);
+    void *second = malloc(2048);
+    if (second) {
+        memset(second, '2', 2048);
+        free(second);
+    }
+    if (first) {
+        void *again = realloc(first, 4096);
+        if (again) {
+            printf("first %p second %p again %p\n", first, second, again);
+            if (again != first) {
+                printf("realloc into adjacent free block failed\n");
+                ++result;
+            }
+            free(again);
+        }
+    }
+#endif
 
     malloc_stats();
 

--- a/test/test-stdlib/test-many-malloc.c
+++ b/test/test-stdlib/test-many-malloc.c
@@ -1,0 +1,109 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2026 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _DEFAULT_SOURCE
+#include <stdlib.h>
+#include <stdio.h>
+
+static size_t
+random_int(size_t count)
+{
+    return ((size_t)random()) % count;
+}
+
+static void
+shuffle(void **values, size_t n)
+{
+    size_t i;
+
+    for (i = 0; i < n - 1; i++) {
+        size_t p = random_int(n - i);
+        void  *t = values[i];
+        values[i] = values[i + p];
+        values[i + p] = t;
+    }
+}
+
+#if __SIZE_MAX__ < 0xffffffffUL
+/*
+ * Compute space for the pointer array and the objects on small
+ * targets
+ */
+#define N ((__SIZE_MAX__) >> 16)
+#else
+
+#if (defined(__MALLOC_SMALL_BUCKET) && __MALLOC_SMALL_BUCKET == 0) && !defined(__MALLOC_SKIP_LIST)
+#define N ((size_t) 1024 * (size_t) 128)
+#else
+#define N ((size_t) 1024 * (size_t) 1024)
+#endif
+
+#endif
+
+#define OBJ_SIZE 8
+
+int
+main(void)
+{
+    void **objs;
+    size_t o;
+
+    objs = calloc(N, sizeof(void *));
+    if (!objs) {
+        printf("cannot allocate objs array\n");
+        return 77;
+    }
+
+    for (o = 0; o < N; o++) {
+        objs[o] = malloc(OBJ_SIZE);
+        if (!objs[o]) {
+            printf("cannot allocate obj %zd\n", o);
+            return 77;
+        }
+        if (o % 100000 == 0)
+            printf("malloc %zd\n", o);
+    }
+
+    shuffle(objs, N);
+
+    for (o = 0; o < N; o++) {
+        free(objs[o]);
+        if (o % 100000 == 0)
+            printf("free %zd\n", o);
+    }
+
+    printf("All done\n");
+    return 0;
+}


### PR DESCRIPTION
Replace the single linked list of free malloc blocks with a skip-list. This converts free from O(N) to O(log(N)) and might serve as an alternative to the bucket-based allocation scheme currently bolted onto the allocator.
    
This is controlled by the new -Dmalloc-skip-list meson option