### PR TITLE
libos/semihost/common: guard ARM-specific exit paths on 16-bit uintptr_t

### DIFF
--- a/libos/semihost/common/exit.c
+++ b/libos/semihost/common/exit.c
@@ -37,6 +37,15 @@
 #include <sys/cdefs.h>
 #include <unistd.h>
 
+/*
+ * ADP_Stopped_ApplicationExit is 0x20026, which does not fit in a
+ * 16-bit uintptr_t and would be silently truncated by the compiler on
+ * targets where sizeof(uintptr_t) < sizeof(int). Targets that need a
+ * word-size-appropriate exit path must supply their own _exit in
+ * their machine directory.
+ */
+#if __SIZEOF_POINTER__ >= 4
+
 __noreturn void
 _exit(int code)
 {
@@ -54,3 +63,5 @@ _exit(int code)
     }
     sys_semihost_exit(ADP_Stopped_ApplicationExit, code);
 }
+
+#endif /* __SIZEOF_POINTER__ >= 4 */

--- a/libos/semihost/common/sys_exit_extended.c
+++ b/libos/semihost/common/sys_exit_extended.c
@@ -36,9 +36,19 @@
 #include "semihost-private.h"
 #include <sys/cdefs.h>
 
+/*
+ * ADP_Stopped_ApplicationExit is 0x20026 and does not fit in a 16-bit
+ * uintptr_t. See libos/semihost/common/exit.c for the analogous guard;
+ * targets that need this call on a smaller word size must supply their
+ * own sys_semihost_exit_extended in their machine directory.
+ */
+#if __SIZEOF_POINTER__ >= 4
+
 __noreturn void
 sys_semihost_exit_extended(uintptr_t code)
 {
     (void)sys_semihost2(SYS_EXIT_EXTENDED, ADP_Stopped_ApplicationExit, code);
     __builtin_unreachable();
 }
+
+#endif /* __SIZEOF_POINTER__ >= 4 */


### PR DESCRIPTION
## Summary

`libos/semihost/common/{exit,sys_exit_extended}.c` unconditionally pass `ADP_Stopped_ApplicationExit = 0x20026` to `sys_semihost_exit()` / `sys_semihost2(SYS_EXIT_EXTENDED, ...)`. On any target where `sizeof(uintptr_t) < sizeof(int)` this value is silently truncated to `0x0026` by the compiler, changing the semihost call's meaning.

Guard both functions with `#if __SIZEOF_POINTER__ >= 4`. On such targets the two translation units become empty; the machine directory must supply its own `_exit` and `sys_semihost_exit_extended` (using whatever wire-format encoding fits its word size).

## No behavior change on any existing target

Only four upstream machines set `has_arm_semihost = true` (arm, aarch64, riscv, loongarch); all are 32- or 64-bit, so `__SIZEOF_POINTER__ >= 4` is true and the guarded code is emitted exactly as before.

The one 16-bit upstream target — MSP430 — does NOT set `has_arm_semihost = true`, uses its own transport, and already supplies its own `_exit` in `libos/semihost/machine/msp430/msp430-exit.c`. It never enters the common code path today.

## What this enables

A future 16-bit ARM-semihost-shaped target that inadvertently sets `has_arm_semihost = true` fails to link cleanly (missing `_exit`) rather than silently truncating the exit reason code to `0x0026` at runtime.

Discovered while porting to MOS 6502 (16-bit `uintptr_t`) — MOS uses an ARM-semihosting-wire-format transport (through a memory-mapped device) and hits this exact truncation. Downstream picomos now works without any skip-list machinery once this guard is in place.

## Test plan

- [x] Confirmed via `grep` that no upstream machine dir with `has_arm_semihost = true` is 16-bit.
- [x] Verified end-to-end downstream (MOS 6502 under MAME): with these guards + no skip-list, `_exit` from a machine-provided implementation wins, and a picolibc-linked `puts(\"hello, mos\"); return 0;` prints and exits cleanly.
- [ ] Upstream CI on arm / aarch64 / riscv / loongarch should show bit-identical output — the preprocessor branch that's taken is unchanged.