### PR TITLE
riscv/`strcmp`: default to single-word loop, restore unroll and fix pair fall-through

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -95,7 +95,7 @@ jobs:
           "-Dsanitize=undefined",
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
-          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
+          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true -Dstrcmp-pair=true",
           "-Danalyzer=true -Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [
@@ -130,7 +130,7 @@ jobs:
           "-Dsanitize=undefined",
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
-          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
+          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true -Dstrcmp-pair=true",
           "-Danalyzer=true -Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [
@@ -165,7 +165,7 @@ jobs:
           "-Dsanitize=undefined",
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
-          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
+          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true -Dstrcmp-pair=true",
           "-Danalyzer=true -Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [
@@ -200,7 +200,7 @@ jobs:
           "-Dsanitize=undefined",
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
-          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
+          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true -Dstrcmp-pair=true",
           "-Danalyzer=true -Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [
@@ -235,7 +235,7 @@ jobs:
           "-Dsanitize=undefined",
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
-          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
+          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true -Dstrcmp-pair=true",
           "-Danalyzer=true -Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [
@@ -270,7 +270,7 @@ jobs:
           "-Dsanitize=undefined",
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
-          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
+          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true -Dstrcmp-pair=true",
           "-Danalyzer=true -Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]
         test: [

--- a/.github/workflows/variants
+++ b/.github/workflows/variants
@@ -6,6 +6,6 @@
           "-Dsanitize=undefined",
 
           # math configurations, one with multithread disabled and with locale, original malloc and atexit/onexit code
-          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true",
+          "-Dsanitize=undefined -Dio-float-exact=false -Dio-long-long=true -Dio-percent-b=true -Dio-long-double=true -Dnewlib-obsolete-math=false -Dwant-math-errno=true -Dsingle-thread=true -Dmb-capable=true -Dmb-extended-charsets=true -Dprintf-small-ultoa=true -Dprintf-percent-n=true -Dstrcmp-pair=true",
           "-Danalyzer=true -Dformat-default=integer -Dfreestanding=true -Dnewlib-obsolete-math=true -Dwant-math-errno=true -Dassert-verbose=true -Dfast-bufio=true -Dstdio-locking=true -Dstdio-exit-flush=true -Dfstat-bufsiz=true -Dmalloc-small-bucket=1024",
         ]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,11 @@ if(NOT DEFINED __FAST_STRCMP)
   option(__FAST_STRCMP "Always optimize strcmp for performance" ON)
 endif()
 
+# Use RISC-V paired-word strcmp (dual-issue / fused-load cores)
+if(NOT DEFINED __STRCMP_PAIR)
+  option(__STRCMP_PAIR "Use RISC-V paired-word strcmp" OFF)
+endif()
+
 # use global errno variable
 if(NOT DEFINED __GLOBAL_ERRNO)
   option(__GLOBAL_ERRNO "use global errno variable" OFF)

--- a/doc/build.md
+++ b/doc/build.md
@@ -43,6 +43,7 @@ These options control some general build configuration values.
 | analyzer                    | false   | Enable the analyzer while compiling with -fanalyzer                                  |
 | assert-verbose              | false   | Display file, line and expression in assert() messages                               |
 | fast-strcmp                 | true    | Always optimize strcmp for performance (to make Dhrystone happy)                     |
+| strcmp-pair                 | false   | Use RISC-V paired-word strcmp (dual-issue / fused-load cores)                        |
 
 ### Installation options
 

--- a/libc/machine/riscv/strcmp.S
+++ b/libc/machine/riscv/strcmp.S
@@ -50,35 +50,58 @@ strcmp:
 #endif
 
 /* -------------------------------------------------------------------
- * Register allocation per target:
+ * STRCMP_PAIR: dual-issue / Fused_LDD schedule (two words per slot).
  *
- *   Non-RV32E (32 regs): use a6, t3, t4, t5 freely.
- *   RV32E (16 regs) + Zbb: remap a6→a5, t3→t0, t4→t1 (a5 is unused
- *                          when Zbb provides orc.b, so it's free as
- *                          the second a1-word slot).
- *   RV32E + non-Zbb: not enough scratch (mask occupies a5, plus 4
- *                    data + 4 intermediates + (-1) const = 10 regs).
- *                    Fall through to single-word loop.
+ * Controlled solely by the build:
+ *   -DSTRCMP_PAIR=1  → paired path (for dual-issue / fusion cores)
+ *   -DSTRCMP_PAIR=0  → ordinary single-word path
+ *   unset / 0        → ordinary single-word path
+ *
+ * RV32E + non-Zbb: not enough scratch for the pair path → forced off.
  * ------------------------------------------------------------------- */
