### PR TITLE
linker: add external_memory cross-property for SDK builds

### DIFF
--- a/doc/linking.md
+++ b/doc/linking.md
@@ -83,6 +83,39 @@ in your linker script:
    malloc. Malloc will still be able to use all memory between the end
    of pre-allocate data and the bottom of the stack area.
 
+### Supplying MEMORY externally (SDK builds)
+
+The variable-based mechanism above bakes the same `MEMORY { flash ...
+ram ... }` layout into every picolibc.ld and only lets callers tweak
+addresses and sizes. That works for a single-target build but not for
+an SDK that wants **one** picolibc build to serve **many** boards
+whose memory maps differ in shape (multiple RAM banks, memory-mapped
+peripherals, non-contiguous regions, ...).
+
+Set the `external_memory` cross-file property to `true` and picolibc
+will emit no `MEMORY {}` block at all. Your board's linker script then
+provides the entire memory map before including picolibc.ld:
+
+	/* my-board.ld */
+	MEMORY {
+	    flash (rx!w) : ORIGIN = 0x08000000, LENGTH = 128K
+	    ram   (rwx)  : ORIGIN = 0x20000000, LENGTH = 16K
+	    /* additional banks, peripherals, etc. */
+	}
+
+	INCLUDE picolibc.ld
+
+Contract: the linker script that INCLUDEs picolibc.ld MUST define at
+least the `flash` and `ram` regions by name (picolibc.ld references
+`ORIGIN(ram)` and `LENGTH(ram)` when computing the initial stack
+pointer). RAM-only targets can point `flash` at the same region as
+`ram`.
+
+Cross file example:
+
+	[properties]
+	external_memory = true
+
 ### Arranging Code and Data in Memory
 
 Where bits of code and data land in memory can be controlled to some

--- a/meson.build
+++ b/meson.build
@@ -1125,6 +1125,20 @@ foreach params : [default_target] + targets
     picolibc_ld_data.set('INIT_PHDRS', init_phdrs)
     picolibc_ld_data.set('INIT_SECTIONS', init_sections)
 
+    # external_memory: when true, picolibc.ld emits no MEMORY {} block
+    # itself. The caller (typically an SDK or a board-support package)
+    # must supply their own linker script that defines the `flash` and
+    # `ram` memory regions and then INCLUDEs picolibc.ld. This lets a
+    # single picolibc build serve many target boards that differ only in
+    # their memory map, without rebuilding picolibc per board.
+    if meson.get_external_property('external_memory', false)
+      picolibc_ld_data.set('MEMORY_BLOCK_OPEN',  '/*')
+      picolibc_ld_data.set('MEMORY_BLOCK_CLOSE', '*/')
+    else
+      picolibc_ld_data.set('MEMORY_BLOCK_OPEN',  '')
+      picolibc_ld_data.set('MEMORY_BLOCK_CLOSE', '')
+    endif
+
     # Get default memory configuration values
 
     _default_flash_addr =  meson.get_external_property('default_flash_addr_' + custom_mem_config,

--- a/picolibc.ld.in
+++ b/picolibc.ld.in
@@ -40,6 +40,13 @@ ENTRY(@PREFIX@_start)
  * some phony values here to make things link for testing
  */
 
+/* When the `external_memory` cross-file property is set, the MEMORY {}
+ * block below is wrapped in /* ... *\/ so it is omitted from the
+ * generated linker script. The caller must supply their own linker
+ * script that defines `flash` and `ram` memory regions and INCLUDEs
+ * this file.
+ */
+@MEMORY_BLOCK_OPEN@
 MEMORY
 {@INIT_MEMORY@
 	flash (rx!w) :
@@ -49,6 +56,7 @@ MEMORY
 		ORIGIN = DEFINED(@PREFIX@__ram) ? @PREFIX@__ram : @DEFAULT_RAM_ADDR@,
 		LENGTH = DEFINED(@PREFIX@__ram_size) ? @PREFIX@__ram_size : @DEFAULT_RAM_SIZE@
 }
+@MEMORY_BLOCK_CLOSE@
 
 PHDRS
 {@INIT_PHDRS@


### PR DESCRIPTION
## Summary

picolibc.ld currently bakes the `MEMORY {}` block into every generated linker script, with only `ORIGIN`/`LENGTH` values swappable via caller-provided `__flash` / `__ram` symbols. That works for a single-target build but forces an SDK that supports many boards to rebuild picolibc once per board just to swap the memory map.

This PR adds a new cross-file property `external_memory`. When true, the MEMORY {} block is wrapped in `/* ... */` so it's omitted from the generated `picolibc.ld`. The board-support script provides its own `MEMORY {}` block (including any additional banks or memory-mapped peripherals) and then `INCLUDE picolibc.ld`.

This enables one picolibc build to serve every board of a given architecture — the model arm-none-eabi already ships for Cortex-M.

## Contract

The outer linker script must define `flash` and `ram` regions by name; `picolibc.ld` references `ORIGIN(ram)` / `LENGTH(ram)` when computing the initial stack pointer. RAM-only targets can alias `flash` to `ram`.

```ld
/* my-board.ld */
MEMORY {
    flash (rx!w) : ORIGIN = 0x08000000, LENGTH = 128K
    ram   (rwx)  : ORIGIN = 0x20000000, LENGTH = 16K
}
INCLUDE picolibc.ld
```

Cross file:
```ini
[properties]
external_memory = true
```

## Test plan

- [x] Default (`external_memory = false` / unset) produces bit-identical `picolibc.ld` — the substitution variables are empty strings, so the template passes through unchanged.
- [x] With `external_memory = true`, the generated `picolibc.ld` has the entire `MEMORY {}` block wrapped in `/* ... */` and is otherwise identical.
- [x] Verified end-to-end on an out-of-tree MOS 6502 SDK: hello.c compiles and links against a shared `libc.a` while the board's own linker script supplies the MEMORY map. Same libc.a would serve every other MOS-family board (C64, NES, Apple II, ...) via that board's own MEMORY definition.
- [ ] CI on existing targets should show no diffs to their generated `picolibc.ld`.