### PR TITLE
errno: add weak fallback for errno-function builds

### DIFF
--- a/libc/errno/errno.c
+++ b/libc/errno/errno.c
@@ -37,4 +37,19 @@
 
 #ifndef __PICOLIBC_ERRNO_FUNCTION
 __THREAD_LOCAL_ERRNO int errno;
+#elif !defined(__USE_SYSTEM_LIBC)
+/*
+ * The operating system is expected to provide this accessor. Define a weak
+ * fallback so that libc remains self-contained at link time; without one,
+ * every link that pulls in a libc function touching errno fails unless the
+ * OS is present. Toolchain builds rely on such links succeeding when probing
+ * target capabilities.
+ */
+static __THREAD_LOCAL_ERRNO int __picolibc_errno;
+
+__weak int *
+__PICOLIBC_ERRNO_FUNCTION(void)
+{
+    return &__picolibc_errno;
+}
 #endif


### PR DESCRIPTION
__PICOLIBC_ERRNO_FUNCTION provides only a function declaration, so any link that pulls in a libc function touching errno fails without the OS. 

**That breaks toolchain configure probes**: libstdc++ falls back to compile-only tests and mistakes declared-but-absent POSIX APIs for available ones.

Provide a weak definition that the OS overrides, except when building against a system libc, where the accessor belongs to the host.