-#if defined(__riscv_e) || defined(__riscv_32e)
-#  ifdef __riscv_zbb
-#    define R_W1A a5    /* second a1 word (was a6) */
-#    define R_O0  t0    /* orc.b result 0 (was t3) */
-#    define R_O1  t1    /* orc.b result 1 (was t4) */
-#    define STRCMP_PAIR 1
-#  else
-     /* RV32E + non-Zbb: not enough registers, use single-word loop */
-#    define STRCMP_PAIR 0
-#  endif
-#else
-#  define R_W1A a6
-#  define R_O0  t3
-#  define R_O1  t4
-#  define R_TMP t5     /* non-Zbb intermediate (was t5) */
-#  define STRCMP_PAIR 1
+#ifndef STRCMP_PAIR
+#  define STRCMP_PAIR 0
+#endif
+#if STRCMP_PAIR && (defined(__riscv_e) || defined(__riscv_32e)) \
+    && !defined(__riscv_zbb)
+#  undef STRCMP_PAIR
+#  define STRCMP_PAIR 0
 #endif
 
 #if STRCMP_PAIR
+/* Register allocation for the pair path. */
+#  if defined(__riscv_e) || defined(__riscv_32e)
+#    define R_W1A a5    /* second a1 word */
+#    define R_O0  t0
+#    define R_O1  t1
+#  else
+#    define R_W1A a6
+#    define R_O0  t3
+#    define R_O1  t4
+#    define R_TMP t5
+#  endif
+
+/* Words per paired-loop iteration (must be even, 2..6).
+ * Override with -DSTRCMP_UNROLL=N. */
+#ifndef STRCMP_UNROLL
+#  if __riscv_xlen == 32 && !(defined(__riscv_e) || defined(__riscv_32e))
+#    define STRCMP_UNROLL 6
+#  else
+#    define STRCMP_UNROLL 4
+#  endif
+#endif
+#if (STRCMP_UNROLL & 1) || STRCMP_UNROLL < 2 || STRCMP_UNROLL > 6
+#  error "STRCMP_UNROLL must be an even value in 2..6"
+#endif
+#endif /* STRCMP_PAIR */
+
+#if STRCMP_PAIR
+/* Note on over-read: the second word of each pair is loaded before the
+ * first word has been tested for a null byte, so this reads up to one
+ * aligned word past the word holding the terminator - one word more than
+ * the single-word loop did.  Both pointers are SZREG-aligned here, so a
+ * load never straddles a boundary, but the extra word can land in the
+ * following page.  */
   .macro check_word_pair i n
     /* --- Fused_LDD #1: two loads from base a0 (back-to-back) --- */
     REG_L a2, \i*SZREG(a0)
@@ -112,62 +135,70 @@ strcmp:
     or    R_O1, R_O1, R_TMP
 #endif
 
-    /* --- Branches grouped at end --- */
+    /* --- Branches grouped at end.  The out-of-line fixups live in
+     *     foundnull so that a non-final pair falls straight through into
+     *     the next pair.                                            --- */
     bne   R_O0, t2, .Lnull\i
     bne   a2, a3, .Lmismatch
     bne   R_O1, t2, .Lnull_hi_\i
     .if \i+2-\n
-      bne a4, R_W1A, .Lmismatch_hi_\i   /* a4 vs R_W1A */
+      bne a4, R_W1A, .Lmismatch_hi
     .else
       add a0, a0, \n*SZREG
       add a1, a1, \n*SZREG
       beq a4, R_W1A, .Lloop
-      j   .Lmismatch_hi_\i
+      # fall through to .Lmismatch_hi
     .endif
