### PR TITLE
Added option for excluding headers/sources during build

### DIFF
--- a/libc/include/meson.build
+++ b/libc/include/meson.build
@@ -113,6 +113,18 @@ if enable_libdl
   inc_headers += ['dlfcn.h']
 endif
 
+if exclude_headers.length() > 0
+  inc_headers_kept = []
+  foreach header : inc_headers
+    if fs.name('@0@'.format(header)) in exclude_headers
+      message('libc: excluding ' + fs.name('@0@'.format(header)) + ' (-Dexclude-headers)')
+    else
+      inc_headers_kept += header
+    endif
+  endforeach
+  inc_headers = inc_headers_kept
+endif
+
 if really_install
   install_headers(inc_headers,
                   install_dir: include_dir)

--- a/libc/meson.build
+++ b/libc/meson.build
@@ -38,6 +38,9 @@ libdirs = ['argz', 'ctype', 'errno', 'iconv', 'locale',
            'stdio', 'stdlib', 'string', 'time', 'xdr',
            'uchar', 'ubsan']
 
+exclude_srcs = get_option('exclude-sources')
+exclude_headers = get_option('exclude-headers')
+
 if use_stdlib
   libdirs += ['native']
 endif
@@ -72,6 +75,18 @@ endforeach
 
 if not has_os_library
   src_cpart += src_os_fallback
+endif
+
+if exclude_srcs.length() > 0
+  src_cpart_kept = []
+  foreach src : src_cpart
+    if fs.name('@0@'.format(src)) in exclude_srcs
+      message('libc: excluding ' + fs.name('@0@'.format(src)) + ' (-Dexclude-sources)')
+    else
+      src_cpart_kept += src
+    endif
+  endforeach
+  src_cpart = src_cpart_kept
 endif
 
 subdir('include')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -67,6 +67,10 @@ option('sanitize', type: 'string', value: 'none',
        description: 'Code sanitizer to use')
 option('use-hlt-semihosting', type: 'boolean', value: 'false',
         description: 'Enable HLT Semihosting (only valid for Armv8)')
+option('exclude-sources', type: 'array', value: [],
+       description: 'Source basenames to omit from libc')
+option('exclude-headers', type: 'array', value: [],
+       description: 'Header basenames to omit from libc')
 
 #
 # Installation options


### PR DESCRIPTION
Often times for compiling for different OS'es, I've have had to exclude certain sources from compilation. Having a custom option for this would be a nice-to-have.

Please let me know if there would be some other smart way of doing this.