### PR TITLE
meson: place .init in ram for noflash linker scripts

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1276,6 +1276,21 @@ foreach params : [default_target] + targets
     picolibc_noflash_ld_data.set('INITTLS', '')
     picolibc_noflash_ld_data.set('DATATLS', ld_comment)
 
+    # The default .init section inherited from picolibc_ld_data targets
+    # `flash`. In a noflash build there is no distinct flash region — it
+    # either does not exist or is aliased to `ram` — so `.init > flash`
+    # is either nonsensical or overlaps `.text`. Redirect .init to ram
+    # in the noflash variant.
+    #
+    # Only applies when the default (single-.init) init-sections layout
+    # is in use; when the target enables `additional_sections` /
+    # `separate_boot_flash`, the inherited multi-section init layout
+    # (with its own explicit regions) is preserved.
+    if additional_sections == []
+      picolibc_noflash_ld_data.set('INIT_SECTIONS',
+        default_init_section_template.format(init_section_name, 'ram', 'text'))
+    endif
+
     # place all remaining sections in ram
 
     # attributes for regular executable sections


### PR DESCRIPTION
## Summary

The generated `picolibc_noflash.ld` inherits its `INIT_SECTIONS` placement (`.init : { ... } > flash`) from `picolibc_ld_data`, then overrides every other output section — `.text`, `.rodata`, `.data`, etc. — to target `ram`. `.init` is the odd one out, still targeting `flash`.

That is either nonsensical (on a target with no distinct flash region) or actively broken (when `flash` is aliased to `ram` and `.init > flash` overlaps `.text > ram`). This patch redirects `.init` to `ram` in the noflash variant.

Only applies to the default single-`.init` layout. Targets that enable `additional_sections` / `separate_boot_flash` keep the inherited multi-section init layout, since those explicitly configure per-section regions and may want distinct behavior.

## Impact on existing targets

The 4 upstream machines with `has_arm_semihost = true` (arm, aarch64, riscv, loongarch) currently consume the noflash script through picolibc's own test harness. They configure `_default_noflash_flash_addr` != `_default_noflash_ram_addr`, so `.init > flash` and `.text > ram` do not overlap — the current behavior "happens to work" because the two load addresses are simply distinct RAM regions, and `.init` loads fine from what is nominally called `flash`.

After this patch those targets get `.init > ram` too. Semantically correct — a noflash build has no flash — and no runtime code cares which of two non-overlapping RAM-load-address ranges `.init` came from.

## What this enables

RAM-only targets where `flash` aliases `ram` (e.g., a 6502-family board where all storage is a single physical RAM region) can now consume `picolibc_noflash.ld` directly with matching `__flash` / `__ram` overrides. Prior to this, they had to work around the `.init > flash` overlap either by inventing a distinct fake flash region or by carrying a downstream patch.

## Test plan

- [x] Verified end-to-end on a downstream 6502 target: with this patch, a symbol-override linker script (`__flash = __ram = 0x0200`, `__flash_size = __ram_size = 0xFAE0`, `INCLUDE picolibc_noflash.ld`) links cleanly, the ELF loads correctly under emulation, and `hello.elf` runs. Prior to this patch, `.init > flash` overlapped `.text > ram` and lld refused to link.
- [ ] Upstream CI on arm / aarch64 / riscv / loongarch should show no functional change — noflash tests continue to run.