-
-.Lnull_hi_\i:
-    mv    a2, a4
-    mv    a3, R_W1A
-    j     .Lnull\i\()_p1
-.Lmismatch_hi_\i:
-    mv    a2, a4
-    mv    a3, R_W1A
-    j     .Lmismatch
   .endm
 
   .macro foundnull i n
-    .ifne \i
 .Lnull\i:
+    .ifne \i
       add   a0, a0, \i*SZREG
       add   a1, a1, \i*SZREG
-    .else
-.Lnull0:
     .endif
     bne   a2, a3, .Lmisaligned
     li    a0, 0
     ret
-    .ifeq \i & 1
-.Lnull\i\()_p1:
+
+.Lnull_hi_\i:
+    mv    a2, a4
+    mv    a3, R_W1A
       add   a0, a0, \i*SZREG+SZREG
       add   a1, a1, \i*SZREG+SZREG
       bne   a2, a3, .Lmisaligned
       li    a0, 0
       ret
-    .endif
   .endm
 
 .Lloop:
-  check_word_pair 0 2
+  check_word_pair 0 STRCMP_UNROLL
+#if STRCMP_UNROLL >= 4
+  check_word_pair 2 STRCMP_UNROLL
+#endif
+#if STRCMP_UNROLL >= 6
+  check_word_pair 4 STRCMP_UNROLL
+#endif
 
-#else  /* !STRCMP_PAIR : RV32E + non-Zbb fallback (single word) */
+  /* .Lmismatch only reads a2/a3, so every pair shares one fixup, which
+   * then falls through into .Lmismatch.  */
+.Lmismatch_hi:
+  mv    a2, a4
+  mv    a3, R_W1A
+
+#else  /* !STRCMP_PAIR : classic single-word loop (single-issue / short-string) */
 
   .macro check_one_word i n
     REG_L a2, \i*SZREG(a0)
     REG_L a3, \i*SZREG(a1)
+#ifdef __riscv_zbb
+    orc.b a4, a2
+#else
     and   a4, a2, a5
     or    t1, a2, a5
     add   a4, a4, a5
     or    a4, a4, t1
+#endif
     bne   a4, t2, .Lnull\i
     .if \i+1-\n
       bne a2, a3, .Lmismatch
@@ -175,7 +206,7 @@ strcmp:
       add a0, a0, \n*SZREG
       add a1, a1, \n*SZREG
       beq a2, a3, .Lloop
-      j   .Lmismatch
+      # fall through to .Lmismatch
     .endif
   .endm
 
@@ -184,16 +215,28 @@ strcmp:
 .Lnull\i:
       add   a0, a0, \i*SZREG
       add   a1, a1, \i*SZREG
-    .else
+      .ifeq \i-1
 .Lnull0:
     .endif
     bne   a2, a3, .Lmisaligned
     li    a0, 0
     ret
+    .endif
   .endm
 
 .Lloop:
-  check_one_word 0 1
+  /* Favor strings of a couple dozen chars (Dhrystone-sized). */
+#if __riscv_xlen == 32
+  check_one_word 0 5
+  check_one_word 1 5
+  check_one_word 2 5
+  check_one_word 3 5
+  check_one_word 4 5
+#else
+  check_one_word 0 3
+  check_one_word 1 3
+  check_one_word 2 3
+#endif
 
 #endif /* STRCMP_PAIR */
 
@@ -296,10 +339,23 @@ strcmp:
 
   # cases in which a null byte was detected
 #if STRCMP_PAIR
-  foundnull 0 2
-  foundnull 1 2
+  foundnull 0 STRCMP_UNROLL
+#if STRCMP_UNROLL >= 4
+  foundnull 2 STRCMP_UNROLL
+#endif
+#if STRCMP_UNROLL >= 6
+  foundnull 4 STRCMP_UNROLL
+#endif
+#elif __riscv_xlen == 32
+  foundnull 0 5  /* no-op; .Lnull0 is emitted inside foundnull 1 */
+  foundnull 1 5
+  foundnull 2 5
+  foundnull 3 5
+  foundnull 4 5
 #else
-  foundnull 0 1
+  foundnull 0 3  /* no-op; .Lnull0 is emitted inside foundnull 1 */
+  foundnull 1 3
+  foundnull 2 3
 #endif
 #if !defined(__riscv_zbb) && SZREG != 4
 .align 3

--- a/libc/machine/riscv/strcmp.S
+++ b/libc/machine/riscv/strcmp.S
@@ -59,7 +59,9 @@ strcmp:
  *
  * RV32E + non-Zbb: not enough scratch for the pair path → forced off.
  * ------------------------------------------------------------------- */
-#ifndef STRCMP_PAIR
+#if defined(__STRCMP_PAIR)
+#  define STRCMP_PAIR 1
+#else
 #  define STRCMP_PAIR 0
 #endif
 #if STRCMP_PAIR && (defined(__riscv_e) || defined(__riscv_32e)) \

--- a/meson.build
+++ b/meson.build
@@ -475,6 +475,7 @@ foreach ld : test_link_args_extra
 endforeach
 
 fast_strcmp = get_option('fast-strcmp')
+strcmp_pair = get_option('strcmp-pair')
 
 mb_capable = get_option('mb-capable')
 mb_extended_charsets = mb_capable and get_option('mb-extended-charsets')
@@ -1490,6 +1491,7 @@ conf_data.set('__IEEE_LIBM', not get_option('want-math-errno'), description: 'ma
 conf_data.set('__MATH_ERRNO', get_option('want-math-errno'), description: 'math library sets errno')
 conf_data.set('__PREFER_SIZE_OVER_SPEED', get_option('optimization') == 's', description: 'Optimize for space over speed')
 conf_data.set('__FAST_STRCMP', fast_strcmp, description: 'Always optimize strcmp for performance')
+conf_data.set('__STRCMP_PAIR', strcmp_pair, description: 'Use RISC-V paired-word strcmp')
 conf_data.set('__GLOBAL_ERRNO', get_option('newlib-global-errno'), description: 'use global errno variable')
 conf_data.set('__INIT_FINI_ARRAY', get_option('initfini-array'), description: 'Support INIT_ARRAY linker sections')
 conf_data.set('__INIT_FINI_FUNCS', get_option('initfini'), description: 'Support _init() and _fini() functions')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -61,6 +61,8 @@ option('assert-verbose', type: 'boolean', value: true,
        description: 'Assert provides verbose information')
 option('fast-strcmp', type: 'boolean', value: true,
        description: 'Always optimize strcmp for performance')
+option('strcmp-pair', type: 'boolean', value: false,
+       description: 'Use RISC-V paired-word strcmp (dual-issue / fused-load cores)')
 option('sanitize', type: 'string', value: 'none',
        description: 'Code sanitizer to use')
 option('use-hlt-semihosting', type: 'boolean', value: 'false',

--- a/picolibc.h.in
+++ b/picolibc.h.in
@@ -11,6 +11,9 @@
 /* Always optimize strcmp for performance */
 #cmakedefine __FAST_STRCMP
 
+/* Use RISC-V paired-word strcmp (dual-issue / fused-load cores) */
+#cmakedefine __STRCMP_PAIR
+
 /* use global errno variable */
 #cmakedefine __GLOBAL_ERRNO
 


### PR DESCRIPTION

- Default to the classic single-word loop; enable the dual-issue/Fused_LDD pair schedule only when the build passes `-DSTRCMP_PAIR=1`.
- Added `STRCMP_UNROLL`: `6` words on `RV32`, `4` on `RV64`, `4` on `RV32E`; overridable via `-DSTRCMP_UNROLL=`, guarded by `#error` on invalid values.
- Moved fixup stubs out of line into `foundnull`; all pairs now share one `.Lmismatch_hi` that falls through into `.Lmismatch`.
- Restoring `orc.b` and the `5/3` unroll in the non-pair loop.


The reason behind this MR is that not all RISC-V cores supports dual-issue or Fused_LDD  so these regressed significantly when executing the pair-word path.  And in standard I couldn't find any global macro to indicate if the feature is available or not.

So now it's added as optional implementation, Defining STRCMP_PAIR=1, will activate the pair-word path and get the benefits of   dual-issue or Fused_LDD if the the core supports. 
